### PR TITLE
fix form control requires and fieldName defaults

### DIFF
--- a/app/frontend/components/shared/form/email-form-control.tsx
+++ b/app/frontend/components/shared/form/email-form-control.tsx
@@ -11,7 +11,12 @@ interface IEmailFormControlProps extends FormControlProps {
   fieldName?: string
 }
 
-export const EmailFormControl = ({ validate, fieldName = null, required = true, ...rest }: IEmailFormControlProps) => {
+export const EmailFormControl = ({
+  validate,
+  fieldName = "email",
+  required = true,
+  ...rest
+}: IEmailFormControlProps) => {
   const { register, formState } = useFormContext()
   const { t } = useTranslation()
   const errorMessage = fieldArrayCompatibleErrorMessage(fieldName, formState)
@@ -22,8 +27,8 @@ export const EmailFormControl = ({ validate, fieldName = null, required = true, 
       <InputGroup>
         <Flex w="full" direction="column">
           <Input
-            {...register(fieldName || "email", {
-              required: true,
+            {...register(fieldName, {
+              required: required && t("ui.isRequired", { field: t("auth.emailLabel") }),
               validate: {
                 matchesEmailRegex: (str) => !validate || EMAIL_REGEX.test(str) || t("ui.invalidEmail"),
               },

--- a/app/frontend/components/shared/form/password-form-control.tsx
+++ b/app/frontend/components/shared/form/password-form-control.tsx
@@ -26,7 +26,7 @@ interface IPasswordFormControlProps extends FormControlProps {
 export const PasswordFormControl = ({
   validate,
   label,
-  fieldName,
+  fieldName = "password",
   required = true,
   ...rest
 }: IPasswordFormControlProps) => {
@@ -41,8 +41,8 @@ export const PasswordFormControl = ({
       <InputGroup>
         <Flex w="full" direction="column">
           <Input
-            {...register(fieldName || "password", {
-              required: required,
+            {...register(fieldName, {
+              required: required && t("ui.isRequired", { field: label }),
               validate: {
                 matchesPasswordRegex: (str) =>
                   !required ||

--- a/app/frontend/components/shared/form/username-form-control.tsx
+++ b/app/frontend/components/shared/form/username-form-control.tsx
@@ -8,6 +8,7 @@ interface IUsernameFormControlProps extends FormControlProps {
   autoFocus?: boolean
   autoComplete?: string
   defaultValue?: string
+  required?: boolean
 }
 
 export const UsernameFormControl = ({
@@ -15,6 +16,7 @@ export const UsernameFormControl = ({
   autoFocus,
   autoComplete,
   defaultValue,
+  required,
   ...rest
 }: IUsernameFormControlProps) => {
   const { register, formState } = useFormContext()
@@ -27,7 +29,7 @@ export const UsernameFormControl = ({
         <Flex w="full" direction="column">
           <Input
             {...register("username", {
-              required: true,
+              required: required && t("ui.isRequired", { field: t("auth.usernameLabel") }),
               validate: {
                 satisfiesUsernameRegex: (str) =>
                   !validate || (str.length >= 2 && str.length < 128) || t("ui.invalidInput"),


### PR DESCRIPTION
Fix bug not being able to open up the profile screen.

This was do to a new form helper that I added to make my form controls still reusable in the case of using them in field arrays. It was assuming that fieldName would be defined.

fieldName is now always defined using parameter defaults instead of || in the fieldName prop.

Also fixed the "is required" message across all of these reusable form controls.

