### PR TITLE
[bphh-594] Fixes issue with adding new section and section block not …

### DIFF
--- a/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/index.tsx
@@ -6,6 +6,7 @@ import React, { useEffect, useRef, useState } from "react"
 import { FormProvider, useFieldArray, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { RemoveScroll } from "react-remove-scroll"
+import { v4 as uuidv4 } from "uuid"
 import { useRequirementTemplate } from "../../../../hooks/resources/use-requirement-template"
 import { IRequirementTemplate } from "../../../../models/requirement-template"
 import { ITemplateSectionBlockModel } from "../../../../models/template-section-block"
@@ -178,10 +179,15 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
     formattedData.requirementTemplateSectionsAttributes.forEach((sectionAttributes, sectionIndex) => {
       const existingMSTSection = requirementTemplate.getRequirementSectionById(sectionAttributes.id)
 
+      // if this is a new section, set id null to mark it to be created
+      // on the backend
+      if (!existingMSTSection) {
+        sectionAttributes.id = null
+      }
       sectionAttributes.position = sectionIndex
       sectionAttributes.templateSectionBlocksAttributes.forEach((sectionBlockAttributes, blockIndex) => {
         // if the section is new or if the block is moved to this section
-        // from another section, then we set the id to null so that it get's created
+        // from another section, then we set the id to null so that it gets created
         // on the new section by rails.
         if (!existingMSTSection || !existingMSTSection.hasTemplateSectionBlock(sectionBlockAttributes.id)) {
           sectionBlockAttributes.id = null
@@ -249,6 +255,7 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
     ).length
 
     prependToSectionsAttributes({
+      id: uuidv4(),
       name: `${defaultName} ${numUneditedNewSections + 1}`,
       templateSectionBlocksAttributes: [],
     })

--- a/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/sections-display.tsx
@@ -5,6 +5,7 @@ import * as R from "ramda"
 import React from "react"
 import { useFieldArray, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
+import { v4 as uuidv4 } from "uuid"
 import { useMst } from "../../../../setup/root"
 import { IRequirementTemplateSectionAttributes } from "../../../../types/api-request"
 import { EditableInputWithControls } from "../../../shared/editable-input-with-controls"
@@ -130,7 +131,7 @@ const SectionDisplay = observer(
           <RequirementsLibraryDrawer
             defaultButtonProps={{ alignSelf: "center" }}
             onUse={(requirementBlock, closeDrawer) => {
-              appendSectionBlock({ requirementBlockId: requirementBlock.id })
+              appendSectionBlock({ id: uuidv4(), requirementBlockId: requirementBlock.id })
               closeDrawer()
             }}
           />


### PR DESCRIPTION
## Description
Fixes issue with adding new section and section block not having front-end ids causing issues with reordering and not saving new sections properly
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ X] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-594
https://hous-bssb.atlassian.net/browse/BPHH-595
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->
