### PR TITLE
Add service to check step code compliance

### DIFF
--- a/app/models/mechanical_energy_use_intensity_reference.rb
+++ b/app/models/mechanical_energy_use_intensity_reference.rb
@@ -1,0 +1,2 @@
+class MechanicalEnergyUseIntensityReference < ApplicationRecord
+end

--- a/app/models/step_code.rb
+++ b/app/models/step_code.rb
@@ -4,4 +4,6 @@ class StepCode < ApplicationRecord
   has_one :pre_construction_checklist, -> { where(stage: :pre_construction) }, class_name: "StepCodeChecklist"
 
   after_create :create_pre_construction_checklist
+
+  accepts_nested_attributes_for :data_entries
 end

--- a/app/models/step_code.rb
+++ b/app/models/step_code.rb
@@ -1,3 +1,7 @@
 class StepCode < ApplicationRecord
-  has_many :data_entries, class_name: "StepCodeDataEntry"
+  has_many :data_entries, class_name: "StepCodeDataEntry", dependent: :destroy
+  has_many :checklists, class_name: "StepCodeChecklist", dependent: :destroy
+  has_one :pre_construction_checklist, -> { where(stage: :pre_construction) }, class_name: "StepCodeChecklist"
+
+  after_create :create_pre_construction_checklist
 end

--- a/app/models/step_code_checklist.rb
+++ b/app/models/step_code_checklist.rb
@@ -1,0 +1,15 @@
+class StepCodeChecklist < ApplicationRecord
+  belongs_to :step_code
+
+  delegate :data_entries, to: :step_code
+
+  enum stage: %i[pre_construction mid_construction as_built]
+
+  def energy_step
+    StepCode::Compliance::ProposeStep::Energy.new(self).call.proposed_step
+  end
+
+  def zero_carbon_step
+    StepCode::Compliance::ProposeStep::ZeroCarbon.new(self).call.proposed_step
+  end
+end

--- a/app/models/thermal_energy_demand_intensity_reference.rb
+++ b/app/models/thermal_energy_demand_intensity_reference.rb
@@ -1,0 +1,2 @@
+class ThermalEnergyDemandIntensityReference < ApplicationRecord
+end

--- a/app/services/step_code/compliance/check_requirements/energy/airtightness.rb
+++ b/app/services/step_code/compliance/check_requirements/energy/airtightness.rb
@@ -1,0 +1,28 @@
+# ACH - Air Changes per Hour @ 50Pa
+# NLA - Normalized Leakage Area (cm2/m2) @ 10Pa
+# NLR - Normalized Leakage Rate (L/s/m^2) @ 50Pa
+
+class StepCode::Compliance::CheckRequirements::Energy::Airtightness < StepCode::Compliance::CheckRequirements::Energy::Base
+  def requirements_met?
+    total(:ach) <= ach_requirement || total(:nla) <= nla_requirement || nlr <= nlr_requirement
+  end
+
+  private
+
+  def ach_requirement
+    tedi_reference.ach
+  end
+
+  def nla_requirement
+    tedi_reference.nla
+  end
+
+  def nlr
+    return 0 if total_heated_floor_area <= 0
+    total(:building_volume) * total(:ach) * 1000 / 3600 / total(:building_envelope_surface_area)
+  end
+
+  def nlr_requirement
+    tedi_reference.nlr
+  end
+end

--- a/app/services/step_code/compliance/check_requirements/energy/base.rb
+++ b/app/services/step_code/compliance/check_requirements/energy/base.rb
@@ -1,0 +1,29 @@
+class StepCode::Compliance::CheckRequirements::Energy::Base
+  KWH_PER_GJ = 227.78
+
+  def initialize(checklist:, step:)
+    @checklist = checklist
+    @step = step
+  end
+
+  private
+
+  attr_reader :checklist, :step
+
+  def stage
+    @stage ||= checklist.stage == :as_built ? :as_built : :proposed
+  end
+
+  def total(field)
+    checklist.data_entries.where(stage: stage).sum(field)
+  end
+
+  def total_heated_floor_area
+    @total_heated_floor_area ||= total(:above_grade_heated_floor_area) + total(:below_grade_heated_floor_area)
+  end
+
+  def tedi_reference
+    @tedi_reference ||=
+      ThermalEnergyDemandIntensityReference.find_by("hdd @> :hdd AND step = :step", hdd: total(:hdd), step: step)
+  end
+end

--- a/app/services/step_code/compliance/check_requirements/energy/meui.rb
+++ b/app/services/step_code/compliance/check_requirements/energy/meui.rb
@@ -1,0 +1,59 @@
+# MEUI - Mechanical Energy Use Intensity
+
+class StepCode::Compliance::CheckRequirements::Energy::MEUI < StepCode::Compliance::CheckRequirements::Energy::Base
+  def requirements_met?
+    (meui != 0 && meui <= meui_requirement) || meui_percent_improvement >= meui_percent_improvement_requirement
+  end
+
+  private
+
+  def meui
+    @meui ||= energy_target / total_heated_floor_area * KWH_PER_GJ
+  end
+
+  def energy_target
+    total(:aec) - total(:baseloads)
+  end
+
+  def meui_requirement
+    MechanicalEnergyUseIntensityReference.find_by(
+      "hdd @> :hdd AND conditioned_space_percent @> :conditioned_percent AND step = :step AND conditioned_space_area @> :conditioned_area",
+      hdd: total(:hdd),
+      step: step,
+      conditioned_percent:,
+      conditioned_area: total_heated_floor_area.round,
+    ).meui
+  end
+
+  def conditioned_percent
+    @conditioned_percent ||= total_cooling_capacity / total(:design_cooling_load)
+  end
+
+  def total_cooling_capacity
+    @total_cooling_capacity ||=
+      (
+        total(:ac_cooling_capacity) + total(:air_heat_pump_cooling_capacity) +
+          total(:grounded_heat_pump_cooling_capacity) + total(:water_heat_pump_cooling_capacity)
+      ) * 1000
+  end
+
+  def meui_percent_improvement_requirement
+    if total(:building_volume) > 300
+      tedi_reference.ltrh_over_300
+    else
+      tedi_reference.ltrh_under_300
+    end
+  end
+
+  def meui_percent_improvement
+    @meui_improvement_percentage ||= ((ref_energy_target - energy_consumption) / ref_energy_target * 100).round(2)
+  end
+
+  def ref_energy_target
+    @ref_energy_target ||= total(:ref_aec) - total(:baseloads)
+  end
+
+  def energy_consumption
+    @energy_consumption ||= total(:aec) - total(:baseloads)
+  end
+end

--- a/app/services/step_code/compliance/check_requirements/energy/tedi.rb
+++ b/app/services/step_code/compliance/check_requirements/energy/tedi.rb
@@ -1,0 +1,32 @@
+# TEDI - Thermal Energy Demand Intensity (kWh/m^2/year)
+# HLR - Heat Loss Reduction
+# GSHL - Gross Space Heat Loss
+
+class StepCode::Compliance::CheckRequirements::Energy::TEDI < StepCode::Compliance::CheckRequirements::Energy::Base
+  def requirements_met?
+    (tedi != 0 && tedi <= tedi_requirement) || tedi_hlr_percent >= tedi_hlr_percent_requirement
+  end
+
+  private
+
+  def tedi
+    @tedi ||= total(:aux_energy_required) / 1000 / total_heated_floor_area * KWH_PER_GJ
+  end
+
+  def tedi_requirement
+    @tedi_requirement ||= tedi_reference.hdd_adjusted_tedi
+  end
+
+  def tedi_hlr_percent_requirement
+    if total(:building_volume) > 300
+      tedi_reference.gshl_under_300
+    else
+      tedi_reference.gshl_over_300
+    end
+  end
+
+  def tedi_hlr_percent
+    reference = total(:ref_gshl)
+    ((reference - total(:proposed_gshl)) / reference * 100).round(0)
+  end
+end

--- a/app/services/step_code/compliance/check_requirements/zero_carbon/base.rb
+++ b/app/services/step_code/compliance/check_requirements/zero_carbon/base.rb
@@ -1,0 +1,59 @@
+# GHG: Greenhouse Gas
+# EF: Emission Factor
+
+class StepCode::Compliance::CheckRequirements::ZeroCarbon::Base
+  ELECTRICITY_EF = 0.011
+  NATURAL_GAS_EF = 0.18
+  PROPANE_EF = 0.2155
+
+  attr_reader :checklist, :step
+
+  def initialize(checklist:, step:)
+    @checklist = checklist
+    @step = step
+  end
+
+  private
+
+  def stage
+    @stage ||= checklist.stage == :as_built ? :as_built : :proposed
+  end
+
+  def total(field)
+    checklist.data_entries.where(stage: stage).sum(field)
+  end
+
+  def min(field)
+    checklist.data_entries.where(stage: stage).minimum(field)
+  end
+
+  def total_heated_floor_area
+    @total_heated_floor_area ||= total(:above_grade_heated_floor_area) + total(:below_grade_heated_floor_area)
+  end
+
+  def total_ghg
+    @total_ghg ||= other_ghg + district_energy_ghg + propane_ghg + natural_gas_ghg + electricity_ghg
+  end
+
+  def electricity_ghg
+    total("electrical_consumption * #{ELECTRICITY_EF}")
+  end
+
+  def natural_gas_ghg
+    total("natural_gas_consumption * #{NATURAL_GAS_EF}")
+  end
+
+  def propane_ghg
+    total("propane_consumption * #{PROPANE_EF}")
+  end
+
+  # district energy and other GHG require user provided EF and consumption
+
+  def district_energy_ghg
+    total("district_energy_consumption * district_energy_ef")
+  end
+
+  def other_ghg
+    total("other_consumption * other_ef")
+  end
+end

--- a/app/services/step_code/compliance/check_requirements/zero_carbon/co2.rb
+++ b/app/services/step_code/compliance/check_requirements/zero_carbon/co2.rb
@@ -1,0 +1,20 @@
+class StepCode::Compliance::CheckRequirements::ZeroCarbon::CO2 < StepCode::Compliance::CheckRequirements::ZeroCarbon::Base
+  def requirements_met?
+    return false if total_ghg == 0
+    co2 <= co2_requirement && total_ghg <= co2_max_requirement
+  end
+
+  private
+
+  def co2
+    total_ghg / total_heated_floor_area
+  end
+
+  def co2_requirement
+    ZERO_CARBON_REFERENCES.dig(step, :carbon_per_floor_area)
+  end
+
+  def co2_max_requirement
+    ZERO_CARBON_REFERENCES.dig(step, :carbon_per_floor_area_max)
+  end
+end

--- a/app/services/step_code/compliance/check_requirements/zero_carbon/ghg.rb
+++ b/app/services/step_code/compliance/check_requirements/zero_carbon/ghg.rb
@@ -1,0 +1,14 @@
+# GHG: Greenhouse Gas
+
+class StepCode::Compliance::CheckRequirements::ZeroCarbon::GHG < StepCode::Compliance::CheckRequirements::ZeroCarbon::Base
+  def requirements_met?
+    return false unless total_ghg != 0
+    total_ghg <= total_ghg_requirement
+  end
+
+  private
+
+  def total_ghg_requirement
+    ZERO_CARBON_REFERENCES.dig(step, :total_carbon)
+  end
+end

--- a/app/services/step_code/compliance/check_requirements/zero_carbon/prescriptive.rb
+++ b/app/services/step_code/compliance/check_requirements/zero_carbon/prescriptive.rb
@@ -1,0 +1,45 @@
+class StepCode::Compliance::CheckRequirements::ZeroCarbon::Prescriptive < StepCode::Compliance::CheckRequirements::ZeroCarbon::Base
+  def requirements_met?
+    heating_passed? && hot_water_passed? && other_passed?
+  end
+
+  private
+
+  def heating_passed?
+    StepCode::References::FUEL_TYPE_RATINGS[heating] >= StepCode::References::FUEL_TYPE_RATINGS[heating_requirement]
+  end
+
+  def heating
+    min(
+      "CASE WHEN GREATEST(heating_furnace, heating_boiler, heating_combo) > 1 THEN 'carbon' ELSE 'zero_carbon' END",
+    ).to_sym
+  end
+
+  def heating_requirement
+    ZERO_CARBON_REFERENCES.dig(step, :fuel_type_heating)
+  end
+
+  def hot_water_passed?
+    StepCode::References::FUEL_TYPE_RATINGS[hot_water] >= StepCode::References::FUEL_TYPE_RATINGS[hot_water_requirement]
+  end
+
+  def hot_water
+    total(:hot_water) > 1 ? :carbon : :zero_carbon
+  end
+
+  def hot_water_requirement
+    ZERO_CARBON_REFERENCES.dig(step, :fuel_type_hot_water)
+  end
+
+  def other_passed?
+    StepCode::References::FUEL_TYPE_RATINGS[other] >= StepCode::References::FUEL_TYPE_RATINGS[other_requirement]
+  end
+
+  def other
+    min("CASE WHEN GREATEST(cooking, laundry) > 1 THEN 'carbon' ELSE 'zero_carbon' END").to_sym
+  end
+
+  def other_requirement
+    StepCode::Reference::ZERO_CARBON_REFERENCES.dig(step, :fuel_type_other)
+  end
+end

--- a/app/services/step_code/compliance/propose_step/base.rb
+++ b/app/services/step_code/compliance/propose_step/base.rb
@@ -1,0 +1,38 @@
+class StepCode::Compliance::ProposeStep::Base
+  attr_accessor :step, :final_step_reached
+
+  MIN_REQUIRED_STEP = 3
+  MAX_STEP = 5
+
+  def initialize(checklist:)
+    @checklist = checklist
+  end
+
+  def call
+    self.final_step_reached = false
+    self.step = MIN_REQUIRED_STEP
+
+    until final_step_reached || step > MAX_STEP
+      if requirements_met?
+        self.step += 1
+      else
+        self.step = nil if step == MIN_REQUIRED_STEP
+        self.final_step_reached = true
+      end
+    end
+    self.step = step - 1 if step && step > MIN_REQUIRED_STEP
+    return self
+  end
+
+  private
+
+  attr_reader :checklist
+
+  def requirements_met?
+    checkers.all? { |c| self.send(c).requirements_met? }
+  end
+
+  def checkers
+    raise NotImplementedError, "#{__method__} is not implemented"
+  end
+end

--- a/app/services/step_code/compliance/propose_step/energy.rb
+++ b/app/services/step_code/compliance/propose_step/energy.rb
@@ -1,0 +1,17 @@
+class StepCode::Compliance::ProposeStep::Energy < StepCode::Compliance::ProposeStep::Base
+  def checkers
+    %i[meui tedi airtightness]
+  end
+
+  def meui
+    StepCode::Compliance::CheckRequirements::Energy::MEUI.new(step: step, checklist: checklist)
+  end
+
+  def tedi
+    StepCode::Compliance::CheckRequirements::Energy::TEDI.new(step: step, checklist: checklist)
+  end
+
+  def airtightness
+    StepCode::Compliance::CheckRequirements::Energy::Airtightness.new(step: step, checklist: checklist)
+  end
+end

--- a/app/services/step_code/compliance/propose_step/zero_carbon.rb
+++ b/app/services/step_code/compliance/propose_step/zero_carbon.rb
@@ -1,0 +1,17 @@
+class StepCode::Compliance::ProposeStep::ZeroCarbon < StepCode::Compliance::ProposeStep::Base
+  def checkers
+    %i[ghg, co2, prescriptive]
+  end
+
+  def ghg
+    @ghg ||= StepCode::Compliance::CheckRequirements::ZeroCarbon::GHG.new(step:, checklist:).call
+  end
+
+  def co2
+    @co2 ||= StepCode::Compliance::CheckRequirements::ZeroCarbon::CO2.new(step:, checklist:).call
+  end
+
+  def prescriptive
+    @prescriptive ||= StepCode::Compliance::CheckRequirements::ZeroCarbon::Prescriptive.new(step:, checklist:).call
+  end
+end

--- a/app/services/step_code/meui_references_seeder.rb
+++ b/app/services/step_code/meui_references_seeder.rb
@@ -1,0 +1,35 @@
+class StepCode::MEUIReferencesSeeder
+  def self.seed!
+    file_name = "#{Rails.root}/db/templates/meui_references.xlsx"
+    if File.exist?(file_name)
+      xlsx = Roo::Spreadsheet.open(file_name)
+
+      MechanicalEnergyUseIntensityReference.transaction do
+        header_row = xlsx.row(1)
+        data_rows = (2..xlsx.last_row).map { |i| xlsx.row(i).map { |cell| MAPPINGS[cell] || cell } }
+
+        data_rows.each do |row|
+          data_hash = Hash[header_row.zip(row)]
+          MechanicalEnergyUseIntensityReference.create!(data_hash)
+        end
+      end
+    end
+  end
+
+  MAPPINGS = {
+    "4 - Less than 3000" => ..2999,
+    "5 - 3000 to 3999" => 3000..3999,
+    "6 - 4000 to 4999" => 4000..4999,
+    "7A - 5000 to 5999" => 5000..5999,
+    "7B - 6000 to 6999" => 6000..6999,
+    "8 - More than 6999" => 7000..,
+    "Not more than 50%" => ..0.5,
+    "More than 50%" => 0.5...,
+    "≤ 50" => ..50,
+    "51 to 75" => 51..75,
+    "76 to 120" => 76..120,
+    "121 to 165" => 121..165,
+    "166 to 210" => 166..210,
+    "> 210" => 210..,
+  }
+end

--- a/app/services/step_code/references.rb
+++ b/app/services/step_code/references.rb
@@ -1,0 +1,38 @@
+class StepCode::References
+  ZERO_CARBON_REFERENCES = {
+    1 => {
+      total_carbon: nil,
+      carbon_per_floor_area: nil,
+      carbon_per_floor_area_max: nil,
+      fuel_type_heating: nil,
+      fuel_type_hot_water: nil,
+      fuel_type_other: nil,
+    },
+    2 => {
+      total_carbon: 1050,
+      carbon_per_floor_area: 6,
+      carbon_per_floor_area_max: 2400,
+      fuel_type_heating: :zero_carbon,
+      fuel_type_hot_water: nil,
+      fuel_type_other: nil,
+    },
+    3 => {
+      total_carbon: 440,
+      carbon_per_floor_area: 2.5,
+      carbon_per_floor_area_max: 800,
+      fuel_type_heating: :zero_carbon,
+      fuel_type_hot_water: :zero_carbon,
+      fuel_type_other: nil,
+    },
+    4 => {
+      total_carbon: 265,
+      carbon_per_floor_area: 1.5,
+      carbon_per_floor_area_max: 500,
+      fuel_type_heating: :zero_carbon,
+      fuel_type_hot_water: :zero_carbon,
+      fuel_type_other: :zero_carbon,
+    },
+  }
+
+  FUEL_TYPE_RATINGS = { carbon: 2, zero_carbon: 3 }
+end

--- a/app/services/step_code/tedi_references_seeder.rb
+++ b/app/services/step_code/tedi_references_seeder.rb
@@ -1,0 +1,27 @@
+class StepCode::TEDIReferencesSeeder
+  def self.seed!
+    file_name = "#{Rails.root}/db/templates/tedi_references.xlsx"
+    if File.exist?(file_name)
+      xlsx = Roo::Spreadsheet.open(file_name)
+
+      ThermalEnergyDemandIntensityReference.transaction do
+        header_row = xlsx.row(1)
+        data_rows = (2..xlsx.last_row).map { |i| xlsx.row(i).map { |cell| MAPPINGS[cell] || cell } }
+
+        data_rows.each do |row|
+          data_hash = Hash[header_row.zip(row)]
+          ThermalEnergyDemandIntensityReference.create!(data_hash)
+        end
+      end
+    end
+  end
+
+  MAPPINGS = {
+    "4 - Less than 3000" => ..2999,
+    "5 - 3000 to 3999" => 3000..3999,
+    "6 - 4000 to 4999" => 4000..4999,
+    "7A - 5000 to 5999" => 5000..5999,
+    "7B - 6000 to 6999" => 6000..6999,
+    "8 - More than 6999" => 7000..,
+  }
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,9 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym "RESTful"
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "MEUI" # Mechanical Energy Use Intensity
+  inflect.acronym "TEDI" # Thermal Energy Demand Intensity
+  inflect.acronym "GHG" # Greenhouse Gas
+  inflect.acronym "CO2" # Carbon Dioxide
+end

--- a/db/migrate/20240130185555_create_mechanical_energy_use_intensity_references.rb
+++ b/db/migrate/20240130185555_create_mechanical_energy_use_intensity_references.rb
@@ -1,0 +1,17 @@
+class CreateMechanicalEnergyUseIntensityReferences < ActiveRecord::Migration[7.1]
+  def change
+    create_table :mechanical_energy_use_intensity_references, id: :uuid do |t|
+      t.int4range :hdd
+      t.numrange :conditioned_space_percent
+      t.integer :step
+      t.int4range :conditioned_space_area
+      t.integer :meui
+      t.timestamps
+    end
+
+    add_index :mechanical_energy_use_intensity_references,
+              %i[hdd conditioned_space_percent step conditioned_space_area],
+              unique: true,
+              name: "meui_composite_index"
+  end
+end

--- a/db/migrate/20240201003400_create_thermal_energy_demand_intensity_references.rb
+++ b/db/migrate/20240201003400_create_thermal_energy_demand_intensity_references.rb
@@ -1,0 +1,20 @@
+class CreateThermalEnergyDemandIntensityReferences < ActiveRecord::Migration[7.1]
+  def change
+    create_table :thermal_energy_demand_intensity_references, id: :uuid do |t|
+      t.int4range :hdd
+      t.integer :step
+      t.decimal :ach
+      t.decimal :nla
+      t.decimal :nlr
+      t.integer :ltrh_over_300 # meui percent lower than reference house
+      t.integer :ltrh_under_300
+      t.integer :tedi
+      t.integer :hdd_adjusted_tedi
+      t.integer :gshl_over_300
+      t.integer :gshl_under_300
+      t.timestamps
+    end
+
+    add_index :thermal_energy_demand_intensity_references, %i[hdd step], unique: true, name: "tedi_composite_index"
+  end
+end

--- a/db/migrate/20240206221124_create_step_code_checklists.rb
+++ b/db/migrate/20240206221124_create_step_code_checklists.rb
@@ -1,0 +1,10 @@
+class CreateStepCodeChecklists < ActiveRecord::Migration[7.1]
+  def change
+    create_table :step_code_checklists, id: :uuid do |t|
+      t.references :step_code, foreign_key: :true, type: :uuid
+      t.integer :stage, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -141,3 +141,7 @@ RequirementTemplate.reindex
 # Requirments block will get created from requiremetms templates
 puts "Seeding requirements..."
 RequirementsFromXlsxSeeder.seed
+
+# Energy Step Code Reference Tables
+StepCode::MEUIReferencesSeeder.seed!
+StepCode::TEDIReferencesSeeder.seed!

--- a/db/templates/meui_references.xlsx
+++ b/db/templates/meui_references.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8914308fd37bca888becfbc3ec3ed39759c6a760d83b5385dc4bf5e14fa7f745
+size 17401

--- a/db/templates/tedi_references.xlsx
+++ b/db/templates/tedi_references.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:685a6bf608981269936f9ae9940a2ac651f219010ec18672b820d854c029abfe
+size 12614

--- a/spec/factories/step_code_checklists.rb
+++ b/spec/factories/step_code_checklists.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :step_code_checklist do
+  end
+end

--- a/spec/factories/step_code_data_entries.rb
+++ b/spec/factories/step_code_data_entries.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :step_code_data_entry do
+    stage { :proposed }
+  end
+end

--- a/spec/factories/step_codes.rb
+++ b/spec/factories/step_codes.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :step_code do
+  end
+end

--- a/spec/services/step_code/compliance/check_requirements/energy/airtightness_spec.rb
+++ b/spec/services/step_code/compliance/check_requirements/energy/airtightness_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe StepCode::Compliance::CheckRequirements::Energy::Airtightness do
+  let(:step) { 3 }
+  let!(:step_code) { create(:step_code, data_entries_attributes:) }
+  subject(:compliance_checker) do
+    StepCode::Compliance::CheckRequirements::Energy::Airtightness.new(
+      checklist: step_code.pre_construction_checklist,
+      step: step,
+    )
+  end
+
+  let(:ach_requirement) { 55 }
+  let(:nla_requirement) { 40 }
+  let(:nlr_requirement) { 35 }
+
+  before :each do
+    allow(subject).to receive(:ach_requirement) { ach_requirement }
+    allow(subject).to receive(:nla_requirement) { nla_requirement }
+    allow(subject).to receive(:nlr_requirement) { nlr_requirement }
+  end
+
+  context "when total ACH meets the energy step requirement" do
+    let(:data_entries_attributes) { [{ stage: :proposed, ach: 22 }, { stage: :proposed, ach: 22 }] }
+
+    it_behaves_like "a passing step code requirement"
+  end
+
+  context "when total NLA meets the energy step requirement" do
+    let(:data_entries_attributes) { [{ stage: :proposed, ach: 32, nla: 18 }, { stage: :proposed, ach: 32, nla: 18 }] }
+
+    it_behaves_like "a passing step code requirement"
+  end
+
+  context "when NLR meets the energy step requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          ach: 52,
+          nla: 42,
+          above_grade_heated_floor_area: 117.9,
+          below_grade_heated_floor_area: 109.9,
+          building_volume: 624.9,
+          building_envelope_surface_area: 517.40,
+        },
+      ]
+    end
+
+    it_behaves_like "a passing step code requirement"
+  end
+
+  context "when ACH, NLA, and NLR all do not meet energy step requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          ach: 72,
+          nla: 42,
+          above_grade_heated_floor_area: 117.9,
+          below_grade_heated_floor_area: 109.9,
+          building_volume: 1624.9,
+          building_envelope_surface_area: 517.40,
+        },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+end

--- a/spec/services/step_code/compliance/check_requirements/energy/meui_spec.rb
+++ b/spec/services/step_code/compliance/check_requirements/energy/meui_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe StepCode::Compliance::CheckRequirements::Energy::MEUI do
+  let(:step) { 3 }
+  let!(:step_code) { create(:step_code, data_entries_attributes:) }
+  subject(:compliance_checker) do
+    StepCode::Compliance::CheckRequirements::Energy::MEUI.new(
+      checklist: step_code.pre_construction_checklist,
+      step: step,
+    )
+  end
+
+  before :each do
+    StepCode::MEUIReferencesSeeder.seed!
+    StepCode::TEDIReferencesSeeder.seed!
+  end
+
+  context "when meui is present and does not exceed the energy step requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          aec: 45.56,
+          baseloads: 25.62,
+          above_grade_heated_floor_area: 117.9,
+          below_grade_heated_floor_area: 109.9,
+          hdd: 2851,
+          design_cooling_load: 2189.98,
+          air_heat_pump_cooling_capacity: 9,
+        },
+      ]
+    end
+
+    it_behaves_like "a passing step code requirement"
+  end
+
+  context "when meui does not meet energy step requirement but percent improvement does" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          aec: 45.56,
+          baseloads: 25.62,
+          above_grade_heated_floor_area: 7.9,
+          below_grade_heated_floor_area: 9.9,
+          hdd: 2851,
+          design_cooling_load: 2189.98,
+          air_heat_pump_cooling_capacity: 9,
+          building_volume: 624.9,
+          ref_aec: 72.92,
+        },
+      ]
+    end
+
+    it_behaves_like "a passing step code requirement"
+  end
+
+  context "when neither meui nor percent improvement meets energy step requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          aec: 65.56,
+          baseloads: 25.62,
+          above_grade_heated_floor_area: 7.9,
+          below_grade_heated_floor_area: 9.9,
+          hdd: 2851,
+          design_cooling_load: 2189.98,
+          air_heat_pump_cooling_capacity: 9,
+          building_volume: 624.9,
+          ref_aec: 72.92,
+        },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+end

--- a/spec/services/step_code/compliance/check_requirements/energy/tedi_spec.rb
+++ b/spec/services/step_code/compliance/check_requirements/energy/tedi_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe StepCode::Compliance::CheckRequirements::Energy::TEDI do
+  let(:step) { 3 }
+  let!(:step_code) { create(:step_code, data_entries_attributes:) }
+  subject(:compliance_checker) do
+    StepCode::Compliance::CheckRequirements::Energy::TEDI.new(
+      checklist: step_code.pre_construction_checklist,
+      step: step,
+    )
+  end
+
+  before :each do
+    StepCode::TEDIReferencesSeeder.seed!
+  end
+
+  context "when tedi is present and does not exceed the energy step requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          aux_energy_required: 15065.98,
+          above_grade_heated_floor_area: 117.9,
+          below_grade_heated_floor_area: 109.9,
+          building_volume: 624.9,
+          proposed_gshl: 44.11,
+          ref_gshl: 62.35,
+          hdd: 2851,
+        },
+      ]
+    end
+
+    it_behaves_like "a passing step code requirement"
+  end
+
+  context "when tedi does not meet energy step requirement but percent improvement does" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          aux_energy_required: 35065.98,
+          above_grade_heated_floor_area: 117.9,
+          below_grade_heated_floor_area: 59.9,
+          building_volume: 624.9,
+          proposed_gshl: 44.11,
+          ref_gshl: 62.35,
+          hdd: 2851,
+        },
+      ]
+    end
+
+    it_behaves_like "a passing step code requirement"
+  end
+
+  context "when neither tedi nor percent improvement meets energy step requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          aux_energy_required: 35065.98,
+          above_grade_heated_floor_area: 117.9,
+          below_grade_heated_floor_area: 59.9,
+          building_volume: 624.9,
+          proposed_gshl: 61.11,
+          ref_gshl: 62.35,
+          hdd: 2851,
+        },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+end

--- a/spec/services/step_code/compliance/check_requirements/zero_carbon/co2_spec.rb
+++ b/spec/services/step_code/compliance/check_requirements/zero_carbon/co2_spec.rb
@@ -1,0 +1,133 @@
+RSpec.describe StepCode::Compliance::CheckRequirements::ZeroCarbon::CO2 do
+  let(:step) { 3 }
+  let!(:step_code) { create(:step_code, data_entries_attributes:) }
+  subject(:compliance_checker) do
+    StepCode::Compliance::CheckRequirements::ZeroCarbon::CO2.new(
+      checklist: step_code.pre_construction_checklist,
+      step: step,
+    )
+  end
+
+  let(:co2_requirement) { 2.5 }
+  let(:co2_max_requirement) { 800 }
+
+  before :each do
+    allow(subject).to receive(:co2_requirement) { co2_requirement }
+    allow(subject).to receive(:co2_max_requirement) { co2_max_requirement }
+  end
+
+  context "when total GHG is zero" do
+    let(:data_entries_attributes) do
+      [{ stage: :proposed, electrical_consumption: 0, natural_gas_consumption: 0, propane_consumption: 0 }]
+    end
+    it_behaves_like "a failed step code requirement"
+  end
+
+  context "when CO2 and GHG both meet requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          electrical_consumption: 45.53,
+          natural_gas_consumption: 0.02,
+          propane_consumption: 0,
+          above_grade_heated_floor_area: 117.9,
+          below_grade_heated_floor_area: 109.90,
+        },
+        {
+          stage: :proposed,
+          electrical_consumption: 45.93,
+          natural_gas_consumption: 0.02,
+          propane_consumption: 0,
+          above_grade_heated_floor_area: 117.9,
+          below_grade_heated_floor_area: 109.90,
+        },
+      ]
+    end
+
+    it_behaves_like "a passing step code requirement"
+  end
+
+  context "when CO2 does not meet requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          electrical_consumption: 185.53,
+          natural_gas_consumption: 20.02,
+          propane_consumption: 23.02,
+          above_grade_heated_floor_area: 2.9,
+          below_grade_heated_floor_area: 1.8,
+        },
+        {
+          stage: :proposed,
+          electrical_consumption: 185.93,
+          natural_gas_consumption: 20.02,
+          propane_consumption: 23.02,
+          above_grade_heated_floor_area: 1.2,
+          below_grade_heated_floor_area: 1.4,
+        },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+
+  context "when CO2 passes but total GHG does not meet requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          electrical_consumption: 945.53,
+          natural_gas_consumption: 32.02,
+          propane_consumption: 49.38,
+          district_energy_consumption: 223.23,
+          district_energy_ef: 32.3,
+          above_grade_heated_floor_area: 911.2,
+          below_grade_heated_floor_area: 2221.4,
+        },
+        {
+          stage: :proposed,
+          electrical_consumption: 1225.93,
+          natural_gas_consumption: 33.02,
+          propane_consumption: 48.32,
+          district_energy_consumption: 223.23,
+          district_energy_ef: 32.3,
+          above_grade_heated_floor_area: 911.2,
+          below_grade_heated_floor_area: 2221.4,
+        },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+
+  context "when neither CO2 nor total GHG meets energy step requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          electrical_consumption: 145.53,
+          natural_gas_consumption: 32.02,
+          propane_consumption: 99.38,
+          district_energy_consumption: 23.23,
+          district_energy_ef: 32.3,
+          above_grade_heated_floor_area: 111.2,
+          below_grade_heated_floor_area: 21.4,
+        },
+        {
+          stage: :proposed,
+          electrical_consumption: 425.93,
+          natural_gas_consumption: 33.02,
+          propane_consumption: 98.32,
+          district_energy_consumption: 23.23,
+          district_energy_ef: 32.3,
+          above_grade_heated_floor_area: 111.2,
+          below_grade_heated_floor_area: 21.4,
+        },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+end

--- a/spec/services/step_code/compliance/check_requirements/zero_carbon/ghg_spec.rb
+++ b/spec/services/step_code/compliance/check_requirements/zero_carbon/ghg_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe StepCode::Compliance::CheckRequirements::ZeroCarbon::GHG do
+  let(:step) { 3 }
+  let!(:step_code) { create(:step_code, data_entries_attributes:) }
+  subject(:compliance_checker) do
+    StepCode::Compliance::CheckRequirements::ZeroCarbon::GHG.new(
+      checklist: step_code.pre_construction_checklist,
+      step: step,
+    )
+  end
+
+  let(:total_ghg_requirement) { 440 }
+
+  before :each do
+    allow(subject).to receive(:total_ghg_requirement) { total_ghg_requirement }
+  end
+
+  context "when total GHG requirement is zero" do
+    let(:data_entries_attributes) do
+      [
+        { stage: :proposed, electrical_consumption: 0, natural_gas_consumption: 0, propane_consumption: 0 },
+        { stage: :proposed, electrical_consumption: 0, natural_gas_consumption: 0, propane_consumption: 0 },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+
+  context "when total GHG meets the requirement" do
+    let(:data_entries_attributes) do
+      [
+        { stage: :proposed, electrical_consumption: 45.53, natural_gas_consumption: 0.02, propane_consumption: 0 },
+        { stage: :proposed, electrical_consumption: 45.93, natural_gas_consumption: 0.02, propane_consumption: 0 },
+      ]
+    end
+
+    it_behaves_like "a passing step code requirement"
+  end
+
+  context "when total GHG does not meet requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          electrical_consumption: 145.53,
+          natural_gas_consumption: 32.02,
+          propane_consumption: 99.38,
+          district_energy_consumption: 223.23,
+          district_energy_ef: 32.3,
+        },
+        {
+          stage: :proposed,
+          electrical_consumption: 425.93,
+          natural_gas_consumption: 33.02,
+          propane_consumption: 98.32,
+          district_energy_consumption: 223.23,
+          district_energy_ef: 32.3,
+        },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+end

--- a/spec/services/step_code/compliance/check_requirements/zero_carbon/prescriptive_spec.rb
+++ b/spec/services/step_code/compliance/check_requirements/zero_carbon/prescriptive_spec.rb
@@ -1,0 +1,96 @@
+RSpec.describe StepCode::Compliance::CheckRequirements::ZeroCarbon::Prescriptive do
+  let(:step) { 3 }
+  let!(:step_code) { create(:step_code, data_entries_attributes:) }
+  subject(:compliance_checker) do
+    StepCode::Compliance::CheckRequirements::ZeroCarbon::Prescriptive.new(
+      checklist: step_code.pre_construction_checklist,
+      step: step,
+    )
+  end
+
+  let(:heating_requirement) { :zero_carbon }
+  let(:hot_water_requirement) { :zero_carbon }
+  let(:other_requirement) { :zero_carbon }
+
+  before :each do
+    allow(subject).to receive(:heating_requirement) { heating_requirement }
+    allow(subject).to receive(:hot_water_requirement) { hot_water_requirement }
+    allow(subject).to receive(:other_requirement) { other_requirement }
+  end
+
+  context "when heating requirement is not met" do
+    let(:data_entries_attributes) do
+      [
+        { stage: :proposed, heating_furnace: 0.9, heating_boiler: 0.2, heating_combo: 1.1 },
+        { stage: :proposed, heating_furnace: 0.9, heating_boiler: 0, heating_combo: 0.9 },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+
+  context "when hot water requirement is not met" do
+    let(:data_entries_attributes) do
+      [
+        { stage: :proposed, heating_furnace: 0.9, heating_boiler: 0, heating_combo: 0.9, hot_water: 0.8 },
+        { stage: :proposed, heating_furnace: 0.9, heating_boiler: 0, heating_combo: 0.9, hot_water: 0.5 },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+
+  context "when other requirement is not met" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          heating_furnace: 0.9,
+          heating_boiler: 0,
+          heating_combo: 0.9,
+          hot_water: 0.8,
+          cooking: 0.2,
+          laundry: 0.6,
+        },
+        {
+          stage: :proposed,
+          heating_furnace: 0.9,
+          heating_boiler: 0,
+          heating_combo: 0.9,
+          hot_water: 0.5,
+          cooking: 0.4,
+          laundry: 0.7,
+        },
+      ]
+    end
+
+    it_behaves_like "a failed step code requirement"
+  end
+
+  context "when heating, hot water, and other all meet the requirement" do
+    let(:data_entries_attributes) do
+      [
+        {
+          stage: :proposed,
+          heating_furnace: 0.9,
+          heating_boiler: 0,
+          heating_combo: 0.9,
+          hot_water: 0.4,
+          cooking: 0.2,
+          laundry: 0.4,
+        },
+        {
+          stage: :proposed,
+          heating_furnace: 0.9,
+          heating_boiler: 0,
+          heating_combo: 0.9,
+          hot_water: 0.5,
+          cooking: 0.2,
+          laundry: 0.4,
+        },
+      ]
+    end
+
+    it_behaves_like "a passing step code requirement"
+  end
+end

--- a/spec/services/step_code/compliance/propose_step/base_spec.rb
+++ b/spec/services/step_code/compliance/propose_step/base_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe StepCode::Compliance::ProposeStep::Base do
+  let(:step_code) { build(:step_code) }
+  let(:minimum_step) { StepCode::Compliance::ProposeStep::Base::MIN_REQUIRED_STEP }
+  subject(:compliance_checker) do
+    StepCode::Compliance::ProposeStep::Base.new(checklist: step_code.pre_construction_checklist)
+  end
+
+  before :each do
+    iterations = expected_step ? expected_step - minimum_step + 2 : 1
+    results =
+      Array.new(iterations) do |n|
+        step = minimum_step + n
+        expected_step ? step <= expected_step : false
+      end
+    allow(subject).to receive(:requirements_met?).and_return(*results)
+    subject.call
+  end
+
+  context "when requirements are not met for the minimum step" do
+    let(:expected_step) { nil }
+
+    it_behaves_like "a step code compliance check"
+  end
+
+  context "when requirements are met for the minimum step" do
+    let(:expected_step) { minimum_step }
+
+    it_behaves_like "a step code compliance check"
+  end
+
+  context "when requirements are met for a step beyond the minimum step" do
+    let(:expected_step) { minimum_step + 1 }
+
+    it_behaves_like "a step code compliance check"
+  end
+end

--- a/spec/support/shared_examples/step_code_compliance.rb
+++ b/spec/support/shared_examples/step_code_compliance.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.shared_examples "a step code compliance check" do
+  it "sets the proposed step as expected" do
+    expect(subject.step).to eq(expected_step)
+  end
+end
+
+RSpec.shared_examples "a passing step code requirement" do
+  it "returns true" do
+    expect(subject.requirements_met?).to be true
+  end
+end
+
+RSpec.shared_examples "a failed step code requirement" do
+  it "returns false" do
+    expect(subject.requirements_met?).to be false
+  end
+end


### PR DESCRIPTION
[BPHH-545]

## Description

Adds a service that returns the step code compliance check results. This includes the proposed step achieved and whether requirements are met as well as the supporting data.

To determine the proposed step, the service loops over the steps incrementally to find the maximum step where requirements are met. There are two separate steps to achieve - the energy step and the zero carbon step.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Implements [BPHH-545](https://hous-bssb.atlassian.net/browse/BPHH-545).

## Steps to QA

1. Migrate DB
2. If there are no step codes in the DB, initialize one:
- Download test H2K file (see Jira ticket `test.h2k`)
- Open a rails console and run the following:

```
xml_file_path = 'path/to/test.h2k'
xml = Nokogiri::XML(File.read(xml_file_path))
StepCode::InitializeFromHot2000.new(xml:).call
```

3. Run the compliance check on the step code:

```
checklist = StepCode.last.pre_construction_checklist
result = StepCode::Compliance::ProposeStep::Energy.new(checklist:).call
```

The result should include the `proposed_step`, `requirements_met`, along with the data used to generate the result (e.g. meui, tedi, etc.)

## UI Accessibility Checklist

N/A

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant **- will do this as part of [BPHH-546](https://hous-bssb.atlassian.net/browse/BPHH-546)**
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

N/A
