### PR TITLE
refactor user search to use both jurisdction and user index policies …

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -12,8 +12,8 @@ class Api::ApplicationController < ActionController::API
 
   protected
 
-  def apply_search_authorization(results)
-    results.select { |result| policy(result).send("#{action_name}?".to_sym) }
+  def apply_search_authorization(results, policy_action = action_name)
+    results.select { |result| policy(result).send("#{policy_action}?".to_sym) }
   end
 
   def skip_pundit?

--- a/app/controllers/api/jurisdictions_controller.rb
+++ b/app/controllers/api/jurisdictions_controller.rb
@@ -3,12 +3,12 @@ class Api::JurisdictionsController < Api::ApplicationController
   include Api::Concerns::Search::JurisdictionUsers
 
   before_action :set_jurisdiction, only: %i[show search_users]
-  skip_after_action :verify_policy_scoped, only: [:index]
+  skip_after_action :verify_policy_scoped, only: %i[index search_users]
 
   def index
     perform_search
     authorized_results = apply_search_authorization(@search.results)
-    render_success @search.results,
+    render_success authorized_results,
                    nil,
                    {
                      meta: {
@@ -29,7 +29,6 @@ class Api::JurisdictionsController < Api::ApplicationController
   # POST /api/jurisdiction
   def create
     @jurisdiction = Jurisdiction.build(jurisdiction_params)
-
     authorize @jurisdiction
 
     if @jurisdiction.save
@@ -54,7 +53,8 @@ class Api::JurisdictionsController < Api::ApplicationController
   def search_users
     authorize @jurisdiction
     perform_user_search
-    render_success @user_search.results,
+    authorized_results = apply_search_authorization(@user_search.results, "index")
+    render_success authorized_results,
                    nil,
                    {
                      meta: {

--- a/app/controllers/api/requirement_blocks_controller.rb
+++ b/app/controllers/api/requirement_blocks_controller.rb
@@ -9,7 +9,7 @@ class Api::RequirementBlocksController < Api::ApplicationController
   def index
     perform_search
     authorized_results = apply_search_authorization(@search.results)
-    render_success @search.results,
+    render_success authorized_results,
                    nil,
                    {
                      meta: {

--- a/app/policies/jurisdiction_policy.rb
+++ b/app/policies/jurisdiction_policy.rb
@@ -16,7 +16,7 @@ class JurisdictionPolicy < ApplicationPolicy
   end
 
   def search_users?
-    user.super_admin? || (user.review_manager? && user.jurisdiction == record)
+    user.super_admin? || (user.review_manager? && user.jurisdiciton_id == record.id)
   end
 
   class Scope < Scope

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -8,6 +8,13 @@ class UserPolicy < ApplicationPolicy
   end
 
   def invite_reviewer?
+    invite?
+  end
+
+  # This method is used as a scope in jurisdiciton user search
+  def index?
+    (user.super_admin? && record.review_manager?) ||
+      (user.review_manager? && user.jurisdiciton_id == record.jurisdiction_id)
   end
 
   class Scope < Scope


### PR DESCRIPTION
…for filtering out reviewers for super admins

## Description

new requirement: super admins should not be able to see reviewers.

this fixes my fancy search policy hack and applies this logic as a filter.
