### PR TITLE
Refactor shared text form control

### DIFF
--- a/app/frontend/components/domains/authentication/register-screen.tsx
+++ b/app/frontend/components/domains/authentication/register-screen.tsx
@@ -6,8 +6,8 @@ import { useMst } from "../../../setup/root"
 import { BackButton } from "../../shared/buttons/back-button"
 import { CenterContainer } from "../../shared/containers/center-container"
 import { EmailFormControl } from "../../shared/form/email-form-control"
+import { TextFormControl } from "../../shared/form/input-form-control"
 import { PasswordFormControl } from "../../shared/form/password-form-control"
-import { TextFormControl } from "../../shared/form/text-form-control"
 import { UsernameFormControl } from "../../shared/form/username-form-control"
 import { RouterLink } from "../../shared/navigation/router-link"
 
@@ -58,10 +58,10 @@ export const RegisterScreen = ({}: IRegisterScreenProps) => {
               </Flex>
               <Box border="1px solid" borderColor="border.light" padding={6}>
                 <UsernameFormControl validate autoFocus />
-                <EmailFormControl mb={4} validate />
-                <TextFormControl label={t("auth.userFirstNameLabel")} fieldName="firstName" mb={4} required={true} />
-                <TextFormControl label={t("auth.userLastNameLabel")} fieldName="lastName" mb={4} required={true} />
-                <TextFormControl label={t("auth.organizationLabel")} fieldName="organization" mb={4} required={false} />
+                <EmailFormControl mb={4} validate required />
+                <TextFormControl label={t("auth.userFirstNameLabel")} fieldName="firstName" mb={4} required />
+                <TextFormControl label={t("auth.userLastNameLabel")} fieldName="lastName" mb={4} required />
+                <TextFormControl label={t("auth.organizationLabel")} fieldName="organization" mb={4} />
                 <FormControl>
                   <Controller
                     name="certified"

--- a/app/frontend/components/domains/jurisdictions/contacts/contact-grid.tsx
+++ b/app/frontend/components/domains/jurisdictions/contacts/contact-grid.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next"
 import { useMst } from "../../../../setup/root"
 import { IContact } from "../../../../types/types"
 import { EmailFormControl } from "../../../shared/form/email-form-control"
-import { TextFormControl } from "../../../shared/form/text-form-control"
+import { TextFormControl } from "../../../shared/form/input-form-control"
 import { Can } from "../../../shared/user/can"
 
 interface IContactGridProps {
@@ -112,20 +112,16 @@ const ContactFields = ({ index, remove }: IContactFieldsProps) => {
       <Flex justify="flex-end">
         <IconButton variant="tertiary" icon={<X />} aria-label={"remove contact"} onClick={() => remove(index)} />
       </Flex>
-      <TextFormControl label={t("contact.fields.name")} fieldName={`contactsAttributes.${index}.name`} />
-      <TextFormControl label={t("contact.fields.title")} fieldName={`contactsAttributes.${index}.title`} />
-      <TextFormControl label={t("contact.fields.department")} fieldName={`contactsAttributes.${index}.department`} />
-      <EmailFormControl validate fieldName={`contactsAttributes.${index}.email`} required={false} />
+      <TextFormControl label={t("contact.fields.name")} fieldName={`contactsAttributes.${index}.name`} required />
+      <TextFormControl label={t("contact.fields.title")} fieldName={`contactsAttributes.${index}.title`} required />
       <TextFormControl
-        label={t("contact.fields.phoneNumber")}
-        fieldName={`contactsAttributes.${index}.phoneNumber`}
-        required={false}
+        label={t("contact.fields.department")}
+        fieldName={`contactsAttributes.${index}.department`}
+        required
       />
-      <TextFormControl
-        label={t("contact.fields.extension")}
-        fieldName={`contactsAttributes.${index}.extension`}
-        required={false}
-      />
+      <EmailFormControl validate fieldName={`contactsAttributes.${index}.email`} />
+      <TextFormControl label={t("contact.fields.phoneNumber")} fieldName={`contactsAttributes.${index}.phoneNumber`} />
+      <TextFormControl label={t("contact.fields.extension")} fieldName={`contactsAttributes.${index}.extension`} />
     </Flex>
   )
 }

--- a/app/frontend/components/domains/jurisdictions/new-jurisdiction-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/new-jurisdiction-screen.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom"
 import { IJurisdiction } from "../../../models/jurisdiction"
 import { useMst } from "../../../setup/root"
 import { AsyncRadioGroup } from "../../shared/base/inputs/async-radio-group"
-import { TextFormControl } from "../../shared/form/text-form-control"
+import { TextFormControl } from "../../shared/form/input-form-control"
 import { RouterLinkButton } from "../../shared/navigation/router-link-button"
 
 export type TCreateJurisdictionFormData = {
@@ -89,7 +89,7 @@ export const NewJurisdictionScreen = observer(() => {
                       />
                     </Center>
                     <Box w="50%">
-                      <TextFormControl label={t("jurisdiction.new.nameLabel")} fieldName={"name"} />
+                      <TextFormControl label={t("jurisdiction.new.nameLabel")} fieldName={"name"} required />
                     </Box>
                   </Flex>
                 </Flex>

--- a/app/frontend/components/domains/requirement-template/new-requirement-tempate-screen.tsx
+++ b/app/frontend/components/domains/requirement-template/new-requirement-tempate-screen.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from "react-router-dom"
 import { IRequirementTemplate } from "../../../models/requirement-template"
 import { useMst } from "../../../setup/root"
 import { AsyncRadioGroup } from "../../shared/base/inputs/async-radio-group"
-import { TextFormControl } from "../../shared/form/text-form-control"
+import { TextFormControl } from "../../shared/form/input-form-control"
 
 export type TCreateRequirementTemplateFormData = {
   description: string
@@ -72,7 +72,7 @@ export const NewRequirementTemplateScreen = observer(({}: INewRequirementTemplat
             </Flex>
 
             <Flex direction="column" as="section" w="full">
-              <TextFormControl label={t("requirementTemplate.fields.description")} fieldName={"description"} />
+              <TextFormControl label={t("requirementTemplate.fields.description")} fieldName={"description"} required />
               <Text fontSize="sm" color="border.base">
                 {t("requirementTemplate.new.descriptionHelpText")}
               </Text>

--- a/app/frontend/components/domains/users/accept-invitation-screen.tsx
+++ b/app/frontend/components/domains/users/accept-invitation-screen.tsx
@@ -6,8 +6,8 @@ import { useSearchParams } from "react-router-dom"
 import { useQuickSubmit } from "../../../hooks/use-quick-submit"
 import { useMst } from "../../../setup/root"
 import { CenterContainer } from "../../shared/containers/center-container"
+import { TextFormControl } from "../../shared/form/input-form-control"
 import { PasswordFormControl } from "../../shared/form/password-form-control"
-import { TextFormControl } from "../../shared/form/text-form-control"
 import { UsernameFormControl } from "../../shared/form/username-form-control"
 
 interface IAcceptInvitationScreenProps {}
@@ -70,8 +70,8 @@ export const AcceptInvitationScreen = ({}: IAcceptInvitationScreenProps) => {
               <Input hidden={true} {...register("invitationToken")} />
               <UsernameFormControl validate autoComplete="off" mb={0} />
               <Flex gap={4} w="full">
-                <TextFormControl label="First Name" fieldName="firstName" />
-                <TextFormControl label="Last Name" fieldName="lastName" />
+                <TextFormControl label="First Name" fieldName="firstName" required />
+                <TextFormControl label="Last Name" fieldName="lastName" required />
               </Flex>
               <PasswordFormControl validate mb={0} />
               <Text>{t("auth.passwordRequirements")}</Text>

--- a/app/frontend/components/domains/users/profile-screen.tsx
+++ b/app/frontend/components/domains/users/profile-screen.tsx
@@ -18,8 +18,8 @@ import { useNavigate } from "react-router-dom"
 import { useMst } from "../../../setup/root"
 import { EUserRoles } from "../../../types/enums"
 import { EmailFormControl } from "../../shared/form/email-form-control"
+import { TextFormControl } from "../../shared/form/input-form-control"
 import { PasswordFormControl } from "../../shared/form/password-form-control"
-import { TextFormControl } from "../../shared/form/text-form-control"
 import { UsernameFormControl } from "../../shared/form/username-form-control"
 
 interface IProfileScreenProps {}
@@ -68,19 +68,14 @@ export const ProfileScreen = observer(({}: IProfileScreenProps) => {
             </InputGroup>
             <Box as="section" gap={6} w="full" p={6} border="solid 1px" borderColor="border.light">
               <UsernameFormControl isDisabled />
-              <EmailFormControl mb={4} />
+              <EmailFormControl required mb={4} />
               <Flex gap={{ base: 4, md: 6 }} mb={4} direction={{ base: "column", md: "row" }}>
-                <TextFormControl label={t("user.firstName")} fieldName="firstName" />
-                <TextFormControl label={t("user.lastName")} fieldName="lastName" />
+                <TextFormControl label={t("user.firstName")} fieldName="firstName" required />
+                <TextFormControl label={t("user.lastName")} fieldName="lastName" required />
               </Flex>
               {currentUser.isSubmitter && (
                 <>
-                  <TextFormControl
-                    label={t("auth.organizationLabel")}
-                    fieldName="organization"
-                    required={false}
-                    mb={4}
-                  />
+                  <TextFormControl label={t("auth.organizationLabel")} fieldName="organization" mb={4} />
                   <FormControl>
                     <Controller
                       name="certified"

--- a/app/frontend/components/shared/base/inputs/user-input.tsx
+++ b/app/frontend/components/shared/base/inputs/user-input.tsx
@@ -41,7 +41,7 @@ export const UserInput = observer(({ index, remove, jurisdictionId }: IUserInput
             )}
           />
         </FormControl>
-        <EmailFormControl fieldName={`users.${index}.email`} flex={3} validate />
+        <EmailFormControl fieldName={`users.${index}.email`} flex={3} validate required />
         <NameFormControl label="First Name (optional)" index={index} subFieldName="firstName" />
         <NameFormControl label="Last Name (optional)" index={index} subFieldName="lastName" />
         {invited && (

--- a/app/frontend/components/shared/form/email-form-control.tsx
+++ b/app/frontend/components/shared/form/email-form-control.tsx
@@ -11,12 +11,7 @@ interface IEmailFormControlProps extends FormControlProps {
   fieldName?: string
 }
 
-export const EmailFormControl = ({
-  validate,
-  fieldName = "email",
-  required = true,
-  ...rest
-}: IEmailFormControlProps) => {
+export const EmailFormControl = ({ validate, fieldName = "email", required, ...rest }: IEmailFormControlProps) => {
   const { register, formState } = useFormContext()
   const { t } = useTranslation()
   const errorMessage = fieldArrayCompatibleErrorMessage(fieldName, formState)

--- a/app/frontend/components/shared/form/input-form-control.tsx
+++ b/app/frontend/components/shared/form/input-form-control.tsx
@@ -1,16 +1,48 @@
 import { Flex, FormControl, FormControlProps, FormErrorMessage, FormLabel, Input, InputGroup } from "@chakra-ui/react"
+import { t } from "i18next"
+import * as R from "ramda"
 import React from "react"
 import { useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { fieldArrayCompatibleErrorMessage } from "./form-helpers"
 
-interface ITextFormControlProps extends FormControlProps {
+interface IInputFormControlProps extends FormControlProps {
   label: string
   fieldName: string
   required?: boolean
+  validate?: any
+  inputProps?: any
 }
 
-export const TextFormControl = ({ label, fieldName, required = true, ...rest }: ITextFormControlProps) => {
+export const TextFormControl = (props: IInputFormControlProps) => {
+  return (
+    <InputFormControl
+      {...R.mergeDeepRight(
+        {
+          inputProps: { type: "text" },
+          validate: {
+            satisfiesLength: (str) =>
+              !props.required || (str?.length >= 1 && str?.length < 128) || t("ui.invalidInput"),
+          },
+        },
+        props
+      )}
+    />
+  )
+}
+
+export const NumberFormControl = (props: IInputFormControlProps) => {
+  return <InputFormControl {...R.mergeDeepRight({ inputProps: { type: "number", step: 0.01 } }, props)} />
+}
+
+const InputFormControl = ({
+  label,
+  fieldName,
+  required,
+  validate,
+  inputProps = {},
+  ...rest
+}: IInputFormControlProps) => {
   const { register, formState } = useFormContext()
   const { t } = useTranslation()
   const errorMessage = fieldArrayCompatibleErrorMessage(fieldName, formState)
@@ -22,12 +54,10 @@ export const TextFormControl = ({ label, fieldName, required = true, ...rest }: 
           <Input
             {...register(fieldName, {
               required: required && t("ui.isRequired", { field: label }),
-              validate: {
-                satisfiesLength: (str) => !required || (str?.length >= 1 && str?.length < 128) || t("ui.invalidInput"),
-              },
+              validate,
             })}
             bg="greys.white"
-            type={"text"}
+            {...inputProps}
           />
           {errorMessage && <FormErrorMessage>{errorMessage}</FormErrorMessage>}
         </Flex>


### PR DESCRIPTION
- extract input form control and add support for number form control
- make required default to false to simplify props

## Description

Refactors the shared `TextFormControl` component to support number inputs. Changes the default value of `required` prop to false as this allows easier prop passing, e.g. `<TextFormControl required />` / `<TextFormControl />` vs. `<TextFormControl />` / `<TextFormControl required={false} />`. Also makes `EmailFormControl` default to required false for the same reason.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

extracted out from (BPHH-431)[https://hous-bssb.atlassian.net/browse/BPHH-431]

## Steps to QA

Verify text and email inputs still work properly

## UI Accessibility Checklist

N/A

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [ ] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

No
