### PR TITLE
add models for permit classifications

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,2 @@
+class Activity < PermitClassification
+end

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -5,13 +5,6 @@ class PermitApplication < ApplicationRecord
   # Custom validation
   validate :submitter_must_have_role
 
-  enum permit_type: { residential: 0 }, _default: 0
-  enum building_type: {
-         detatched: 0, # detached house (with or without secondary suite)
-         semi_detatched: 1, # semi-detached house/duplex/townhouse/row house
-         small_appartment: 2, # small apartment/houseplex
-       },
-       _default: 0
   enum status: { draft: 0, submitted: 1, viewed: 2 }, _default: 0
 
   private

--- a/app/models/permit_classification.rb
+++ b/app/models/permit_classification.rb
@@ -1,0 +1,6 @@
+class PermitClassification < ApplicationRecord
+  # This class will have a 'type' column for STI.
+
+  validates :code, presence: true, uniqueness: :true
+  validates :name, presence: true
+end

--- a/app/models/permit_type.rb
+++ b/app/models/permit_type.rb
@@ -1,0 +1,2 @@
+class PermitType < PermitClassification
+end

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -1,0 +1,14 @@
+class RequirementTemplate < ApplicationRecord
+  belongs_to :activity, class_name: "Activity"
+  belongs_to :permit_type, class_name: "PermitType"
+
+  validates :activity_id, uniqueness: { scope: :permit_type_id }
+  validate :ensure_correct_type_for_permit_type_and_activity
+
+  private
+
+  def ensure_correct_type_for_permit_type_and_activity
+    errors.add(:permit_type, "must be of type PermitType") unless permit_type.type == "PermitType"
+    errors.add(:activity, "must be of type Activity") unless activity.type == "Activity"
+  end
+end

--- a/app/services/permit_classification_seeder.rb
+++ b/app/services/permit_classification_seeder.rb
@@ -1,0 +1,24 @@
+class PermitClassificationSeeder
+  def self.seed
+    # Define PermitType data
+    permit_types = [
+      { name: "Low Residential", code: "low_residential" },
+      { name: "Medium Residential", code: "medium_residential" },
+      { name: "High Residential", code: "high_residential" },
+    ]
+
+    # Create PermitTypes
+    permit_types.each { |pt_attrs| PermitType.find_or_create_by!(pt_attrs) }
+
+    # Define Activity data
+    activities = [
+      { name: "New Construction", code: "new_construction" },
+      { name: "Addition, Alteration, or Renovation", code: "addition_alteration_renovation" },
+      { name: "Site Alteration", code: "site_alteration" },
+      { name: "Demolition", code: "demolition" },
+    ]
+
+    # Create Activities
+    activities.each { |activity_attrs| Activity.find_or_create_by!(activity_attrs) }
+  end
+end

--- a/db/migrate/20231208191423_create_permit_applications.rb
+++ b/db/migrate/20231208191423_create_permit_applications.rb
@@ -1,8 +1,6 @@
 class CreatePermitApplications < ActiveRecord::Migration[7.1]
   def change
     create_table :permit_applications, id: :uuid do |t|
-      t.integer :permit_type, default: 0
-      t.integer :building_type, default: 0
       t.integer :status, default: 0
       t.references :submitter, null: false, foreign_key: { to_table: :users }, type: :uuid
       t.references :jurisdiction, null: false, foreign_key: true, type: :uuid

--- a/db/migrate/20240102215215_create_permit_classifications.rb
+++ b/db/migrate/20240102215215_create_permit_classifications.rb
@@ -1,0 +1,13 @@
+class CreatePermitClassifications < ActiveRecord::Migration[7.1]
+  def change
+    create_table :permit_classifications, id: :uuid do |t|
+      t.string :name, null: false
+      t.string :code, null: false
+      t.string :type, null: false
+
+      t.timestamps
+    end
+
+    add_index :permit_classifications, :code, unique: true
+  end
+end

--- a/db/migrate/20240102221154_create_requirement_templates.rb
+++ b/db/migrate/20240102221154_create_requirement_templates.rb
@@ -1,0 +1,12 @@
+class CreateRequirementTemplates < ActiveRecord::Migration[7.1]
+  def change
+    create_table :requirement_templates, id: :uuid do |t|
+      t.references :activity, null: false, foreign_key: { to_table: :permit_classifications }, type: :uuid
+      t.references :permit_type, null: false, foreign_key: { to_table: :permit_classifications }, type: :uuid
+
+      t.timestamps
+    end
+
+    add_index :requirement_templates, %i[permit_type_id activity_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_14_224612) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_02_221154) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -54,8 +54,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_14_224612) do
   end
 
   create_table "permit_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.integer "permit_type", default: 0
-    t.integer "building_type", default: 0
     t.integer "status", default: 0
     t.uuid "submitter_id", null: false
     t.uuid "jurisdiction_id", null: false
@@ -63,6 +61,27 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_14_224612) do
     t.datetime "updated_at", null: false
     t.index ["jurisdiction_id"], name: "index_permit_applications_on_jurisdiction_id"
     t.index ["submitter_id"], name: "index_permit_applications_on_submitter_id"
+  end
+
+  create_table "permit_classifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.string "code", null: false
+    t.string "type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_permit_classifications_on_code", unique: true
+  end
+
+  create_table "requirement_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "activity_id", null: false
+    t.uuid "permit_type_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["activity_id"], name: "index_requirement_templates_on_activity_id"
+    t.index %w[permit_type_id activity_id],
+            name: "index_requirement_templates_on_permit_type_id_and_activity_id",
+            unique: true
+    t.index ["permit_type_id"], name: "index_requirement_templates_on_permit_type_id"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -105,5 +124,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_14_224612) do
   add_foreign_key "contacts", "jurisdictions"
   add_foreign_key "permit_applications", "jurisdictions"
   add_foreign_key "permit_applications", "users", column: "submitter_id"
+  add_foreign_key "requirement_templates", "permit_classifications", column: "activity_id"
+  add_foreign_key "requirement_templates", "permit_classifications", column: "permit_type_id"
   add_foreign_key "users", "jurisdictions"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,13 +11,17 @@
 # Creating Jurisdictions
 5.times { FactoryBot.create(:jurisdiction) }
 
-FactoryBot.create(
-  :user,
-  :super_admin,
-  email: "admin@example.com",
-  username: "admin@example.com",
-  password: "P@ssword1",
-).confirm
+user = User.find_by(email: "admin@example.com")
+
+unless user
+  FactoryBot.create(
+    :user,
+    :super_admin,
+    email: "admin@example.com",
+    username: "admin@example.com",
+    password: "P@ssword1",
+  ).confirm
+end
 
 # Creating Users with different roles
 5.times do
@@ -35,3 +39,18 @@ submitters = User.where(role: "submitter")
 
 # Creating Contacts
 jurisdictions.each { |j| rand(3..5).times { FactoryBot.create(:contact, jurisdiction: j) } }
+
+PermitClassificationSeeder.seed
+
+activity1 = Activity.find_by_code("new_construction")
+activity2 = Activity.find_by_code("demolition")
+
+# Create PermitType records
+permit_type1 = PermitType.find_by_code("low_residential")
+permit_type2 = PermitType.find_by_code("high_residential")
+
+# Create RequirementTemplate records
+RequirementTemplate.find_or_create_by!(activity: activity1, permit_type: permit_type1)
+RequirementTemplate.find_or_create_by!(activity: activity1, permit_type: permit_type2)
+RequirementTemplate.find_or_create_by!(activity: activity2, permit_type: permit_type1)
+RequirementTemplate.find_or_create_by!(activity: activity2, permit_type: permit_type2)

--- a/spec/factories/permit_applications.rb
+++ b/spec/factories/permit_applications.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :permit_application do
-    permit_type { 0 }
     association :submitter, factory: :user, role: "submitter"
     association :jurisdiction
   end

--- a/spec/factories/permit_classification.rb
+++ b/spec/factories/permit_classification.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :activity, class: "Activity" do
+    name { "Default Activity Name" }
+    code { "default_activity_code" }
+  end
+
+  factory :permit_type, class: "PermitType" do
+    name { "Default Permit Type Name" }
+    code { "default_permit_type_code" }
+  end
+end

--- a/spec/factories/requirement_templates.rb
+++ b/spec/factories/requirement_templates.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :requirement_template do
+    association :activity, factory: :activity
+    association :permit_type, factory: :permit_type
+
+    # Add additional attributes for RequirementTemplate here if needed
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,44 +8,20 @@ FactoryBot.define do
 
     trait :submitter do
       role { :submitter }
-      sequence :email do |n|
-        "submitter#{n}@example.com"
-      end
-      sequence :username do |n|
-        "submitter#{n}"
-      end
     end
 
     trait :review_manager do
       role { :review_manager }
-      sequence :email do |n|
-        "review_manager#{n}@example.com"
-      end
-      sequence :username do |n|
-        "review_manager#{n}"
-      end
       association :jurisdiction
     end
 
     trait :reviewer do
       role { :reviewer }
-      sequence :email do |n|
-        "reviewer#{n}@example.com"
-      end
-      sequence :username do |n|
-        "reviewer#{n}"
-      end
       association :jurisdiction
     end
 
     trait :super_admin do
       role { :super_admin }
-      sequence :email do |n|
-        "super_admin#{n}@example.com"
-      end
-      sequence :username do |n|
-        "super_admin#{n}"
-      end
       password { "P@ssword1" }
     end
 

--- a/spec/models/permit_application_spec.rb
+++ b/spec/models/permit_application_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe PermitApplication, type: :model do
   end
 
   describe "enums" do
-    xit { should define_enum_for(:permit_type).with_values(residential: 0) }
     it { should define_enum_for(:status).with_values(draft: 0, submitted: 1, viewed: 2) }
     it { should define_enum_for(:building_type).with_values(detatched: 0, semi_detatched: 1, small_appartment: 2) }
   end

--- a/spec/models/permit_type_spec.rb
+++ b/spec/models/permit_type_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe PermitType, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/requirement_template_spec.rb
+++ b/spec/models/requirement_template_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe RequirementsTemplate, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Description

Adds models, factories, seeders for the permit classification STI which will let us create an arbitray set of permit classifications. Currently there is PermitType and Activity (aka WorkType)

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://app.shortcut.com/codechallengell/story/66489/setup-building-permit-options

## Steps to QA

Set up the db and seed with rails db:seed

This should create a set of PermitTypes and Activities, and some RequirementTemplates to use them.

No frontend in this PR.

## General Checklist

- [ x] ✅ Provide tests for your changes where relevant
- [x ] 📝 Use descriptive commit messages
- [ x] 📗 Update any related documentation and include any relevant screenshots
- [x ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [ x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

