### PR TITLE
Bugfix/various template bugfixe

### DIFF
--- a/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/index.tsx
@@ -36,7 +36,7 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
   const { requirementTemplate, error } = useRequirementTemplate()
   const formMethods = useForm({ defaultValues: formFormDefaults(requirementTemplate) })
   const { control, reset, watch, setValue, handleSubmit } = formMethods
-  const { prepend: prependToSectionsAttributes } = useFieldArray({
+  const { append: appendToSectionsAttributes } = useFieldArray({
     name: `requirementTemplateSectionsAttributes`,
     control,
   })
@@ -254,11 +254,17 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
       sectionAttributes.name?.startsWith(defaultName)
     ).length
 
-    prependToSectionsAttributes({
+    const sectionAttributes = {
       id: uuidv4(),
       name: `${defaultName} ${numUneditedNewSections + 1}`,
       templateSectionBlocksAttributes: [],
-    })
+    }
+
+    appendToSectionsAttributes(sectionAttributes)
+
+    setTimeout(() => {
+      scrollIntoView(sectionAttributes.id)
+    }, 200)
   }
 
   function setSectionRef(el: HTMLElement, id: string) {

--- a/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/sections-display.tsx
@@ -134,6 +134,7 @@ const SectionDisplay = observer(
               appendSectionBlock({ id: uuidv4(), requirementBlockId: requirementBlock.id })
               closeDrawer()
             }}
+            disableUseForBlockIds={new Set(watchedSectionBlocks.map((sectionBlock) => sectionBlock.requirementBlockId))}
           />
         </Stack>
       </Box>

--- a/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/sections-display.tsx
@@ -74,6 +74,7 @@ const SectionDisplay = observer(
         <Box w={"36px"} border={"4px solid"} borderColor={"theme.yellow"} mb={2} />
         <HStack
           w={"full"}
+          maxW={"798px"}
           justifyContent={"space-between"}
           _hover={{ "button:nth-of-type(1)": { visibility: "visible" } }}
         >

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
@@ -2,11 +2,7 @@ import {
   Box,
   Button,
   Checkbox,
-  CheckboxGroup,
   CheckboxProps,
-  FormControl,
-  FormHelperText,
-  FormLabel,
   FormLabelProps,
   HStack,
   IconButton,
@@ -329,25 +325,133 @@ const requirementsComponentMap = {
   },
 
   [ERequirementType.checkbox]: function <TFieldValues>({
-    label,
-    helperText,
-    options = defaultOptions,
+    multiOptionProps,
+    editableLabelProps,
+    editableHelperTextProps,
+    checkboxProps,
   }: TRequirementEditProps<TFieldValues>) {
     const { t } = useTranslation()
+    const { controlProps, ...restCheckboxProps } = checkboxProps
+
+    if (!multiOptionProps) {
+      import.meta.env.DEV && console.error("multiOptionProps is required for checkbox requirement edit")
+      return null
+    }
+
+    const { useFieldArrayProps, onOptionValueChange, getOptionValue } = multiOptionProps
+
+    const { fields, append, remove } = useFieldArray<TFieldValues>(useFieldArrayProps)
+
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...labelProps}>
-          {label || t("requirementsLibrary.requirementTypeLabels.multiSelectCheckbox")}
-        </FormLabel>
-        <CheckboxGroup>
-          <Stack>
-            {options.map((option) => (
-              <Checkbox value={option}>{option}</Checkbox>
-            ))}
-          </Stack>
-        </CheckboxGroup>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <Stack spacing={4}>
+        <EditableInputWithControls
+          defaultValue={t("requirementsLibrary.modals.defaultRequirementLabel")}
+          {...editableLabelProps}
+        />
+        <Stack>
+          {fields.map((field, idx) => (
+            <HStack key={field.id}>
+              <Box
+                border={"1px solid"}
+                borderColor={"border.light"}
+                bg={"white"}
+                w={"16px"}
+                h={"16px"}
+                borderRadius={"sm"}
+              />
+              <Input
+                bg={"white"}
+                size={"sm"}
+                value={getOptionValue(idx).label}
+                onChange={(e) => onOptionValueChange(idx, e.target.value)}
+                w={"150px"}
+              />
+              <IconButton aria-label={"remove option"} variant={"unstyled"} icon={<X />} onClick={() => remove(idx)} />
+            </HStack>
+          ))}
+
+          {/*  @ts-ignore*/}
+          <Button variant={"link"} textDecoration={"underline"} onClick={() => append({ value: "", label: "" })}>
+            {t("requirementsLibrary.modals.addOptionButton")}
+          </Button>
+          <EditableInputWithControls
+            initialHint={t("requirementsLibrary.modals.addHelpText")}
+            placeholder={t("requirementsLibrary.modals.helpTextPlaceHolder")}
+            {...editableHelperTextProps}
+          />
+        </Stack>
+
+        <Controller<TFieldValues>
+          {...controlProps}
+          render={({ field: checkboxField }) => (
+            // @ts-ignore
+            <Checkbox {...restCheckboxProps} {...checkboxField}>
+              {t("requirementsLibrary.modals.optionalForSubmitters")}
+            </Checkbox>
+          )}
+        />
+      </Stack>
+    )
+  },
+  [ERequirementType.select]: function <TFieldValues>({
+    multiOptionProps,
+    editableLabelProps,
+    editableHelperTextProps,
+    checkboxProps,
+  }: TRequirementEditProps<TFieldValues>) {
+    const { t } = useTranslation()
+    const { controlProps, ...restCheckboxProps } = checkboxProps
+
+    if (!multiOptionProps) {
+      import.meta.env.DEV && console.error("multiOptionProps is required for select requirement edit")
+      return null
+    }
+
+    const { useFieldArrayProps, onOptionValueChange, getOptionValue } = multiOptionProps
+
+    const { fields, append, remove } = useFieldArray<TFieldValues>(useFieldArrayProps)
+
+    return (
+      <Stack spacing={4}>
+        <EditableInputWithControls
+          defaultValue={t("requirementsLibrary.modals.defaultRequirementLabel")}
+          {...editableLabelProps}
+        />
+        <Stack>
+          {fields.map((field, idx) => (
+            <HStack key={field.id}>
+              <Input
+                bg={"white"}
+                size={"sm"}
+                value={getOptionValue(idx).label}
+                onChange={(e) => onOptionValueChange(idx, e.target.value)}
+                w={"150px"}
+              />
+              <IconButton aria-label={"remove option"} variant={"unstyled"} icon={<X />} onClick={() => remove(idx)} />
+            </HStack>
+          ))}
+
+          {/*  @ts-ignore*/}
+          <Button variant={"link"} textDecoration={"underline"} onClick={() => append({ value: "", label: "" })}>
+            {t("requirementsLibrary.modals.addOptionButton")}
+          </Button>
+          <EditableInputWithControls
+            initialHint={t("requirementsLibrary.modals.addHelpText")}
+            placeholder={t("requirementsLibrary.modals.helpTextPlaceHolder")}
+            {...editableHelperTextProps}
+          />
+        </Stack>
+
+        <Controller<TFieldValues>
+          {...controlProps}
+          render={({ field: checkboxField }) => (
+            // @ts-ignore
+            <Checkbox {...restCheckboxProps} {...checkboxField}>
+              {t("requirementsLibrary.modals.optionalForSubmitters")}
+            </Checkbox>
+          )}
+        />
+      </Stack>
     )
   },
 }

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
@@ -1,9 +1,9 @@
 import {
   Button,
+  ButtonProps,
   HStack,
   Menu,
   MenuButton,
-  MenuButtonProps,
   MenuDivider,
   MenuItem,
   MenuList,
@@ -16,7 +16,7 @@ import React, { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 
 interface IProps {
-  menuButtonProps?: Partial<MenuButtonProps>
+  menuButtonProps?: Partial<ButtonProps>
   onRemove?: () => void
   emitOpenState?: (isOpen: boolean) => void
 }

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Text, VStack } from "@chakra-ui/react"
+import { Box, Button, Flex, HStack, Text, VStack } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
 import React, { useState } from "react"
@@ -22,8 +22,11 @@ export const FieldsSetup = observer(function FieldsSetup() {
     control,
     name: "requirementsAttributes",
   })
-  const [requirementToEdit, setRequirementToEdit] = useState<string | null>()
-  const [isAnyEditOptionsMenuOpen, setIsAnyEditOptionsMenuOpen] = useState<boolean>(false)
+  const [requirementIdsToEdit, setRequirementIdsToEdit] = useState<Record<string, boolean>>({})
+
+  const toggleRequirementToEdit = (requirementId: string) => {
+    setRequirementIdsToEdit((pastState) => ({ ...pastState, [requirementId]: !pastState[requirementId] }))
+  }
 
   const onUseRequirement = (requirementType: ERequirementType) => {
     append({
@@ -50,7 +53,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
   const hasFields = fields.length > 0
 
   function isRequirementInEditMode(id: string) {
-    return requirementToEdit === id
+    return !!requirementIdsToEdit[id]
   }
 
   return (
@@ -110,13 +113,13 @@ export const FieldsSetup = observer(function FieldsSetup() {
                   _hover={{
                     bg: "theme.blueLight",
                     "& .requirement-edit-btn": {
-                      visibility: isRequirementInEditMode(field.id) ? "hidden" : "visible",
+                      visibility: "visible",
                     },
                   }}
                   _focus={{
                     bg: "theme.blueLight",
                     "& .requirement-edit-btn": {
-                      visibility: isRequirementInEditMode(field.id) ? "hidden" : "visible",
+                      visibility: "visible",
                     },
                   }}
                   tabIndex={0}
@@ -124,9 +127,6 @@ export const FieldsSetup = observer(function FieldsSetup() {
                   pt={index !== 0 ? 1 : 0}
                   pb={5}
                   pos={"relative"}
-                  onMouseLeave={() => {
-                    isRequirementInEditMode(field.id) && !isAnyEditOptionsMenuOpen && setRequirementToEdit(null)
-                  }}
                 >
                   <Box
                     w={"full"}
@@ -141,13 +141,14 @@ export const FieldsSetup = observer(function FieldsSetup() {
                       requirementType={requirementType}
                       editableLabelProps={{
                         color: "text.link",
+                        w: `calc(100% - 220px)`,
                         editableInputProps: {
                           ...register(`requirementsAttributes.${index}.label`, {
                             required: true,
                             value: t("requirementsLibrary.modals.defaultRequirementLabel"),
                           }),
                           "aria-label": "Edit Label",
-                          w: "calc(100% - 60px)",
+                          // w: `calc(100% - ${isRequirementInEditMode(field.id) ? "280px" : "60px"})`,
                         },
                       }}
                       editableHelperTextProps={{
@@ -221,7 +222,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
                       label={watch(`requirementsAttributes.${index}.label`)}
                       helperText={watchedHint}
                       labelProps={{
-                        w: "calc(100% - 60px)",
+                        w: `calc(100% - 60px})`,
                       }}
                       unit={
                         requirementType === ERequirementType.number
@@ -236,31 +237,27 @@ export const FieldsSetup = observer(function FieldsSetup() {
                       }}
                     />
                   </Box>
-                  <Button
-                    className={"requirement-edit-btn"}
-                    variant={"primary"}
-                    pos={"absolute"}
-                    right={0}
-                    top={0}
-                    size={"sm"}
-                    visibility={"hidden"}
-                    onClick={() => {
-                      setRequirementToEdit(field.id)
-                    }}
-                  >
-                    {t("ui.edit")}
-                  </Button>
-                  {isRequirementInEditMode(field.id) && (
-                    <OptionsMenu
-                      menuButtonProps={{
-                        pos: "absolute",
-                        right: 0,
-                        top: 0,
+                  <HStack pos={"absolute"} right={0} top={0} spacing={4}>
+                    {isRequirementInEditMode(field.id) && (
+                      <OptionsMenu
+                        menuButtonProps={{
+                          size: "sm",
+                        }}
+                        onRemove={() => remove(index)}
+                      />
+                    )}
+                    <Button
+                      className={"requirement-edit-btn"}
+                      visibility={isRequirementInEditMode(field.id) ? "visible" : "hidden"}
+                      variant={"primary"}
+                      size={"sm"}
+                      onClick={() => {
+                        toggleRequirementToEdit(field.id)
                       }}
-                      onRemove={() => remove(index)}
-                      emitOpenState={(isOpen) => setIsAnyEditOptionsMenuOpen(isOpen)}
-                    />
-                  )}
+                    >
+                      {t(isRequirementInEditMode(field.id) ? "ui.done" : "ui.edit")}
+                    </Button>
+                  </HStack>
                 </Box>
               )
             })}

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -148,7 +148,6 @@ export const FieldsSetup = observer(function FieldsSetup() {
                             value: t("requirementsLibrary.modals.defaultRequirementLabel"),
                           }),
                           "aria-label": "Edit Label",
-                          // w: `calc(100% - ${isRequirementInEditMode(field.id) ? "280px" : "60px"})`,
                         },
                       }}
                       editableHelperTextProps={{

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -188,24 +188,28 @@ export const FieldsSetup = observer(function FieldsSetup() {
                             }
                           : undefined
                       }
-                      multiOptionProps={{
-                        useFieldArrayProps: {
-                          control,
-                          name: `requirementsAttributes.${index}.inputOptions.valueOptions`,
-                        },
-                        onOptionValueChange: (optionNIndex, optionValue) => {
-                          setValue(
-                            `requirementsAttributes.${index}.inputOptions.valueOptions.${optionNIndex}.value`,
-                            optionValue
-                          )
-                          setValue(
-                            `requirementsAttributes.${index}.inputOptions.valueOptions.${optionNIndex}.label`,
-                            optionValue
-                          )
-                        },
-                        getOptionValue: (idx) =>
-                          watch(`requirementsAttributes.${index}.inputOptions.valueOptions.${idx}`),
-                      }}
+                      multiOptionProps={
+                        isMultiOptionRequirement(requirementType)
+                          ? {
+                              useFieldArrayProps: {
+                                control,
+                                name: `requirementsAttributes.${index}.inputOptions.valueOptions`,
+                              },
+                              onOptionValueChange: (optionNIndex, optionValue) => {
+                                setValue(
+                                  `requirementsAttributes.${index}.inputOptions.valueOptions.${optionNIndex}.value`,
+                                  optionValue
+                                )
+                                setValue(
+                                  `requirementsAttributes.${index}.inputOptions.valueOptions.${optionNIndex}.label`,
+                                  optionValue
+                                )
+                              },
+                              getOptionValue: (idx) =>
+                                watch(`requirementsAttributes.${index}.inputOptions.valueOptions.${idx}`),
+                            }
+                          : undefined
+                      }
                     />
                   </Box>
                   <Box

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
@@ -132,7 +132,6 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
                 <HStack>
                   <Button
                     variant={"primary"}
-                    type={"submit"}
                     isDisabled={isSubmitting || !isValid}
                     isLoading={isSubmitting}
                     onClick={handleSubmit(onSubmit)}

--- a/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
@@ -18,12 +18,14 @@ interface IProps {
   defaultButtonProps?: Partial<ButtonProps>
   renderTriggerButton?: (props: ButtonProps & { ref: Ref<HTMLElement> }) => JSX.Element
   onUse?: (requirementBlock: IRequirementBlock, closeDrawer?: () => void) => void
+  disableUseForBlockIds?: Set<string>
 }
 
 export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDrawer({
   defaultButtonProps,
   renderTriggerButton,
   onUse,
+  disableUseForBlockIds,
 }: IProps) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -51,7 +53,12 @@ export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDr
             flex={1}
             p={8}
             renderActionButton={({ requirementBlock }) => (
-              <Button size={"sm"} variant={"primary"} onClick={() => onUse(requirementBlock, onClose)}>
+              <Button
+                size={"sm"}
+                variant={"primary"}
+                onClick={() => onUse(requirementBlock, onClose)}
+                isDisabled={disableUseForBlockIds.has(requirementBlock.id)}
+              >
                 {t("ui.use")}
               </Button>
             )}

--- a/db/migrate/20240213233640_drop_tag_tables.rb
+++ b/db/migrate/20240213233640_drop_tag_tables.rb
@@ -1,0 +1,6 @@
+class DropTagTables < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20240213234230_acts_as_taggable_on_migration_with_uuid.rb
+++ b/db/migrate/20240213234230_acts_as_taggable_on_migration_with_uuid.rb
@@ -1,0 +1,32 @@
+class ActsAsTaggableOnMigrationWithUuid < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table ActsAsTaggableOn.tags_table, id: :uuid do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table, id: :uuid do |t|
+      t.references :tag, type: :uuid, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true, type: :uuid
+      t.references :tagger, polymorphic: true, type: :uuid
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[taggable_id taggable_type context],
+              name: "taggings_taggable_context_idx"
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20240213234552_add_missing_unique_indices_with_uuid.rb
+++ b/db/migrate/20240213234552_add_missing_unique_indices_with_uuid.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddMissingUniqueIndicesWithUuid < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: "taggings_taggable_context_idx"
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true,
+              name: "taggings_idx"
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: "taggings_idx"
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[taggable_id taggable_type context],
+              name: "taggings_taggable_context_idx"
+  end
+end

--- a/db/migrate/20240213234626_add_taggings_counter_cache_to_tags_with_uuid.rb
+++ b/db/migrate/20240213234626_add_taggings_counter_cache_to_tags_with_uuid.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddTaggingsCounterCacheToTagsWithUuid < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20240213234711_add_missing_taggable_index_with_uuid.rb
+++ b/db/migrate/20240213234711_add_missing_taggable_index_with_uuid.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddMissingTaggableIndexWithUuid < ActiveRecord::Migration[6.0]
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table,
+              %i[taggable_id taggable_type context],
+              name: "taggings_taggable_context_idx"
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: "taggings_taggable_context_idx"
+  end
+end

--- a/db/migrate/20240213234749_change_collation_for_tag_names_with_uuid.rb
+++ b/db/migrate/20240213234749_change_collation_for_tag_names_with_uuid.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+
+class ChangeCollationForTagNamesWithUuid < ActiveRecord::Migration[6.0]
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute(
+        "ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;",
+      )
+    end
+  end
+end

--- a/db/migrate/20240213234813_add_missing_indexes_on_taggings_with_uuid.rb
+++ b/db/migrate/20240213234813_add_missing_indexes_on_taggings_with_uuid.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AddMissingIndexesOnTaggingsWithUuid < ActiveRecord::Migration[6.0]
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+      add_index ActsAsTaggableOn.taggings_table, :taggable_id
+    end
+    unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+      add_index ActsAsTaggableOn.taggings_table, :taggable_type
+    end
+    unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+      add_index ActsAsTaggableOn.taggings_table, :tagger_id
+    end
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, %i[tagger_id tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table,
+                         %i[taggable_id taggable_type tagger_id context],
+                         name: "taggings_idy"
+      add_index ActsAsTaggableOn.taggings_table, %i[taggable_id taggable_type tagger_id context], name: "taggings_idy"
+    end
+  end
+end

--- a/db/migrate/20240213234941_add_tenant_to_taggings_with_uuid.rb
+++ b/db/migrate/20240213234941_add_tenant_to_taggings_with_uuid.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddTenantToTaggingsWithUuid < ActiveRecord::Migration[6.0]
+  def self.up
+    add_column ActsAsTaggableOn.taggings_table, :tenant, :string, limit: 128
+    add_index ActsAsTaggableOn.taggings_table, :tenant unless index_exists? ActsAsTaggableOn.taggings_table, :tenant
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, :tenant
+    remove_column ActsAsTaggableOn.taggings_table, :tenant
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_13_234941) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "allowlisted_jwts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "allowlisted_jwts",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "jti", null: false
     t.string "aud"
     t.datetime "exp", null: false
@@ -26,12 +29,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
     t.index ["user_id"], name: "index_allowlisted_jwts_on_user_id"
   end
 
-  create_table "assets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "assets",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "contacts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "contacts",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name"
     t.string "title"
     t.string "email"
@@ -49,11 +58,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
     t.uuid "requirement_template_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["jurisdiction_id"], name: "index_jurisdiction_requirement_templates_on_jurisdiction_id"
-    t.index ["requirement_template_id"], name: "idx_on_requirement_template_id_df1d54db04"
+    t.index ["jurisdiction_id"],
+            name: "index_jurisdiction_requirement_templates_on_jurisdiction_id"
+    t.index ["requirement_template_id"],
+            name: "idx_on_requirement_template_id_df1d54db04"
   end
 
-  create_table "jurisdictions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "jurisdictions",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name"
     t.text "description_html"
     t.datetime "created_at", null: false
@@ -70,10 +84,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
     t.string "prefix", null: false
     t.string "submission_email"
     t.index ["prefix"], name: "index_jurisdictions_on_prefix", unique: true
-    t.index ["regional_district_id"], name: "index_jurisdictions_on_regional_district_id"
+    t.index ["regional_district_id"],
+            name: "index_jurisdictions_on_regional_district_id"
   end
 
-  create_table "permit_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "permit_applications",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.integer "status", default: 0
     t.uuid "submitter_id", null: false
     t.uuid "jurisdiction_id", null: false
@@ -88,13 +106,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
     t.string "number"
     t.datetime "submitted_at"
     t.index ["activity_id"], name: "index_permit_applications_on_activity_id"
-    t.index ["jurisdiction_id"], name: "index_permit_applications_on_jurisdiction_id"
-    t.index ["number"], name: "index_permit_applications_on_number", unique: true
-    t.index ["permit_type_id"], name: "index_permit_applications_on_permit_type_id"
+    t.index ["jurisdiction_id"],
+            name: "index_permit_applications_on_jurisdiction_id"
+    t.index ["number"],
+            name: "index_permit_applications_on_number",
+            unique: true
+    t.index ["permit_type_id"],
+            name: "index_permit_applications_on_permit_type_id"
     t.index ["submitter_id"], name: "index_permit_applications_on_submitter_id"
   end
 
-  create_table "permit_classifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "permit_classifications",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name", null: false
     t.string "code", null: false
     t.string "type", null: false
@@ -105,7 +130,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
     t.index ["code"], name: "index_permit_classifications_on_code", unique: true
   end
 
-  create_table "requirement_blocks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "requirement_blocks",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name", null: false
     t.integer "sign_off_role", default: 0, null: false
     t.integer "reviewer_role", default: 0, null: false
@@ -120,16 +148,24 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
     t.index ["sku"], name: "index_requirement_blocks_on_sku", unique: true
   end
 
-  create_table "requirement_template_sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "requirement_template_sections",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name"
     t.uuid "requirement_template_id", null: false
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["requirement_template_id"], name: "index_requirement_template_sections_on_requirement_template_id"
+    t.index ["requirement_template_id"],
+            name:
+              "index_requirement_template_sections_on_requirement_template_id"
   end
 
-  create_table "requirement_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "requirement_templates",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "activity_id", null: false
     t.uuid "permit_type_id", null: false
     t.datetime "created_at", null: false
@@ -140,11 +176,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
     t.date "scheduled_for"
     t.datetime "discarded_at"
     t.index ["activity_id"], name: "index_requirement_templates_on_activity_id"
-    t.index ["discarded_at"], name: "index_requirement_templates_on_discarded_at"
-    t.index ["permit_type_id"], name: "index_requirement_templates_on_permit_type_id"
+    t.index ["discarded_at"],
+            name: "index_requirement_templates_on_discarded_at"
+    t.index ["permit_type_id"],
+            name: "index_requirement_templates_on_permit_type_id"
   end
 
-  create_table "requirements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "requirements",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "requirement_code", null: false
     t.string "label"
     t.integer "input_type", null: false
@@ -158,42 +199,60 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
     t.datetime "updated_at", null: false
     t.uuid "requirement_block_id", null: false
     t.integer "position"
-    t.index ["requirement_block_id"], name: "index_requirements_on_requirement_block_id"
+    t.index ["requirement_block_id"],
+            name: "index_requirements_on_requirement_block_id"
   end
 
-  create_table "supporting_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "supporting_documents",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "permit_application_id", null: false
     t.string "file_data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "compliance_data"
-    t.index ["permit_application_id"], name: "index_supporting_documents_on_permit_application_id"
+    t.index ["permit_application_id"],
+            name: "index_supporting_documents_on_permit_application_id"
   end
 
-  create_table "taggings", force: :cascade do |t|
-    t.bigint "tag_id"
+  create_table "taggings",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
+    t.uuid "tag_id"
     t.string "taggable_type"
-    t.bigint "taggable_id"
+    t.uuid "taggable_id"
     t.string "tagger_type"
-    t.bigint "tagger_id"
+    t.uuid "tagger_id"
     t.string "context", limit: 128
     t.datetime "created_at", precision: nil
     t.string "tenant", limit: 128
     t.index ["context"], name: "index_taggings_on_context"
-    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index %w[tag_id taggable_id taggable_type context tagger_id tagger_type],
+            name: "taggings_idx",
+            unique: true
     t.index ["tag_id"], name: "index_taggings_on_tag_id"
-    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
-    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index %w[taggable_id taggable_type context],
+            name: "taggings_taggable_context_idx"
+    t.index %w[taggable_id taggable_type tagger_id context],
+            name: "taggings_idy"
     t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
-    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index %w[taggable_type taggable_id],
+            name: "index_taggings_on_taggable_type_and_taggable_id"
     t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
-    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index %w[tagger_id tagger_type],
+            name: "index_taggings_on_tagger_id_and_tagger_type"
     t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
-    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+    t.index %w[tagger_type tagger_id],
+            name: "index_taggings_on_tagger_type_and_tagger_id"
     t.index ["tenant"], name: "index_taggings_on_tenant"
   end
 
-  create_table "tags", force: :cascade do |t|
+  create_table "tags",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -201,17 +260,25 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  create_table "template_section_blocks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "template_section_blocks",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "requirement_template_section_id", null: false
     t.uuid "requirement_block_id", null: false
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["requirement_block_id"], name: "index_template_section_blocks_on_requirement_block_id"
-    t.index ["requirement_template_section_id"], name: "idx_on_requirement_template_section_id_5469986497"
+    t.index ["requirement_block_id"],
+            name: "index_template_section_blocks_on_requirement_block_id"
+    t.index ["requirement_template_section_id"],
+            name: "idx_on_requirement_template_section_id_5469986497"
   end
 
-  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "users",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "email", null: false
     t.string "username"
     t.string "organization"
@@ -243,15 +310,23 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["confirmation_token"],
+            name: "index_users_on_confirmation_token",
+            unique: true
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+    t.index ["invitation_token"],
+            name: "index_users_on_invitation_token",
+            unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
+    t.index %w[invited_by_type invited_by_id], name: "index_users_on_invited_by"
     t.index ["jurisdiction_id"], name: "index_users_on_jurisdiction_id"
-    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index %w[provider uid],
+            name: "index_users_on_provider_and_uid",
+            unique: true
+    t.index ["reset_password_token"],
+            name: "index_users_on_reset_password_token",
+            unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
@@ -259,14 +334,24 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_10_010209) do
   add_foreign_key "contacts", "jurisdictions"
   add_foreign_key "jurisdiction_requirement_templates", "jurisdictions"
   add_foreign_key "jurisdiction_requirement_templates", "requirement_templates"
-  add_foreign_key "jurisdictions", "jurisdictions", column: "regional_district_id"
+  add_foreign_key "jurisdictions",
+                  "jurisdictions",
+                  column: "regional_district_id"
   add_foreign_key "permit_applications", "jurisdictions"
-  add_foreign_key "permit_applications", "permit_classifications", column: "activity_id"
-  add_foreign_key "permit_applications", "permit_classifications", column: "permit_type_id"
+  add_foreign_key "permit_applications",
+                  "permit_classifications",
+                  column: "activity_id"
+  add_foreign_key "permit_applications",
+                  "permit_classifications",
+                  column: "permit_type_id"
   add_foreign_key "permit_applications", "users", column: "submitter_id"
   add_foreign_key "requirement_template_sections", "requirement_templates"
-  add_foreign_key "requirement_templates", "permit_classifications", column: "activity_id"
-  add_foreign_key "requirement_templates", "permit_classifications", column: "permit_type_id"
+  add_foreign_key "requirement_templates",
+                  "permit_classifications",
+                  column: "activity_id"
+  add_foreign_key "requirement_templates",
+                  "permit_classifications",
+                  column: "permit_type_id"
   add_foreign_key "requirements", "requirement_blocks"
   add_foreign_key "supporting_documents", "permit_applications"
   add_foreign_key "taggings", "tags"


### PR DESCRIPTION
## Description
Various template and requirement block related bug fixes
- Disable ability to  add more than 1 of the same requirement block to same section in template builder for better user feedback
- Make requirement block editor edit more persistent with done button
- Reimplement missing edit mode for checkbox and select requirement type. This was previously done but forgotten to commit
- Align remove button with requirement block for requirement template builder
- Add migrations to drop original acts as taggable tables, and add new migrations to create acts as taggable related tables with uuids. This fixes bug with saving multiple of same associations
- Refactor add sections in template builder to add sections to end of form instead of top, and add a scroll to function after

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-485
https://hous-bssb.atlassian.net/browse/BPHH-599
https://hous-bssb.atlassian.net/browse/BPHH-560
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->