### PR TITLE
add useSearch hook and querystring compatibility for all search

### DIFF
--- a/app/frontend/components/domains/jurisdictions/index.tsx
+++ b/app/frontend/components/domains/jurisdictions/index.tsx
@@ -1,7 +1,8 @@
 import { Box, Center, Container, Flex, Heading, Text, VStack } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
-import React, { useEffect } from "react"
+import React from "react"
 import { useTranslation } from "react-i18next"
+import { useSearch } from "../../../hooks/use-search"
 import { useMst } from "../../../setup/root"
 import { Paginator } from "../../shared/base/inputs/paginator"
 import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
@@ -20,16 +21,13 @@ export const JurisdictionIndexScreen = observer(function JurisdictionIndex() {
     totalPages,
     totalCount,
     countPerPage,
-    fetchJurisdictions,
     handleCountPerPageChange,
     handlePageChange,
     isSearching,
   } = jurisdictionStore
   const { t } = useTranslation()
 
-  useEffect(() => {
-    fetchJurisdictions()
-  }, [])
+  useSearch(jurisdictionStore)
 
   return (
     <Container maxW="container.lg" p={8} as={"main"}>

--- a/app/frontend/components/domains/jurisdictions/users/index.tsx
+++ b/app/frontend/components/domains/jurisdictions/users/index.tsx
@@ -1,9 +1,10 @@
 import { Box, Center, Container, Flex, Heading, VStack } from "@chakra-ui/react"
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
-import React, { useEffect } from "react"
+import React from "react"
 import { useTranslation } from "react-i18next"
 import { useJurisdiction } from "../../../../hooks/resources/use-jurisdiction"
+import { useSearch } from "../../../../hooks/use-search"
 import { ErrorScreen } from "../../../shared/base/error-screen"
 import { Paginator } from "../../../shared/base/inputs/paginator"
 import { PerPageSelect } from "../../../shared/base/inputs/per-page-select"
@@ -22,10 +23,7 @@ export const JurisdictionUserIndexScreen = observer(function JurisdictionUserInd
 
   const { currentJurisdiction, error } = useJurisdiction()
 
-  useEffect(() => {
-    if (!currentJurisdiction) return
-    currentJurisdiction.fetchUsers()
-  }, [currentJurisdiction])
+  useSearch(currentJurisdiction)
 
   if (error) return <ErrorScreen />
   if (!currentJurisdiction) return <LoadingScreen />

--- a/app/frontend/components/domains/requirement-template/index.tsx
+++ b/app/frontend/components/domains/requirement-template/index.tsx
@@ -1,7 +1,8 @@
 import { Box, Center, Container, Flex, GridItemProps, Heading, Text, VStack } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
-import React, { useEffect } from "react"
+import React from "react"
 import { useTranslation } from "react-i18next"
+import { useSearch } from "../../../hooks/use-search"
 import { useMst } from "../../../setup/root"
 import { Paginator } from "../../shared/base/inputs/paginator"
 import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
@@ -30,16 +31,13 @@ export const RequirementTemplatesScreen = observer(function RequirementTemplate(
     totalPages,
     totalCount,
     countPerPage,
-    fetchRequirementTemplates,
     handleCountPerPageChange,
     handlePageChange,
     isSearching,
   } = requirementTemplateStore
   const { t } = useTranslation()
 
-  useEffect(() => {
-    fetchRequirementTemplates()
-  }, [])
+  useSearch(requirementTemplateStore)
 
   return (
     <Container maxW="container.lg" p={8} as="main">

--- a/app/frontend/components/domains/requirements-library/index.tsx
+++ b/app/frontend/components/domains/requirements-library/index.tsx
@@ -15,8 +15,9 @@ import {
 import { Archive } from "@phosphor-icons/react"
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
-import React, { useEffect } from "react"
+import React from "react"
 import { useTranslation } from "react-i18next"
+import { useSearch } from "../../../hooks/use-search"
 import { useMst } from "../../../setup/root"
 import { Paginator } from "../../shared/base/inputs/paginator"
 import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
@@ -33,16 +34,13 @@ export const RequirementsLibraryScreen = observer(function RequirementsLibrary()
     totalPages,
     totalCount,
     countPerPage,
-    fetchRequirementBlocks,
     handleCountPerPageChange,
     handlePageChange,
     isSearching,
   } = requirementBlockStore
   const { t } = useTranslation()
 
-  useEffect(() => {
-    fetchRequirementBlocks()
-  }, [])
+  useSearch(requirementBlockStore)
 
   return (
     <Container maxW="container.lg" p={8} as="main">

--- a/app/frontend/hooks/use-search.ts
+++ b/app/frontend/hooks/use-search.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react"
+import { ISearch } from "../lib/create-search-model"
+
+export const useSearch = (searchModel: ISearch) => {
+  useEffect(() => {
+    if (!searchModel) return
+
+    const queryParams = new URLSearchParams(location.search)
+    const query = queryParams.get("query")
+    const currentPage = queryParams.get("currentPage")
+    const countPerPage = queryParams.get("countPerPage")
+    const sort = queryParams.get("sort")
+
+    if (query) searchModel.setQuery(decodeURIComponent(query))
+    if (currentPage) searchModel.setCurrentPage(parseInt(decodeURIComponent(currentPage)))
+    if (countPerPage) searchModel.setCountPerPage(parseInt(decodeURIComponent(countPerPage)))
+    if (sort) searchModel.applySort(JSON.parse(decodeURIComponent(sort)))
+
+    searchModel.fetchData({
+      page: searchModel.currentPage,
+      countPerPage: searchModel.countPerPage,
+    })
+  }, [searchModel])
+}

--- a/app/frontend/lib/create-search-model.ts
+++ b/app/frontend/lib/create-search-model.ts
@@ -1,6 +1,7 @@
 import { flow, Instance, types } from "mobx-state-tree"
 import { ESortDirection } from "../types/enums"
 import { ISort } from "../types/types"
+import { setQueryParam } from "../utils/utility-funcitons"
 
 interface IFetchOptions {
   reset?: boolean
@@ -27,11 +28,18 @@ export const createSearchModel = <TSortField, TFetchOptions extends IFetchOption
         self.currentPage = 1
         self.totalPages = null
         self.totalCount = null
+        setQueryParam("currentPage", "1")
       },
       setCountPerPage(countPerPage: number) {
+        setQueryParam("countPerPage", countPerPage.toString())
         self.countPerPage = countPerPage
       },
+      setCurrentPage(currentPage: number) {
+        setQueryParam("currentPage", currentPage.toString())
+        self.currentPage = currentPage
+      },
       setQuery(query: string) {
+        setQueryParam("query", query)
         self.query = !!query?.trim() ? query : null
       },
       fetchData: flow(function* (opts?: TFetchOptions) {
@@ -47,10 +55,12 @@ export const createSearchModel = <TSortField, TFetchOptions extends IFetchOption
         return yield self.fetchData({ reset: true, ...opts })
       }),
       applySort: flow(function* (sort: ISort<TSortField>, opts?: TFetchOptions) {
+        setQueryParam("sort", JSON.stringify(sort))
         self.sort = sort
         return yield self.fetchData(opts)
       }),
       clearSort: flow(function* (opts?: TFetchOptions) {
+        setQueryParam("sort", undefined)
         self.sort = null
         return yield self.fetchData(opts)
       }),
@@ -72,11 +82,18 @@ export const createSearchModel = <TSortField, TFetchOptions extends IFetchOption
         }
       }),
       handlePageChange: flow(function* (page: number, opts?: TFetchOptions) {
+        setQueryParam("currentPage", page.toString())
         return yield self.fetchData({ page, ...opts })
       }),
       handleCountPerPageChange: flow(function* (countPerPage: number, opts?: TFetchOptions) {
+        setQueryParam("countPerPage", countPerPage.toString())
         return yield self.fetchData({ countPerPage, ...opts })
       }),
+      resetAll() {
+        self.resetPages()
+        self.applySort(null)
+        self.setQuery(null)
+      },
     }))
 
 export interface ISearch extends Instance<ReturnType<typeof createSearchModel>> {}

--- a/app/frontend/utils/utility-funcitons.ts
+++ b/app/frontend/utils/utility-funcitons.ts
@@ -35,3 +35,13 @@ export function toCamelCase(input: string): string {
       .join("")
   )
 }
+
+export function setQueryParam(key: string, value: string) {
+  const searchParams = new URLSearchParams(window.location.search)
+  if (!value) {
+    searchParams.delete(key)
+  } else {
+    searchParams.set(key, encodeURIComponent(value))
+  }
+  window.history.replaceState({}, "", `${window.location.pathname}?${searchParams.toString()}`)
+}


### PR DESCRIPTION
## Description

Adds a special hook for use with the searchmodel compose paradigm - this adds querystring functionality such that search results can be shared and not lost if the browser is refreshed!

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

All Search screen tickets
https://hous-bssb.atlassian.net/browse/BPHH-351?atlOrigin=eyJpIjoiZmUwNTQzYTA0ZTBlNDI0ZWIwNmM1YjA4ODk0OTk1N2YiLCJwIjoiaiJ9

Go to any search grid page such as manage jurisdictions as super_admin, set some search and sort parameters, notice the URL querystring change
refresh the page, notice that the store values get set!
WooHoo!!