### PR TITLE
add editable nickname to permit applications and add submission infobox

### DIFF
--- a/app/controllers/api/concerns/search/permit_applications.rb
+++ b/app/controllers/api/concerns/search/permit_applications.rb
@@ -23,7 +23,6 @@ module Api::Concerns::Search::PermitApplications
     elsif @jurisdiction.present?
       search_conditions[:where] = { jurisdiction_id: @jurisdiction.id }
     end
-
     @permit_application_search = PermitApplication.search(query, **search_conditions)
   end
 

--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -37,13 +37,7 @@ class Api::PermitApplicationsController < Api::ApplicationController
         AutomatedCompliance::AutopopulateJob.perform_later(@permit_application)
       end
       render_success @permit_application,
-                     (
-                       if permit_application_params["submission_data"].present?
-                         "permit_application.save_draft_success"
-                       else
-                         "permit_application.update_success"
-                       end
-                     ),
+                     ("permit_application.save_draft_success"),
                      { blueprint: PermitApplicationBlueprint }
     else
       render_error "permit_application.update_error",
@@ -55,7 +49,6 @@ class Api::PermitApplicationsController < Api::ApplicationController
 
   def submit
     authorize @permit_application
-
     signed = permit_application_params["submission_data"]["data"]["section-completion-key"]["signed"]
 
     #for submissions, we do not run the automated compliance as that should have already been complete

--- a/app/frontend/components/domains/authentication/login-screen.tsx
+++ b/app/frontend/components/domains/authentication/login-screen.tsx
@@ -53,7 +53,7 @@ export const LoginScreen = ({}: ILoginScreenProps) => {
         <FormProvider {...formMethods}>
           <form onSubmit={handleSubmit(onSubmit)}>
             <VStack spacing={4}>
-              <Text>{t("auth.loginInstructions")}</Text>]{" "}
+              <Text>{t("auth.loginInstructions")}</Text>{" "}
               <Box w="full">
                 <UsernameFormControl autoFocus />
                 <PasswordFormControl />

--- a/app/frontend/components/domains/permit-application/checklist-sidebar.tsx
+++ b/app/frontend/components/domains/permit-application/checklist-sidebar.tsx
@@ -35,7 +35,7 @@ export const ChecklistSideBar = observer(({ permitApplication, completedSections
         borderColor="greys.grey02"
         maxW={378}
       >
-        <Tabs orientation="vertical" index={selectedTabIndex} w="full" pt={160}>
+        <Tabs orientation="vertical" index={selectedTabIndex} w="full" pt={195}>
           <TabList w="full" border={0}>
             {formJson.components.map((section) => {
               return (

--- a/app/frontend/components/domains/permit-application/contact-summary-modal.tsx
+++ b/app/frontend/components/domains/permit-application/contact-summary-modal.tsx
@@ -84,14 +84,14 @@ export const ContactSummaryModal = ({ isOpen, onOpen, onClose, permitApplication
               </Box>
             </Box>
 
-            {contacts.map((contact, index) => (
+            {contacts.map((contact) => (
               <Box key={contact.id} className={"contact-index-grid-row"} role={"row"} display={"contents"}>
-                <SearchGridItem key={`title-${index}`}>{contact.title}</SearchGridItem>
-                <SearchGridItem key={`name-${index}`}>{contact.name}</SearchGridItem>
-                <SearchGridItem key={`organization-${index}`}>{contact.organization}</SearchGridItem>
-                <SearchGridItem key={`email-${index}`}>{contact.email}</SearchGridItem>
-                <SearchGridItem key={`phone-${index}`}>{contact.phone}</SearchGridItem>
-                <SearchGridItem key={`address-${index}`}>{contact.address}</SearchGridItem>
+                <SearchGridItem key={`title-${contact.id}`}>{contact.title}</SearchGridItem>
+                <SearchGridItem key={`name-${contact.id}`}>{contact.name}</SearchGridItem>
+                <SearchGridItem key={`organization-${contact.id}`}>{contact.organization}</SearchGridItem>
+                <SearchGridItem key={`email-${contact.id}`}>{contact.email}</SearchGridItem>
+                <SearchGridItem key={`phone-${contact.id}`}>{contact.phone}</SearchGridItem>
+                <SearchGridItem key={`address-${contact.id}`}>{contact.address}</SearchGridItem>
               </Box>
             ))}
           </SearchGrid>

--- a/app/frontend/components/domains/permit-application/contact-summary-modal.tsx
+++ b/app/frontend/components/domains/permit-application/contact-summary-modal.tsx
@@ -1,0 +1,102 @@
+import {
+  Box,
+  Button,
+  Flex,
+  GridItem,
+  Heading,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { Download } from "@phosphor-icons/react"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { IPermitApplication } from "../../../models/permit-application"
+import { EContactSortFields } from "../../../types/enums"
+import { GridHeader } from "../../shared/grid/grid-header"
+import { SearchGrid } from "../../shared/grid/search-grid"
+import { SearchGridItem } from "../../shared/grid/search-grid-item"
+
+export interface IContactSummaryModalProps extends ReturnType<typeof useDisclosure> {
+  permitApplication: IPermitApplication
+}
+
+export const ContactSummaryModal = ({ isOpen, onOpen, onClose, permitApplication }) => {
+  const { t } = useTranslation()
+
+  const { contacts } = permitApplication
+
+  return (
+    <Modal onClose={onClose} isOpen={isOpen} size="5xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Flex w="full" justify="space-between" my={6}>
+            <Heading as="h1" textTransform={"capitalize"}>
+              {t("permitApplication.show.contactsSummary")}
+            </Heading>
+            <Button variant="link" leftIcon={<Download />}>
+              {t("permitApplication.show.downloadApplication")}
+            </Button>
+          </Flex>
+          <ModalCloseButton fontSize="11px" />
+        </ModalHeader>
+        <ModalBody py={6}>
+          <SearchGrid templateColumns="repeat(6, 1fr)">
+            <Box display={"contents"} role={"rowgroup"}>
+              <Box display={"contents"} role={"row"}>
+                <GridItem
+                  as={Flex}
+                  gridColumn={"span 6"}
+                  p={6}
+                  bg={"greys.grey10"}
+                  justifyContent={"space-between"}
+                  align="center"
+                >
+                  <Text role={"heading"} as={"h3"} color={"black"} fontSize={"sm"} height="fit-content">
+                    {t("permitApplication.show.contactSummaryHeading")}
+                  </Text>
+                </GridItem>
+              </Box>
+              <Box display={"contents"} role={"row"}>
+                {Object.values(EContactSortFields).map((field) => (
+                  <GridHeader key={field} role={"columnheader"} cursor="default">
+                    <Flex
+                      w={"full"}
+                      justifyContent={"space-between"}
+                      cursor="default"
+                      borderRight={"1px solid"}
+                      borderColor={"border.light"}
+                      px={4}
+                    >
+                      <Text textAlign="left" cursor="default">
+                        {field}
+                      </Text>
+                      {/* <SortIcon<EJurisdictionSortFields> field={field} currentSort={sort} /> */}
+                    </Flex>
+                  </GridHeader>
+                ))}
+              </Box>
+            </Box>
+
+            {contacts.map((contact, index) => (
+              <Box key={contact.id} className={"contact-index-grid-row"} role={"row"} display={"contents"}>
+                <SearchGridItem key={`title-${index}`}>{contact.title}</SearchGridItem>
+                <SearchGridItem key={`name-${index}`}>{contact.name}</SearchGridItem>
+                <SearchGridItem key={`organization-${index}`}>{contact.organization}</SearchGridItem>
+                <SearchGridItem key={`email-${index}`}>{contact.email}</SearchGridItem>
+                <SearchGridItem key={`phone-${index}`}>{contact.phone}</SearchGridItem>
+                <SearchGridItem key={`address-${index}`}>{contact.address}</SearchGridItem>
+              </Box>
+            ))}
+          </SearchGrid>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -1,23 +1,40 @@
-import { Box, Button, Flex, HStack, Heading, Text } from "@chakra-ui/react"
+import { Box, Button, Flex, HStack, Text, Tooltip } from "@chakra-ui/react"
 import { CaretRight } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
-import React, { useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
+import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
+import { useNavigate } from "react-router-dom"
 import { usePermitApplication } from "../../../hooks/resources/use-permit-application"
 import { useInterval } from "../../../hooks/use-interval"
 import { handleScrollToBottom } from "../../../utils/utility-funcitons"
 import { ErrorScreen } from "../../shared/base/error-screen"
 import { LoadingScreen } from "../../shared/base/loading-screen"
+import { EditableInputWithControls } from "../../shared/editable-input-with-controls"
 import { PermitApplicationStatusTag } from "../../shared/permit-applications/permit-application-status-tag"
 import { RequirementForm } from "../../shared/permit-applications/requirement-form"
 import { ChecklistSideBar } from "./checklist-sidebar"
 
 interface IEditPermitApplicationScreenProps {}
 
+type TPermitApplicationMetadataForm = {
+  nickname: string
+}
+
 export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationScreenProps) => {
   const { currentPermitApplication, error } = usePermitApplication()
   const { t } = useTranslation()
   const formRef = useRef(null)
+  const navigate = useNavigate()
+
+  const getDefaultPermitApplicationMetadataValues = () => ({ nickname: currentPermitApplication?.nickname })
+
+  const { register, watch, setValue, handleSubmit, reset } = useForm<TPermitApplicationMetadataForm>({
+    mode: "onChange",
+    defaultValues: getDefaultPermitApplicationMetadataValues(),
+  })
+
+  const nicknameWatch = watch("nickname")
 
   const [completedSections, setCompletedSections] = useState({})
 
@@ -36,7 +53,21 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
     } catch (e) {}
   }
 
+  const handleClickFinishLater = async () => {
+    await handleSave()
+    navigate("/")
+  }
+
+  const onSubmitMetadata = (formValues) => {
+    currentPermitApplication.update(formValues)
+  }
+
   useInterval(handleSave, 60000) // save progress every minute
+
+  useEffect(() => {
+    // sets the defaults subject to application load
+    reset(getDefaultPermitApplicationMetadataValues())
+  }, [currentPermitApplication?.nickname])
 
   if (error) return <ErrorScreen error={error} />
   if (!currentPermitApplication) return <LoadingScreen />
@@ -56,21 +87,55 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
         zIndex={10}
         maxH="96px"
       >
-        <HStack gap={4}>
+        <HStack gap={4} flex={1}>
           <PermitApplicationStatusTag
             bg="transparent"
             color="greys.white"
             permitApplication={currentPermitApplication}
           />
-          <Flex direction="column">
-            <Heading as="h3" fontSize="xl" mb={0}>
-              {nickname}
-            </Heading>
+          <Flex direction="column" w="full">
+            <form onSubmit={handleSubmit(onSubmitMetadata)}>
+              <Tooltip label={t("permitApplication.edit.clickToWriteNickname")} placement="top-start">
+                <Box>
+                  <EditableInputWithControls
+                    w="full"
+                    initialHint={t("permitApplication.edit.clickToWriteNickname")}
+                    value={nicknameWatch || ""}
+                    controlsProps={{
+                      iconButtonProps: {
+                        color: "greys.white",
+                      },
+                      saveButtonProps: { display: "none" },
+                    }}
+                    editableInputProps={{
+                      fontWeight: 700,
+                      fontSize: "xl",
+                      width: "100%",
+                      ...register("nickname", {
+                        maxLength: {
+                          value: 256,
+                          message: t("ui.invalidInput"),
+                        },
+                      }),
+                      onBlur: handleSubmit(onSubmitMetadata),
+                      "aria-label": "Edit Nickname",
+                    }}
+                    editablePreviewProps={{
+                      fontWeight: 700,
+                      fontSize: "xl",
+                    }}
+                    aria-label={"Edit Nickname"}
+                    onCancel={(previousValue) => setValue("nickname", previousValue)}
+                  />
+                </Box>
+              </Tooltip>
+            </form>
+
             <Text>{permitTypeAndActivity}</Text>
           </Flex>
         </HStack>
         <HStack gap={4}>
-          <Button variant="primary" onClick={handleSave}>
+          <Button variant="primary" onClick={handleClickFinishLater}>
             {t("permitApplication.edit.saveDraft")}
           </Button>
           <Button rightIcon={<CaretRight />} onClick={handleScrollToBottom}>

--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -72,7 +72,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
   if (error) return <ErrorScreen error={error} />
   if (!currentPermitApplication) return <LoadingScreen />
 
-  const { permitTypeAndActivity, formJson, nickname } = currentPermitApplication
+  const { permitTypeAndActivity, formJson, number } = currentPermitApplication
 
   return (
     <>
@@ -85,14 +85,11 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
         position="sticky"
         top={0}
         zIndex={10}
-        maxH="96px"
+        py={3}
+        maxH="112px"
       >
         <HStack gap={4} flex={1}>
-          <PermitApplicationStatusTag
-            bg="transparent"
-            color="greys.white"
-            permitApplication={currentPermitApplication}
-          />
+          <PermitApplicationStatusTag permitApplication={currentPermitApplication} />
           <Flex direction="column" w="full">
             <form onSubmit={handleSubmit(onSubmitMetadata)}>
               <Tooltip label={t("permitApplication.edit.clickToWriteNickname")} placement="top-start">
@@ -132,6 +129,12 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
             </form>
 
             <Text>{permitTypeAndActivity}</Text>
+            <Text mt={1}>
+              {t("permitApplication.fields.number")}:{" "}
+              <Text as="span" fontWeight={700}>
+                {number}
+              </Text>
+            </Text>
           </Flex>
         </HStack>
         <HStack gap={4}>

--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -116,7 +116,6 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
                         color: "greys.white",
                         display: isSubmitted ? "none" : "block",
                       },
-                      saveButtonProps: { display: "none" },
                     }}
                     editableInputProps={{
                       fontWeight: 700,

--- a/app/frontend/components/shared/base/flash-message.tsx
+++ b/app/frontend/components/shared/base/flash-message.tsx
@@ -26,7 +26,7 @@ export const FlashMessage = observer(() => {
   return null
 })
 
-const CustomToast = ({ title, description, status }: ToastProps) => {
+export const CustomToast = ({ title, description, status }: ToastProps) => {
   const iconMap = {
     success: <CheckCircle size={20} />,
     warning: <Warning size={20} />,

--- a/app/frontend/components/shared/permit-applications/permit-application-card.tsx
+++ b/app/frontend/components/shared/permit-applications/permit-application-card.tsx
@@ -108,7 +108,7 @@ export const PermitApplicationCard = ({ permitApplication }: IPermitApplicationC
             variant="primary"
             w={{ base: "full", md: "fit-content" }}
           >
-            {t("ui.resume")}
+            {permitApplication.isSubmitted ? t("ui.view") : t("ui.resume")}
           </RouterLinkButton>
         </Flex>
       </Flex>

--- a/app/frontend/components/shared/permit-applications/permit-application-status-tag.tsx
+++ b/app/frontend/components/shared/permit-applications/permit-application-status-tag.tsx
@@ -1,20 +1,34 @@
 import { Tag, TagProps } from "@chakra-ui/react"
 import React from "react"
 import { IPermitApplication } from "../../../models/permit-application"
+import { EPermitApplicationStatus } from "../../../types/enums"
 
 interface IPermitApplicationStatusTagProps extends TagProps {
   permitApplication: IPermitApplication
 }
 
 export const PermitApplicationStatusTag = ({ permitApplication, ...rest }: IPermitApplicationStatusTagProps) => {
+  const bgMap = {
+    [EPermitApplicationStatus.viewed]: "theme.blueAlt",
+    [EPermitApplicationStatus.submitted]: "theme.yellow",
+    [EPermitApplicationStatus.draft]: "theme.blueLight",
+  }
+
+  const colorMap = {
+    [EPermitApplicationStatus.viewed]: "greys.white",
+    [EPermitApplicationStatus.submitted]: "text.link",
+    [EPermitApplicationStatus.draft]: "text.link",
+  }
+
   return (
     <Tag
       p={1}
+      bg={bgMap[permitApplication.status]}
+      color={colorMap[permitApplication.status]}
       fontWeight="bold"
       border="1px solid"
       borderColor="border.light"
       textTransform="uppercase"
-      color="text.link"
       minW="fit-content"
       {...rest}
     >

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -17,6 +17,7 @@ import {
 import { ArrowUp } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 
+import { format } from "date-fns"
 import React, { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
@@ -26,6 +27,7 @@ import { IErrorsBoxData } from "../../../types/types"
 import { getCompletedSectionsFromForm } from "../../../utils/formio-component-traversal"
 import { handleScrollToTop } from "../../../utils/utility-funcitons"
 import { ErrorsBox } from "../../domains/permit-application/errors-box"
+import { CustomToast } from "../base/flash-message"
 import { Form } from "../chefs"
 
 interface IRequirementFormProps {
@@ -157,8 +159,16 @@ export const RequirementForm = observer(
 
     return (
       <>
-        <VStack position="relative" left="378px" right={0} w="calc(100% - 378px)" h={"full"}>
+        <Flex direction="column" gap={4} position="relative" left="378px" right={0} w="calc(100% - 378px)" h={"full"}>
           <ErrorsBox errorBox={errorBoxData} />
+          {permitApplication?.submittedAt && (
+            <CustomToast
+              description={t("permitApplication.edit.wasSubmitted", {
+                date: format(permitApplication.submittedAt, "MMM d, yyyy h:mm a"),
+              })}
+              status="info"
+            />
+          )}
           <HStack spacing={10} w={"full"} h={"full"} alignItems={"flex-start"} pr={8}>
             <Box as={"section"} flex={1} className={"form-wrapper"} scrollMargin={96} ref={boxRef}>
               <Form
@@ -166,7 +176,7 @@ export const RequirementForm = observer(
                 formReady={formReady}
                 submission={submissionData}
                 onSubmit={onFormSubmit}
-                options={permitApplication ? {} : { readOnly: true }}
+                options={permitApplication ? { readOnly: !!permitApplication.submittedAt } : { readOnly: true }}
                 onBlur={onBlur}
               />
             </Box>
@@ -179,7 +189,7 @@ export const RequirementForm = observer(
               </Button>
             </VStack>
           </HStack>
-        </VStack>
+        </Flex>
         {isOpen && (
           <Modal onClose={onClose} isOpen={isOpen} size="2xl">
             <ModalOverlay />
@@ -213,7 +223,6 @@ export const RequirementForm = observer(
                   </Flex>
                 </Flex>
               </ModalBody>
-              {/* Add ModalBody, ModalFooter or any other content you need here */}
             </ModalContent>
           </Modal>
         )}

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -163,7 +163,7 @@ export const RequirementForm = observer(
           <ErrorsBox errorBox={errorBoxData} />
           {permitApplication?.submittedAt && (
             <CustomToast
-              description={t("permitApplication.edit.wasSubmitted", {
+              description={t("permitApplication.show.wasSubmitted", {
                 date: format(permitApplication.submittedAt, "MMM d, yyyy h:mm a"),
               })}
               status="info"
@@ -176,7 +176,7 @@ export const RequirementForm = observer(
                 formReady={formReady}
                 submission={submissionData}
                 onSubmit={onFormSubmit}
-                options={permitApplication ? { readOnly: !!permitApplication.submittedAt } : { readOnly: true }}
+                options={permitApplication ? { readOnly: permitApplication.isSubmitted } : { readOnly: true }}
                 onBlur={onBlur}
               />
             </Box>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -247,6 +247,8 @@ const options = {
             permit: "Permit",
             fullAddress: "Full Address",
             pidPin: "PID / PIN",
+            clickToWriteNickname: "Click to write a nickname",
+            wasSubmitted: "Application was submitted on {{ date }}",
           },
         },
         requirementsLibrary: {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -84,6 +84,7 @@ const options = {
         },
         ui: {
           back: "Back",
+          backHome: "Back to home",
           yes: "Yes",
           no: "No",
           show: "Show",
@@ -248,7 +249,12 @@ const options = {
             fullAddress: "Full Address",
             pidPin: "PID / PIN",
             clickToWriteNickname: "Click to write a nickname",
+          },
+          show: {
             wasSubmitted: "Application was submitted on {{ date }}",
+            contactsSummary: "Contacts Summary",
+            downloadApplication: "Download application",
+            contactSummaryHeading: "List of all contacts on this application",
           },
         },
         requirementsLibrary: {

--- a/app/frontend/models/jurisdiction.ts
+++ b/app/frontend/models/jurisdiction.ts
@@ -45,7 +45,6 @@ export const JurisdictionModel = types
       const sortByCreatedAt = R.sort<IContact>((a, b) => (a.createdAt as number) - (b.createdAt as number))
 
       return sortByCreatedAt(self.contacts)[0]
-      // return self.contacts[0]
     },
   }))
   .actions((self) => ({

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -37,7 +37,7 @@ export const PermitApplicationModel = types
       return self.jurisdiction.name
     },
     get permitTypeAndActivity() {
-      return `${self.activity.name} ${self.permitType.name}`.trim()
+      return `${self.activity.name} - ${self.permitType.name}`.trim()
     },
     get flattenedBlocks() {
       return self.formJson.components

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -57,6 +57,9 @@ export const PermitApplicationModel = types
     blockKey(sectionId, blockId) {
       return `formSubmissionDataRSTsection${sectionId}|RB${blockId}`
     },
+    get isSubmitted() {
+      return !!self.submittedAt
+    },
   }))
   .views((self) => ({
     indexOfBlockId: (blockId: string) => {
@@ -67,6 +70,42 @@ export const PermitApplicationModel = types
     },
     get blockClasses() {
       return self.flattenedBlocks.map((b) => `formio-component-${b.key}`)
+    },
+    get contacts() {
+      return [
+        {
+          title: "STUBBED",
+          name: "John Doe",
+          organization: "Acme Corp",
+          email: "johndoe@example.com",
+          phone: "555-1234",
+          address: "1234 Elm Street, Anytown, AT 12345",
+        },
+        {
+          title: "STUBBED",
+          name: "Jane Smith",
+          organization: "Widget Inc",
+          email: "janesmith@example.com",
+          phone: "555-5678",
+          address: "5678 Oak Avenue, Anycity, AC 67890",
+        },
+        {
+          title: "STUBBED",
+          name: "Sam Johnson",
+          organization: "Gadgets LLC",
+          email: "samjohnson@example.com",
+          phone: "555-9101",
+          address: "9101 Pine Road, Somewhere, SW 10112",
+        },
+        {
+          title: "STUBBED",
+          name: "Alex Lee",
+          organization: "Innovatech",
+          email: "alexlee@example.com",
+          phone: "555-1213",
+          address: "1213 Maple Lane, Nowhere, NW 21314",
+        },
+      ]
     },
   }))
   .actions((self) => ({

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -17,7 +17,6 @@ export const PermitApplicationStoreModel = types
       permitApplicationMap: types.map(PermitApplicationModel),
       tablePermitApplications: types.array(types.reference(PermitApplicationModel)),
       currentPermitApplication: types.maybeNull(types.reference(PermitApplicationModel)),
-      isFetchingPermitApplications: types.optional(types.boolean, false),
     }),
     createSearchModel<EPermitApplicationSortFields>("searchPermitApplications")
   )
@@ -105,7 +104,6 @@ export const PermitApplicationStoreModel = types
           perPage: opts?.countPerPage ?? self.countPerPage,
         }
       )
-
       if (response.ok) {
         self.mergeUpdateAll(response.data.data, "permitApplicationMap")
         // dual purpose method also serves the submitters

--- a/app/frontend/styles/theme/components/button.ts
+++ b/app/frontend/styles/theme/components/button.ts
@@ -74,6 +74,9 @@ export const Button = {
         _hover: { bg: "greys.grey02", borderColor: "border.base" },
       },
     },
+    ghost: {
+      _hover: { bg: "lighten.100", _disabled: { ...disabledStyles }, _active: { ...activeStyles } },
+    },
     link: {
       color: "text.link",
       fontWeight: "normal",

--- a/app/frontend/styles/theme/components/input.ts
+++ b/app/frontend/styles/theme/components/input.ts
@@ -22,7 +22,7 @@ const styles = {
     outline: {
       field: {
         borderColor: "border.light",
-        _hover: { borderColor: "border.base" },
+        _hover: { borderColor: "greys.grey01" },
       },
     },
   },

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -61,6 +61,14 @@ export enum ERequirementTemplateSortFields {
   jurisdictionsSize = "jurisdictions_size",
 }
 
+export enum EContactSortFields {
+  title = "title",
+  name = "name",
+  organization = "organization",
+  email = "email",
+  phone = "phone",
+  address = "address",
+}
 export enum EPermitApplicationSortFields {
   number = "number",
   permitClassification = "permit_classification",

--- a/app/models/concerns/traverse_data_json.rb
+++ b/app/models/concerns/traverse_data_json.rb
@@ -4,7 +4,9 @@ module TraverseDataJson
   #used to take a hash, deeply search and flatten the results into a file array
   #block expects an array to be returned
   def find_file_fields_and_transform!(hash, files, &block)
-    hash&.each do |key, value|
+    return {} unless hash.present?
+
+    hash.each do |key, value|
       if key.ends_with?("_file")
         files.concat(block.call(key, value)) if value.present?
       else
@@ -26,7 +28,9 @@ module TraverseDataJson
   #used to take a hash, deeply search and map results back into a key hash
   #block expects a value to be there
   def find_file_fields_and_transform_hash!(hash, files_hash, &block)
-    hash&.each do |key, value|
+    return {} unless hash.present?
+
+    hash.each do |key, value|
       if key.ends_with?("_file")
         files_hash[key] = block.call(key, value) if value.present?
       else

--- a/app/models/concerns/traverse_data_json.rb
+++ b/app/models/concerns/traverse_data_json.rb
@@ -4,7 +4,7 @@ module TraverseDataJson
   #used to take a hash, deeply search and flatten the results into a file array
   #block expects an array to be returned
   def find_file_fields_and_transform!(hash, files, &block)
-    hash.each do |key, value|
+    hash&.each do |key, value|
       if key.ends_with?("_file")
         files.concat(block.call(key, value)) if value.present?
       else
@@ -26,7 +26,7 @@ module TraverseDataJson
   #used to take a hash, deeply search and map results back into a key hash
   #block expects a value to be there
   def find_file_fields_and_transform_hash!(hash, files_hash, &block)
-    hash.each do |key, value|
+    hash&.each do |key, value|
       if key.ends_with?("_file")
         files_hash[key] = block.call(key, value) if value.present?
       else

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,6 +1,7 @@
 class Contact < ApplicationRecord
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :phone_number, phone: true
+  validates :cell_number, phone: true
   before_validation :normalize_phone_number
 
   belongs_to :jurisdiction

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -54,9 +54,7 @@ class PermitApplication < ApplicationRecord
   end
 
   def assign_default_nickname
-    nickname = "#{jurisdiction_name}: #{full_address || pid || pin || id}"
-    self.nickname = nickname
-    return nickname
+    self.nickname = "#{jurisdiction_name}: #{full_address || pid || pin || id}"
   end
 
   def assign_unique_number

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -1,7 +1,7 @@
 class PermitApplication < ApplicationRecord
   include FormSupportingDocuments
-  searchkick searchable: %i[number nickname permit_classifications submitter status],
-             word_start: %i[number nickname permit_classifications submitter status]
+  searchkick searchable: %i[number nickname full_address permit_classifications submitter status],
+             word_start: %i[number nickname full_address permit_classifications submitter status]
 
   belongs_to :submitter, class_name: "User"
   belongs_to :jurisdiction
@@ -18,18 +18,21 @@ class PermitApplication < ApplicationRecord
   # Custom validation
 
   validate :submitter_must_have_role
+  validates :nickname, presence: true
+
   enum status: { draft: 0, submitted: 1, viewed: 2 }, _default: 0
 
   delegate :name, to: :jurisdiction, prefix: true
   delegate :code, :name, to: :permit_type, prefix: true
   delegate :code, :name, to: :activity, prefix: true
 
-  before_create :assign_unique_number
+  before_create :assign_unique_number, :assign_default_nickname
   before_save :set_submitted_at, if: :status_changed?
 
   def search_data
     {
       number: number,
+      nickname: nickname,
       nickname: nickname,
       permit_classifications: "#{permit_type.name} #{activity.name}",
       submitter: "#{submitter.name} #{submitter.email}",
@@ -40,11 +43,6 @@ class PermitApplication < ApplicationRecord
     }
   end
 
-  #stubs for UI
-  def nickname
-    "#{jurisdiction_name}: #{full_address || pid || pin || id}"
-  end
-
   def form_json
     #TODO: add versioning for requirement templates, etc.  for now just stub the return of the requirement template to use and its form data
     #need to look up jurisidcitional version and enablement as well
@@ -53,6 +51,12 @@ class PermitApplication < ApplicationRecord
 
   def number_prefix
     jurisdiction.prefix
+  end
+
+  def assign_default_nickname
+    nickname = "#{jurisdiction_name}: #{full_address || pid || pin || id}"
+    self.nickname = nickname
+    return nickname
   end
 
   def assign_unique_number

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,9 +207,6 @@ en:
       update_error:
         title: Oops
         message: "%{error_message}"
-      update_success:
-        title: ""
-        message: "Permit application successfully updated!"
       save_draft_success:
         title: ""
         message: "Permit application successfully saved as draft!"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,6 +209,9 @@ en:
         message: "%{error_message}"
       update_success:
         title: ""
+        message: "Permit application successfully updated!"
+      save_draft_success:
+        title: ""
         message: "Permit application successfully saved as draft!"
       submit_error:
         title: Oops

--- a/db/migrate/20240228184946_add_nickname_to_permit_applications.rb
+++ b/db/migrate/20240228184946_add_nickname_to_permit_applications.rb
@@ -1,0 +1,5 @@
+class AddNicknameToPermitApplications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :permit_applications, :nickname, :string
+  end
+end

--- a/db/migrate/20240228231537_add_organization_to_contacts.rb
+++ b/db/migrate/20240228231537_add_organization_to_contacts.rb
@@ -1,6 +1,6 @@
 class AddOrganizationToContacts < ActiveRecord::Migration[7.1]
   def change
     add_column :contacts, :organization, :string
-    add_column :contacts, :cell, :string
+    add_column :contacts, :cell_number, :string
   end
 end

--- a/db/migrate/20240228231537_add_organization_to_contacts.rb
+++ b/db/migrate/20240228231537_add_organization_to_contacts.rb
@@ -1,0 +1,6 @@
+class AddOrganizationToContacts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :contacts, :organization, :string
+    add_column :contacts, :cell, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_28_184946) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_28_231537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -50,6 +50,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_28_184946) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "department"
+    t.string "organization"
+    t.string "cell"
     t.index ["jurisdiction_id"], name: "index_contacts_on_jurisdiction_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_28_231537) do
     t.datetime "updated_at", null: false
     t.string "department"
     t.string "organization"
-    t.string "cell"
+    t.string "cell_number"
     t.index ["jurisdiction_id"], name: "index_contacts_on_jurisdiction_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_22_203547) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_28_184946) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -122,6 +122,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_22_203547) do
     t.string "number"
     t.datetime "submitted_at"
     t.datetime "signed_off_at"
+    t.string "nickname"
     t.index ["activity_id"], name: "index_permit_applications_on_activity_id"
     t.index ["jurisdiction_id"],
             name: "index_permit_applications_on_jurisdiction_id"

--- a/spec/factories/permit_applications.rb
+++ b/spec/factories/permit_applications.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     permit_type { PermitType.first || association(:permit_type) }
     activity { Activity.first || association(:activity) }
     status { :draft }
+    sequence(:nickname) { |n| "Permit Application Nickname #{n}" }
   end
 end


### PR DESCRIPTION
## Description

add controller logic, migration, input and form, validation, etc for nickname
also add info box and readonly option for submitted forms

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-672
https://hous-bssb.atlassian.net/browse/BPHH-518

## Steps to QA

log in as submitter
view a draft permit, edit a nickname by clicking on, typing, clicking off
save and finish later - now goes back one to index after saving
go to a submitted application, see the blue info box
See fields are now disabled (readonly)

## UI Accessibility Checklist

passes wave
