### PR TITLE
 Remove deprecated react-leaflet types

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@types/leaflet": "^1.9.8",
     "@types/quill": "^2.0.14",
     "@types/ramda": "^0.29.9",
-    "@types/react-leaflet": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
     "@typescript-eslint/parser": "^6.13.2",
     "eslint-plugin-jsx-a11y": "^6.8.0",


### PR DESCRIPTION
## Description
 Remove deprecated react-leaflet types causing develop deploy to fail
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [X ] 📦 Chore (Release)
- [ ] ✅ Test
