### PR TITLE
Add parameterized classification option endpoint

### DIFF
--- a/app/blueprints/permit_classification_option_blueprint.rb
+++ b/app/blueprints/permit_classification_option_blueprint.rb
@@ -1,0 +1,5 @@
+class PermitClassificationOptionBlueprint < OptionBlueprint
+  fields :label
+
+  association :value, blueprint: PermitClassificationBlueprint
+end

--- a/app/controllers/api/permit_classifications_controller.rb
+++ b/app/controllers/api/permit_classifications_controller.rb
@@ -3,4 +3,38 @@ class Api::PermitClassificationsController < Api::ApplicationController
     @permit_classifications = policy_scope(PermitClassification)
     render_success @permit_classifications, nil, { blueprint: PermitClassificationBlueprint }
   end
+
+  def permit_classification_options
+    authorize :permit_classification, :permit_classification_options?
+    begin
+      permit_classifications =
+        if activity_option_params[:published].present?
+          query = RequirementTemplate.includes(:permit_type).includes(:activity)
+
+          query = query.where(permit_type_id: activity_option_params[:permit_type_id]) if activity_option_params[
+            :permit_type_id
+          ].present?
+
+          query = query.where(activity_id: activity_option_params[:activity_id]) if activity_option_params[
+            :activity_id
+          ].present?
+
+          query.map(&activity_option_params[:type].underscore.to_sym).uniq
+        else
+          PermitClassification.where(type: activity_option_params[:type])
+        end
+
+      options = permit_classifications.map { |pc| { label: pc.name, value: pc } }
+
+      render_success options, nil, { blueprint: PermitClassificationOptionBlueprint }
+    rescue StandardError => e
+      render_error "permit_classification.options_error" and return
+    end
+  end
+
+  private
+
+  def activity_option_params
+    params.permit(%i[type published permit_type_id activity_id])
+  end
 end

--- a/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
@@ -28,7 +28,7 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
       site: null as IOption,
     },
   })
-  const { handleSubmit, formState, control } = formMethods
+  const { handleSubmit, formState, control, watch } = formMethods
   const { isSubmitting } = formState
   const { geocoderStore, permitClassificationStore } = useMst()
   const { fetchSiteOptions } = geocoderStore
@@ -37,6 +37,8 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
   const onSubmit = (formValues) => {
     // TODO
   }
+
+  const permitTypeWatch = watch("permitType")
 
   return (
     <Flex as="main" direction="column" w="full" bg="greys.white">
@@ -48,7 +50,7 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
         <form onSubmit={handleSubmit(onSubmit)}>
           <FormProvider {...formMethods}>
             <Flex direction="column" gap={12} w="full" bg="greys.white">
-              <Flex as="section" direction="column">
+              <Flex as="section" direction="column" gap={2}>
                 <YellowLineSmall />
                 <Heading fontSize="xl">{t("permitApplication.new.locationHeading")}</Heading>
                 <Controller
@@ -74,7 +76,7 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
                   }}
                 />
               </Flex>
-              <Flex as="section" direction="column">
+              <Flex as="section" direction="column" gap={2}>
                 <YellowLineSmall />
                 <Heading fontSize="xl">{t("permitApplication.new.permitTypeHeading")}</Heading>
                 <Controller
@@ -84,7 +86,7 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
                     return (
                       <PermitTypeRadioSelect
                         w="full"
-                        fetchOptions={fetchPermitTypeOptions}
+                        fetchOptions={() => fetchPermitTypeOptions(true)}
                         onChange={onChange}
                         value={value}
                         isLoading={isLoading}
@@ -93,11 +95,17 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
                   }}
                 />
               </Flex>
-              <Flex as="section" direction="column">
-                <YellowLineSmall />
-                <Heading fontSize="xl">{t("permitApplication.new.workTypeHeading")}</Heading>
-                <ActivityList fetchOptions={fetchActivityOptions} isLoading={isLoading} />
-              </Flex>
+              {permitTypeWatch && (
+                <Flex as="section" direction="column" gap={2}>
+                  <YellowLineSmall />
+                  <Heading fontSize="xl">{t("permitApplication.new.workTypeHeading")}</Heading>
+                  <ActivityList
+                    fetchOptions={() => fetchActivityOptions(true, permitTypeWatch)}
+                    permitTypeId={permitTypeWatch}
+                    isLoading={isLoading}
+                  />
+                </Flex>
+              )}
               <BackButton isDisabled={isSubmitting} />
             </Flex>
           </FormProvider>

--- a/app/frontend/components/domains/requirement-template/new-requirement-tempate-screen.tsx
+++ b/app/frontend/components/domains/requirement-template/new-requirement-tempate-screen.tsx
@@ -21,7 +21,7 @@ export const NewRequirementTemplateScreen = observer(({}: INewRequirementTemplat
   const { t } = useTranslation()
   const {
     requirementTemplateStore: { createRequirementTemplate },
-    permitClassificationStore: { fetchPermitTypeIdOptions, fetchActivityIdOptions },
+    permitClassificationStore: { fetchPermitTypeOptions, fetchActivityOptions },
   } = useMst()
 
   const formMethods = useForm<TCreateRequirementTemplateFormData>({
@@ -58,13 +58,15 @@ export const NewRequirementTemplateScreen = observer(({}: INewRequirementTemplat
 
             <Flex gap={8} w="full" as="section">
               <AsyncRadioGroup
+                valueField="id"
                 label={t("requirementTemplate.fields.permitType")}
-                fetchOptions={fetchPermitTypeIdOptions}
+                fetchOptions={fetchPermitTypeOptions}
                 fieldName={"permitTypeId"}
               />
               <AsyncRadioGroup
+                valueField="id"
                 label={t("requirementTemplate.fields.activity")}
-                fetchOptions={fetchActivityIdOptions}
+                fetchOptions={fetchActivityOptions}
                 fieldName={"activityId"}
               />
             </Flex>

--- a/app/frontend/components/shared/base/inputs/async-radio-group.tsx
+++ b/app/frontend/components/shared/base/inputs/async-radio-group.tsx
@@ -6,67 +6,73 @@ import { useTranslation } from "react-i18next"
 import { IOption } from "../../../../types/types"
 import { SharedSpinner } from "../shared-spinner"
 
-interface IAsyncRadioGroupProps extends FlexProps {
+interface IAsyncRadioGroupProps<T> extends FlexProps {
   label: string
-  fetchOptions: () => Promise<IOption[]>
+  valueField?: string
+  fetchOptions: () => Promise<IOption<T>[]>
   fieldName: string
 }
 
-export const AsyncRadioGroup = observer(({ label, fetchOptions, fieldName, ...rest }: IAsyncRadioGroupProps) => {
-  const { control } = useFormContext()
-  const [options, setOptions] = useState<IOption[]>([])
+export const AsyncRadioGroup = observer(
+  <T,>({ label, fetchOptions, fieldName, valueField, ...rest }: IAsyncRadioGroupProps<T>) => {
+    const { control } = useFormContext()
+    const [options, setOptions] = useState<IOption<T>[]>([])
 
-  const [error, setError] = useState<Error | undefined>(undefined)
+    const [error, setError] = useState<Error | undefined>(undefined)
 
-  const { t } = useTranslation()
+    const { t } = useTranslation()
 
-  useEffect(() => {
-    ;(async () => {
-      try {
-        const opts = await fetchOptions()
-        setOptions(opts)
-      } catch (e) {
-        setError(e instanceof Error ? e : new Error(t("errors.fetchOptions")))
-      }
-    })()
-  }, [])
+    useEffect(() => {
+      ;(async () => {
+        try {
+          const opts = await fetchOptions()
+          setOptions(opts)
+        } catch (e) {
+          setError(e instanceof Error ? e : new Error(t("errors.fetchOptions")))
+        }
+      })()
+    }, [])
 
-  return options?.length > 0 ? (
-    <Flex direction="column" w="full" {...rest}>
-      <Text mb={1}>{label}</Text>
-      {error ? (
-        <Text>{error.message}</Text>
-      ) : (
-        <Controller
-          name={fieldName}
-          control={control}
-          rules={{ required: true }}
-          render={({ field: { onChange, value } }) => {
-            return (
-              <RadioGroup
-                onChange={onChange}
-                value={value}
-                bg="greys.grey03"
-                flex={1}
-                p={4}
-                border="1px solid"
-                borderColor="greys.grey02"
-                borderRadius="sm"
-              >
-                <Stack direction="column">
-                  {options.map((option) => (
-                    <Radio key={option.value} value={option.value} bg="white">
-                      {option.label}
-                    </Radio>
-                  ))}
-                </Stack>
-              </RadioGroup>
-            )
-          }}
-        />
-      )}
-    </Flex>
-  ) : (
-    <SharedSpinner />
-  )
-})
+    return options?.length > 0 ? (
+      <Flex direction="column" w="full" {...rest}>
+        <Text mb={1}>{label}</Text>
+        {error ? (
+          <Text>{error.message}</Text>
+        ) : (
+          <Controller
+            name={fieldName}
+            control={control}
+            rules={{ required: true }}
+            render={({ field: { onChange, value } }) => {
+              return (
+                <RadioGroup
+                  onChange={onChange}
+                  value={value}
+                  bg="greys.grey03"
+                  flex={1}
+                  p={4}
+                  border="1px solid"
+                  borderColor="greys.grey02"
+                  borderRadius="sm"
+                >
+                  <Stack direction="column">
+                    {options.map((option) => {
+                      const optionValue = valueField ? option.value[valueField] : option.value
+                      return (
+                        <Radio key={optionValue} value={optionValue} bg="white">
+                          {option.label}
+                        </Radio>
+                      )
+                    })}
+                  </Stack>
+                </RadioGroup>
+              )
+            }}
+          />
+        )}
+      </Flex>
+    ) : (
+      <SharedSpinner />
+    )
+  }
+)

--- a/app/frontend/components/shared/permit-classification/activity-list.tsx
+++ b/app/frontend/components/shared/permit-classification/activity-list.tsx
@@ -10,16 +10,17 @@ import { SharedSpinner } from "../base/shared-spinner"
 interface IPermitTypeRadioSelect extends FlexProps {
   fetchOptions: () => Promise<IOption<IActivity>[]>
   isLoading: boolean
+  permitTypeId?: string
 }
 
-export const ActivityList = ({ fetchOptions, isLoading, ...rest }: IPermitTypeRadioSelect) => {
+export const ActivityList = ({ fetchOptions, isLoading, permitTypeId, ...rest }: IPermitTypeRadioSelect) => {
   const [activityOptions, setActivityOptions] = useState<IOption<IActivity>[]>([])
 
   useEffect(() => {
     ;(async () => {
       setActivityOptions(await fetchOptions())
     })()
-  }, [])
+  }, [permitTypeId])
 
   if (isLoading) return <SharedSpinner />
 

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -2,6 +2,7 @@ import { ApiResponse, ApisauceInstance, create, Monitor } from "apisauce"
 import { TCreateRequirementTemplateFormData } from "../../components/domains/requirement-template/new-requirement-tempate-screen"
 import { IJurisdiction } from "../../models/jurisdiction"
 import { IPermitApplication } from "../../models/permit-application"
+import { IPermitType } from "../../models/permit-classification"
 import { IRequirementTemplate } from "../../models/requirement-template"
 import { IUser } from "../../models/user"
 import { IRequirementBlockParams, IRequirementTemplateUpdateParams, ITagSearchParams } from "../../types/api-request"
@@ -103,6 +104,20 @@ export class Api {
 
   async fetchPermitClassifications() {
     return this.client.get<IOptionResponse>(`/permit_classifications`)
+  }
+
+  async fetchPermitClassificationOptions(
+    type,
+    published = false,
+    permit_type_id: string = null,
+    activity_id: string = null
+  ) {
+    return this.client.post<IOptionResponse<IPermitType>>(`/permit_classifications/permit_classification_options`, {
+      type: type,
+      published: published,
+      permit_type_id: permit_type_id, // Use empty string if null
+      activity_id: activity_id, // Use empty string if null
+    })
   }
 
   async createJurisdiction(params) {

--- a/app/frontend/stores/permit-classification-store.ts
+++ b/app/frontend/stores/permit-classification-store.ts
@@ -2,9 +2,8 @@ import { Instance, flow, types } from "mobx-state-tree"
 import { withEnvironment } from "../lib/with-environment"
 import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
-import { ActivityModel, IActivity, IPermitType, PermitTypeModel } from "../models/permit-classification"
+import { ActivityModel, PermitTypeModel } from "../models/permit-classification"
 import { EPermitClassificationType } from "../types/enums"
-import { IOption } from "../types/types"
 
 export const PermitClassificationStoreModel = types
   .model("PermitClassificationStore", {
@@ -64,21 +63,20 @@ export const PermitClassificationStoreModel = types
     }),
   }))
   .actions((self) => ({
-    fetchPermitTypeIdOptions: flow(function* () {
-      if (self.permitTypeMap.size === 0) yield self.fetchPermitClassifications()
-      return self.permitTypes.map((pt) => ({ label: pt.name, value: pt.id })) as IOption[]
+    fetchPermitTypeOptions: flow(function* (publishedOnly = false) {
+      const response = yield self.environment.api.fetchPermitClassificationOptions(
+        EPermitClassificationType.PermitType,
+        publishedOnly
+      )
+      return response.data.data
     }),
-    fetchActivityIdOptions: flow(function* () {
-      if (self.activityMap.size === 0) yield self.fetchPermitClassifications()
-      return self.activities.map((a) => ({ label: a.name, value: a.id })) as IOption[]
-    }),
-    fetchPermitTypeOptions: flow(function* () {
-      if (self.permitTypeMap.size === 0) yield self.fetchPermitClassifications()
-      return self.permitTypes.map((pt) => ({ label: pt.name, value: pt })) as IOption<IPermitType>[]
-    }),
-    fetchActivityOptions: flow(function* () {
-      if (self.activityMap.size === 0) yield self.fetchPermitClassifications()
-      return self.activities.map((a) => ({ label: a.name, value: a })) as IOption<IActivity>[]
+    fetchActivityOptions: flow(function* (publishedOnly = false, activityId = null) {
+      const response = yield self.environment.api.fetchPermitClassificationOptions(
+        EPermitClassificationType.Activity,
+        publishedOnly,
+        activityId
+      )
+      return response.data.data
     }),
   }))
 

--- a/app/frontend/types/api-responses.ts
+++ b/app/frontend/types/api-responses.ts
@@ -31,4 +31,4 @@ export interface IAcceptInvitationResponse extends IApiResponse<{}, { redirectUr
 
 export interface IInvitationResponse extends IApiResponse<{ invited: IUser[]; emailTaken: IUser[] }, {}> {}
 
-export interface IOptionResponse extends IApiResponse<IOption[], IPageMeta> {}
+export interface IOptionResponse<T = string> extends IApiResponse<IOption<T>[], IPageMeta> {}

--- a/app/policies/permit_classification_policy.rb
+++ b/app/policies/permit_classification_policy.rb
@@ -3,6 +3,10 @@ class PermitClassificationPolicy < ApplicationPolicy
     true
   end
 
+  def permit_classification_options?
+    index?
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,10 @@ en:
       pid_error:
         title: Oops
         message: Error encountered fetching pid for address
+    permit_classification:
+      options_error:
+        title: Oops
+        message: Error encountered fetching permit classification options
     user:
       login_error:
         title: Failed to login.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
     end
 
     resources :permit_classifications, only: %i[index] do
+      post "permit_classification_options", on: :collection
     end
 
     resources :geocoder, only: %i[] do

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "@types/leaflet": "^1.9.8",
         "@types/quill": "^2.0.14",
         "@types/ramda": "^0.29.9",
-        "@types/react-leaflet": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^6.13.2",
         "@typescript-eslint/parser": "^6.13.2",
         "eslint-plugin-jsx-a11y": "^6.8.0",
@@ -2609,16 +2608,6 @@
       "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-leaflet": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-leaflet/-/react-leaflet-3.0.0.tgz",
-      "integrity": "sha512-p8R9mVKbCDDqOdW+M6GyJJuFn6q+IgDFYavFiOIvaWHuOe5kIHZEtCy1pfM43JIA6JiB3D/aDoby7C51eO+XSg==",
-      "deprecated": "This is a stub types definition. react-leaflet provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "react-leaflet": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -11076,15 +11065,6 @@
       "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
       "requires": {
         "@types/react": "*"
-      }
-    },
-    "@types/react-leaflet": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-leaflet/-/react-leaflet-3.0.0.tgz",
-      "integrity": "sha512-p8R9mVKbCDDqOdW+M6GyJJuFn6q+IgDFYavFiOIvaWHuOe5kIHZEtCy1pfM43JIA6JiB3D/aDoby7C51eO+XSg==",
-      "dev": true,
-      "requires": {
-        "react-leaflet": "*"
       }
     },
     "@types/react-transition-group": {


### PR DESCRIPTION
## Description

Adds an endpoint that optionally shows only options that pertain to classifications of published templates.
Works for both classification types as well as the non-published case for seeing all available types, making it a universal endpoint for classification options.


## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-539

## Steps to QA

Create a new template as superadmin, you should see all of the classification options right away
Create a new permit application as submitter. You should first see the published permit types, then after selecting you see the appropriate published work types.
