### PR TITLE
adding historic site integration and geometry intersect

### DIFF
--- a/app/services/automated_compliance/historic_site.rb
+++ b/app/services/automated_compliance/historic_site.rb
@@ -1,0 +1,22 @@
+class AutomatedCompliance::HistoricSite < AutomatedCompliance::Base
+  def call(permit_application)
+    return if permit_application.pid.blank?
+    #extraction of parcel data can be done via LTSA base
+    response = Integrations::LtsaParcelMapBc.new.historic_site_by_pid(pid: permit_application.pid)
+    if response.success?
+      attributes = response.body.dig("features", 0, "attributes")
+
+      if attributes.present?
+        updated_submission_data = permit_application.submission_data || { "data" => {} }
+        permit_application
+          .automated_compliance_requirements_for_module("HistoricSite")
+          .each do |field_id, req|
+            if attributes[req.input_options.dig("computed_compliance", "value")] == "Y"
+              updated_submission_data["data"][field_id] = "Yes"
+            end
+          end
+        permit_application.update(submission_data: updated_submission_data)
+      end
+    end
+  end
+end

--- a/app/services/integrations/ltsa_parcel_map_bc.rb
+++ b/app/services/integrations/ltsa_parcel_map_bc.rb
@@ -1,5 +1,10 @@
 class Integrations::LtsaParcelMapBc
   attr_accessor :client, :api_path
+
+  PARCEL_SERVICE = "/whse/bcgw_pub_whse_cadastre/MapServer/0"
+  HISTORIC_SERVICE = "/whse/bcgw_pub_whse_human_cultural_economic/MapServer/1"
+  IMAP_SERVICE = "/mpcm/bcgw/MapServer/dynamicLayer"
+
   def initialize
     parsed_url = URI.parse(ENV["GEO_LTSA_PARCELMAP_REST_URL"])
     @client = Faraday.new(ENV["GEO_LTSA_PARCELMAP_REST_URL"]) { |f| f.response :json, content_type: /\bjson$/ }
@@ -10,8 +15,37 @@ class Integrations::LtsaParcelMapBc
     pid:,
     fields: "PID,PARCEL_STATUS,PARCEL_NAME,PARCEL_CLASS,OWNER_TYPE,MUNICIPALITY,REGIONAL_DISTRICT,WHEN_UPDATED,FEATURE_AREA_SQM"
   )
-    @client.get(
-      "query?f=json&returnIdsOnly=false&returnCountOnly=false&where=PID='#{pid}'&returnGeometry=true&spatialRel=esriSpatialRelIntersects&outFields=#{fields}",
-    )
+    query = "returnIdsOnly=false&returnCountOnly=false"
+    query += "&where=PID='#{pid}'"
+    query += "&returnGeometry=true&spatialRel=esriSpatialRelIntersects"
+    query += "&outFields=#{fields}"
+    @client.get("#{ENV["GEO_LTSA_PARCELMAP_REST_URL"]}#{PARCEL_SERVICE}/query?f=json&#{query}")
+  end
+
+  def historic_site_by_pid(pid:)
+    query = "where=HISTORIC_SITE_IND='Y' AND PARCEL_DESCRIPTION='#{pid}'&returnGeometry=true&outFields=*"
+    response = @client.get("#{ENV["GEO_LTSA_PARCELMAP_REST_URL"]}#{HISTORIC_SERVICE}/query?f=json&#{query}")
+    #assuem if there is a parcel description match not to use ltsa geometry matching
+    return response if response.success? && response.body.dig("features").length > 0
+
+    #get geometry from pid
+    response_for_geometry = get_details_by_pid(pid: pid, fields: "PID")
+    if response_for_geometry.success? && response_for_geometry.body.dig("features", 0, "geometry")
+      #interesect the geometry from the city over
+      pid_geo = response_for_geometry.body.dig("features", 0, "geometry")
+      query =
+        "where=HISTORIC_SITE_IND='Y'&returnGeometry=true&spatialRel=esriSpatialRelIntersects&geometry=#{CGI.escape(pid_geo.to_json)}&geometryType=esriGeometryPolygon&outFields=*"
+      @client.get("#{ENV["GEO_LTSA_PARCELMAP_REST_URL"]}#{HISTORIC_SERVICE}/query?f=json&#{query}")
+    else
+      raise ArgumentError.new("invalid geometry returned")
+    end
+  end
+
+  def get_dynamic_features_by_pid(pid:)
+    #call the get_details_by_pid to get the active polygon for the parcel
+    query = "returnIdsOnly=false&returnCountOnly=false"
+
+    @client.get("#{ENV["GEO_LTSA_PARCELMAP_REST_URL"]}#{PARCEL_SERVICE}/query?f=json&#{query}")
+    # https://maps.gov.bc.ca/arcserver/rest/services/mpcm/bcgw/MapServer/dynamicLayer/query?layer=Your_Layer_Definition&f=json&returnGeometry=true&spatialRel=esriSpatialRelIntersects&geometry={"rings":[[[x1, y1], [x2, y2], [x3, y3], ..., [x1, y1]]],"spatialReference":{"wkid":Spatial_Reference_ID}}&geometryType=esriGeometryPolygon&inSR=Spatial_Reference_ID&outSR=Spatial_Reference_ID
   end
 end

--- a/spec/factories/requirement_templates.rb
+++ b/spec/factories/requirement_templates.rb
@@ -40,5 +40,28 @@ FactoryBot.define do
         end
       end
     end
+
+    factory :requirement_template_with_heritage do
+      after(:create) do |template|
+        create_list(:requirement_template_section, 1, requirement_template: template).each do |section|
+          create_list(:requirement_block, 1).each do |block|
+            create(:template_section_block, requirement_template_section: section, requirement_block: block)
+            create(
+              :requirement,
+              requirement_code: "heritage_resource",
+              requirement_block: block,
+              input_type: :checkbox,
+              input_options: {
+                value_options: [{ value: "true", label: "Yes" }, { value: "false", label: "No" }],
+                computed_compliance: {
+                  module: "HistoricSite",
+                  value: "HISTORIC_SITE_IND",
+                },
+              },
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/services/automated_compliance/historic_site_spec.rb
+++ b/spec/services/automated_compliance/historic_site_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe AutomatedCompliance::HistoricSite do
+  let!(:requirement_template) { create(:requirement_template_with_heritage) }
+
+  context "a PID that is a historic site and parcel description matches" do
+    let!(:permit_application) do
+      create(
+        :permit_application,
+        permit_type: requirement_template.permit_type,
+        activity: requirement_template.activity,
+        pid: "000561444",
+        full_address: "1275 ST. DAVID ST, VICTORIA, BC, V8S 4Z1",
+      )
+    end
+
+    it "respond to let them know that this is a historic site and they should check it carefully" do
+      VCR.use_cassette("automated_compliance/historic_site/matched_by_legal") do
+        AutomatedCompliance::HistoricSite.new.call(permit_application)
+        expect(
+          permit_application.submission_data.dig("data", permit_application.automated_compliance_requirements.keys[0]),
+        ).to eq("Yes")
+      end
+    end
+  end
+
+  context "a PID that is a historic site and the parcel desription does not match the PID" do
+    let!(:permit_application) do
+      create(
+        :permit_application,
+        permit_type: requirement_template.permit_type,
+        activity: requirement_template.activity,
+        pid: "005706297",
+        full_address: "770 BERNARD AVE, KELOWNA, BC, V1Y 6P5",
+      )
+    end
+
+    it "respond to let them know that this is a historic site and they should check it carefully" do
+      VCR.use_cassette("automated_compliance/historic_site/matched_by_geometry") do
+        AutomatedCompliance::HistoricSite.new.call(permit_application)
+        expect(
+          permit_application.submission_data.dig("data", permit_application.automated_compliance_requirements.keys[0]),
+        ).to eq("Yes")
+      end
+    end
+  end
+
+  context "a PID not on a historic site" do
+    let!(:permit_application) do
+      create(
+        :permit_application,
+        permit_type: requirement_template.permit_type,
+        activity: requirement_template.activity,
+        pid: "004920414",
+        full_address: "595 BURRARD ST, VANCOUVER, BC, V7X 1M4",
+      )
+    end
+
+    it "respond to let them know that this is a historic site and they should check it carefully" do
+      VCR.use_cassette("automated_compliance/historic_site/unmatched") do
+        AutomatedCompliance::HistoricSite.new.call(permit_application)
+        expect(
+          (permit_application.submission_data || {}).dig(
+            "data",
+            permit_application.automated_compliance_requirements.keys[0],
+          ),
+        ).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/automated_compliance/historic_site/matched_by_geometry.yml
+++ b/spec/vcr_cassettes/automated_compliance/historic_site/matched_by_geometry.yml
@@ -1,0 +1,170 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<GEO_LTSA_PARCELMAP_REST_URL>/whse/bcgw_pub_whse_human_cultural_economic/MapServer/1/query?f=json&outFields=%2A&returnGeometry=true&where=HISTORIC_SITE_IND%3D%27Y%27+AND+PARCEL_DESCRIPTION%3D%27005706297%27"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      date:
+      - Tue, 13 Feb 2024 00:49:18 GMT
+      server:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+      vary:
+      - Origin
+      cache-control:
+      - max-age=0,must-revalidate
+      etag:
+      - db4a24e1
+      x-esri-ftiles-cache-compress:
+      - 'true'
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=UTF-8
+      content-length:
+      - '935'
+      access-control-allow-origin:
+      - "(null)"
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-methods:
+      - POST, GET, OPTIONS, HEAD
+      access-control-allow-headers:
+      - X-Requested-With, Referer, Origin, Content-Type, SOAPAction, Authorization,
+        Accept
+      access-control-max-age:
+      - '1000'
+      x-frame-options:
+      - allow-from (null)
+    body:
+      encoding: UTF-8
+      string: '{"displayFieldName":"COMMON_SITE_NAME","fieldAliases":{"HISTORIC_ENVIRONMENT_ID":"HISTORIC_ENVIRONMENT_ID","HISTORIC_ENVIRONMENT_SITE_ID":"HISTORIC_ENVIRONMENT_SITE_ID","BORDENNUMBER":"BORDENNUMBER","HISTORIC_SITE_IND":"HISTORIC_SITE_IND","REGISTRATION_STATUS":"REGISTRATION_STATUS","COMMON_SITE_NAME":"COMMON_SITE_NAME","OTHER_SITE_NAMES":"OTHER_SITE_NAMES","PARCEL_DESCRIPTION":"PARCEL_DESCRIPTION","STREET_NUMBER":"STREET_NUMBER","STREET_NAME":"STREET_NAME","LOCALITY":"LOCALITY","PROVINCE":"PROVINCE","JURISDICTION_NAMES":"JURISDICTION_NAMES","RECOGNITION_GOVERNMENT":"RECOGNITION_GOVERNMENT","RECOGNITION_GOVERNMENT_LEVEL":"RECOGNITION_GOVERNMENT_LEVEL","RECOGNITION_TYPE":"RECOGNITION_TYPE","RECOGNITION_START_DATE":"RECOGNITION_START_DATE","CONSTRUCTION_YEAR":"CONSTRUCTION_YEAR","CONSTRUCTION_YEAR_QUALIFIER":"CONSTRUCTION_YEAR_QUALIFIER","CONSTRUCTION_YEAR_DATETTYPE":"CONSTRUCTION_YEAR_DATETTYPE","STMT_OF_SIGNIFICANCE_DESC":"STMT_OF_SIGNIFICANCE_DESC","CRHP_IND":"CRHP_IND","ARCHITECT_NAMES":"ARCHITECT_NAMES","BUILDER_NAMES":"BUILDER_NAMES","CURRENT_FUNCTIONAL_CATEGORIES":"CURRENT_FUNCTIONAL_CATEGORIES","HISTORIC_FUNCTIONAL_CATEGORIES":"HISTORIC_FUNCTIONAL_CATEGORIES","AREA_HECTARES":"AREA_HECTARES","FEATURE_AREA_SQM":"FEATURE_AREA_SQM","FEATURE_LENGTH_M":"FEATURE_LENGTH_M","OBJECTID":"OBJECTID","SHAPE.AREA":"SHAPE.AREA","SHAPE.LEN":"SHAPE.LEN"},"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":102190,"latestWkid":3005},"fields":[{"name":"HISTORIC_ENVIRONMENT_ID","type":"esriFieldTypeInteger","alias":"HISTORIC_ENVIRONMENT_ID"},{"name":"HISTORIC_ENVIRONMENT_SITE_ID","type":"esriFieldTypeInteger","alias":"HISTORIC_ENVIRONMENT_SITE_ID"},{"name":"BORDENNUMBER","type":"esriFieldTypeString","alias":"BORDENNUMBER","length":13},{"name":"HISTORIC_SITE_IND","type":"esriFieldTypeString","alias":"HISTORIC_SITE_IND","length":1},{"name":"REGISTRATION_STATUS","type":"esriFieldTypeString","alias":"REGISTRATION_STATUS","length":20},{"name":"COMMON_SITE_NAME","type":"esriFieldTypeString","alias":"COMMON_SITE_NAME","length":150},{"name":"OTHER_SITE_NAMES","type":"esriFieldTypeString","alias":"OTHER_SITE_NAMES","length":600},{"name":"PARCEL_DESCRIPTION","type":"esriFieldTypeString","alias":"PARCEL_DESCRIPTION","length":100},{"name":"STREET_NUMBER","type":"esriFieldTypeString","alias":"STREET_NUMBER","length":10},{"name":"STREET_NAME","type":"esriFieldTypeString","alias":"STREET_NAME","length":50},{"name":"LOCALITY","type":"esriFieldTypeString","alias":"LOCALITY","length":50},{"name":"PROVINCE","type":"esriFieldTypeString","alias":"PROVINCE","length":10},{"name":"JURISDICTION_NAMES","type":"esriFieldTypeString","alias":"JURISDICTION_NAMES","length":1400},{"name":"RECOGNITION_GOVERNMENT","type":"esriFieldTypeString","alias":"RECOGNITION_GOVERNMENT","length":65},{"name":"RECOGNITION_GOVERNMENT_LEVEL","type":"esriFieldTypeString","alias":"RECOGNITION_GOVERNMENT_LEVEL","length":30},{"name":"RECOGNITION_TYPE","type":"esriFieldTypeString","alias":"RECOGNITION_TYPE","length":40},{"name":"RECOGNITION_START_DATE","type":"esriFieldTypeDate","alias":"RECOGNITION_START_DATE","length":8},{"name":"CONSTRUCTION_YEAR","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR","length":10},{"name":"CONSTRUCTION_YEAR_QUALIFIER","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR_QUALIFIER","length":10},{"name":"CONSTRUCTION_YEAR_DATETTYPE","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR_DATETTYPE","length":20},{"name":"STMT_OF_SIGNIFICANCE_DESC","type":"esriFieldTypeString","alias":"STMT_OF_SIGNIFICANCE_DESC","length":4000},{"name":"CRHP_IND","type":"esriFieldTypeString","alias":"CRHP_IND","length":1},{"name":"ARCHITECT_NAMES","type":"esriFieldTypeString","alias":"ARCHITECT_NAMES","length":300},{"name":"BUILDER_NAMES","type":"esriFieldTypeString","alias":"BUILDER_NAMES","length":300},{"name":"CURRENT_FUNCTIONAL_CATEGORIES","type":"esriFieldTypeString","alias":"CURRENT_FUNCTIONAL_CATEGORIES","length":500},{"name":"HISTORIC_FUNCTIONAL_CATEGORIES","type":"esriFieldTypeString","alias":"HISTORIC_FUNCTIONAL_CATEGORIES","length":500},{"name":"AREA_HECTARES","type":"esriFieldTypeDouble","alias":"AREA_HECTARES"},{"name":"FEATURE_AREA_SQM","type":"esriFieldTypeDouble","alias":"FEATURE_AREA_SQM"},{"name":"FEATURE_LENGTH_M","type":"esriFieldTypeDouble","alias":"FEATURE_LENGTH_M"},{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID"},{"name":"SHAPE.AREA","type":"esriFieldTypeDouble","alias":"SHAPE.AREA"},{"name":"SHAPE.LEN","type":"esriFieldTypeDouble","alias":"SHAPE.LEN"}],"features":[]}'
+  recorded_at: Tue, 13 Feb 2024 00:49:18 GMT
+- request:
+    method: get
+    uri: "<GEO_LTSA_PARCELMAP_REST_URL>/whse/bcgw_pub_whse_cadastre/MapServer/0/query?f=json&outFields=PID&returnCountOnly=false&returnGeometry=true&returnIdsOnly=false&spatialRel=esriSpatialRelIntersects&where=PID%3D%27005706297%27"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      date:
+      - Tue, 13 Feb 2024 00:49:18 GMT
+      server:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+      vary:
+      - Origin
+      cache-control:
+      - max-age=0,must-revalidate
+      etag:
+      - 642aa8df
+      x-esri-ftiles-cache-compress:
+      - 'true'
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=UTF-8
+      content-length:
+      - '313'
+      access-control-allow-origin:
+      - "(null)"
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-methods:
+      - POST, GET, OPTIONS, HEAD
+      access-control-allow-headers:
+      - X-Requested-With, Referer, Origin, Content-Type, SOAPAction, Authorization,
+        Accept
+      access-control-max-age:
+      - '1000'
+      x-frame-options:
+      - allow-from (null)
+    body:
+      encoding: UTF-8
+      string: '{"displayFieldName":"PARCEL_NAME","fieldAliases":{"PID":"PID"},"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":102190,"latestWkid":3005},"fields":[{"name":"PID","type":"esriFieldTypeString","alias":"PID","length":9}],"features":[{"attributes":{"PID":"005706297"},"geometry":{"rings":[[[1467479.7934000008,562712.94749999978],[1467495.0843000002,562714.2918999996],[1467498.7279000003,562672.70409999974],[1467483.4252000004,562671.36370000057],[1467479.7934000008,562712.94749999978]]]}}]}'
+  recorded_at: Tue, 13 Feb 2024 00:49:19 GMT
+- request:
+    method: get
+    uri: "<GEO_LTSA_PARCELMAP_REST_URL>/whse/bcgw_pub_whse_human_cultural_economic/MapServer/1/query?f=json&geometry=%7B%22rings%22%3A%5B%5B%5B1467479.7934000008%2C562712.9474999998%5D%2C%5B1467495.0843000002%2C562714.2918999996%5D%2C%5B1467498.7279000003%2C562672.7040999997%5D%2C%5B1467483.4252000004%2C562671.3637000006%5D%2C%5B1467479.7934000008%2C562712.9474999998%5D%5D%5D%7D&geometryType=esriGeometryPolygon&outFields=%2A&returnGeometry=true&spatialRel=esriSpatialRelIntersects&where=HISTORIC_SITE_IND%3D%27Y%27"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      date:
+      - Tue, 13 Feb 2024 00:49:18 GMT
+      server:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+      vary:
+      - Origin
+      cache-control:
+      - max-age=0,must-revalidate
+      etag:
+      - c9dff614
+      x-esri-ftiles-cache-compress:
+      - 'true'
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=UTF-8
+      content-length:
+      - '1486'
+      access-control-allow-origin:
+      - "(null)"
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-methods:
+      - POST, GET, OPTIONS, HEAD
+      access-control-allow-headers:
+      - X-Requested-With, Referer, Origin, Content-Type, SOAPAction, Authorization,
+        Accept
+      access-control-max-age:
+      - '1000'
+      x-frame-options:
+      - allow-from (null)
+    body:
+      encoding: UTF-8
+      string: '{"displayFieldName":"COMMON_SITE_NAME","fieldAliases":{"HISTORIC_ENVIRONMENT_ID":"HISTORIC_ENVIRONMENT_ID","HISTORIC_ENVIRONMENT_SITE_ID":"HISTORIC_ENVIRONMENT_SITE_ID","BORDENNUMBER":"BORDENNUMBER","HISTORIC_SITE_IND":"HISTORIC_SITE_IND","REGISTRATION_STATUS":"REGISTRATION_STATUS","COMMON_SITE_NAME":"COMMON_SITE_NAME","OTHER_SITE_NAMES":"OTHER_SITE_NAMES","PARCEL_DESCRIPTION":"PARCEL_DESCRIPTION","STREET_NUMBER":"STREET_NUMBER","STREET_NAME":"STREET_NAME","LOCALITY":"LOCALITY","PROVINCE":"PROVINCE","JURISDICTION_NAMES":"JURISDICTION_NAMES","RECOGNITION_GOVERNMENT":"RECOGNITION_GOVERNMENT","RECOGNITION_GOVERNMENT_LEVEL":"RECOGNITION_GOVERNMENT_LEVEL","RECOGNITION_TYPE":"RECOGNITION_TYPE","RECOGNITION_START_DATE":"RECOGNITION_START_DATE","CONSTRUCTION_YEAR":"CONSTRUCTION_YEAR","CONSTRUCTION_YEAR_QUALIFIER":"CONSTRUCTION_YEAR_QUALIFIER","CONSTRUCTION_YEAR_DATETTYPE":"CONSTRUCTION_YEAR_DATETTYPE","STMT_OF_SIGNIFICANCE_DESC":"STMT_OF_SIGNIFICANCE_DESC","CRHP_IND":"CRHP_IND","ARCHITECT_NAMES":"ARCHITECT_NAMES","BUILDER_NAMES":"BUILDER_NAMES","CURRENT_FUNCTIONAL_CATEGORIES":"CURRENT_FUNCTIONAL_CATEGORIES","HISTORIC_FUNCTIONAL_CATEGORIES":"HISTORIC_FUNCTIONAL_CATEGORIES","AREA_HECTARES":"AREA_HECTARES","FEATURE_AREA_SQM":"FEATURE_AREA_SQM","FEATURE_LENGTH_M":"FEATURE_LENGTH_M","OBJECTID":"OBJECTID","SHAPE.AREA":"SHAPE.AREA","SHAPE.LEN":"SHAPE.LEN"},"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":102190,"latestWkid":3005},"fields":[{"name":"HISTORIC_ENVIRONMENT_ID","type":"esriFieldTypeInteger","alias":"HISTORIC_ENVIRONMENT_ID"},{"name":"HISTORIC_ENVIRONMENT_SITE_ID","type":"esriFieldTypeInteger","alias":"HISTORIC_ENVIRONMENT_SITE_ID"},{"name":"BORDENNUMBER","type":"esriFieldTypeString","alias":"BORDENNUMBER","length":13},{"name":"HISTORIC_SITE_IND","type":"esriFieldTypeString","alias":"HISTORIC_SITE_IND","length":1},{"name":"REGISTRATION_STATUS","type":"esriFieldTypeString","alias":"REGISTRATION_STATUS","length":20},{"name":"COMMON_SITE_NAME","type":"esriFieldTypeString","alias":"COMMON_SITE_NAME","length":150},{"name":"OTHER_SITE_NAMES","type":"esriFieldTypeString","alias":"OTHER_SITE_NAMES","length":600},{"name":"PARCEL_DESCRIPTION","type":"esriFieldTypeString","alias":"PARCEL_DESCRIPTION","length":100},{"name":"STREET_NUMBER","type":"esriFieldTypeString","alias":"STREET_NUMBER","length":10},{"name":"STREET_NAME","type":"esriFieldTypeString","alias":"STREET_NAME","length":50},{"name":"LOCALITY","type":"esriFieldTypeString","alias":"LOCALITY","length":50},{"name":"PROVINCE","type":"esriFieldTypeString","alias":"PROVINCE","length":10},{"name":"JURISDICTION_NAMES","type":"esriFieldTypeString","alias":"JURISDICTION_NAMES","length":1400},{"name":"RECOGNITION_GOVERNMENT","type":"esriFieldTypeString","alias":"RECOGNITION_GOVERNMENT","length":65},{"name":"RECOGNITION_GOVERNMENT_LEVEL","type":"esriFieldTypeString","alias":"RECOGNITION_GOVERNMENT_LEVEL","length":30},{"name":"RECOGNITION_TYPE","type":"esriFieldTypeString","alias":"RECOGNITION_TYPE","length":40},{"name":"RECOGNITION_START_DATE","type":"esriFieldTypeDate","alias":"RECOGNITION_START_DATE","length":8},{"name":"CONSTRUCTION_YEAR","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR","length":10},{"name":"CONSTRUCTION_YEAR_QUALIFIER","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR_QUALIFIER","length":10},{"name":"CONSTRUCTION_YEAR_DATETTYPE","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR_DATETTYPE","length":20},{"name":"STMT_OF_SIGNIFICANCE_DESC","type":"esriFieldTypeString","alias":"STMT_OF_SIGNIFICANCE_DESC","length":4000},{"name":"CRHP_IND","type":"esriFieldTypeString","alias":"CRHP_IND","length":1},{"name":"ARCHITECT_NAMES","type":"esriFieldTypeString","alias":"ARCHITECT_NAMES","length":300},{"name":"BUILDER_NAMES","type":"esriFieldTypeString","alias":"BUILDER_NAMES","length":300},{"name":"CURRENT_FUNCTIONAL_CATEGORIES","type":"esriFieldTypeString","alias":"CURRENT_FUNCTIONAL_CATEGORIES","length":500},{"name":"HISTORIC_FUNCTIONAL_CATEGORIES","type":"esriFieldTypeString","alias":"HISTORIC_FUNCTIONAL_CATEGORIES","length":500},{"name":"AREA_HECTARES","type":"esriFieldTypeDouble","alias":"AREA_HECTARES"},{"name":"FEATURE_AREA_SQM","type":"esriFieldTypeDouble","alias":"FEATURE_AREA_SQM"},{"name":"FEATURE_LENGTH_M","type":"esriFieldTypeDouble","alias":"FEATURE_LENGTH_M"},{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID"},{"name":"SHAPE.AREA","type":"esriFieldTypeDouble","alias":"SHAPE.AREA"},{"name":"SHAPE.LEN","type":"esriFieldTypeDouble","alias":"SHAPE.LEN"}],"features":[{"attributes":{"HISTORIC_ENVIRONMENT_ID":151973,"HISTORIC_ENVIRONMENT_SITE_ID":8,"BORDENNUMBER":"DlQu-49","HISTORIC_SITE_IND":"Y","REGISTRATION_STATUS":"Registered","COMMON_SITE_NAME":"
+        770 Bernard Avenue\r\n  \r\n","OTHER_SITE_NAMES":"W.D. Harvey House","PARCEL_DESCRIPTION":null,"STREET_NUMBER":"770","STREET_NAME":"Bernard
+        Avenue","LOCALITY":"Kelowna","PROVINCE":"BC","JURISDICTION_NAMES":"GIS Municipalities:
+        Kelowna; GIS RegionalDistrict: Central Okanagan","RECOGNITION_GOVERNMENT":"Kelowna","RECOGNITION_GOVERNMENT_LEVEL":"Municipal","RECOGNITION_TYPE":"Heritage
+        Revitalization Agreement","RECOGNITION_START_DATE":1089676800000,"CONSTRUCTION_YEAR":"1907","CONSTRUCTION_YEAR_QUALIFIER":"Circa","CONSTRUCTION_YEAR_DATETTYPE":"Construction","STMT_OF_SIGNIFICANCE_DESC":"Local
+        Government: The historic place is the two-storey stucco-clad house, built
+        in 1907, set on a mature landscaped lot at 770 Bernard Avenue in Kelowna''s
+        historic North Central neighbourhood. \r\n  \r\n","CRHP_IND":"Y","ARCHITECT_NAMES":null,"BUILDER_NAMES":"F.R.E.
+        DeHart   ","CURRENT_FUNCTIONAL_CATEGORIES":"Residence","HISTORIC_FUNCTIONAL_CATEGORIES":"Residence","AREA_HECTARES":0.06414,"FEATURE_AREA_SQM":641.3997,"FEATURE_LENGTH_M":114.2314,"OBJECTID":11006900,"SHAPE.AREA":0,"SHAPE.LEN":0},"geometry":{"rings":[[[1467483.4260000009,562671.3629999999],[1467479.7799999993,562712.95800000057],[1467495.0830000006,562714.30000000075],[1467498.7280000001,562672.70500000007],[1467483.4260000009,562671.3629999999]]]}}]}'
+  recorded_at: Tue, 13 Feb 2024 00:49:19 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/automated_compliance/historic_site/matched_by_legal.yml
+++ b/spec/vcr_cassettes/automated_compliance/historic_site/matched_by_legal.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<GEO_LTSA_PARCELMAP_REST_URL>/whse/bcgw_pub_whse_human_cultural_economic/MapServer/1/query?f=json&outFields=%2A&returnGeometry=true&where=HISTORIC_SITE_IND%3D%27Y%27+AND+PARCEL_DESCRIPTION%3D%27000561444%27"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      date:
+      - Tue, 13 Feb 2024 00:46:54 GMT
+      server:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+      vary:
+      - Origin
+      cache-control:
+      - max-age=0,must-revalidate
+      etag:
+      - '46813049'
+      x-esri-ftiles-cache-compress:
+      - 'true'
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=UTF-8
+      content-length:
+      - '1527'
+      access-control-allow-origin:
+      - "(null)"
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-methods:
+      - POST, GET, OPTIONS, HEAD
+      access-control-allow-headers:
+      - X-Requested-With, Referer, Origin, Content-Type, SOAPAction, Authorization,
+        Accept
+      access-control-max-age:
+      - '1000'
+      x-frame-options:
+      - allow-from (null)
+    body:
+      encoding: UTF-8
+      string: '{"displayFieldName":"COMMON_SITE_NAME","fieldAliases":{"HISTORIC_ENVIRONMENT_ID":"HISTORIC_ENVIRONMENT_ID","HISTORIC_ENVIRONMENT_SITE_ID":"HISTORIC_ENVIRONMENT_SITE_ID","BORDENNUMBER":"BORDENNUMBER","HISTORIC_SITE_IND":"HISTORIC_SITE_IND","REGISTRATION_STATUS":"REGISTRATION_STATUS","COMMON_SITE_NAME":"COMMON_SITE_NAME","OTHER_SITE_NAMES":"OTHER_SITE_NAMES","PARCEL_DESCRIPTION":"PARCEL_DESCRIPTION","STREET_NUMBER":"STREET_NUMBER","STREET_NAME":"STREET_NAME","LOCALITY":"LOCALITY","PROVINCE":"PROVINCE","JURISDICTION_NAMES":"JURISDICTION_NAMES","RECOGNITION_GOVERNMENT":"RECOGNITION_GOVERNMENT","RECOGNITION_GOVERNMENT_LEVEL":"RECOGNITION_GOVERNMENT_LEVEL","RECOGNITION_TYPE":"RECOGNITION_TYPE","RECOGNITION_START_DATE":"RECOGNITION_START_DATE","CONSTRUCTION_YEAR":"CONSTRUCTION_YEAR","CONSTRUCTION_YEAR_QUALIFIER":"CONSTRUCTION_YEAR_QUALIFIER","CONSTRUCTION_YEAR_DATETTYPE":"CONSTRUCTION_YEAR_DATETTYPE","STMT_OF_SIGNIFICANCE_DESC":"STMT_OF_SIGNIFICANCE_DESC","CRHP_IND":"CRHP_IND","ARCHITECT_NAMES":"ARCHITECT_NAMES","BUILDER_NAMES":"BUILDER_NAMES","CURRENT_FUNCTIONAL_CATEGORIES":"CURRENT_FUNCTIONAL_CATEGORIES","HISTORIC_FUNCTIONAL_CATEGORIES":"HISTORIC_FUNCTIONAL_CATEGORIES","AREA_HECTARES":"AREA_HECTARES","FEATURE_AREA_SQM":"FEATURE_AREA_SQM","FEATURE_LENGTH_M":"FEATURE_LENGTH_M","OBJECTID":"OBJECTID","SHAPE.AREA":"SHAPE.AREA","SHAPE.LEN":"SHAPE.LEN"},"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":102190,"latestWkid":3005},"fields":[{"name":"HISTORIC_ENVIRONMENT_ID","type":"esriFieldTypeInteger","alias":"HISTORIC_ENVIRONMENT_ID"},{"name":"HISTORIC_ENVIRONMENT_SITE_ID","type":"esriFieldTypeInteger","alias":"HISTORIC_ENVIRONMENT_SITE_ID"},{"name":"BORDENNUMBER","type":"esriFieldTypeString","alias":"BORDENNUMBER","length":13},{"name":"HISTORIC_SITE_IND","type":"esriFieldTypeString","alias":"HISTORIC_SITE_IND","length":1},{"name":"REGISTRATION_STATUS","type":"esriFieldTypeString","alias":"REGISTRATION_STATUS","length":20},{"name":"COMMON_SITE_NAME","type":"esriFieldTypeString","alias":"COMMON_SITE_NAME","length":150},{"name":"OTHER_SITE_NAMES","type":"esriFieldTypeString","alias":"OTHER_SITE_NAMES","length":600},{"name":"PARCEL_DESCRIPTION","type":"esriFieldTypeString","alias":"PARCEL_DESCRIPTION","length":100},{"name":"STREET_NUMBER","type":"esriFieldTypeString","alias":"STREET_NUMBER","length":10},{"name":"STREET_NAME","type":"esriFieldTypeString","alias":"STREET_NAME","length":50},{"name":"LOCALITY","type":"esriFieldTypeString","alias":"LOCALITY","length":50},{"name":"PROVINCE","type":"esriFieldTypeString","alias":"PROVINCE","length":10},{"name":"JURISDICTION_NAMES","type":"esriFieldTypeString","alias":"JURISDICTION_NAMES","length":1400},{"name":"RECOGNITION_GOVERNMENT","type":"esriFieldTypeString","alias":"RECOGNITION_GOVERNMENT","length":65},{"name":"RECOGNITION_GOVERNMENT_LEVEL","type":"esriFieldTypeString","alias":"RECOGNITION_GOVERNMENT_LEVEL","length":30},{"name":"RECOGNITION_TYPE","type":"esriFieldTypeString","alias":"RECOGNITION_TYPE","length":40},{"name":"RECOGNITION_START_DATE","type":"esriFieldTypeDate","alias":"RECOGNITION_START_DATE","length":8},{"name":"CONSTRUCTION_YEAR","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR","length":10},{"name":"CONSTRUCTION_YEAR_QUALIFIER","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR_QUALIFIER","length":10},{"name":"CONSTRUCTION_YEAR_DATETTYPE","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR_DATETTYPE","length":20},{"name":"STMT_OF_SIGNIFICANCE_DESC","type":"esriFieldTypeString","alias":"STMT_OF_SIGNIFICANCE_DESC","length":4000},{"name":"CRHP_IND","type":"esriFieldTypeString","alias":"CRHP_IND","length":1},{"name":"ARCHITECT_NAMES","type":"esriFieldTypeString","alias":"ARCHITECT_NAMES","length":300},{"name":"BUILDER_NAMES","type":"esriFieldTypeString","alias":"BUILDER_NAMES","length":300},{"name":"CURRENT_FUNCTIONAL_CATEGORIES","type":"esriFieldTypeString","alias":"CURRENT_FUNCTIONAL_CATEGORIES","length":500},{"name":"HISTORIC_FUNCTIONAL_CATEGORIES","type":"esriFieldTypeString","alias":"HISTORIC_FUNCTIONAL_CATEGORIES","length":500},{"name":"AREA_HECTARES","type":"esriFieldTypeDouble","alias":"AREA_HECTARES"},{"name":"FEATURE_AREA_SQM","type":"esriFieldTypeDouble","alias":"FEATURE_AREA_SQM"},{"name":"FEATURE_LENGTH_M","type":"esriFieldTypeDouble","alias":"FEATURE_LENGTH_M"},{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID"},{"name":"SHAPE.AREA","type":"esriFieldTypeDouble","alias":"SHAPE.AREA"},{"name":"SHAPE.LEN","type":"esriFieldTypeDouble","alias":"SHAPE.LEN"}],"features":[{"attributes":{"HISTORIC_ENVIRONMENT_ID":138851,"HISTORIC_ENVIRONMENT_SITE_ID":10,"BORDENNUMBER":"DcRt-184","HISTORIC_SITE_IND":"Y","REGISTRATION_STATUS":"Registered","COMMON_SITE_NAME":"Johnston
+        House","OTHER_SITE_NAMES":"Mrs. H.L. Johnston House","PARCEL_DESCRIPTION":"000561444","STREET_NUMBER":"1275","STREET_NAME":"St.
+        David Street","LOCALITY":"Oak Bay","PROVINCE":"BC","JURISDICTION_NAMES":"GIS
+        Municipalities: Oak Bay; GIS RegionalDistrict: Capital","RECOGNITION_GOVERNMENT":"Oak
+        Bay","RECOGNITION_GOVERNMENT_LEVEL":"Municipal","RECOGNITION_TYPE":"Community
+        Heritage Register","RECOGNITION_START_DATE":1112054400000,"CONSTRUCTION_YEAR":"1922","CONSTRUCTION_YEAR_QUALIFIER":"Circa","CONSTRUCTION_YEAR_DATETTYPE":"Construction","STMT_OF_SIGNIFICANCE_DESC":"Local
+        Government: Situated on a well treed corner lot, the Johnston House is a front-gabled,
+        1 1/2 story, Craftsman style building in the Marina area.  It has a front
+        gable roof with two dormers, a wide front porch supported by four pillars,
+        and a full basement.","CRHP_IND":"Y","ARCHITECT_NAMES":"H.L. Johnston","BUILDER_NAMES":null,"CURRENT_FUNCTIONAL_CATEGORIES":"Residence","HISTORIC_FUNCTIONAL_CATEGORIES":"Residence","AREA_HECTARES":0.09765,"FEATURE_AREA_SQM":976.4696,"FEATURE_LENGTH_M":132.7035,"OBJECTID":11006902,"SHAPE.AREA":0,"SHAPE.LEN":0},"geometry":{"rings":[[[1199446.2149999999,382471.54399999976],[1199445.4619999994,382493.53099999949],[1199489.7799999993,382495.07100000046],[1199490.5010000002,382473.03500000015],[1199485.8969999999,382472.87099999934],[1199446.2149999999,382471.54399999976]]]}}]}'
+  recorded_at: Tue, 13 Feb 2024 00:46:55 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/automated_compliance/historic_site/unmatched.yml
+++ b/spec/vcr_cassettes/automated_compliance/historic_site/unmatched.yml
@@ -1,0 +1,162 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<GEO_LTSA_PARCELMAP_REST_URL>/whse/bcgw_pub_whse_human_cultural_economic/MapServer/1/query?f=json&outFields=%2A&returnGeometry=true&where=HISTORIC_SITE_IND%3D%27Y%27+AND+PARCEL_DESCRIPTION%3D%27004920414%27"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      date:
+      - Tue, 13 Feb 2024 00:55:20 GMT
+      server:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+      vary:
+      - Origin
+      cache-control:
+      - max-age=0,must-revalidate
+      etag:
+      - db4a24e1
+      x-esri-ftiles-cache-compress:
+      - 'true'
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=UTF-8
+      content-length:
+      - '935'
+      access-control-allow-origin:
+      - "(null)"
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-methods:
+      - POST, GET, OPTIONS, HEAD
+      access-control-allow-headers:
+      - X-Requested-With, Referer, Origin, Content-Type, SOAPAction, Authorization,
+        Accept
+      access-control-max-age:
+      - '1000'
+      x-frame-options:
+      - allow-from (null)
+    body:
+      encoding: UTF-8
+      string: '{"displayFieldName":"COMMON_SITE_NAME","fieldAliases":{"HISTORIC_ENVIRONMENT_ID":"HISTORIC_ENVIRONMENT_ID","HISTORIC_ENVIRONMENT_SITE_ID":"HISTORIC_ENVIRONMENT_SITE_ID","BORDENNUMBER":"BORDENNUMBER","HISTORIC_SITE_IND":"HISTORIC_SITE_IND","REGISTRATION_STATUS":"REGISTRATION_STATUS","COMMON_SITE_NAME":"COMMON_SITE_NAME","OTHER_SITE_NAMES":"OTHER_SITE_NAMES","PARCEL_DESCRIPTION":"PARCEL_DESCRIPTION","STREET_NUMBER":"STREET_NUMBER","STREET_NAME":"STREET_NAME","LOCALITY":"LOCALITY","PROVINCE":"PROVINCE","JURISDICTION_NAMES":"JURISDICTION_NAMES","RECOGNITION_GOVERNMENT":"RECOGNITION_GOVERNMENT","RECOGNITION_GOVERNMENT_LEVEL":"RECOGNITION_GOVERNMENT_LEVEL","RECOGNITION_TYPE":"RECOGNITION_TYPE","RECOGNITION_START_DATE":"RECOGNITION_START_DATE","CONSTRUCTION_YEAR":"CONSTRUCTION_YEAR","CONSTRUCTION_YEAR_QUALIFIER":"CONSTRUCTION_YEAR_QUALIFIER","CONSTRUCTION_YEAR_DATETTYPE":"CONSTRUCTION_YEAR_DATETTYPE","STMT_OF_SIGNIFICANCE_DESC":"STMT_OF_SIGNIFICANCE_DESC","CRHP_IND":"CRHP_IND","ARCHITECT_NAMES":"ARCHITECT_NAMES","BUILDER_NAMES":"BUILDER_NAMES","CURRENT_FUNCTIONAL_CATEGORIES":"CURRENT_FUNCTIONAL_CATEGORIES","HISTORIC_FUNCTIONAL_CATEGORIES":"HISTORIC_FUNCTIONAL_CATEGORIES","AREA_HECTARES":"AREA_HECTARES","FEATURE_AREA_SQM":"FEATURE_AREA_SQM","FEATURE_LENGTH_M":"FEATURE_LENGTH_M","OBJECTID":"OBJECTID","SHAPE.AREA":"SHAPE.AREA","SHAPE.LEN":"SHAPE.LEN"},"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":102190,"latestWkid":3005},"fields":[{"name":"HISTORIC_ENVIRONMENT_ID","type":"esriFieldTypeInteger","alias":"HISTORIC_ENVIRONMENT_ID"},{"name":"HISTORIC_ENVIRONMENT_SITE_ID","type":"esriFieldTypeInteger","alias":"HISTORIC_ENVIRONMENT_SITE_ID"},{"name":"BORDENNUMBER","type":"esriFieldTypeString","alias":"BORDENNUMBER","length":13},{"name":"HISTORIC_SITE_IND","type":"esriFieldTypeString","alias":"HISTORIC_SITE_IND","length":1},{"name":"REGISTRATION_STATUS","type":"esriFieldTypeString","alias":"REGISTRATION_STATUS","length":20},{"name":"COMMON_SITE_NAME","type":"esriFieldTypeString","alias":"COMMON_SITE_NAME","length":150},{"name":"OTHER_SITE_NAMES","type":"esriFieldTypeString","alias":"OTHER_SITE_NAMES","length":600},{"name":"PARCEL_DESCRIPTION","type":"esriFieldTypeString","alias":"PARCEL_DESCRIPTION","length":100},{"name":"STREET_NUMBER","type":"esriFieldTypeString","alias":"STREET_NUMBER","length":10},{"name":"STREET_NAME","type":"esriFieldTypeString","alias":"STREET_NAME","length":50},{"name":"LOCALITY","type":"esriFieldTypeString","alias":"LOCALITY","length":50},{"name":"PROVINCE","type":"esriFieldTypeString","alias":"PROVINCE","length":10},{"name":"JURISDICTION_NAMES","type":"esriFieldTypeString","alias":"JURISDICTION_NAMES","length":1400},{"name":"RECOGNITION_GOVERNMENT","type":"esriFieldTypeString","alias":"RECOGNITION_GOVERNMENT","length":65},{"name":"RECOGNITION_GOVERNMENT_LEVEL","type":"esriFieldTypeString","alias":"RECOGNITION_GOVERNMENT_LEVEL","length":30},{"name":"RECOGNITION_TYPE","type":"esriFieldTypeString","alias":"RECOGNITION_TYPE","length":40},{"name":"RECOGNITION_START_DATE","type":"esriFieldTypeDate","alias":"RECOGNITION_START_DATE","length":8},{"name":"CONSTRUCTION_YEAR","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR","length":10},{"name":"CONSTRUCTION_YEAR_QUALIFIER","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR_QUALIFIER","length":10},{"name":"CONSTRUCTION_YEAR_DATETTYPE","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR_DATETTYPE","length":20},{"name":"STMT_OF_SIGNIFICANCE_DESC","type":"esriFieldTypeString","alias":"STMT_OF_SIGNIFICANCE_DESC","length":4000},{"name":"CRHP_IND","type":"esriFieldTypeString","alias":"CRHP_IND","length":1},{"name":"ARCHITECT_NAMES","type":"esriFieldTypeString","alias":"ARCHITECT_NAMES","length":300},{"name":"BUILDER_NAMES","type":"esriFieldTypeString","alias":"BUILDER_NAMES","length":300},{"name":"CURRENT_FUNCTIONAL_CATEGORIES","type":"esriFieldTypeString","alias":"CURRENT_FUNCTIONAL_CATEGORIES","length":500},{"name":"HISTORIC_FUNCTIONAL_CATEGORIES","type":"esriFieldTypeString","alias":"HISTORIC_FUNCTIONAL_CATEGORIES","length":500},{"name":"AREA_HECTARES","type":"esriFieldTypeDouble","alias":"AREA_HECTARES"},{"name":"FEATURE_AREA_SQM","type":"esriFieldTypeDouble","alias":"FEATURE_AREA_SQM"},{"name":"FEATURE_LENGTH_M","type":"esriFieldTypeDouble","alias":"FEATURE_LENGTH_M"},{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID"},{"name":"SHAPE.AREA","type":"esriFieldTypeDouble","alias":"SHAPE.AREA"},{"name":"SHAPE.LEN","type":"esriFieldTypeDouble","alias":"SHAPE.LEN"}],"features":[]}'
+  recorded_at: Tue, 13 Feb 2024 00:55:20 GMT
+- request:
+    method: get
+    uri: "<GEO_LTSA_PARCELMAP_REST_URL>/whse/bcgw_pub_whse_cadastre/MapServer/0/query?f=json&outFields=PID&returnCountOnly=false&returnGeometry=true&returnIdsOnly=false&spatialRel=esriSpatialRelIntersects&where=PID%3D%27004920414%27"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      date:
+      - Tue, 13 Feb 2024 00:55:20 GMT
+      server:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+      vary:
+      - Origin
+      cache-control:
+      - max-age=0,must-revalidate
+      etag:
+      - 8f1ced7
+      x-esri-ftiles-cache-compress:
+      - 'true'
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=UTF-8
+      content-length:
+      - '506'
+      access-control-allow-origin:
+      - "(null)"
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-methods:
+      - POST, GET, OPTIONS, HEAD
+      access-control-allow-headers:
+      - X-Requested-With, Referer, Origin, Content-Type, SOAPAction, Authorization,
+        Accept
+      access-control-max-age:
+      - '1000'
+      x-frame-options:
+      - allow-from (null)
+    body:
+      encoding: UTF-8
+      string: '{"displayFieldName":"PARCEL_NAME","fieldAliases":{"PID":"PID"},"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":102190,"latestWkid":3005},"fields":[{"name":"PID","type":"esriFieldTypeString","alias":"PID","length":9}],"features":[{"attributes":{"PID":"004920414"},"geometry":{"rings":[[[1209646.6718000006,478712.6707000006],[1209657.1593999993,478724.16860000044],[1209660.7565000001,478720.8694000002],[1209670.4297000002,478731.4824000001],[1209729.9145999998,478677.30650000088],[1209696.8468999993,478641.31709999964],[1209690.3472000007,478647.05480000004],[1209683.4916999992,478652.36229999922],[1209676.3089000005,478657.21770000085],[1209668.8285000008,478661.60080000013],[1209661.0814999994,478665.49340000004],[1209653.1001999993,478668.87939999998],[1209644.9174000006,478671.74479999952],[1209636.5672999993,478674.07770000026],[1209628.0843000002,478675.86840000004],[1209611.5759999994,478678.76170000061],[1209644.4203999992,478714.71629999951],[1209646.6718000006,478712.6707000006]]]}}]}'
+  recorded_at: Tue, 13 Feb 2024 00:55:20 GMT
+- request:
+    method: get
+    uri: "<GEO_LTSA_PARCELMAP_REST_URL>/whse/bcgw_pub_whse_human_cultural_economic/MapServer/1/query?f=json&geometry=%7B%22rings%22%3A%5B%5B%5B1209646.6718000006%2C478712.6707000006%5D%2C%5B1209657.1593999993%2C478724.16860000044%5D%2C%5B1209660.7565000001%2C478720.8694000002%5D%2C%5B1209670.4297000002%2C478731.4824000001%5D%2C%5B1209729.9145999998%2C478677.3065000009%5D%2C%5B1209696.8468999993%2C478641.31709999964%5D%2C%5B1209690.3472000007%2C478647.05480000004%5D%2C%5B1209683.4916999992%2C478652.3622999992%5D%2C%5B1209676.3089000005%2C478657.21770000085%5D%2C%5B1209668.8285000008%2C478661.60080000013%5D%2C%5B1209661.0814999994%2C478665.49340000004%5D%2C%5B1209653.1001999993%2C478668.8794%5D%2C%5B1209644.9174000006%2C478671.7447999995%5D%2C%5B1209636.5672999993%2C478674.07770000026%5D%2C%5B1209628.0843000002%2C478675.86840000004%5D%2C%5B1209611.5759999994%2C478678.7617000006%5D%2C%5B1209644.4203999992%2C478714.7162999995%5D%2C%5B1209646.6718000006%2C478712.6707000006%5D%5D%5D%7D&geometryType=esriGeometryPolygon&outFields=%2A&returnGeometry=true&spatialRel=esriSpatialRelIntersects&where=HISTORIC_SITE_IND%3D%27Y%27"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.9.0
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      date:
+      - Tue, 13 Feb 2024 00:55:20 GMT
+      server:
+      - ''
+      x-content-type-options:
+      - nosniff
+      x-xss-protection:
+      - 1; mode=block
+      vary:
+      - Origin
+      cache-control:
+      - max-age=0,must-revalidate
+      etag:
+      - db4a24e1
+      x-esri-ftiles-cache-compress:
+      - 'true'
+      content-encoding:
+      - gzip
+      content-type:
+      - application/json;charset=UTF-8
+      content-length:
+      - '935'
+      access-control-allow-origin:
+      - "(null)"
+      access-control-allow-credentials:
+      - 'true'
+      access-control-allow-methods:
+      - POST, GET, OPTIONS, HEAD
+      access-control-allow-headers:
+      - X-Requested-With, Referer, Origin, Content-Type, SOAPAction, Authorization,
+        Accept
+      access-control-max-age:
+      - '1000'
+      x-frame-options:
+      - allow-from (null)
+    body:
+      encoding: UTF-8
+      string: '{"displayFieldName":"COMMON_SITE_NAME","fieldAliases":{"HISTORIC_ENVIRONMENT_ID":"HISTORIC_ENVIRONMENT_ID","HISTORIC_ENVIRONMENT_SITE_ID":"HISTORIC_ENVIRONMENT_SITE_ID","BORDENNUMBER":"BORDENNUMBER","HISTORIC_SITE_IND":"HISTORIC_SITE_IND","REGISTRATION_STATUS":"REGISTRATION_STATUS","COMMON_SITE_NAME":"COMMON_SITE_NAME","OTHER_SITE_NAMES":"OTHER_SITE_NAMES","PARCEL_DESCRIPTION":"PARCEL_DESCRIPTION","STREET_NUMBER":"STREET_NUMBER","STREET_NAME":"STREET_NAME","LOCALITY":"LOCALITY","PROVINCE":"PROVINCE","JURISDICTION_NAMES":"JURISDICTION_NAMES","RECOGNITION_GOVERNMENT":"RECOGNITION_GOVERNMENT","RECOGNITION_GOVERNMENT_LEVEL":"RECOGNITION_GOVERNMENT_LEVEL","RECOGNITION_TYPE":"RECOGNITION_TYPE","RECOGNITION_START_DATE":"RECOGNITION_START_DATE","CONSTRUCTION_YEAR":"CONSTRUCTION_YEAR","CONSTRUCTION_YEAR_QUALIFIER":"CONSTRUCTION_YEAR_QUALIFIER","CONSTRUCTION_YEAR_DATETTYPE":"CONSTRUCTION_YEAR_DATETTYPE","STMT_OF_SIGNIFICANCE_DESC":"STMT_OF_SIGNIFICANCE_DESC","CRHP_IND":"CRHP_IND","ARCHITECT_NAMES":"ARCHITECT_NAMES","BUILDER_NAMES":"BUILDER_NAMES","CURRENT_FUNCTIONAL_CATEGORIES":"CURRENT_FUNCTIONAL_CATEGORIES","HISTORIC_FUNCTIONAL_CATEGORIES":"HISTORIC_FUNCTIONAL_CATEGORIES","AREA_HECTARES":"AREA_HECTARES","FEATURE_AREA_SQM":"FEATURE_AREA_SQM","FEATURE_LENGTH_M":"FEATURE_LENGTH_M","OBJECTID":"OBJECTID","SHAPE.AREA":"SHAPE.AREA","SHAPE.LEN":"SHAPE.LEN"},"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":102190,"latestWkid":3005},"fields":[{"name":"HISTORIC_ENVIRONMENT_ID","type":"esriFieldTypeInteger","alias":"HISTORIC_ENVIRONMENT_ID"},{"name":"HISTORIC_ENVIRONMENT_SITE_ID","type":"esriFieldTypeInteger","alias":"HISTORIC_ENVIRONMENT_SITE_ID"},{"name":"BORDENNUMBER","type":"esriFieldTypeString","alias":"BORDENNUMBER","length":13},{"name":"HISTORIC_SITE_IND","type":"esriFieldTypeString","alias":"HISTORIC_SITE_IND","length":1},{"name":"REGISTRATION_STATUS","type":"esriFieldTypeString","alias":"REGISTRATION_STATUS","length":20},{"name":"COMMON_SITE_NAME","type":"esriFieldTypeString","alias":"COMMON_SITE_NAME","length":150},{"name":"OTHER_SITE_NAMES","type":"esriFieldTypeString","alias":"OTHER_SITE_NAMES","length":600},{"name":"PARCEL_DESCRIPTION","type":"esriFieldTypeString","alias":"PARCEL_DESCRIPTION","length":100},{"name":"STREET_NUMBER","type":"esriFieldTypeString","alias":"STREET_NUMBER","length":10},{"name":"STREET_NAME","type":"esriFieldTypeString","alias":"STREET_NAME","length":50},{"name":"LOCALITY","type":"esriFieldTypeString","alias":"LOCALITY","length":50},{"name":"PROVINCE","type":"esriFieldTypeString","alias":"PROVINCE","length":10},{"name":"JURISDICTION_NAMES","type":"esriFieldTypeString","alias":"JURISDICTION_NAMES","length":1400},{"name":"RECOGNITION_GOVERNMENT","type":"esriFieldTypeString","alias":"RECOGNITION_GOVERNMENT","length":65},{"name":"RECOGNITION_GOVERNMENT_LEVEL","type":"esriFieldTypeString","alias":"RECOGNITION_GOVERNMENT_LEVEL","length":30},{"name":"RECOGNITION_TYPE","type":"esriFieldTypeString","alias":"RECOGNITION_TYPE","length":40},{"name":"RECOGNITION_START_DATE","type":"esriFieldTypeDate","alias":"RECOGNITION_START_DATE","length":8},{"name":"CONSTRUCTION_YEAR","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR","length":10},{"name":"CONSTRUCTION_YEAR_QUALIFIER","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR_QUALIFIER","length":10},{"name":"CONSTRUCTION_YEAR_DATETTYPE","type":"esriFieldTypeString","alias":"CONSTRUCTION_YEAR_DATETTYPE","length":20},{"name":"STMT_OF_SIGNIFICANCE_DESC","type":"esriFieldTypeString","alias":"STMT_OF_SIGNIFICANCE_DESC","length":4000},{"name":"CRHP_IND","type":"esriFieldTypeString","alias":"CRHP_IND","length":1},{"name":"ARCHITECT_NAMES","type":"esriFieldTypeString","alias":"ARCHITECT_NAMES","length":300},{"name":"BUILDER_NAMES","type":"esriFieldTypeString","alias":"BUILDER_NAMES","length":300},{"name":"CURRENT_FUNCTIONAL_CATEGORIES","type":"esriFieldTypeString","alias":"CURRENT_FUNCTIONAL_CATEGORIES","length":500},{"name":"HISTORIC_FUNCTIONAL_CATEGORIES","type":"esriFieldTypeString","alias":"HISTORIC_FUNCTIONAL_CATEGORIES","length":500},{"name":"AREA_HECTARES","type":"esriFieldTypeDouble","alias":"AREA_HECTARES"},{"name":"FEATURE_AREA_SQM","type":"esriFieldTypeDouble","alias":"FEATURE_AREA_SQM"},{"name":"FEATURE_LENGTH_M","type":"esriFieldTypeDouble","alias":"FEATURE_LENGTH_M"},{"name":"OBJECTID","type":"esriFieldTypeOID","alias":"OBJECTID"},{"name":"SHAPE.AREA","type":"esriFieldTypeDouble","alias":"SHAPE.AREA"},{"name":"SHAPE.LEN","type":"esriFieldTypeDouble","alias":"SHAPE.LEN"}],"features":[]}'
+  recorded_at: Tue, 13 Feb 2024 00:55:20 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr_cassettes/automated_compliance/parcel_info_extractor/details.yml
+++ b/spec/vcr_cassettes/automated_compliance/parcel_info_extractor/details.yml
@@ -1,57 +1,58 @@
 ---
 http_interactions:
-- request:
-    method: get
-    uri: "<GEO_LTSA_PARCELMAP_REST_URL>/query?f=json&outFields=PID%2CPARCEL_STATUS%2CPARCEL_NAME%2CPARCEL_CLASS%2COWNER_TYPE%2CMUNICIPALITY%2CREGIONAL_DISTRICT%2CWHEN_UPDATED%2CFEATURE_AREA_SQM&returnCountOnly=false&returnGeometry=true&returnIdsOnly=false&spatialRel=esriSpatialRelIntersects&where=PID%3D%27031562868%27"
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v2.9.0
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      date:
-      - Wed, 07 Feb 2024 08:01:32 GMT
-      server:
-      - ''
-      x-content-type-options:
-      - nosniff
-      x-xss-protection:
-      - 1; mode=block
-      vary:
-      - Origin
-      cache-control:
-      - max-age=0,must-revalidate
-      etag:
-      - d3d4b939
-      x-esri-ftiles-cache-compress:
-      - 'true'
-      content-encoding:
-      - gzip
-      content-type:
-      - application/json;charset=UTF-8
-      content-length:
-      - '651'
-      access-control-allow-origin:
-      - "(null)"
-      access-control-allow-credentials:
-      - 'true'
-      access-control-allow-methods:
-      - POST, GET, OPTIONS, HEAD
-      access-control-allow-headers:
-      - X-Requested-With, Referer, Origin, Content-Type, SOAPAction, Authorization,
-        Accept
-      access-control-max-age:
-      - '1000'
-      x-frame-options:
-      - allow-from (null)
-    body:
-      encoding: UTF-8
-      string: '{"displayFieldName":"PARCEL_NAME","fieldAliases":{"PID":"PID","PARCEL_STATUS":"PARCEL_STATUS","PARCEL_NAME":"PARCEL_NAME","PARCEL_CLASS":"PARCEL_CLASS","OWNER_TYPE":"OWNER_TYPE","MUNICIPALITY":"MUNICIPALITY","REGIONAL_DISTRICT":"REGIONAL_DISTRICT","WHEN_UPDATED":"WHEN_UPDATED","FEATURE_AREA_SQM":"FEATURE_AREA_SQM"},"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":102190,"latestWkid":3005},"fields":[{"name":"PID","type":"esriFieldTypeString","alias":"PID","length":9},{"name":"PARCEL_STATUS","type":"esriFieldTypeString","alias":"PARCEL_STATUS","length":20},{"name":"PARCEL_NAME","type":"esriFieldTypeString","alias":"PARCEL_NAME","length":50},{"name":"PARCEL_CLASS","type":"esriFieldTypeString","alias":"PARCEL_CLASS","length":50},{"name":"OWNER_TYPE","type":"esriFieldTypeString","alias":"OWNER_TYPE","length":50},{"name":"MUNICIPALITY","type":"esriFieldTypeString","alias":"MUNICIPALITY","length":254},{"name":"REGIONAL_DISTRICT","type":"esriFieldTypeString","alias":"REGIONAL_DISTRICT","length":50},{"name":"WHEN_UPDATED","type":"esriFieldTypeDate","alias":"WHEN_UPDATED","length":8},{"name":"FEATURE_AREA_SQM","type":"esriFieldTypeDouble","alias":"FEATURE_AREA_SQM"}],"features":[{"attributes":{"PID":"031562868","PARCEL_STATUS":"Active","PARCEL_NAME":"031562868","PARCEL_CLASS":"Subdivision","OWNER_TYPE":"Federal","MUNICIPALITY":"Vancouver,
-        City of","REGIONAL_DISTRICT":"Metro Vancouver Regional District","WHEN_UPDATED":1657211120000,"FEATURE_AREA_SQM":6244.2759},"geometry":{"rings":[[[1210045.2017000001,478683.38869999908],[1210096.3984999992,478739.42960000038],[1210113.8822000008,478727.88189999945],[1210114.4697999991,478727.49349999987],[1210157.1992000006,478688.5569000002],[1210103.7675000001,478629.99100000039],[1210045.2017000001,478683.38869999908]]]}}]}'
-  recorded_at: Wed, 07 Feb 2024 08:01:32 GMT
+  - request:
+      method: get
+      uri: "<GEO_LTSA_PARCELMAP_REST_URL>/whse/bcgw_pub_whse_cadastre/MapServer/0/query?f=json&outFields=PID%2CPARCEL_STATUS%2CPARCEL_NAME%2CPARCEL_CLASS%2COWNER_TYPE%2CMUNICIPALITY%2CREGIONAL_DISTRICT%2CWHEN_UPDATED%2CFEATURE_AREA_SQM&returnCountOnly=false&returnGeometry=true&returnIdsOnly=false&spatialRel=esriSpatialRelIntersects&where=PID%3D%27031562868%27"
+      body:
+        encoding: US-ASCII
+        string: ""
+      headers:
+        User-Agent:
+          - Faraday v2.9.0
+    response:
+      status:
+        code: 200
+        message: ""
+      headers:
+        date:
+          - Wed, 07 Feb 2024 08:01:32 GMT
+        server:
+          - ""
+        x-content-type-options:
+          - nosniff
+        x-xss-protection:
+          - 1; mode=block
+        vary:
+          - Origin
+        cache-control:
+          - max-age=0,must-revalidate
+        etag:
+          - d3d4b939
+        x-esri-ftiles-cache-compress:
+          - "true"
+        content-encoding:
+          - gzip
+        content-type:
+          - application/json;charset=UTF-8
+        content-length:
+          - "651"
+        access-control-allow-origin:
+          - "(null)"
+        access-control-allow-credentials:
+          - "true"
+        access-control-allow-methods:
+          - POST, GET, OPTIONS, HEAD
+        access-control-allow-headers:
+          - X-Requested-With, Referer, Origin, Content-Type, SOAPAction, Authorization,
+            Accept
+        access-control-max-age:
+          - "1000"
+        x-frame-options:
+          - allow-from (null)
+      body:
+        encoding: UTF-8
+        string:
+          '{"displayFieldName":"PARCEL_NAME","fieldAliases":{"PID":"PID","PARCEL_STATUS":"PARCEL_STATUS","PARCEL_NAME":"PARCEL_NAME","PARCEL_CLASS":"PARCEL_CLASS","OWNER_TYPE":"OWNER_TYPE","MUNICIPALITY":"MUNICIPALITY","REGIONAL_DISTRICT":"REGIONAL_DISTRICT","WHEN_UPDATED":"WHEN_UPDATED","FEATURE_AREA_SQM":"FEATURE_AREA_SQM"},"geometryType":"esriGeometryPolygon","spatialReference":{"wkid":102190,"latestWkid":3005},"fields":[{"name":"PID","type":"esriFieldTypeString","alias":"PID","length":9},{"name":"PARCEL_STATUS","type":"esriFieldTypeString","alias":"PARCEL_STATUS","length":20},{"name":"PARCEL_NAME","type":"esriFieldTypeString","alias":"PARCEL_NAME","length":50},{"name":"PARCEL_CLASS","type":"esriFieldTypeString","alias":"PARCEL_CLASS","length":50},{"name":"OWNER_TYPE","type":"esriFieldTypeString","alias":"OWNER_TYPE","length":50},{"name":"MUNICIPALITY","type":"esriFieldTypeString","alias":"MUNICIPALITY","length":254},{"name":"REGIONAL_DISTRICT","type":"esriFieldTypeString","alias":"REGIONAL_DISTRICT","length":50},{"name":"WHEN_UPDATED","type":"esriFieldTypeDate","alias":"WHEN_UPDATED","length":8},{"name":"FEATURE_AREA_SQM","type":"esriFieldTypeDouble","alias":"FEATURE_AREA_SQM"}],"features":[{"attributes":{"PID":"031562868","PARCEL_STATUS":"Active","PARCEL_NAME":"031562868","PARCEL_CLASS":"Subdivision","OWNER_TYPE":"Federal","MUNICIPALITY":"Vancouver,
+          City of","REGIONAL_DISTRICT":"Metro Vancouver Regional District","WHEN_UPDATED":1657211120000,"FEATURE_AREA_SQM":6244.2759},"geometry":{"rings":[[[1210045.2017000001,478683.38869999908],[1210096.3984999992,478739.42960000038],[1210113.8822000008,478727.88189999945],[1210114.4697999991,478727.49349999987],[1210157.1992000006,478688.5569000002],[1210103.7675000001,478629.99100000039],[1210045.2017000001,478683.38869999908]]]}}]}'
+    recorded_at: Wed, 07 Feb 2024 08:01:32 GMT
 recorded_with: VCR 6.2.0


### PR DESCRIPTION
## Description

This adds the historic site custom compliance.  It will check off something if it is found in the historic site search.  We may may want to separate provincial sites later.

## What type of PR is this? (check all applicable)

- [ x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ x ] ✅ Test

## Related Tickets & Documents

Split off from story https://hous-bssb.atlassian.net/browse/BPHH-177 into
https://hous-bssb.atlassian.net/browse/BPHH-603

## Steps to QA

Test specs pass.
When you run save on the permit application, it should trigger the backend to call the address and return the historic site.  Please read the specs to test sites that are historic.
This also requires customCompliance module "HistoricSite" to be set up on a requirement.

## UI Accessibility Checklist
No front end here.

## General Checklist

- [ x] ✅ Provide tests for your changes where relevant
- [ x] 📝 Use descriptive commit messages
- [ x] 📗 Update any related documentation and include any relevant screenshots
- [ x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state
