### PR TITLE
Update compliance check with spreadsheet fixes

### DIFF
--- a/app/controllers/api/step_codes_controller.rb
+++ b/app/controllers/api/step_codes_controller.rb
@@ -37,6 +37,7 @@ class Api::StepCodesController < Api::ApplicationController
     params.require(:step_code).permit(
       :name,
       :permit_application_id,
+      pre_construction_checklist_attributes: [:compliance_path],
       data_entries_attributes: [
         :district_energy_ef,
         :district_energy_consumption,

--- a/app/frontend/components/domains/step-code/edit/compliance-summary/index.tsx
+++ b/app/frontend/components/domains/step-code/edit/compliance-summary/index.tsx
@@ -2,11 +2,10 @@ import { HStack, Heading, Text, VStack } from "@chakra-ui/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
 import React from "react"
-import { Controller, useFormContext } from "react-hook-form"
+import { useFormContext } from "react-hook-form"
 import { IStepCodeChecklist } from "../../../../../models/step-code-checklist"
 import { TextFormControl } from "../../../../shared/form/input-form-control"
 import { ChecklistSection } from "../shared/checklist-section"
-import { CompliancePathSelect } from "./compliance-path-select"
 import { translationPrefix } from "./translation-prefix"
 
 interface IProps {
@@ -18,10 +17,12 @@ export const ComplianceSummary = observer(function ComplianceSummary({ checklist
 
   return (
     <ChecklistSection heading={t(`${translationPrefix}.heading`)}>
-      <Controller
-        control={control}
-        name="compliancePath"
-        render={({ field: { onChange, value } }) => <CompliancePathSelect onChange={onChange} value={value} />}
+      <TextFormControl
+        label={t(`${translationPrefix}.compliancePath.label`)}
+        inputProps={{
+          isDisabled: true,
+          value: t(`${translationPrefix}.compliancePath.options.${checklist.compliancePath}`),
+        }}
       />
 
       {/* Step Requirements */}

--- a/app/frontend/components/domains/step-code/new/compliance-path-select.tsx
+++ b/app/frontend/components/domains/step-code/new/compliance-path-select.tsx
@@ -14,8 +14,8 @@ import { CaretDown } from "@phosphor-icons/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
 import React from "react"
-import { useMst } from "../../../../../setup/root"
-import { EStepCodeCompliancePath } from "../../../../../types/enums"
+import { useMst } from "../../../../setup/root"
+import { EStepCodeCompliancePath } from "../../../../types/enums"
 import { translationPrefix } from "./translation-prefix"
 
 interface IProps {
@@ -46,7 +46,7 @@ export const CompliancePathSelect = observer(function CompliancePathSelect({ onC
               >
                 {value
                   ? t(`${translationPrefix}.compliancePath.options.${value}`)
-                  : t(`${translationPrefix}.compliancePath.select`)}
+                  : t(`${translationPrefix}.compliancePath.label`)}
               </Input>
               <InputRightElement children={<CaretDown color="gray.300" />} />
             </InputGroup>

--- a/app/frontend/components/domains/step-code/new/new.tsx
+++ b/app/frontend/components/domains/step-code/new/new.tsx
@@ -9,6 +9,7 @@ import { useMst } from "../../../../setup/root"
 import { requestPresignedUrl, uploadFileInChunks } from "../../../../utils/uploads"
 import { SharedSpinner } from "../../../shared/base/shared-spinner"
 import { FileFormControl, NumberFormControl, TextFormControl } from "../../../shared/form/input-form-control"
+import { CompliancePathSelect } from "./compliance-path-select"
 import { PermitApplicationSelect } from "./permit-application-select"
 
 export const NewStepCodeForm = observer(function NewStepCodeForm() {
@@ -30,7 +31,11 @@ export const NewStepCodeForm = observer(function NewStepCodeForm() {
 
   const formMethods = useForm({
     mode: "onChange",
-    defaultValues: { permitApplicationId: null, dataEntriesAttributes: [dataEntryAttributes] },
+    defaultValues: {
+      permitApplicationId: null,
+      preConstructionChecklistAttributes: { compliancePath: null },
+      dataEntriesAttributes: [dataEntryAttributes],
+    },
   })
   const { control, handleSubmit, setValue, setError, clearErrors, formState } = formMethods
   const { isValid, isSubmitting } = formState
@@ -144,6 +149,15 @@ export const NewStepCodeForm = observer(function NewStepCodeForm() {
                       rules={{ required: true }}
                       render={({ field: { onChange, value } }) => (
                         <PermitApplicationSelect onChange={onChange} value={value} />
+                      )}
+                    />
+
+                    <Controller
+                      control={control}
+                      name="preConstructionChecklistAttributes.compliancePath"
+                      rules={{ required: true }}
+                      render={({ field: { onChange, value } }) => (
+                        <CompliancePathSelect onChange={onChange} value={value} />
                       )}
                     />
 

--- a/app/frontend/components/domains/step-code/new/translation-prefix.ts
+++ b/app/frontend/components/domains/step-code/new/translation-prefix.ts
@@ -1,0 +1,2 @@
+type TPrefix = "stepCode.new"
+export const translationPrefix = "stepCode.new"

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -344,6 +344,15 @@ const options = {
             create: "Create",
             addData: "Add Data",
             selectPermitApplication: "Select Permit Application",
+            compliancePath: {
+              label: "Compliance Path",
+              options: {
+                step_code_ers: "9.36.6 BC Energy Step Code ERS",
+                step_code_necb: "9.36.6 BC Energy Step Code NECB",
+                passive_house: "9.36.6 Passive House",
+                step_code: "9.36.5 BC Energy Step Code",
+              },
+            },
           },
         },
         stepCodeChecklist: {
@@ -378,15 +387,6 @@ const options = {
             },
             codeComplianceSummary: {
               heading: "B: Code Compliance Summary",
-              compliancePath: {
-                select: "Compliance Path",
-                options: {
-                  step_code_ers: "9.36.6 BC Energy Step Code ERS",
-                  step_code_necb: "9.36.6 BC Energy Step Code NECB",
-                  passive_house: "9.36.6 Passive House",
-                  step_code: "9.36.5 BC Energy Step Code",
-                },
-              },
               energyStepCode: {
                 heading: "Energy Step Code",
                 stepRequired: "Step Required",

--- a/app/models/step_code.rb
+++ b/app/models/step_code.rb
@@ -10,9 +10,8 @@ class StepCode < ApplicationRecord
   has_many :checklists, class_name: "StepCodeChecklist", dependent: :destroy
   has_one :pre_construction_checklist, -> { where(stage: :pre_construction) }, class_name: "StepCodeChecklist"
 
-  after_create :create_pre_construction_checklist
-
   accepts_nested_attributes_for :data_entries
+  accepts_nested_attributes_for :pre_construction_checklist
 
   validates :name, presence: true
 end

--- a/app/services/step_code/compliance/check_requirements/energy/meui.rb
+++ b/app/services/step_code/compliance/check_requirements/energy/meui.rb
@@ -44,6 +44,7 @@ class StepCode::Compliance::CheckRequirements::Energy::MEUI < StepCode::Complian
   end
 
   def meui_percent_improvement
+    return nil if ref_energy_target == 0 || checklist.step_code?
     @meui_improvement_percentage ||= ((ref_energy_target - energy_consumption) / ref_energy_target * 100).round(2)
   end
 

--- a/app/services/step_code/compliance/check_requirements/energy/tedi.rb
+++ b/app/services/step_code/compliance/check_requirements/energy/tedi.rb
@@ -25,6 +25,7 @@ class StepCode::Compliance::CheckRequirements::Energy::TEDI < StepCode::Complian
 
   def tedi_hlr_percent
     reference = total(:ref_gshl)
+    return 0 if reference == 0 || checklist.compliance_path == :step_code
     ((reference - total(:proposed_gshl)) / reference * 100).round(0)
   end
 end

--- a/spec/services/step_code/compliance/check_requirements/energy/tedi_spec.rb
+++ b/spec/services/step_code/compliance/check_requirements/energy/tedi_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe StepCode::Compliance::CheckRequirements::Energy::TEDI do
     it_behaves_like PASSING_STEP_CODE
   end
 
-  context "when tedi does not meet energy step requirement but percent improvement does" do
+  context "when tedi does not meet energy step requirement but HLR % improvement does" do
     let(:data_entries_attributes) do
       [
         {
@@ -50,7 +50,8 @@ RSpec.describe StepCode::Compliance::CheckRequirements::Energy::TEDI do
     it_behaves_like PASSING_STEP_CODE
   end
 
-  context "when neither tedi nor percent improvement meets energy step requirement" do
+  context "when neither tedi nor HLR % improvement meets energy step requirement" do
+    let(:ref_gshl) { 62.35 }
     let(:data_entries_attributes) do
       [
         {
@@ -60,12 +61,36 @@ RSpec.describe StepCode::Compliance::CheckRequirements::Energy::TEDI do
           below_grade_heated_floor_area: 59.9,
           building_volume: 624.9,
           proposed_gshl: 61.11,
-          ref_gshl: 62.35,
+          ref_gshl: ref_gshl,
           hdd: 2851,
         },
       ]
     end
 
-    it_behaves_like FAILED_STEP_CODE
+    context "where the reference house GSHL is specified and compliance path is not 9.36.5" do
+      it_behaves_like FAILED_STEP_CODE
+    end
+
+    context "where the reference house GSHL is not specified" do
+      let(:ref_gshl) { 0 }
+
+      it "sets tedi_hlr_percent to zero" do
+        expect(subject.tedi_hlr_percent).to eq 0
+      end
+
+      it_behaves_like FAILED_STEP_CODE
+    end
+
+    context "where the compliance path is not 9.36.5" do
+      before :each do
+        allow(step_code.pre_construction_checklist).to receive(:compliance_path).and_return(:step_code)
+      end
+
+      it "sets tedi_hlr_percent to zero" do
+        expect(subject.tedi_hlr_percent).to eq 0
+      end
+
+      it_behaves_like FAILED_STEP_CODE
+    end
   end
 end


### PR DESCRIPTION
## Description

Updates the compliance check logic with the fixes applies to the step code checklist spreadsheet. This changes the MEUI % improvement and HLR % requirement calculations to handle blank reference house values and 9.36.5 compliance path step codes. This requires the compliance path select to be moved to the new step code form since this is now a pre-requisite for determining MEUI % improvement and HLR percent requirement compliance.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Implements [BPHH-688](https://hous-bssb.atlassian.net/browse/BPHH-688).

## Steps to QA

Create new step code with 9.36.5 energy step code selected as compliance path. The step code should create successfully and the MEUI % improvement and HLR % improvement should be undefined under the energy step code compliance section of the checklist.

## UI Accessibility Checklist

N/A

## General Checklist

- [x] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

No
