### PR TITLE
Feature/bphh 665/view scheduled published versions

### DIFF
--- a/app/blueprints/requirement_template_blueprint.rb
+++ b/app/blueprints/requirement_template_blueprint.rb
@@ -4,10 +4,10 @@ class RequirementTemplateBlueprint < Blueprinter::Base
 
   association :permit_type, blueprint: PermitClassificationBlueprint
   association :activity, blueprint: PermitClassificationBlueprint
+  association :template_versions, blueprint: TemplateVersionBlueprint
 
   view :extended do
     association :requirement_template_sections, blueprint: RequirementTemplateSectionBlueprint
-    association :template_versions, blueprint: TemplateVersionBlueprint
     association :published_template_version, blueprint: TemplateVersionBlueprint
   end
 

--- a/app/blueprints/template_version_blueprint.rb
+++ b/app/blueprints/template_version_blueprint.rb
@@ -1,4 +1,8 @@
 class TemplateVersionBlueprint < Blueprinter::Base
   identifier :id
   fields :status, :version_date, :created_at, :updated_at
+
+  view :extended do
+    fields :denormalized_template_json, :form_json, :requirement_blocks_json
+  end
 end

--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -1,5 +1,8 @@
 class Api::TemplateVersionsController < Api::ApplicationController
-  before_action :set_template_version, only: %i[show]
+  before_action :set_template_version, only: :show
+
+  def index
+  end
 
   def show
     authorize @template_version

--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -1,0 +1,15 @@
+class Api::TemplateVersionsController < Api::ApplicationController
+  before_action :set_template_version, only: %i[show]
+
+  def show
+    authorize @template_version
+
+    render_success @template_version, nil, { blueprint: TemplateVersionBlueprint, blueprint_opts: { view: :extended } }
+  end
+
+  private
+
+  def set_template_version
+    @template_version = TemplateVersion.find(params[:id])
+  end
+end

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -27,6 +27,7 @@ import { SuccessfulSubmissionScreen } from "../permit-application/successful-sub
 import { RequirementTemplatesScreen } from "../requirement-template"
 import { EditRequirementTemplateScreen } from "../requirement-template/edit-requirement-template-screen"
 import { NewRequirementTemplateScreen } from "../requirement-template/new-requirement-tempate-screen"
+import { TemplateVersionScreen } from "../requirement-template/template-version-screen"
 import { RequirementsLibraryScreen } from "../requirements-library"
 import { AcceptInvitationScreen } from "../users/accept-invitation-screen"
 import { InviteScreen } from "../users/invite-screen"
@@ -80,6 +81,7 @@ const AppRoutes = observer(() => {
       <Route path="/requirement-templates" element={<RequirementTemplatesScreen />} />
       <Route path="/requirement-templates/new" element={<NewRequirementTemplateScreen />} />
       <Route path="/requirement-templates/:requirementTemplateId/edit" element={<EditRequirementTemplateScreen />} />
+      <Route path="/template-versions/:templateVersionId" element={<TemplateVersionScreen />} />
     </>
   )
 

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -32,8 +32,14 @@ function isTemplateEditPath(path: string): boolean {
   return regex.test(path)
 }
 
+function isTemplateVersionPath(path: string): boolean {
+  const regex = /^\/template-versions\/([a-f\d-]+)$/
+
+  return regex.test(path)
+}
+
 function shouldHideSubNavbarForPath(path: string): boolean {
-  const matchers: Array<(path: string) => boolean> = [(path) => path === "/", isTemplateEditPath]
+  const matchers: Array<(path: string) => boolean> = [(path) => path === "/", isTemplateEditPath, isTemplateVersionPath]
 
   return matchers.some((matcher) => matcher(path))
 }

--- a/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/builder-header.tsx
+++ b/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/builder-header.tsx
@@ -1,37 +1,51 @@
 import { Container, Heading, HStack, Text, VStack } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
-import * as R from "ramda"
 import React from "react"
-import { useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { IRequirementTemplate } from "../../../../models/requirement-template"
-import { EditableInputWithControls } from "../../../shared/editable-input-with-controls"
+import { ETemplateVersionStatus } from "../../../../types/enums"
+import { IDenormalizedTemplate } from "../../../../types/types"
 import { TemplateStatusTag } from "../../../shared/requirement-template/template-status-tag"
+import { VersionTag } from "../../../shared/version-tag"
 import { SubNavBar } from "../../navigation/sub-nav-bar"
-import { IRequirementTemplateForm } from "./index"
 
 interface IProps {
-  requirementTemplate: IRequirementTemplate
+  requirementTemplate: Pick<IDenormalizedTemplate, "id" | "description" | "activity" | "permitType">
+  renderDescription?: () => JSX.Element
+  status?: ETemplateVersionStatus
+  versionDate?: Date
 }
 
-export const BuilderHeader = observer(function BuilderHeader({ requirementTemplate }: IProps) {
+export const BuilderHeader = observer(function BuilderHeader({
+  requirementTemplate,
+  status,
+  versionDate,
+  renderDescription,
+}: IProps) {
   const { t } = useTranslation()
-  const { register, watch, setValue } = useFormContext<IRequirementTemplateForm>()
-  const watchedDescription = watch("description")
+  const breadCrumbs =
+    status === ETemplateVersionStatus.draft
+      ? [
+          {
+            href: "/requirement-templates",
+            title: t("site.breadcrumb.requirementTemplates"),
+          },
+          {
+            href: `/requirements-template${requirementTemplate.id}/edit`,
+            title: t("site.breadcrumb.editTemplate"),
+          },
+        ]
+      : [
+          {
+            href: "/template-versions",
+            title: t("site.breadcrumb.templateVersions"),
+          },
+        ]
+
   return (
     <Container as={"header"} maxW={"container.lg"} px={8}>
       <HStack justifyContent={"space-between"}>
         <SubNavBar
-          staticBreadCrumbs={[
-            {
-              href: "/requirement-templates",
-              title: t("site.breadcrumb.requirementTemplates"),
-            },
-            {
-              href: `/requirements-template${requirementTemplate.id}/edit`,
-              title: t("site.breadcrumb.editTemplate"),
-            },
-          ]}
+          staticBreadCrumbs={breadCrumbs}
           breadCrumbContainerProps={{ px: 0, sx: { ol: { pl: 0 } }, minW: undefined }}
           borderBottom={"none"}
           h={"fit-content"}
@@ -47,24 +61,11 @@ export const BuilderHeader = observer(function BuilderHeader({ requirementTempla
         </Heading>
         <HStack>
           <Text fontWeight={700}>{t("requirementTemplate.fields.description")}:</Text>
-          <EditableInputWithControls
-            initialHint={t("requirementsLibrary.modals.clickToWriteDisplayName")}
-            value={watchedDescription || ""}
-            editableInputProps={{
-              ...register("description"),
-              "aria-label": "Edit Template Description",
-            }}
-            color={R.isEmpty(watchedDescription) ? "text.link" : undefined}
-            aria-label={"Edit Template Description"}
-            onCancel={(previousValue) => setValue("description", previousValue)}
-          />
+          {renderDescription ? renderDescription() : <Text as="span">{requirementTemplate.description}</Text>}
         </HStack>
-        <HStack>
-          <TemplateStatusTag requirementTemplate={requirementTemplate} />
-          {/*  TODO: versioning is changing, implement later*/}
-          {/*<Tag py={1} px={2} borderRadius="sm" backgroundColor={"greys.grey03"} color={"text.secondary"}>*/}
-          {/*  {stubVersion}*/}
-          {/*</Tag>*/}
+        <HStack alignItems={"flex-start"} spacing={2}>
+          <TemplateStatusTag status={status} scheduledFor={versionDate} />
+          {status === ETemplateVersionStatus.published && <VersionTag versionDate={versionDate} />}
         </HStack>
       </VStack>
     </Container>

--- a/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/editable-builder-header.tsx
+++ b/app/frontend/components/domains/requirement-template/edit-requirement-template-screen/editable-builder-header.tsx
@@ -1,0 +1,39 @@
+import { observer } from "mobx-react-lite"
+import * as R from "ramda"
+import React from "react"
+import { useFormContext } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import { IRequirementTemplate } from "../../../../models/requirement-template"
+import { ETemplateVersionStatus } from "../../../../types/enums"
+import { EditableInputWithControls } from "../../../shared/editable-input-with-controls"
+import { BuilderHeader } from "./builder-header"
+import { IRequirementTemplateForm } from "./index"
+
+interface IProps {
+  requirementTemplate: IRequirementTemplate
+}
+
+export const EditableBuilderHeader = observer(function EditableBuilderHeader({ requirementTemplate }: IProps) {
+  const { t } = useTranslation()
+  const { register, watch, setValue } = useFormContext<IRequirementTemplateForm>()
+  const watchedDescription = watch("description")
+  return (
+    <BuilderHeader
+      requirementTemplate={requirementTemplate}
+      status={ETemplateVersionStatus.draft}
+      renderDescription={() => (
+        <EditableInputWithControls
+          initialHint={t("requirementsLibrary.modals.clickToWriteDisplayName")}
+          value={watchedDescription || ""}
+          editableInputProps={{
+            ...register("description"),
+            "aria-label": "Edit Template Description",
+          }}
+          color={R.isEmpty(watchedDescription) ? "text.link" : undefined}
+          aria-label={"Edit Template Description"}
+          onCancel={(previousValue) => setValue("description", previousValue)}
+        />
+      )}
+    />
+  )
+})

--- a/app/frontend/components/domains/requirement-template/grid-header.tsx
+++ b/app/frontend/components/domains/requirement-template/grid-header.tsx
@@ -18,7 +18,7 @@ export const GridHeaders = observer(function GridHeaders() {
       <Box display={"contents"} role={"row"}>
         <GridItem
           as={Flex}
-          gridColumn={"span 7"}
+          gridColumn={"span 6"}
           p={6}
           bg={"greys.grey10"}
           justifyContent={"space-between"}

--- a/app/frontend/components/domains/requirement-template/index.tsx
+++ b/app/frontend/components/domains/requirement-template/index.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 import { useSearch } from "../../../hooks/use-search"
 import { useMst } from "../../../setup/root"
+import { ETemplateVersionStatus } from "../../../types/enums"
 import { Paginator } from "../../shared/base/inputs/paginator"
 import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
 import { SharedSpinner } from "../../shared/base/shared-spinner"
@@ -61,7 +62,7 @@ export const RequirementTemplatesScreen = observer(function RequirementTemplate(
               return (
                 <Box key={rt.id} className={"requirements-template-grid-row"} role={"row"} display={"contents"}>
                   <SearchGridItem>
-                    <TemplateStatusTag requirementTemplate={rt} />
+                    <TemplateStatusTag status={ETemplateVersionStatus.draft} />
                   </SearchGridItem>
                   <SearchGridItem fontWeight="bold">{rt.permitType.name}</SearchGridItem>
                   <SearchGridItem fontWeight="bold">{rt.activity.name}</SearchGridItem>

--- a/app/frontend/components/domains/requirement-template/index.tsx
+++ b/app/frontend/components/domains/requirement-template/index.tsx
@@ -4,18 +4,16 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 import { useSearch } from "../../../hooks/use-search"
 import { useMst } from "../../../setup/root"
-import { ETemplateVersionStatus } from "../../../types/enums"
 import { Paginator } from "../../shared/base/inputs/paginator"
 import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
 import { SharedSpinner } from "../../shared/base/shared-spinner"
 import { ToggleArchivedButton } from "../../shared/buttons/show-archived-button"
 import { SearchGrid } from "../../shared/grid/search-grid"
 import { SearchGridItem } from "../../shared/grid/search-grid-item"
-import { RouterLink } from "../../shared/navigation/router-link"
 import { RouterLinkButton } from "../../shared/navigation/router-link-button"
-import { ManageRequirementTemplateMenu } from "../../shared/requirement-template/mange-requirement-template-menu"
-import { TemplateStatusTag } from "../../shared/requirement-template/template-status-tag"
+import { VersionTag } from "../../shared/version-tag"
 import { GridHeaders } from "./grid-header"
+import { TenmplateVersionsSidebar } from "./template-versions-sidebar"
 
 export const RequirementTemplatesScreen = observer(function RequirementTemplate() {
   const { requirementTemplateStore } = useMst()
@@ -50,7 +48,7 @@ export const RequirementTemplatesScreen = observer(function RequirementTemplate(
           </RouterLinkButton>
         </Flex>
 
-        <SearchGrid templateColumns="repeat(3, 1fr) 2fr repeat(3, 1fr)">
+        <SearchGrid templateColumns="repeat(2, 1fr) 2fr repeat(3, 1fr)">
           <GridHeaders />
 
           {isSearching ? (
@@ -61,19 +59,17 @@ export const RequirementTemplatesScreen = observer(function RequirementTemplate(
             tableRequirementTemplates.map((rt) => {
               return (
                 <Box key={rt.id} className={"requirements-template-grid-row"} role={"row"} display={"contents"}>
-                  <SearchGridItem>
-                    <TemplateStatusTag status={ETemplateVersionStatus.draft} />
-                  </SearchGridItem>
                   <SearchGridItem fontWeight="bold">{rt.permitType.name}</SearchGridItem>
                   <SearchGridItem fontWeight="bold">{rt.activity.name}</SearchGridItem>
                   <SearchGridItem>{rt.description}</SearchGridItem>
-                  <SearchGridItem>{rt.version}</SearchGridItem>
+                  <SearchGridItem>
+                    {rt.publishedTemplateVersion?.versionDate ? (
+                      <VersionTag versionDate={rt.publishedTemplateVersion.versionDate} />
+                    ) : null}
+                  </SearchGridItem>
                   <SearchGridItem>{rt.jurisdictionsSize}</SearchGridItem>
                   <SearchGridItem>
-                    <Flex justify="space-between" w="full" gap={2}>
-                      <RouterLink to={`${rt.id}/edit`}>{t("ui.edit")}</RouterLink>
-                      <ManageRequirementTemplateMenu requirementTemplate={rt} searchModel={requirementTemplateStore} />
-                    </Flex>
+                    <TenmplateVersionsSidebar requirementTemplate={rt} />
                   </SearchGridItem>
                 </Box>
               )

--- a/app/frontend/components/domains/requirement-template/sections-sidebar.tsx
+++ b/app/frontend/components/domains/requirement-template/sections-sidebar.tsx
@@ -1,26 +1,23 @@
 import { Box, Button, Divider, Heading, HeadingProps, HStack, Stack, Text } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
-import { useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { useMst } from "../../../../setup/root"
-import { IRequirementTemplateForm } from "./index"
+import { IDenormalizedRequirementTemplateSection } from "../../../types/types"
 
 interface IProps {
   onEdit?: () => void
   onItemClick?: (id: string) => void
   sectionIdToHighlight: null | string
+  sections: IDenormalizedRequirementTemplateSection[]
 }
 
 export const SectionsSidebar = observer(function SectionsSidebar({
   onEdit,
   onItemClick,
   sectionIdToHighlight,
+  sections,
 }: IProps) {
   const { t } = useTranslation()
-  const { watch } = useFormContext<IRequirementTemplateForm>()
-  const { requirementBlockStore } = useMst()
-  const watchedSections = watch("requirementTemplateSectionsAttributes")
   const highLightedSectionStyles: Partial<HeadingProps> = {
     bg: "theme.blueLight",
     color: "text.link",
@@ -38,16 +35,20 @@ export const SectionsSidebar = observer(function SectionsSidebar({
       boxShadow={"elevations.elevation01"}
       overflow={"auto"}
     >
-      <HStack w={"full"} justifyContent={"space-between"} bg={"greys.grey03"} py={5} px={4}>
-        <Text as={"h3"} fontSize={"sm"} fontWeight={400} color={"text.secondary"} textTransform={"uppercase"}>
-          {t("requirementTemplate.edit.sectionsSidebarTitle")}
-        </Text>
-        <Button variant={"secondary"} onClick={onEdit} size={"sm"}>
-          {t("requirementTemplate.edit.reorderButton")}
-        </Button>
-      </HStack>
+      {onEdit && (
+        <HStack w={"full"} justifyContent={"space-between"} bg={"greys.grey03"} py={5} px={4}>
+          <>
+            <Text as={"h3"} fontSize={"sm"} fontWeight={400} color={"text.secondary"} textTransform={"uppercase"}>
+              {t("requirementTemplate.edit.sectionsSidebarTitle")}
+            </Text>
+            <Button variant={"secondary"} onClick={onEdit} size={"sm"}>
+              {t("requirementTemplate.edit.reorderButton")}
+            </Button>
+          </>
+        </HStack>
+      )}
       <Stack w={"full"} spacing={4} alignItems={"flex-start"} py={2}>
-        {watchedSections?.map((section, index) => {
+        {sections?.map((section, index) => {
           const isHighlightedSection = sectionIdToHighlight === section.id
           return (
             <React.Fragment key={section.id}>
@@ -67,9 +68,9 @@ export const SectionsSidebar = observer(function SectionsSidebar({
                 >
                   {section.name}
                 </Heading>
-                {section.templateSectionBlocksAttributes.length > 0 && (
+                {section.templateSectionBlocks.length > 0 && (
                   <Box as={"ol"} sx={{ listStyle: "none" }} w={"full"} p={0} m={0}>
-                    {section.templateSectionBlocksAttributes.map((sectionBlock) => {
+                    {section.templateSectionBlocks.map((sectionBlock) => {
                       return (
                         <Text
                           as={"li"}
@@ -81,14 +82,14 @@ export const SectionsSidebar = observer(function SectionsSidebar({
                           onClick={() => onItemClick?.(sectionBlock.id)}
                           cursor={"pointer"}
                         >
-                          {requirementBlockStore?.getRequirementBlockById(sectionBlock.requirementBlockId)?.name}
+                          {sectionBlock.requirementBlock?.name}
                         </Text>
                       )
                     })}
                   </Box>
                 )}
               </Box>
-              {index < watchedSections.length - 1 && <Divider borderColor={"border.light"} m={0} />}
+              {index < sections.length - 1 && <Divider borderColor={"border.light"} m={0} />}
             </React.Fragment>
           )
         })}

--- a/app/frontend/components/domains/requirement-template/template-version-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/template-version-screen/index.tsx
@@ -1,0 +1,164 @@
+import { Button, Flex, Stack } from "@chakra-ui/react"
+import { ArrowUp } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React, { useEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { RemoveScroll } from "react-remove-scroll"
+import { useNavigate } from "react-router-dom"
+import { useTemplateVersion } from "../../../../hooks/resources/use-template-version"
+import { ETemplateVersionStatus } from "../../../../types/enums"
+import { ErrorScreen } from "../../../shared/base/error-screen"
+import { LoadingScreen } from "../../../shared/base/loading-screen"
+import { BuilderHeader } from "../edit-requirement-template-screen/builder-header"
+import { SectionsSidebar } from "../sections-sidebar"
+import { SectionsDisplay } from "./sections-display"
+
+const scrollToIdPrefix = "template-version-scroll-to-id-"
+export const formScrollToId = (id: string) => `${scrollToIdPrefix}${id}`
+
+export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
+  const { templateVersion, error } = useTemplateVersion()
+  const denormalizedTemplate = templateVersion?.denormalizedTemplateJson
+  const { t } = useTranslation()
+  const rightContainerRef = useRef<HTMLDivElement>()
+  const [shouldCollapseAll, setShouldCollapseAll] = useState(false)
+  const [sectionsInViewStatuses, setSectionsInViewStatuses] = useState<Record<string, boolean>>({})
+  const sectionRefs = useRef<Record<string, HTMLElement | null>>({})
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const options = {
+      root: rightContainerRef?.current,
+      rootMargin: "0px",
+      threshold: 0.1,
+    }
+
+    const observer = new IntersectionObserver(handleSectionIntersection, options)
+
+    Object.values(sectionRefs.current).forEach((ref) => {
+      if (ref) {
+        observer.observe(ref)
+      }
+    })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [denormalizedTemplate?.requirementTemplateSections])
+
+  if (error) return <ErrorScreen error={error} />
+  if (!templateVersion?.isFullyLoaded) return <LoadingScreen />
+
+  const templateSections = denormalizedTemplate?.requirementTemplateSections ?? []
+  const hasNoSections = templateSections.length === 0
+
+  const currentSectionId = (() => {
+    const firstInViewSection = templateSections.find((section) => sectionsInViewStatuses[section.id])
+
+    return firstInViewSection?.id ?? null
+  })()
+
+  const onClose = () => {
+    window.history.state && window.history.state.idx > 0 ? navigate(-1) : navigate(`/requirement-templates`)
+  }
+
+  return (
+    // the height 1px is needed other wise scroll does not work
+    // as it seems like the browser has issues calculating height for flex=1 containers
+    <RemoveScroll style={{ width: "100%", flex: "1", height: "1px" }}>
+      <Flex flexDir={"column"} w={"full"} maxW={"full"} h="full" as="main">
+        <BuilderHeader
+          requirementTemplate={denormalizedTemplate}
+          status={templateVersion.status}
+          versionDate={
+            templateVersion.status === ETemplateVersionStatus.scheduled ? templateVersion.versionDate : undefined
+          }
+        />
+        <Flex flex={1} w={"full"} h={"1px"} borderTop={"1px solid"} borderColor={"border.base"}>
+          <SectionsSidebar
+            sections={templateSections}
+            onItemClick={scrollIntoView}
+            sectionIdToHighlight={currentSectionId}
+          />
+          <Flex
+            flexDir={"column"}
+            flex={1}
+            h={"full"}
+            bg={hasNoSections ? "greys.grey03" : undefined}
+            overflow={"auto"}
+            ref={rightContainerRef}
+          >
+            <Flex
+              px={6}
+              py={4}
+              bg={"greys.grey03"}
+              w={"full"}
+              justifyContent={"flex-end"}
+              boxShadow={"elevations.elevation02"}
+            >
+              <Button variant={"secondary"} onClick={onClose}>
+                {t("requirementTemplate.edit.closeEditor")}
+              </Button>
+            </Flex>
+            <SectionsDisplay
+              sections={templateSections}
+              shouldCollapseAll={shouldCollapseAll}
+              setSectionRef={setSectionRef}
+            />
+          </Flex>
+        </Flex>
+        <Stack spacing={4} position={"fixed"} bottom={6} right={6} alignItems={"flex-end"}>
+          <Button variant={"greyButton"} leftIcon={<ArrowUp />} pl={"0.6125rem"} onClick={scrollToTop}>
+            {t("requirementTemplate.edit.goToTop")}
+          </Button>
+          <Button variant={"greyButton"} onClick={onCollapseAll}>
+            {t("requirementTemplate.edit.collapseAll")}
+          </Button>
+        </Stack>
+      </Flex>
+    </RemoveScroll>
+  )
+
+  function scrollToTop() {
+    rightContainerRef.current?.scrollTo({ behavior: "smooth", top: 0 })
+  }
+
+  function onCollapseAll() {
+    setShouldCollapseAll(true)
+
+    setTimeout(() => {
+      setShouldCollapseAll(false)
+    }, 500)
+  }
+
+  function scrollIntoView(id: string) {
+    const element = document.getElementById(formScrollToId(id))
+
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" })
+    }
+  }
+
+  function setSectionRef(el: HTMLElement, id: string) {
+    sectionRefs.current[id] = el
+  }
+
+  // modified use case from https://stackoverflow.com/questions/57992340/how-to-get-first-visible-body-element-on-screen-with-pure-javascript
+  function handleSectionIntersection(entries: IntersectionObserverEntry[]) {
+    setSectionsInViewStatuses((pastState) => {
+      const newState = { ...pastState }
+
+      entries.forEach((entry) => {
+        const sectionId = entry.target.getAttribute("data-section-id")
+
+        if (entry.isIntersecting) {
+          newState[sectionId] = true
+        } else {
+          newState[sectionId] = false
+        }
+      })
+
+      return newState
+    })
+  }
+})

--- a/app/frontend/components/domains/requirement-template/template-version-screen/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/template-version-screen/sections-display.tsx
@@ -1,0 +1,67 @@
+import { Box, HStack, Stack, Text } from "@chakra-ui/react"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { formScrollToId } from "."
+import { IDenormalizedRequirementTemplateSection } from "../../../../types/types"
+import { RequirementBlockAccordion } from "../../requirements-library/requirement-block-accordion"
+
+interface IProps {
+  shouldCollapseAll?: boolean
+  setSectionRef: (el: HTMLElement, id: string) => void
+  sections: IDenormalizedRequirementTemplateSection[]
+}
+
+export const SectionsDisplay = observer(function SectionsDisplay(props: IProps) {
+  const { sections } = props
+
+  return (
+    <Stack w={"full"} alignItems={"flex-start"} spacing={16} p={16}>
+      {sections.map((section) => (
+        <SectionDisplay key={section.id} section={section} {...props} />
+      ))}
+    </Stack>
+  )
+})
+
+const SectionDisplay = observer(
+  ({
+    section,
+    shouldCollapseAll,
+    setSectionRef,
+  }: {
+    section: IDenormalizedRequirementTemplateSection
+    shouldCollapseAll?: boolean
+    setSectionRef: (el: HTMLElement, id: string) => void
+  }) => {
+    const sectionBlocks = section.templateSectionBlocks
+    const sectionName = section.name
+
+    return (
+      <Box
+        ref={(el) => setSectionRef(el, section.id)}
+        as={"section"}
+        w={"full"}
+        id={formScrollToId(section.id)}
+        data-section-id={section.id}
+      >
+        <Box w={"36px"} border={"4px solid"} borderColor={"theme.yellow"} mb={2} />
+        <HStack>
+          <Text as="h4" w={"full"} maxW={"798px"} fontWeight={700} fontSize={"2xl"}>
+            {sectionName}
+          </Text>
+        </HStack>
+        <Stack w={"full"} maxW={"798px"} spacing={6} pl={0} mt={6}>
+          {sectionBlocks.map((sectionBlock) => (
+            <RequirementBlockAccordion
+              as={"section"}
+              id={formScrollToId(sectionBlock.id)}
+              key={sectionBlock.id}
+              requirementBlock={sectionBlock.requirementBlock}
+              triggerForceCollapse={shouldCollapseAll}
+            />
+          ))}
+        </Stack>
+      </Box>
+    )
+  }
+)

--- a/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
+++ b/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
@@ -1,0 +1,191 @@
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  Flex,
+  FlexProps,
+  HStack,
+  Stack,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { Pencil } from "@phosphor-icons/react/dist/ssr"
+import { format } from "date-fns"
+import { t } from "i18next"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { IRequirementTemplate } from "../../../models/requirement-template"
+import { ITemplateVersion } from "../../../models/template-version"
+import { ETemplateVersionStatus } from "../../../types/enums"
+import { RouterLink } from "../../shared/navigation/router-link"
+import { TemplateStatusTag } from "../../shared/requirement-template/template-status-tag"
+import { VersionTag } from "../../shared/version-tag"
+
+interface IProps {
+  requirementTemplate: IRequirementTemplate
+}
+export const TenmplateVersionsSidebar = observer(function TemplateVersionsSidebar({ requirementTemplate }: IProps) {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const btnRef = React.useRef()
+  return (
+    <>
+      <Button size="sm" variant={"primary"} onClick={onOpen}>
+        {t("requirementTemplate.versionSidebar.triggerButton")}
+      </Button>
+      <Drawer isOpen={isOpen} placement="right" onClose={onClose} finalFocusRef={btnRef}>
+        <DrawerOverlay />
+        <DrawerContent maxW="644px">
+          <DrawerCloseButton />
+          <DrawerHeader mt={4} px={8} borderBottom="1px solid" borderColor={"border.light"}>
+            <Text as="h2" fontWeight={700} fontSize={"2xl"}>
+              {t("requirementTemplate.versionSidebar.title")}
+            </Text>
+            <Text
+              fontSize={"md"}
+              fontWeight={700}
+              mt={2}
+            >{`${t("requirementTemplate.versionSidebar.subtitlePrefix")} ${requirementTemplate.permitType.name} | ${requirementTemplate.activity.name}`}</Text>
+          </DrawerHeader>
+
+          <DrawerBody py={10} px={8}>
+            <Stack spacing={10}>
+              <Box w="full">
+                <VersionsList
+                  type={ETemplateVersionStatus.published}
+                  templateVersions={
+                    requirementTemplate.publishedTemplateVersion ? [requirementTemplate.publishedTemplateVersion] : []
+                  }
+                />
+              </Box>
+              <Box>
+                <Text as="h3" fontSize={"xl"} fontWeight={700} mb={2}>
+                  {t("requirementTemplate.versionSidebar.listTitles.draft")}
+                </Text>
+
+                <VersionCard
+                  viewRoute={`/requirement-templates/${requirementTemplate.id}/edit`}
+                  status={ETemplateVersionStatus.draft}
+                  updatedAt={requirementTemplate.updatedAt}
+                />
+              </Box>
+
+              <VersionsList
+                type={ETemplateVersionStatus.scheduled}
+                templateVersions={requirementTemplate.scheduledTemplateVersions}
+              />
+            </Stack>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  )
+})
+
+const VersionsList = observer(function VersionsList({
+  type,
+  templateVersions,
+}: {
+  type: Exclude<ETemplateVersionStatus, ETemplateVersionStatus.draft>
+  templateVersions: ITemplateVersion[]
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <Box>
+      <Text as="h3" fontSize={"xl"} fontWeight={700} mb={2}>
+        {t(`requirementTemplate.versionSidebar.listTitles.${type}`)}
+      </Text>
+
+      {templateVersions.map((templateVersion, index) => (
+        <VersionCard
+          key={templateVersion.id}
+          viewRoute={`/template-versions/${templateVersion.id}`}
+          status={type}
+          versionDate={templateVersion.versionDate}
+          borderTop={index !== 0 ? "none" : undefined}
+          borderTopRadius={index === 0 ? "sm" : undefined}
+          borderBottomRadius={index === templateVersions.length - 1 ? "sm" : undefined}
+          borderRadius={"none"}
+        />
+      ))}
+    </Box>
+  )
+})
+
+type TVersionCardProps = Partial<FlexProps> & { viewRoute: string; onUnschedule?: () => void } & (
+    | { status: Exclude<ETemplateVersionStatus, ETemplateVersionStatus.draft>; versionDate: Date; updatedAt?: never }
+    | { status: ETemplateVersionStatus.draft; versionDate?: never; updatedAt: Date }
+  )
+
+const VersionCard = observer(function VersionCard({
+  viewRoute,
+  onUnschedule,
+  status,
+  versionDate,
+  updatedAt,
+  ...containerProps
+}: TVersionCardProps) {
+  const { t } = useTranslation()
+
+  const renderTemplateButton = () => {
+    if (status === ETemplateVersionStatus.published || status === ETemplateVersionStatus.deprecated) {
+      return (
+        <Button as={RouterLink} textDecor={"none"} to={viewRoute} variant={"primary"} size="sm">
+          {t("requirementTemplate.versionSidebar.viewTemplateButton")}
+        </Button>
+      )
+    } else if (status === ETemplateVersionStatus.draft) {
+      return (
+        <Button as={RouterLink} to={viewRoute} textDecor={"none"} variant={"primary"} size="sm" leftIcon={<Pencil />}>
+          {t("translation:requirementTemplate.versionSidebar.resumeDraftButton")}
+        </Button>
+      )
+    } else {
+      return (
+        <ButtonGroup spacing={4}>
+          <Button as={RouterLink} to={viewRoute} textDecor={"none"} variant={"primary"} size="sm">
+            {t("ui.preview")}
+          </Button>
+          <Button variant={"secondary"} size="sm" onClick={onUnschedule} isDisabled>
+            {t("translation:requirementTemplate.versionSidebar.unscheduleButton")}
+          </Button>
+        </ButtonGroup>
+      )
+    }
+  }
+  return (
+    <Flex
+      p={4}
+      border={"1px solid"}
+      borderColor={"border.light"}
+      borderRadius={"sm"}
+      w="full"
+      justifyContent={"space-between"}
+      {...containerProps}
+    >
+      <HStack spacing={16}>
+        <TemplateStatusTag
+          status={status}
+          scheduledFor={status === ETemplateVersionStatus.scheduled && versionDate ? versionDate : undefined}
+        />
+        {status === ETemplateVersionStatus.draft ? (
+          <Text>
+            {t("requirementTemplate.versionSidebar.lastUpdated")}
+            <br />
+            {format(updatedAt, "MMM dd, yyyy")}
+          </Text>
+        ) : (
+          <VersionTag versionDate={versionDate} />
+        )}
+      </HStack>
+      {renderTemplateButton()}
+    </Flex>
+  )
+})

--- a/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
@@ -15,15 +15,15 @@ import { X } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React, { useEffect } from "react"
 import { useTranslation } from "react-i18next"
-import { IRequirementBlock } from "../../../models/requirement-block"
 import { ERequirementType } from "../../../types/enums"
+import { IDenormalizedRequirement, IDenormalizedRequirementBlock } from "../../../types/types"
 import { isQuillEmpty } from "../../../utils/utility-funcitons"
 import { EditorWithPreview } from "../../shared/editor/custom-extensions/editor-with-preview"
 import { RequirementFieldDisplay } from "./requirement-field-display"
 import { RequirementsBlockModal } from "./requirements-block-modal"
 
 type TProps = {
-  requirementBlock: IRequirementBlock
+  requirementBlock: IDenormalizedRequirementBlock
   onRemove?: () => void
   triggerForceCollapse?: boolean
 } & Partial<AccordionProps> &
@@ -125,7 +125,7 @@ export const RequirementBlockAccordion = observer(function RequirementBlockAccor
             px={3}
             mt={isQuillEmpty(requirementBlock.displayDescription) ? 5 : 0}
           >
-            {requirementBlock.requirements.map((requirement, index) => {
+            {requirementBlock.requirements.map((requirement: IDenormalizedRequirement, index) => {
               const requirementType = requirement.inputType
               return (
                 <Box
@@ -148,9 +148,13 @@ export const RequirementBlockAccordion = observer(function RequirementBlockAccor
                     <RequirementFieldDisplay
                       requirementType={requirementType}
                       label={requirement.label}
-                      helperText={requirementBlock.hint}
-                      unit={requirementType === ERequirementType.number ? requirement?.numberUnit ?? null : undefined}
-                      options={requirement?.valueOptions?.map((option) => option.label)}
+                      helperText={requirement?.hint}
+                      unit={
+                        requirementType === ERequirementType.number
+                          ? requirement?.inputOptions?.numberUnit ?? null
+                          : undefined
+                      }
+                      options={requirement?.inputOptions?.valueOptions?.map((option) => option.label)}
                       selectProps={{
                         maxW: "339px",
                       }}

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -345,11 +345,11 @@ $bcgov-alert-success: #dff0d8;
   }
 }
 
-h2 {
-  @include yellowBarHeader;
-}
-
 .form-wrapper {
+  h2 {
+    @include yellowBarHeader;
+  }
+
   .formio-section-container > label {
     @include yellowBarHeader;
     font-size: 24px;

--- a/app/frontend/components/shared/requirement-template/template-status-tag.tsx
+++ b/app/frontend/components/shared/requirement-template/template-status-tag.tsx
@@ -3,32 +3,35 @@ import { CheckSquareOffset, Clock, Pencil } from "@phosphor-icons/react"
 import { format } from "date-fns"
 import React, { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
-import { ERequirementTemplateStatus } from "../../../types/enums"
+import { ETemplateVersionStatus } from "../../../types/enums"
 
 interface ITemplateStatusTagProps {
-  requirementTemplate
+  status: ETemplateVersionStatus
+  scheduledFor?: Date
 }
 
-const statusColors: { [key in ERequirementTemplateStatus]: string } = {
-  [ERequirementTemplateStatus.published]: "semantic.infoLight",
-  [ERequirementTemplateStatus.scheduled]: "semantic.successLight",
-  [ERequirementTemplateStatus.draft]: "semantic.warningLight",
+const statusColors: { [key in ETemplateVersionStatus]: string } = {
+  [ETemplateVersionStatus.published]: "semantic.infoLight",
+  [ETemplateVersionStatus.scheduled]: "semantic.successLight",
+  [ETemplateVersionStatus.draft]: "semantic.warningLight",
+  [ETemplateVersionStatus.deprecated]: "semantic.errorLight",
 }
 
-const statusBorderColors: { [key in ERequirementTemplateStatus]: string } = {
-  [ERequirementTemplateStatus.published]: "semantic.info",
-  [ERequirementTemplateStatus.scheduled]: "semantic.success",
-  [ERequirementTemplateStatus.draft]: "semantic.warning",
+const statusBorderColors: { [key in ETemplateVersionStatus]: string } = {
+  [ETemplateVersionStatus.published]: "semantic.info",
+  [ETemplateVersionStatus.scheduled]: "semantic.success",
+  [ETemplateVersionStatus.draft]: "semantic.warning",
+  [ETemplateVersionStatus.deprecated]: "semantic.error",
 }
 
-const statusIcons: { [key in ERequirementTemplateStatus]: ReactNode } = {
-  [ERequirementTemplateStatus.published]: <CheckSquareOffset />,
-  [ERequirementTemplateStatus.scheduled]: <Clock />,
-  [ERequirementTemplateStatus.draft]: <Pencil />,
+const statusIcons: { [key in ETemplateVersionStatus]: ReactNode } = {
+  [ETemplateVersionStatus.published]: <CheckSquareOffset />,
+  [ETemplateVersionStatus.scheduled]: <Clock />,
+  [ETemplateVersionStatus.draft]: <Pencil />,
+  [ETemplateVersionStatus.deprecated]: <></>,
 }
 
-export const TemplateStatusTag = ({ requirementTemplate }: ITemplateStatusTagProps) => {
-  const status = requirementTemplate.status as ERequirementTemplateStatus
+export const TemplateStatusTag = ({ status, scheduledFor }: ITemplateStatusTagProps) => {
   const color = statusColors[status]
   const borderColor = statusBorderColors[status]
   const { t } = useTranslation()
@@ -48,9 +51,9 @@ export const TemplateStatusTag = ({ requirementTemplate }: ITemplateStatusTagPro
           <Text>{t(`requirementTemplate.status.${status}`)}</Text>
         </HStack>
       </Tag>
-      {requirementTemplate.scheduledFor && (
+      {scheduledFor && (
         <Text fontSize="sm" fontWeight="bold">
-          {format(requirementTemplate.scheduledFor, "yyyy-MM-dd")}
+          {format(scheduledFor, "yyyy-MM-dd")}
         </Text>
       )}
     </Flex>

--- a/app/frontend/components/shared/version-tag.tsx
+++ b/app/frontend/components/shared/version-tag.tsx
@@ -1,0 +1,11 @@
+import { Tag } from "@chakra-ui/react"
+import React from "react"
+import { formatTemplateVersion } from "../../utils/utility-funcitons"
+
+export function VersionTag({ versionDate }: { versionDate: Date }) {
+  return (
+    <Tag bg={"greys.grey03"} color={"text.secondary"} fontSize={"xs"}>
+      {formatTemplateVersion(versionDate)}
+    </Tag>
+  )
+}

--- a/app/frontend/hooks/resources/use-template-version.ts
+++ b/app/frontend/hooks/resources/use-template-version.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { useLocation, useParams } from "react-router-dom"
+import { useMst } from "../../setup/root"
+import { isUUID } from "../../utils/utility-funcitons"
+
+export const useTemplateVersion = () => {
+  const { templateVersionId } = useParams()
+  const { pathname } = useLocation()
+  const { templateVersionStore } = useMst()
+  const templateVersion = templateVersionStore.getTemplateVersionById(templateVersionId)
+  const [error, setError] = useState<Error | undefined>(undefined)
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    if (!isUUID(templateVersionId)) {
+      setError(new Error(t("errors.fetchTemplateVersion")))
+      import.meta.env.DEV && console.error("template version id supplied to useTemplateVersion hook is not a uuid")
+      return
+    }
+
+    if (!templateVersion || !templateVersion.isFullyLoaded) {
+      ;(async () => {
+        try {
+          const isSuccess = await templateVersionStore.fetchTemplateVersion(templateVersionId)
+
+          !isSuccess && setError(new Error(t("errors.fetchTemplateVersion")))
+        } catch (e) {
+          setError(e instanceof Error ? e : new Error(t("errors.fetchTemplateVersion")))
+        }
+      })()
+    }
+  }, [templateVersionId, templateVersion, pathname])
+
+  return { templateVersion, error }
+}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -432,6 +432,7 @@ const options = {
             published: "Published",
             scheduled: "Scheduled",
             draft: "Draft",
+            deprecated: "Deprecated",
           },
           index: {
             tableHeading: "Templates",
@@ -479,6 +480,7 @@ const options = {
             jurisdictions: "Manage Jurisdictions",
             new: "Create New",
             invite: "Invite",
+            templateVersions: "Template Versions",
             requirementsLibrary: "Requirements Library",
             requirementTemplates: "Permit Templates Catalogue",
             edit: "Edit",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -83,6 +83,7 @@ const options = {
             "Becoming a North American leader of digital permitting and construction by digitally integrating permit systems and tools across the housing development sector across B.C. is a commitment of the 2023 Ministry of Housing Homes for People Plan.",
         },
         ui: {
+          preview: "Preview",
           back: "Back",
           yes: "Yes",
           no: "No",
@@ -425,7 +426,7 @@ const options = {
             permitType: "Permit Type",
             activity: "Work Type",
             description: "Description",
-            version: "Version",
+            currentVersion: "Current Version",
             jurisdictionsSize: "Used By",
           },
           status: {
@@ -448,6 +449,21 @@ const options = {
             descriptionHelpText:
               "Provide some context for managers and admin on what kinds of buildings this permit is meant for.",
             createButton: "Create template",
+          },
+          versionSidebar: {
+            triggerButton: "Versions",
+            title: "Template Versions",
+            subtitlePrefix: "For:",
+            viewTemplateButton: "View template",
+            resumeDraftButton: "Resume draft",
+            unscheduleButton: "Unschedule",
+            listTitles: {
+              published: "Published",
+              draft: "Drafts",
+              scheduled: "Scheduled",
+              deprecated: "Deprecated",
+            },
+            lastUpdated: "Last updated",
           },
         },
         site: {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -355,6 +355,7 @@ const options = {
           fetchJurisdiction: "Something went wrong fetching the jurisdiction",
           fetchPermitApplication: "Something went wrong fetching the permit application",
           fetchRequirementTemplate: "Something went wrong fetching the requirement template",
+          fetchTemplateVersion: "Something went wrong fetching the template version",
           fetchOptions: "Something went wrong fetching options",
         },
         user: {

--- a/app/frontend/models/requirement-template.ts
+++ b/app/frontend/models/requirement-template.ts
@@ -2,7 +2,7 @@ import { addDays, isAfter, isSameDay, max } from "date-fns"
 import { Instance, flow, types } from "mobx-state-tree"
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
-import { ERequirementTemplateStatus, ETemplateVerionStatus } from "../types/enums"
+import { ERequirementTemplateStatus, ETemplateVersionStatus } from "../types/enums"
 import { IActivity, IPermitType } from "./permit-classification"
 import { RequirementTemplateSectionModel } from "./requirement-template-section"
 import { TemplateVersionModel } from "./template-version"
@@ -11,7 +11,7 @@ function preProcessor(snapshot) {
   const processedSnapShot = {
     ...snapshot,
     scheduledTemplateVersions: snapshot.templateVersions
-      ?.filter((version) => version.status === ETemplateVerionStatus.scheduled)
+      ?.filter((version) => version.status === ETemplateVersionStatus.scheduled)
       .map((version) => version.id),
     publishedTemplateVersion: snapshot.publishedTemplateVersion?.id,
   }

--- a/app/frontend/models/template-version.ts
+++ b/app/frontend/models/template-version.ts
@@ -1,10 +1,10 @@
 import { Instance, types } from "mobx-state-tree"
-import { ETemplateVerionStatus } from "../types/enums"
+import { ETemplateVersionStatus } from "../types/enums"
 import { IDenormalizedTemplate } from "../types/types"
 
 export const TemplateVersionModel = types.model("TemplateVersionModel").props({
   id: types.identifier,
-  status: types.enumeration(Object.values(ETemplateVerionStatus)),
+  status: types.enumeration(Object.values(ETemplateVersionStatus)),
   versionDate: types.Date,
   denormalizedTemplateJson: types.maybeNull(types.frozen<IDenormalizedTemplate>()),
   isFullyLoaded: types.optional(types.boolean, false),

--- a/app/frontend/models/template-version.ts
+++ b/app/frontend/models/template-version.ts
@@ -2,12 +2,27 @@ import { Instance, types } from "mobx-state-tree"
 import { ETemplateVersionStatus } from "../types/enums"
 import { IDenormalizedTemplate } from "../types/types"
 
-export const TemplateVersionModel = types.model("TemplateVersionModel").props({
-  id: types.identifier,
-  status: types.enumeration(Object.values(ETemplateVersionStatus)),
-  versionDate: types.Date,
-  denormalizedTemplateJson: types.maybeNull(types.frozen<IDenormalizedTemplate>()),
-  isFullyLoaded: types.optional(types.boolean, false),
-})
+export const TemplateVersionModel = types
+  .model("TemplateVersionModel")
+  .props({
+    id: types.identifier,
+    status: types.enumeration(Object.values(ETemplateVersionStatus)),
+    versionDate: types.Date,
+    denormalizedTemplateJson: types.maybeNull(types.frozen<IDenormalizedTemplate>()),
+    isFullyLoaded: types.optional(types.boolean, false),
+  })
+  .views((self) => ({
+    get isPublished() {
+      return self.status === ETemplateVersionStatus.published
+    },
+
+    get isScheduled() {
+      return self.status === ETemplateVersionStatus.scheduled
+    },
+
+    get isDeprecated() {
+      return self.status === ETemplateVersionStatus.deprecated
+    },
+  }))
 
 export interface ITemplateVersion extends Instance<typeof TemplateVersionModel> {}

--- a/app/frontend/models/template-version.ts
+++ b/app/frontend/models/template-version.ts
@@ -1,10 +1,12 @@
 import { Instance, types } from "mobx-state-tree"
 import { ETemplateVerionStatus } from "../types/enums"
+import { IDenormalizedTemplate } from "../types/types"
 
 export const TemplateVersionModel = types.model("TemplateVersionModel").props({
   id: types.identifier,
   status: types.enumeration(Object.values(ETemplateVerionStatus)),
   versionDate: types.Date,
+  denormalizedTemplateJson: types.maybeNull(types.frozen<IDenormalizedTemplate>()),
   isFullyLoaded: types.optional(types.boolean, false),
 })
 

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -5,6 +5,7 @@ import { IJurisdiction } from "../../models/jurisdiction"
 import { IPermitApplication } from "../../models/permit-application"
 import { IPermitType } from "../../models/permit-classification"
 import { IRequirementTemplate } from "../../models/requirement-template"
+import { ITemplateVersion } from "../../models/template-version"
 import { IUser } from "../../models/user"
 import { IRequirementBlockParams, IRequirementTemplateUpdateParams, ITagSearchParams } from "../../types/api-request"
 import {
@@ -243,5 +244,9 @@ export class Api {
 
   async restoreRequirementTemplate(id) {
     return this.client.patch<ApiResponse<IRequirementTemplate>>(`/requirement_templates/${id}/restore`)
+  }
+
+  async fetchTemplateVersion(id: string) {
+    return this.client.get<ApiResponse<ITemplateVersion>>(`/template_version/${id}`)
   }
 }

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -247,6 +247,6 @@ export class Api {
   }
 
   async fetchTemplateVersion(id: string) {
-    return this.client.get<ApiResponse<ITemplateVersion>>(`/template_version/${id}`)
+    return this.client.get<ApiResponse<ITemplateVersion>>(`/template_versions/${id}`)
   }
 }

--- a/app/frontend/stores/root-store.ts
+++ b/app/frontend/stores/root-store.ts
@@ -7,7 +7,7 @@ import { IPermitClassificationStore, PermitClassificationStoreModel } from "./pe
 import { IRequirementBlockStoreModel, RequirementBlockStoreModel } from "./requirement-block-store"
 import { IRequirementTemplateStoreModel, RequirementTemplateStoreModel } from "./requirement-template-store"
 import { ISessionStore, SessionStoreModel } from "./session-store"
-import { TemplateVersionStoreModel } from "./template-version-store"
+import { ITemplateVersionStoreModel, TemplateVersionStoreModel } from "./template-version-store"
 import { IUIStore, UIStoreModel } from "./ui-store"
 import { IUserStore, UserStoreModel } from "./user-store"
 
@@ -38,6 +38,6 @@ export interface IRootStore extends IStateTreeNode {
   userStore: IUserStore
   requirementBlockStore: IRequirementBlockStoreModel
   requirementTemplateStore: IRequirementTemplateStoreModel
-  templateVersionStore: IRequirementTemplateStoreModel
+  templateVersionStore: ITemplateVersionStoreModel
   geocoderStore: IGeocoderStore
 }

--- a/app/frontend/stores/template-version-store.ts
+++ b/app/frontend/stores/template-version-store.ts
@@ -24,6 +24,9 @@ export const TemplateVersionStoreModel = types
 
       if (response.ok) {
         const templateVersion = response.data.data
+
+        templateVersion.isFullyLoaded = true
+
         self.mergeUpdate(templateVersion, "templateVersionMap")
 
         return self.getTemplateVersionById(templateVersion.id)

--- a/app/frontend/stores/template-version-store.ts
+++ b/app/frontend/stores/template-version-store.ts
@@ -1,4 +1,4 @@
-import { Instance, types } from "mobx-state-tree"
+import { flow, Instance, toGenerator, types } from "mobx-state-tree"
 import { withEnvironment } from "../lib/with-environment"
 import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
@@ -17,6 +17,19 @@ export const TemplateVersionStoreModel = types
     getTemplateVersionById(id: string) {
       return self.templateVersionMap.get(id)
     },
+  }))
+  .actions((self) => ({
+    fetchTemplateVersion: flow(function* (id: string) {
+      const response = yield* toGenerator(self.environment.api.fetchTemplateVersion(id))
+
+      if (response.ok) {
+        const templateVersion = response.data.data
+        self.mergeUpdate(templateVersion, "templateVersionMap")
+
+        return self.getTemplateVersionById(templateVersion.id)
+      }
+      return response.ok
+    }),
   }))
 
 export interface ITemplateVersionStoreModel extends Instance<typeof TemplateVersionStoreModel> {}

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -22,10 +22,11 @@ export enum ERequirementTemplateStatus {
   draft = "draft",
 }
 
-export enum ETemplateVerionStatus {
+export enum ETemplateVersionStatus {
   published = "published",
   scheduled = "scheduled",
   deprecated = "deprecated",
+  draft = "draft",
 }
 
 export enum EUserRoles {

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -60,11 +60,10 @@ export enum EUserSortFields {
 }
 
 export enum ERequirementTemplateSortFields {
-  status = "status",
   permitType = "permit_type",
   activity = "activity",
   description = "description",
-  version = "version",
+  currentVersion = "current_version",
   jurisdictionsSize = "jurisdictions_size",
 }
 

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -1,4 +1,5 @@
-import { ENumberUnit, ESortDirection } from "./enums"
+import { IActivity, IPermitType } from "../models/permit-classification"
+import { ENumberUnit, ERequirementType, ESortDirection } from "./enums"
 
 export type TLatLngTuple = [number, number]
 
@@ -53,6 +54,7 @@ export interface IFormIOSection {
   initiallyCollapsed: false
   components: IFormIOBlock[]
 }
+
 export interface IFormIOBlock {
   id: string
   legend: string
@@ -75,4 +77,40 @@ export interface IFormIORequirement {
 
 export interface ISubmissionData {
   data: any[]
+}
+
+export interface IDenormalizedRequirement {
+  id: string
+  label: string
+  inputType: ERequirementType
+  inputOptions: IRequirementOptions
+  hint?: string | null
+}
+
+export interface IDenormalizedRequirementBlock {
+  id: string
+  name: string
+  description?: string
+  displayName: string
+  displayDescription?: string
+  requirements: IDenormalizedRequirement[]
+}
+
+export interface IDenormalizedTemplateSectionBlock {
+  id: string
+  requirementBlock: IDenormalizedRequirementBlock
+}
+
+export interface IDenormalizedRequirementTemplateSection {
+  id: string
+  name: string
+  templateSectionBlocks: IDenormalizedTemplateSectionBlock[]
+}
+
+export interface IDenormalizedTemplate {
+  id: string
+  description?: string
+  permitType: IPermitType
+  activity: IActivity
+  requirementTemplateSections: IDenormalizedRequirementTemplateSection[]
 }

--- a/app/frontend/utils/utility-funcitons.ts
+++ b/app/frontend/utils/utility-funcitons.ts
@@ -1,3 +1,4 @@
+import { format } from "date-fns"
 import { ERequirementType } from "../types/enums"
 import { TDebouncedFunction } from "../types/types"
 
@@ -76,4 +77,8 @@ export function handleScrollToBottom() {
     top: outerFlex.scrollHeight - outerFlex.clientHeight,
     behavior: "instant",
   })
+}
+
+export function formatTemplateVersion(versionDate: Date) {
+  return `v.${format(versionDate, "yyyy.MM.dd")}`
 }

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -107,7 +107,7 @@ class RequirementTemplate < ApplicationRecord
     {
       description: description,
       status: status,
-      version: version,
+      current_version: published_template_version&.version_date,
       permit_type: permit_type.name,
       activity: activity.name,
       discarded: discarded_at.present?,

--- a/app/models/template_version.rb
+++ b/app/models/template_version.rb
@@ -3,4 +3,15 @@ class TemplateVersion < ApplicationRecord
   has_many :jurisdiction_template_version_customizations
 
   enum status: { scheduled: 0, published: 1, deprecated: 2 }, _default: 0
+
+  after_save :reindex_requirement_template_if_published, if: :status_changed?
+
+  private
+
+  def reindex_requirement_template_if_published
+    reindex_requirement_template if published?
+  end
+  def reindex_requirement_template
+    requirement_template.reindex
+  end
 end

--- a/app/policies/template_version_policy.rb
+++ b/app/policies/template_version_policy.rb
@@ -1,0 +1,5 @@
+class TemplateVersionPolicy < ApplicationPolicy
+  def show?
+    !record.scheduled? || user.super_admin?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do
       patch "restore", on: :member
     end
 
+    resources :template_versions, only: %i[show]
+
     resources :jurisdictions, only: %i[index update show create] do
       post "search", on: :collection, to: "jurisdictions#index"
       post "users/search", on: :member, to: "jurisdictions#search_users"


### PR DESCRIPTION
## Description
- Adds template version screen
- Adds side bar to check template version and resume draft

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [X ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
-https://hous-bssb.atlassian.net/browse/BPHH-665
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Navigate to Template Catalogue as super admin
- Click Versions, select resume draft to navigate to edit screen
- Click Publish and schedule a version through the publish modal
- Note the permit and activity type
- Navigate back to the catalogue screen
- Click Versions button for the the permit and activity type noted previously
- You should be able to view the scheduled versions
<!--
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.
Provide any relevant screenshots here.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

