### PR TITLE
Feature/create seeded template/sc 67048

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.xlsx filter=lfs diff=lfs merge=lfs -text

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+git lfs post-checkout "$@"

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+git lfs post-commit "$@"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+git lfs post-merge "$@"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { echo >&2 "\nThis repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks').\n"; exit 2; }
+git lfs pre-push "$@"

--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,8 @@ gem "devise_invitable", "~> 2.0.9"
 gem "devise-jwt", "0.8.1"
 gem "devise-jwt-cookie", "0.5.1"
 gem "dry-container", "0.8.0"
-gem 'omniauth-keycloak', "1.5.1"
-gem 'omniauth-rails_csrf_protection', '1.0.1'
+gem "omniauth-keycloak", "1.5.1"
+gem "omniauth-rails_csrf_protection", "1.0.1"
 
 gem "blueprinter", "~> 0.30.0"
 
@@ -45,15 +45,16 @@ gem "sidekiq", "~> 7.2.0"
 gem "shrine", "~> 3.5.0"
 gem "redis", "~> 5.0.8"
 gem "image_processing", "~> 1.12.2"
-gem 'acts_as_list', "~> 1.1.0"
+gem "acts_as_list", "~> 1.1.0"
 gem "searchkick", "~> 5.3.1"
 gem "elasticsearch", "~> 8.11.0"
-gem 'kaminari', "~> 1.2.2"
-gem 'acts-as-taggable-on', '~> 10.0.0'
+gem "kaminari", "~> 1.2.2"
+gem "acts-as-taggable-on", "~> 10.0.0"
 # Assuming BC Common Object Management Service (COMS) is compatible with S3 formats:
 gem "aws-sdk-s3", "~> 1.141.0"
 gem "pundit", "~> 2.3.1"
 gem "phonelib", "~> 0.8.5"
+gem "roo", "~> 2.10"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,6 +345,9 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    roo (2.10.0)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -365,6 +368,7 @@ GEM
     ruby-vips (2.2.0)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     searchkick (5.3.1)
       activemodel (>= 6.1)
       hashie
@@ -426,6 +430,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
 
 DEPENDENCIES
   acts-as-taggable-on (~> 10.0.0)
@@ -458,6 +463,7 @@ DEPENDENCIES
   pundit (~> 2.3.1)
   rails (~> 7.1.2)
   redis (~> 5.0.8)
+  roo (~> 2.10)
   rspec-rails (~> 6.1.0)
   searchkick (~> 5.3.1)
   shoulda-matchers (~> 5.3.0)

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -2,12 +2,22 @@ class Requirement < ApplicationRecord
   has_many :requirement_block_requirements, dependent: :destroy
   has_many :requirement_blocks, through: :requirement_block_requirements
 
-  enum input_type: { textfield: 0, number: 1, checkbox: 2, select: 3, multi_option_select: 4, date: 5 }, _prefix: true
+  enum input_type: {
+         text: 0,
+         number: 1,
+         checkbox: 2,
+         select: 3,
+         multi_option_select: 4,
+         date: 5,
+         textarea: 6,
+       },
+       _prefix: true
 
+  before_create :set_requirement_code
   validate :validate_options_for_select_inputs
 
   DEFAULT_FORMIO_TYPE_TO_OPTIONS = {
-    textfield: {
+    text: {
       type: "simpletextfield",
     },
     number: {
@@ -85,6 +95,11 @@ class Requirement < ApplicationRecord
   end
 
   private
+
+  # requirement codes should not be auto generated during seeding.  Use uuid if not provided
+  def set_requirement_code
+    self.requirement_code ||= SecureRandom.uuid
+  end
 
   def formio_type_options
     DEFAULT_FORMIO_TYPE_TO_OPTIONS[input_type.to_sym] || {}

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -2,14 +2,12 @@ class Requirement < ApplicationRecord
   has_many :requirement_block_requirements, dependent: :destroy
   has_many :requirement_blocks, through: :requirement_block_requirements
 
-  enum input_type: { text: 0, number: 1, checkbox: 2, select: 3, multi_option_select: 4, date: 5 }, _prefix: true
+  enum input_type: { textfield: 0, number: 1, checkbox: 2, select: 3, multi_option_select: 4, date: 5 }, _prefix: true
 
   validate :validate_options_for_select_inputs
 
-  before_validation :set_requirement_code
-
   DEFAULT_FORMIO_TYPE_TO_OPTIONS = {
-    text: {
+    textfield: {
       type: "simpletextfield",
     },
     number: {
@@ -90,11 +88,6 @@ class Requirement < ApplicationRecord
 
   def formio_type_options
     DEFAULT_FORMIO_TYPE_TO_OPTIONS[input_type.to_sym] || {}
-  end
-
-  # TODO: requirement codes should be auto generated. Using a uuid for now. Later we have to replace it with a more human readable code
-  def set_requirement_code
-    self.requirement_code = SecureRandom.uuid
   end
 
   def validate_options_for_select_inputs

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -4,6 +4,9 @@ class RequirementBlock < ApplicationRecord
   has_many :requirement_block_requirements, -> { order(position: :asc) }, dependent: :destroy
   has_many :requirements, through: :requirement_block_requirements
 
+  has_many :requirement_template_section_requirement_blocks, dependent: :destroy
+  has_many :requirement_templates, through: :requirement_template_requirement_blocks
+
   accepts_nested_attributes_for :requirement_block_requirements, allow_destroy: true
 
   enum sign_off_role: { any: 0 }, _prefix: true

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -5,7 +5,7 @@ class RequirementBlock < ApplicationRecord
   has_many :requirements, through: :requirement_block_requirements
 
   has_many :requirement_template_section_requirement_blocks, dependent: :destroy
-  has_many :requirement_templates, through: :requirement_template_requirement_blocks
+  has_many :requirement_templates, through: :requirement_template_section_requirement_blocks
 
   accepts_nested_attributes_for :requirement_block_requirements, allow_destroy: true
 

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -2,5 +2,17 @@ class RequirementTemplate < ApplicationRecord
   belongs_to :activity
   belongs_to :permit_type
 
+  has_many :requirement_template_sections, -> { order(position: :asc) }, dependent: :destroy
+
   validates :activity_id, uniqueness: { scope: :permit_type_id }
+
+  def to_form_json
+    {
+      id: id,
+      key: "fieldSet#{id}",
+      input: false,
+      tableView: false,
+      components: requirement_template_sections.map(&:to_form_json),
+    }
+  end
 end

--- a/app/models/requirement_template_section.rb
+++ b/app/models/requirement_template_section.rb
@@ -1,0 +1,18 @@
+class RequirementTemplateSection < ApplicationRecord
+  belongs_to :requirement_template
+
+  has_many :requirement_template_section_requirement_blocks, -> { order(position: :asc) }, dependent: :destroy
+  has_many :requirement_blocks, through: :requirement_template_section_requirement_blocks
+
+  def to_form_json
+    {
+      id: id,
+      legend: name,
+      key: "fieldSet#{id}",
+      label: name,
+      input: false,
+      tableView: false,
+      components: requirement_blocks.map(&:to_form_json),
+    }
+  end
+end

--- a/app/models/requirement_template_section_requirement_block.rb
+++ b/app/models/requirement_template_section_requirement_block.rb
@@ -1,0 +1,8 @@
+class RequirementTemplateSectionRequirementBlock < ApplicationRecord
+  belongs_to :requirement_template_section
+  belongs_to :requirement_block
+
+  acts_as_list scope: :requirement_template_section, top_of_list: 0
+
+  validates_uniqueness_of :requirement_block, scope: :requirement_template_section
+end

--- a/app/services/requirements_from_xlsx_seeder.rb
+++ b/app/services/requirements_from_xlsx_seeder.rb
@@ -1,0 +1,132 @@
+class RequirementsFromXlsxSeeder
+  def self.seed
+    file_name = "#{Rails.root}/db/templates/Core Permit Requirements List.xlsx"
+    if File.exist?(file_name)
+      xlsx = Roo::Spreadsheet.open(file_name)
+
+      req_sheet = xlsx.sheet("Dev-Requirements")
+      parsed_req_sheet = req_sheet.parse(headers: true)
+
+      errors = ["Requirements Loading"]
+
+      parsed_req_sheet.each do |row|
+        if row["requirement_code"] && row["requirement_code"] != "requirement_code" #skip anything with no code
+          begin
+            requirement =
+              Requirement.where(requirement_code: row["requirement_code"]).find_or_initialize_by(
+                requirement_code: row["requirement_code"],
+              )
+            requirement.update!(
+              label: row["display_label"],
+              input_type: row["input_type"],
+              hint: row["hint"],
+              required: row["required"].present?,
+              reusable: true, #TODO: DECIDE WHAT CASES ARE NON REUSABLE?
+              input_options: row["input_options"].blank? ? {} : JSON.parse(row["input_options"]), #if parse fails it will raise error
+              #required_for_in_person_hint - text
+              #reusable - boolean
+              required_for_multiple_owners: row["required_for_multiple_owners"].present?,
+            )
+          rescue StandardError => e #ArgumentError, ActiveRecord::ActiveRecordError => e
+            errors << "Error loading #{row["requirement_code"]} - #{e.message}"
+          end
+        end
+      end
+      #loop through requirements and do first or update.  At some point we will not allow updating.
+
+      setup_requirement_template(
+        "new_construction",
+        "low_residential",
+        xlsx.sheet("Dev-RequirementBlocks-House"),
+        errors,
+      )
+
+      #medium density new contruction
+      # setup_requirement_template(
+      #   "new_construction",
+      #   "medium_residential",
+      #   xlsx.sheet("Dev-RequirementBlocks-Townhouse"),
+      #   errors,
+      # )
+
+      puts errors
+    end
+  end
+
+  private
+
+  def self.setup_requirement_template(activity, permit_type, sheet, errors)
+    errors << "#{activity} #{permit_type} loading"
+
+    #create requirements blocks
+    activity = Activity.find_by_code!(activity)
+    permit_type = PermitType.find_by_code!(permit_type)
+    requirement_template =
+      RequirementTemplate.where(activity: activity, permit_type: permit_type).first_or_create(
+        activity: activity,
+        permit_type: permit_type,
+      )
+    setup_sheet(activity, permit_type, sheet, requirement_template, errors)
+  end
+
+  def self.setup_sheet(activity, permit_type, sheet, requirement_template, errors)
+    rs_position_incrementer = 0
+    #create sections first and order them
+    sheet
+      .column(1)
+      .drop(3)
+      .compact
+      .uniq
+      .each do |section_name|
+        rs =
+          requirement_template
+            .requirement_template_sections
+            .where(name: section_name)
+            .first_or_create!(name: section_name)
+        rs.update(position: rs_position_incrementer)
+      end
+
+    rstrb_position_incrementer = {}
+    (4..sheet.last_row).each do |row_index|
+      begin
+        #https://www.vishalon.net/blog/excel-column-letter-to-number-quick-reference but -1 for ruby
+        #if column A(0) Section, C(2) Fieldset and L(11) value
+
+        #go through each requirement block and add them to each section
+        if sheet.row(row_index)[0].present? && sheet.row(row_index)[2] && sheet.row(row_index)[11].present?
+          req_template_section =
+            requirement_template.requirement_template_sections.find { |rs| rs.name == sheet.row(row_index)[0] }
+          rb = RequirementBlock.where(name: sheet.row(row_index)[2]).first_or_create!(name: sheet.row(row_index)[2])
+          req_position_incrementer = 0
+          (11..21).each_with_index do |req_col, req_position|
+            val = sheet.row(row_index)[req_col]
+            if val.present?
+              requirement = Requirement.find_by_requirement_code(val)
+              if requirement
+                rbr =
+                  rb
+                    .requirement_block_requirements
+                    .where(requirement: requirement)
+                    .first_or_initialize(requirement: requirement)
+                rbr.update!(requirement: requirement, position: req_position_incrementer)
+                req_position_incrementer += 1
+              end
+            end
+          end
+
+          rsrb =
+            req_template_section
+              .requirement_template_section_requirement_blocks
+              .where(requirement_block: rb)
+              .first_or_initialize(requirement_block: rb)
+          rsrb.update!(position: rstrb_position_incrementer[req_template_section.name] || 0)
+          rstrb_position_incrementer[req_template_section.name].present? ?
+            rstrb_position_incrementer[req_template_section.name] += 1 :
+            rstrb_position_incrementer[req_template_section.name] = 1
+        end
+      rescue StandardError => e
+        errors << "Error loading #{activity} #{permit_type} - row:#{row_index} - #{e.message}"
+      end
+    end
+  end
+end

--- a/app/services/requirements_from_xlsx_seeder.rb
+++ b/app/services/requirements_from_xlsx_seeder.rb
@@ -83,7 +83,8 @@ class RequirementsFromXlsxSeeder
             .requirement_template_sections
             .where(name: section_name)
             .first_or_create!(name: section_name)
-        rs.update(position: rs_position_incrementer)
+        rs.update!(position: rs_position_incrementer)
+        rs_position_incrementer += 1
       end
 
     rstrb_position_incrementer = {}

--- a/db/migrate/20240109231154_create_requirement_template_sections.rb
+++ b/db/migrate/20240109231154_create_requirement_template_sections.rb
@@ -1,0 +1,11 @@
+class CreateRequirementTemplateSections < ActiveRecord::Migration[7.1]
+  def change
+    create_table :requirement_template_sections, id: :uuid do |t|
+      t.string :name
+      t.references :requirement_template, null: false, foreign_key: true, type: :uuid
+      t.integer :position
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240109231303_create_requirement_template_section_requirement_blocks.rb
+++ b/db/migrate/20240109231303_create_requirement_template_section_requirement_blocks.rb
@@ -1,0 +1,11 @@
+class CreateRequirementTemplateSectionRequirementBlocks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :requirement_template_section_requirement_blocks, id: :uuid do |t|
+      t.references :requirement_template_section, null: false, foreign_key: true, type: :uuid
+      t.references :requirement_block, null: false, foreign_key: true, type: :uuid
+      t.integer :position
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_08_233657) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_09_231303) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -60,6 +60,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_08_233657) do
   end
 
   create_table "permit_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "permit_type", default: 0
+    t.integer "building_type", default: 0
     t.integer "status", default: 0
     t.uuid "submitter_id", null: false
     t.uuid "jurisdiction_id", null: false
@@ -96,6 +98,28 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_08_233657) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_requirement_blocks_on_name", unique: true
+  end
+
+  create_table "requirement_template_section_requirement_blocks",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
+    t.uuid "requirement_template_section_id", null: false
+    t.uuid "requirement_block_id", null: false
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["requirement_block_id"], name: "idx_on_requirement_block_id_7cfbb26f23"
+    t.index ["requirement_template_section_id"], name: "idx_on_requirement_template_section_id_bea21d663c"
+  end
+
+  create_table "requirement_template_sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name"
+    t.uuid "requirement_template_id", null: false
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["requirement_template_id"], name: "index_requirement_template_sections_on_requirement_template_id"
   end
 
   create_table "requirement_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -201,6 +225,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_08_233657) do
   add_foreign_key "permit_applications", "users", column: "submitter_id"
   add_foreign_key "requirement_block_requirements", "requirement_blocks"
   add_foreign_key "requirement_block_requirements", "requirements"
+  add_foreign_key "requirement_template_section_requirement_blocks", "requirement_blocks"
+  add_foreign_key "requirement_template_section_requirement_blocks", "requirement_template_sections"
+  add_foreign_key "requirement_template_sections", "requirement_templates"
   add_foreign_key "requirement_templates", "permit_classifications", column: "activity_id"
   add_foreign_key "requirement_templates", "permit_classifications", column: "permit_type_id"
   add_foreign_key "taggings", "tags"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,8 +60,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_09_231303) do
   end
 
   create_table "permit_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.integer "permit_type", default: 0
-    t.integer "building_type", default: 0
     t.integer "status", default: 0
     t.uuid "submitter_id", null: false
     t.uuid "jurisdiction_id", null: false

--- a/db/templates/Core Permit Requirements List.xlsx
+++ b/db/templates/Core Permit Requirements List.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:04f0fac7479029f8c3efae6fe1938f77d38435955cecf7a9716aa88f459e22aa
-size 318755
+oid sha256:4c30f17accac2d304d1fd0d8de3f89bd5e56b7dc38e2a4fcaa3d0e9509bf2b3f
+size 318421

--- a/db/templates/Core Permit Requirements List.xlsx
+++ b/db/templates/Core Permit Requirements List.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:04f0fac7479029f8c3efae6fe1938f77d38435955cecf7a9716aa88f459e22aa
+size 318755

--- a/spec/factories/requirement_template_section_requirement_blocks.rb
+++ b/spec/factories/requirement_template_section_requirement_blocks.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :requirement_template_section_requirement_block do
+    requirement_template_section { nil }
+    requirement_block { nil }
+    position { 1 }
+  end
+end

--- a/spec/factories/requirement_template_sections.rb
+++ b/spec/factories/requirement_template_sections.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :requirement_template_section do
+    name { "MyString" }
+    code { "MyString" }
+    requirement_template { nil }
+    position { 1 }
+  end
+end

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Requirement, type: :model do
     it "enforces select inputs has defined accepted options" do
       select_requirement = build(:requirement, input_type: "select")
       multi_option_select_requirement = build(:requirement, input_type: "multi_option_select")
-      text_requirement = build(:requirement, input_type: "text")
+      text_requirement = build(:requirement, input_type: "textfield")
       error_message = "select inputs must have options defined"
 
       expect(select_requirement).not_to be_valid
@@ -72,7 +72,7 @@ RSpec.describe Requirement, type: :model do
 
     context "form json" do
       it "returns correct form json for text requirement" do
-        requirement = create(:requirement, label: "Text Requirement", input_type: "text")
+        requirement = create(:requirement, label: "Text Requirement", input_type: "textfield")
         form_json = requirement.to_form_json.reject { |key| key == :id }
         expected_form_json = {
           key: "textRequirement",

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Requirement, type: :model do
     it "enforces select inputs has defined accepted options" do
       select_requirement = build(:requirement, input_type: "select")
       multi_option_select_requirement = build(:requirement, input_type: "multi_option_select")
-      text_requirement = build(:requirement, input_type: "textfield")
+      text_requirement = build(:requirement, input_type: "text")
       error_message = "select inputs must have options defined"
 
       expect(select_requirement).not_to be_valid
@@ -72,7 +72,7 @@ RSpec.describe Requirement, type: :model do
 
     context "form json" do
       it "returns correct form json for text requirement" do
-        requirement = create(:requirement, label: "Text Requirement", input_type: "textfield")
+        requirement = create(:requirement, label: "Text Requirement", input_type: "text")
         form_json = requirement.to_form_json.reject { |key| key == :id }
         expected_form_json = {
           key: "textRequirement",

--- a/spec/models/requirement_template_section_requirement_block_spec.rb
+++ b/spec/models/requirement_template_section_requirement_block_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe RequirementTemplateSectionRequirementBlock, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/requirement_template_section_spec.rb
+++ b/spec/models/requirement_template_section_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe RequirementTemplateSection, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## Description

The purpose of this is to allow seeding of requirements straight from the excel file that the HOUS team is developing.
All devs must ensure they have git lfs set up on their system for this to work, as this permanently puts that seed file through gitlfs.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Please use this format to link: Implements Story [67048](https://app.shortcut.com/codechallengell/story/67048/create-seeded-template).

## Steps to QA

Should be able to run the following seed command now:
```
PermitClassificationSeeder.seed
RequirementsFromXlsxSeeder.seed

RequirementTemplate.first.to_form_json
```
This should add requirements to the backend

## UI Accessibility Checklist
does not apply, backend

## General Checklist

- [x] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [x] 📗 Update any related documentation and include any relevant screenshots
- [x] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

