### PR TITLE
Feature/bphh 357/add requirement to template

### DIFF
--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -1,7 +1,7 @@
 class Api::RequirementTemplatesController < Api::ApplicationController
   include Api::Concerns::Search::RequirementTemplates
 
-  before_action :set_requirement_template, only: %i[show destroy restore]
+  before_action :set_requirement_template, only: %i[show destroy restore update]
   skip_after_action :verify_policy_scoped, only: [:index]
 
   def index
@@ -43,6 +43,21 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     end
   end
 
+  def update
+    authorize @requirement_template
+
+    if @requirement_template.update(requirement_template_params)
+      render_success @requirement_template,
+                     "requirement_template.update_success",
+                     { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
+    else
+      render_error "requirement_template.update_error",
+                   message_opts: {
+                     error_message: @requirement_template.errors.full_messages.join(", "),
+                   }
+    end
+  end
+
   def destroy
     authorize @requirement_template
     if @requirement_template.discard
@@ -68,6 +83,16 @@ class Api::RequirementTemplatesController < Api::ApplicationController
   end
 
   def requirement_template_params
-    params.require(:requirement_template).permit(:description, :activity_id, :permit_type_id)
+    params.require(:requirement_template).permit(
+      :description,
+      :activity_id,
+      :permit_type_id,
+      requirement_template_sections_attributes: [
+        :id,
+        :name,
+        :position,
+        template_section_blocks_attributes: %i[id requirement_block_id position],
+      ],
+    )
   end
 end

--- a/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/index.tsx
@@ -5,17 +5,19 @@ import * as R from "ramda"
 import React, { useEffect } from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
+import { useNavigate } from "react-router-dom"
 import { useRequirementTemplate } from "../../../../hooks/resources/use-requirement-template"
 import { IRequirementTemplate } from "../../../../models/requirement-template"
 import { ITemplateSectionBlockModel } from "../../../../models/template-section-block"
-import { IRequirementTemplateParams } from "../../../../types/api-request"
+import { useMst } from "../../../../setup/root"
+import { IRequirementTemplateUpdateParams } from "../../../../types/api-request"
 import { ErrorScreen } from "../../../shared/base/error-screen"
 import { LoadingScreen } from "../../../shared/base/loading-screen"
 import { BuilderHeader } from "./builder-header"
 import { SectionsDisplay } from "./sections-display"
 import { SectionsDnd } from "./sections-dnd"
 
-export interface IRequirementTemplateForm extends IRequirementTemplateParams {}
+export interface IRequirementTemplateForm extends IRequirementTemplateUpdateParams {}
 
 function formFormDefaults(requirementTemplate?: IRequirementTemplate): IRequirementTemplateForm {
   if (!requirementTemplate) {
@@ -44,10 +46,17 @@ function formFormDefaults(requirementTemplate?: IRequirementTemplate): IRequirem
 }
 
 export const EditRequirementTemplateScreen = observer(function EditRequirementTemplateScreen() {
+  const { requirementTemplateStore } = useMst()
   const { requirementTemplate, error } = useRequirementTemplate()
   const { t } = useTranslation()
   const formMethods = useForm({ defaultValues: formFormDefaults(requirementTemplate) })
-  const { reset, watch, handleSubmit } = formMethods
+  const navigate = useNavigate()
+  const {
+    reset,
+    watch,
+    handleSubmit,
+    formState: { isSubmitting, isValid },
+  } = formMethods
 
   useEffect(() => {
     reset(formFormDefaults(requirementTemplate))
@@ -56,14 +65,21 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
   if (error) return <ErrorScreen />
   if (!requirementTemplate?.isFullyLoaded) return <LoadingScreen />
 
+  const onClose = () => {
+    window.history.state && window.history.state.idx > 0 ? navigate(-1) : navigate(`/requirement-templates`)
+  }
+
   const watchedSectionsAttributes = watch("requirementTemplateSectionsAttributes")
-  const onSubmit = handleSubmit((templateFormData) => {
+
+  const onSubmit = handleSubmit(async (templateFormData) => {
     templateFormData.requirementTemplateSectionsAttributes.forEach((sectionAttributes, sectionIndex) => {
       sectionAttributes.position = sectionIndex
       sectionAttributes.templateSectionBlocksAttributes.forEach((sectionBlockAttributes, blockIndex) => {
         sectionBlockAttributes.position = blockIndex
       })
     })
+
+    return await requirementTemplateStore.updateRequirementTemplate(requirementTemplate.id, templateFormData)
   })
 
   return (
@@ -75,11 +91,19 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
           <Box flex={1} h={"full"}>
             <HStack px={6} py={4} bg={"greys.grey03"} w={"full"} justifyContent={"flex-end"}>
               <HStack spacing={4}>
-                <Button variant={"primary"} isDisabled>
+                <Button
+                  variant={"primary"}
+                  isDisabled={isSubmitting || !isValid}
+                  isLoading={isSubmitting}
+                  onClick={onSubmit}
+                >
                   {t("requirementTemplate.edit.saveDraft")}
                 </Button>
                 <Button variant={"primary"} rightIcon={<CaretRight />} isDisabled>
                   {t("ui.publish")}
+                </Button>
+                <Button variant={"secondary"} isDisabled={isSubmitting} onClick={onClose}>
+                  {t("requirementTemplate.edit.closeEditor")}
                 </Button>
               </HStack>
             </HStack>

--- a/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Flex } from "@chakra-ui/react"
+import { Box, Button, Flex, HStack } from "@chakra-ui/react"
+import { CaretRight } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
 import React, { useEffect } from "react"
@@ -46,7 +47,7 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
   const { requirementTemplate, error } = useRequirementTemplate()
   const { t } = useTranslation()
   const formMethods = useForm({ defaultValues: formFormDefaults(requirementTemplate) })
-  const { reset, watch } = formMethods
+  const { reset, watch, handleSubmit } = formMethods
 
   useEffect(() => {
     reset(formFormDefaults(requirementTemplate))
@@ -56,6 +57,14 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
   if (!requirementTemplate?.isFullyLoaded) return <LoadingScreen />
 
   const watchedSectionsAttributes = watch("requirementTemplateSectionsAttributes")
+  const onSubmit = handleSubmit((templateFormData) => {
+    templateFormData.requirementTemplateSectionsAttributes.forEach((sectionAttributes, sectionIndex) => {
+      sectionAttributes.position = sectionIndex
+      sectionAttributes.templateSectionBlocksAttributes.forEach((sectionBlockAttributes, blockIndex) => {
+        sectionBlockAttributes.position = blockIndex
+      })
+    })
+  })
 
   return (
     <Flex flexDir={"column"} w={"full"} flex={1} as="main">
@@ -64,6 +73,16 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
         <Flex flex={1} borderTop={"1px solid"} borderColor={"border.base"}>
           <SectionsDnd sections={watchedSectionsAttributes} />
           <Box flex={1} h={"full"}>
+            <HStack px={6} py={4} bg={"greys.grey03"} w={"full"} justifyContent={"flex-end"}>
+              <HStack spacing={4}>
+                <Button variant={"primary"} isDisabled>
+                  {t("requirementTemplate.edit.saveDraft")}
+                </Button>
+                <Button variant={"primary"} rightIcon={<CaretRight />} isDisabled>
+                  {t("ui.publish")}
+                </Button>
+              </HStack>
+            </HStack>
             <SectionsDisplay />
           </Box>
         </Flex>

--- a/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/sections-display.tsx
@@ -5,6 +5,7 @@ import { useFieldArray, useFormContext } from "react-hook-form"
 import { useMst } from "../../../../setup/root"
 import { IRequirementTemplateSectionsAttribute } from "../../../../types/api-request"
 import { RequirementBlockDisplay } from "../../requirements-library/requirement-block-display"
+import { RequirementsLibraryDrawer } from "../../requirements-library/requirements-library-drawer"
 import { IRequirementTemplateForm } from "./index"
 
 export const SectionsDisplay = observer(function SectionsDisplay() {
@@ -25,7 +26,7 @@ const SectionDisplay = observer(
     const { requirementBlockStore } = useMst()
     const { control } = useFormContext<IRequirementTemplateForm>()
 
-    const { fields: sectionBlockFields } = useFieldArray({
+    const { fields: sectionBlockFields, append } = useFieldArray({
       name: `requirementTemplateSectionsAttributes.${sectionIndex}.templateSectionBlocksAttributes`,
       control,
     })
@@ -36,7 +37,7 @@ const SectionDisplay = observer(
           <Text as={"h4"} fontWeight={700} fontSize={"2xl"}>
             {section.name}
           </Text>
-          <Stack w={"full"} maxW={"798px"} pl={0}>
+          <Stack w={"full"} maxW={"798px"} spacing={6} pl={0} mt={6}>
             {sectionBlockFields.map((sectionBlock, index) => (
               <RequirementBlockDisplay
                 as={"section"}
@@ -44,6 +45,13 @@ const SectionDisplay = observer(
                 requirementBlock={requirementBlockStore.getRequirementBlockById(sectionBlock.requirementBlockId)}
               />
             ))}
+            <RequirementsLibraryDrawer
+              defaultButtonProps={{ alignSelf: "center" }}
+              onUse={(requirementBlock, closeDrawer) => {
+                append({ requirementBlockId: requirementBlock.id })
+                closeDrawer()
+              }}
+            />
           </Stack>
         </Box>
       </Box>

--- a/app/frontend/components/domains/requirements-library/grid-header.tsx
+++ b/app/frontend/components/domains/requirements-library/grid-header.tsx
@@ -1,7 +1,9 @@
-import { Box, Flex, GridItem, Text, styled } from "@chakra-ui/react"
+import { Box, Flex, GridItem, HStack, Text, Tooltip, styled } from "@chakra-ui/react"
+import { Info } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
+import { ISearch } from "../../../lib/create-search-model"
 import { useMst } from "../../../setup/root"
 import { ERequirementLibrarySortFields } from "../../../types/enums"
 import { SearchInput } from "../../shared/base/search-input"
@@ -26,7 +28,7 @@ export const GridHeaders = observer(function GridHeaders() {
           <Text role={"heading"} as={"h3"} color={"black"} fontSize={"sm"} height="fit-content">
             {t("requirementsLibrary.index.tableHeading")}
           </Text>
-          <SearchInput searchModel={requirementBlockStore} />
+          <SearchInput searchModel={requirementBlockStore as ISearch} />
         </GridItem>
       </Box>
       <Box display={"contents"} role={"row"}>
@@ -43,7 +45,24 @@ export const GridHeaders = observer(function GridHeaders() {
               px={4}
             >
               <Text>{getSortColumnHeader(field)}</Text>
-              <SortIcon<ERequirementLibrarySortFields> field={field} currentSort={sort} />
+              {field === ERequirementLibrarySortFields.associations ? (
+                <HStack w={"fit-content"} spacing={3}>
+                  <SortIcon<ERequirementLibrarySortFields>
+                    field={field}
+                    currentSort={sort}
+                    aria-label={`Sort ${getSortColumnHeader(field)} Icon`}
+                  />
+                  <Tooltip label={t("requirementsLibrary.associationsInfo")}>
+                    <Info aria-label={"Info Icon"} />
+                  </Tooltip>
+                </HStack>
+              ) : (
+                <SortIcon<ERequirementLibrarySortFields>
+                  field={field}
+                  currentSort={sort}
+                  aria-label={`Sort ${getSortColumnHeader(field)}`}
+                />
+              )}
             </Flex>
           </GridHeader>
         ))}

--- a/app/frontend/components/domains/requirements-library/index.tsx
+++ b/app/frontend/components/domains/requirements-library/index.tsx
@@ -1,48 +1,13 @@
-import {
-  Box,
-  Button,
-  Center,
-  Container,
-  Flex,
-  HStack,
-  Heading,
-  ListItem,
-  Tag,
-  Text,
-  UnorderedList,
-  VStack,
-} from "@chakra-ui/react"
+import { Box, Button, Container, Flex, Heading, Text, VStack } from "@chakra-ui/react"
 import { Archive } from "@phosphor-icons/react"
-import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { useSearch } from "../../../hooks/use-search"
-import { ISearch } from "../../../lib/create-search-model"
-import { useMst } from "../../../setup/root"
-import { Paginator } from "../../shared/base/inputs/paginator"
-import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
-import { SharedSpinner } from "../../shared/base/shared-spinner"
-import { SearchGrid } from "../../shared/grid/search-grid"
-import { SearchGridItem } from "../../shared/grid/search-grid-item"
-import { GridHeaders } from "./grid-header"
+import { RequirementBlocksTable } from "./requirement-blocks-table"
 import { RequirementsBlockModal } from "./requirements-block-modal"
 
 export const RequirementsLibraryScreen = observer(function RequirementsLibrary() {
-  const { requirementBlockStore } = useMst()
-  const {
-    tableRequirementBlocks,
-    currentPage,
-    totalPages,
-    totalCount,
-    countPerPage,
-    handleCountPerPageChange,
-    handlePageChange,
-    isSearching,
-  } = requirementBlockStore
   const { t } = useTranslation()
-
-  useSearch(requirementBlockStore as ISearch)
 
   return (
     <Container maxW="container.lg" p={8} as="main">
@@ -59,66 +24,7 @@ export const RequirementsLibraryScreen = observer(function RequirementsLibrary()
           <RequirementsBlockModal />
         </Flex>
 
-        <SearchGrid templateColumns="repeat(4, 1fr) 85px">
-          <GridHeaders />
-
-          {isSearching ? (
-            <Center p={50}>
-              <SharedSpinner />
-            </Center>
-          ) : (
-            tableRequirementBlocks.map((requirementBlock) => {
-              return (
-                <Box
-                  key={requirementBlock.id}
-                  className={"requirements-library-grid-row"}
-                  role={"row"}
-                  display={"contents"}
-                >
-                  <SearchGridItem fontWeight={700}>{requirementBlock.name}</SearchGridItem>
-                  <SearchGridItem>
-                    <HStack as={"ul"} wrap={"wrap"} spacing={1}>
-                      {requirementBlock.associations.map((association) => (
-                        <Tag key={association} as={"li"} bg={"greys.grey03"} color={"text.secondary"} fontSize={"xs"}>
-                          {association}
-                        </Tag>
-                      ))}
-                    </HStack>
-                  </SearchGridItem>
-                  <SearchGridItem>
-                    <UnorderedList>
-                      {requirementBlock.requirements.map((requirement) => {
-                        return (
-                          <ListItem key={requirement.id} color={"text.secondary"} fontSize={"xs"}>
-                            {requirement.label}
-                          </ListItem>
-                        )
-                      })}
-                    </UnorderedList>
-                  </SearchGridItem>
-                  <SearchGridItem fontSize={"sm"}>{format(requirementBlock.updatedAt, "yyyy-MM-dd")}</SearchGridItem>
-                  <SearchGridItem justifyContent={"center"}>
-                    <RequirementsBlockModal requirementBlock={requirementBlock} />
-                  </SearchGridItem>
-                </Box>
-              )
-            })
-          )}
-        </SearchGrid>
-        <Flex w={"full"} justifyContent={"space-between"}>
-          <PerPageSelect
-            handleCountPerPageChange={handleCountPerPageChange}
-            countPerPage={countPerPage}
-            totalCount={totalCount}
-          />
-          <Paginator
-            current={currentPage}
-            total={totalCount}
-            totalPages={totalPages}
-            pageSize={countPerPage}
-            handlePageChange={handlePageChange}
-          />
-        </Flex>
+        <RequirementBlocksTable alignItems={"flex-start"} w={"full"} />
 
         <Button leftIcon={<Archive size={16} />} variant={"secondary"} mt={3}>
           {t("ui.seeArchivedButton")}

--- a/app/frontend/components/domains/requirements-library/requirement-block-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-block-display.tsx
@@ -25,7 +25,6 @@ export const RequirementBlockDisplay = observer(function RequirementBlockDisplay
       border={"1px solid"}
       borderColor={"border.light"}
       borderRadius={"lg"}
-      mt={4}
       {...containerProps}
     >
       <Flex py={3} px={6} w={"full"} background={"greys.grey04"}>

--- a/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
@@ -1,0 +1,117 @@
+import {
+  Box,
+  ButtonProps,
+  Center,
+  Flex,
+  HStack,
+  ListItem,
+  StackProps,
+  Tag,
+  UnorderedList,
+  VStack,
+} from "@chakra-ui/react"
+import { format } from "date-fns"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { useSearch } from "../../../hooks/use-search"
+import { ISearch } from "../../../lib/create-search-model"
+import { IRequirementBlock } from "../../../models/requirement-block"
+import { useMst } from "../../../setup/root"
+import { Paginator } from "../../shared/base/inputs/paginator"
+import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
+import { SharedSpinner } from "../../shared/base/shared-spinner"
+import { SearchGrid } from "../../shared/grid/search-grid"
+import { SearchGridItem } from "../../shared/grid/search-grid-item"
+import { GridHeaders } from "./grid-header"
+import { RequirementsBlockModal } from "./requirements-block-modal"
+
+interface IProps extends Partial<StackProps> {
+  renderActionButton?: (props: ButtonProps & { requirementBlock: IRequirementBlock }) => JSX.Element
+}
+
+export const RequirementBlocksTable = observer(function RequirementBlocksTable({
+  renderActionButton,
+  ...containerProps
+}: IProps) {
+  const { requirementBlockStore } = useMst()
+  const {
+    tableRequirementBlocks,
+    currentPage,
+    totalPages,
+    totalCount,
+    countPerPage,
+    handleCountPerPageChange,
+    handlePageChange,
+    isSearching,
+  } = requirementBlockStore
+
+  useSearch(requirementBlockStore as ISearch)
+  return (
+    <VStack as={"article"} spacing={5} {...containerProps}>
+      <SearchGrid templateColumns="repeat(4, 1fr) 85px">
+        <GridHeaders />
+
+        {isSearching ? (
+          <Center p={50} gridColumn={"span 4"}>
+            <SharedSpinner />
+          </Center>
+        ) : (
+          tableRequirementBlocks.map((requirementBlock) => {
+            return (
+              <Box
+                key={requirementBlock.id}
+                className={"requirements-library-grid-row"}
+                role={"row"}
+                display={"contents"}
+              >
+                <SearchGridItem fontWeight={700}>{requirementBlock.name}</SearchGridItem>
+                <SearchGridItem>
+                  <HStack as={"ul"} wrap={"wrap"} spacing={1}>
+                    {requirementBlock.associations.map((association) => (
+                      <Tag key={association} as={"li"} bg={"greys.grey03"} color={"text.secondary"} fontSize={"xs"}>
+                        {association}
+                      </Tag>
+                    ))}
+                  </HStack>
+                </SearchGridItem>
+                <SearchGridItem>
+                  <UnorderedList>
+                    {requirementBlock.requirements.map((requirement) => {
+                      return (
+                        <ListItem key={requirement.id} color={"text.secondary"} fontSize={"xs"}>
+                          {requirement.label}
+                        </ListItem>
+                      )
+                    })}
+                  </UnorderedList>
+                </SearchGridItem>
+                <SearchGridItem fontSize={"sm"}>{format(requirementBlock.updatedAt, "yyyy-MM-dd")}</SearchGridItem>
+                <SearchGridItem justifyContent={"center"}>
+                  {renderActionButton ? (
+                    renderActionButton({ requirementBlock })
+                  ) : (
+                    <RequirementsBlockModal requirementBlock={requirementBlock} />
+                  )}
+                </SearchGridItem>
+              </Box>
+            )
+          })
+        )}
+      </SearchGrid>
+      <Flex w={"full"} justifyContent={"space-between"}>
+        <PerPageSelect
+          handleCountPerPageChange={handleCountPerPageChange}
+          countPerPage={countPerPage}
+          totalCount={totalCount}
+        />
+        <Paginator
+          current={currentPage}
+          total={totalCount}
+          totalPages={totalPages}
+          pageSize={countPerPage}
+          handlePageChange={handlePageChange}
+        />
+      </Flex>
+    </VStack>
+  )
+})

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
@@ -304,6 +304,7 @@ const requirementsComponentMap = {
             </HStack>
           ))}
 
+          {/*  @ts-ignore*/}
           <Button variant={"link"} textDecoration={"underline"} onClick={() => append({ value: "", label: "" })}>
             {t("requirementsLibrary.modals.addOptionButton")}
           </Button>

--- a/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
@@ -1,0 +1,63 @@
+import {
+  Button,
+  ButtonProps,
+  Drawer,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerOverlay,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { Plus } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React, { Ref, useRef } from "react"
+import { useTranslation } from "react-i18next"
+import { IRequirementBlock } from "../../../models/requirement-block"
+import { RequirementBlocksTable } from "./requirement-blocks-table"
+
+interface IProps {
+  defaultButtonProps?: Partial<ButtonProps>
+  renderTriggerButton?: (props: ButtonProps & { ref: Ref<HTMLElement> }) => JSX.Element
+  onUse?: (requirementBlock: IRequirementBlock, closeDrawer?: () => void) => void
+}
+
+export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDrawer({
+  defaultButtonProps,
+  renderTriggerButton,
+  onUse,
+}: IProps) {
+  const { t } = useTranslation()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const btnRef = useRef<HTMLButtonElement>()
+
+  return (
+    <>
+      {renderTriggerButton?.({ onClick: onOpen, ref: btnRef }) ?? (
+        <Button
+          leftIcon={<Plus size={12} />}
+          variant={"primary"}
+          onClick={onOpen}
+          aria-label={"add requirement to template"}
+          {...defaultButtonProps}
+        >
+          {t("requirementTemplate.edit.addRequirementButton")}
+        </Button>
+      )}
+      <Drawer isOpen={isOpen} onClose={onClose} finalFocusRef={btnRef} placement={"right"}>
+        <DrawerOverlay />
+        <DrawerContent display={"flex"} flexDir={"column"} maxW={"900px"} h={"full"}>
+          <DrawerCloseButton fontSize={"xs"} />
+          <RequirementBlocksTable
+            h={"calc(100% - 120px)"}
+            flex={1}
+            p={8}
+            renderActionButton={({ requirementBlock }) => (
+              <Button size={"sm"} variant={"primary"} onClick={() => onUse(requirementBlock, onClose)}>
+                {t("ui.use")}
+              </Button>
+            )}
+          />
+        </DrawerContent>
+      </Drawer>
+    </>
+  )
+})

--- a/app/frontend/components/shared/grid/search-grid.tsx
+++ b/app/frontend/components/shared/grid/search-grid.tsx
@@ -1,12 +1,12 @@
-import { Grid } from "@chakra-ui/react"
+import { Grid, GridProps } from "@chakra-ui/react"
 import React, { ReactNode } from "react"
 
-interface ISearchGridProps {
+interface ISearchGridProps extends Partial<Omit<GridProps, "templateColumns">> {
   children: ReactNode
   templateColumns: string
 }
 
-export const SearchGrid = ({ children, templateColumns }: ISearchGridProps) => {
+export const SearchGrid = ({ children, templateColumns, ...containerProps }: ISearchGridProps) => {
   return (
     <Grid
       mt={3}
@@ -25,6 +25,7 @@ export const SearchGrid = ({ children, templateColumns }: ISearchGridProps) => {
       border={"1px solid"}
       borderColor={"border.light"}
       borderRadius={"sm"}
+      {...containerProps}
     >
       {children}
     </Grid>

--- a/app/frontend/components/shared/sort-icon.tsx
+++ b/app/frontend/components/shared/sort-icon.tsx
@@ -1,20 +1,27 @@
-import { CaretDown, CaretUp, CaretUpDown } from "@phosphor-icons/react"
+import { CaretDown, CaretUp, CaretUpDown, IconProps } from "@phosphor-icons/react"
 import React from "react"
 import { ESortDirection } from "../../types/enums"
 import { ISort } from "../../types/types"
 
-export function SortIcon<TSortField>({ field, currentSort }: { field: TSortField; currentSort: ISort<TSortField> }) {
+export function SortIcon<TSortField>({
+  field,
+  currentSort,
+  ...rest
+}: {
+  field: TSortField
+  currentSort: ISort<TSortField>
+} & IconProps) {
   if (currentSort?.field == field) {
     // this column is sorted
     switch (currentSort.direction) {
       case ESortDirection.ascending:
-        return <CaretUp size={16} />
+        return <CaretUp size={16} {...rest} />
       case ESortDirection.descending:
-        return <CaretDown size={16} />
+        return <CaretDown size={16} {...rest} />
       default:
-        return <CaretDown size={16} />
+        return <CaretDown size={16} {...rest} />
     }
   } else {
-    return <CaretUpDown size={16} />
+    return <CaretUpDown size={16} {...rest} />
   }
 }

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -207,6 +207,7 @@ const options = {
           },
         },
         requirementsLibrary: {
+          associationsInfo: "Sections, tags, etc...",
           index: {
             title: "Requirements Library",
             description: "List of all Requirement Blocks in the system that can be used inside Templates.",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -366,6 +366,7 @@ const options = {
             addSectionButton: "Add Section",
             addRequirementButton: "Add Requirement",
             saveDraft: "Save as Draft",
+            closeEditor: "Close Editor",
           },
           fields: {
             status: "Status",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -121,6 +121,7 @@ const options = {
           select: "Select",
           notAvailable: "Not available yet",
           isRequired: "{{field}} is required",
+          use: "Use",
         },
         contact: {
           fields: {
@@ -362,6 +363,7 @@ const options = {
             title: "Permit Application Builder",
             dndTitle: "Drag to reorder",
             addSectionButton: "Add Section",
+            addRequirementButton: "Add Requirement",
           },
           fields: {
             status: "Status",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -122,6 +122,7 @@ const options = {
           notAvailable: "Not available yet",
           isRequired: "{{field}} is required",
           use: "Use",
+          publish: "Publish",
         },
         contact: {
           fields: {
@@ -364,6 +365,7 @@ const options = {
             dndTitle: "Drag to reorder",
             addSectionButton: "Add Section",
             addRequirementButton: "Add Requirement",
+            saveDraft: "Save as Draft",
           },
           fields: {
             status: "Status",

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -4,7 +4,7 @@ import { IJurisdiction } from "../../models/jurisdiction"
 import { IPermitApplication } from "../../models/permit-application"
 import { IRequirementTemplate } from "../../models/requirement-template"
 import { IUser } from "../../models/user"
-import { IRequirementBlockParams, ITagSearchParams } from "../../types/api-request"
+import { IRequirementBlockParams, IRequirementTemplateUpdateParams, ITagSearchParams } from "../../types/api-request"
 import {
   IAcceptInvitationResponse,
   IApiResponse,
@@ -163,6 +163,12 @@ export class Api {
 
   async createRequirementTemplate(params: TCreateRequirementTemplateFormData) {
     return this.client.post<ApiResponse<IRequirementTemplate>>(`/requirement_templates`, {
+      requirementTemplate: params,
+    })
+  }
+
+  async updateRequirementTemplate(templateId: string, params: IRequirementTemplateUpdateParams) {
+    return this.client.put<ApiResponse<IRequirementTemplate>>(`/requirement_templates/${templateId}`, {
       requirementTemplate: params,
     })
   }

--- a/app/frontend/stores/requirement-template-store.ts
+++ b/app/frontend/stores/requirement-template-store.ts
@@ -6,6 +6,7 @@ import { withEnvironment } from "../lib/with-environment"
 import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
 import { RequirementTemplateModel } from "../models/requirement-template"
+import { IRequirementTemplateUpdateParams } from "../types/api-request"
 import { ERequirementTemplateSortFields } from "../types/enums"
 import { toCamelCase } from "../utils/utility-funcitons"
 
@@ -91,6 +92,19 @@ export const RequirementTemplateStoreModel = types
         self.requirementTemplateMap.put(response.data)
         return response.data
       }
+    }),
+    updateRequirementTemplate: flow(function* (templateId: string, params: IRequirementTemplateUpdateParams) {
+      const response = yield* toGenerator(self.environment.api.updateRequirementTemplate(templateId, params))
+
+      if (response.ok) {
+        const templateData = response.data.data
+        templateData.isFullyLoaded = true
+        self.mergeUpdate(templateData, "requirementTemplateMap")
+
+        return self.requirementTemplateMap.get(templateData.id)
+      }
+
+      return response.ok
     }),
   }))
 

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -25,11 +25,13 @@ export interface IRequirementBlockParams {
 export interface ITemplateSectionBlocksAttribute {
   id?: string
   requirementBlockId?: string
+  position?: number
 }
 
 export interface IRequirementTemplateSectionsAttribute {
   id?: string
   name?: string
+  position?: number
   templateSectionBlocksAttributes?: ITemplateSectionBlocksAttribute[]
 }
 

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -35,7 +35,7 @@ export interface IRequirementTemplateSectionsAttribute {
   templateSectionBlocksAttributes?: ITemplateSectionBlocksAttribute[]
 }
 
-export interface IRequirementTemplateParams {
+export interface IRequirementTemplateUpdateParams {
   description?: string | null
   requirementTemplateSectionsAttributes?: IRequirementTemplateSectionsAttribute[]
 }

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -1,13 +1,10 @@
 class RequirementBlock < ApplicationRecord
-  searchkick searchable: %i[name requirement_labels associations],
-             word_start: %i[name requirement_labels associations]
+  searchkick searchable: %i[name requirement_labels associations], word_start: %i[name requirement_labels associations]
 
   has_many :requirements, -> { order(position: :asc) }, dependent: :destroy
 
   has_many :template_section_blocks, dependent: :destroy
-  has_many :requirement_template_sections,
-           through: :requirement_template_section_requirement_blocks
-  has_many :requirement_templates, through: :template_section_blocks
+  has_many :requirement_template_sections, through: :template_section_blocks
 
   accepts_nested_attributes_for :requirements, allow_destroy: true
 
@@ -26,7 +23,7 @@ class RequirementBlock < ApplicationRecord
       updated_at: updated_at,
       name: name,
       requirement_labels: requirements.pluck(:label),
-      associations: association_list
+      associations: association_list,
     }
   end
 
@@ -42,7 +39,7 @@ class RequirementBlock < ApplicationRecord
       label: name,
       input: false,
       tableView: false,
-      components: requirements.map { |r| r.to_form_json(key(section_key)) }
+      components: requirements.map { |r| r.to_form_json(key(section_key)) },
     }
   end
 

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -19,6 +19,8 @@ class RequirementTemplate < ApplicationRecord
 
   include Discard::Model
 
+  accepts_nested_attributes_for :requirement_template_sections, allow_destroy: true
+
   def jurisdictions_size
     jurisdictions.size
   end

--- a/app/models/requirement_template_section.rb
+++ b/app/models/requirement_template_section.rb
@@ -4,6 +4,8 @@ class RequirementTemplateSection < ApplicationRecord
   has_many :template_section_blocks, -> { order(position: :asc) }, dependent: :destroy
   has_many :requirement_blocks, through: :template_section_blocks
 
+  accepts_nested_attributes_for :template_section_blocks, allow_destroy: true
+
   def key
     "section#{id}"
   end

--- a/app/policies/requirement_template_policy.rb
+++ b/app/policies/requirement_template_policy.rb
@@ -11,6 +11,10 @@ class RequirementTemplatePolicy < ApplicationPolicy
     user.super_admin?
   end
 
+  def update?
+    create?
+  end
+
   def destroy?
     create?
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -149,6 +149,9 @@ en:
       create_success:
         title: ""
         message: "New template created successfully!"
+      update_success:
+        title: ""
+        message: "Template updated successfully!"
       create_error:
         title: Oops
         message: "%{error_message}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
       post "search", on: :collection, to: "requirement_blocks#index"
     end
 
-    resources :requirement_templates, only: %i[show create destroy] do
+    resources :requirement_templates, only: %i[show create destroy update] do
       post "search", on: :collection, to: "requirement_templates#index"
       patch "restore", on: :member
     end
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
 
     post "tags/search", to: "tags#index", as: :tags_search
 
-    get "storage/s3" => "storage#upload" #use a storage controller instead of shrine mount since we want api authentication before being able to access
+    get "storage/s3" => "storage#upload" # use a storage controller instead of shrine mount since we want api authentication before being able to access
     get "storage/s3/download" => "storage#download"
     get "storage/s3/delete" => "storage#delete"
   end


### PR DESCRIPTION
## Description
- Refactors Requirement Blocks Table to reusable component
- Adds `Add Requiremen`t button and drawer to Requirement Template Builder (edit page)
- Adds api, controllers methods and corresponding front-end actions to be able to update Requirement Template

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-357
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- In your Rails console find a template with at least one section, note the id
- On the web app Navigate to templates catalogue, and click edit on the template noted in previous step
- Click edit to navigate to edit/ builder page
- Scroll down to the last item of a section, and click `Add Requirement` button
- Verify requirement blocks drawer opens and is functional
- Select any requirement block by clicking `Use button`
- Click `Save a Draft button` on top
- Refresh page, the requirement block added should persist
<img width="1038" alt="Screenshot 2024-02-06 at 2 39 46 PM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/e04e627a-c890-47c5-91c6-523aa4fd651f">



<!--
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.
Provide any relevant screenshots here.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

