### PR TITLE
[bphh-524] added error box to the right if it is triggered.

### DIFF
--- a/app/frontend/components/domains/permit-application/errors-box.tsx
+++ b/app/frontend/components/domains/permit-application/errors-box.tsx
@@ -1,0 +1,57 @@
+import { Box, Button, Collapse, Flex, Heading, Text, VStack, useDisclosure } from "@chakra-ui/react"
+import { CaretDown, CaretUp, WarningCircle } from "@phosphor-icons/react"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { IErrorsBoxData } from "../../../types/types"
+import { ScrollLink } from "../../shared/permit-applications/scroll-link"
+
+interface IErrorBoxProps {
+  errorBox: IErrorsBoxData[] //need to add types
+}
+
+export const ErrorsBox = ({ errorBox }: IErrorBoxProps) => {
+  const { t } = useTranslation()
+  const { isOpen, onToggle } = useDisclosure()
+  if (errorBox.length == 0) {
+    return <React.Fragment key={"errors"}></React.Fragment>
+  }
+  return (
+    <Box
+      key={"errors"}
+      bgColor={"semantic.errorLight"}
+      borderColor={"semantic.error"}
+      borderWidth={"1px"}
+      borderRadius="lg"
+      maxH="360px"
+      position="fixed"
+      right="20px"
+      top="160px"
+      zIndex={9}
+      p={4}
+      maxW={"300px"}
+      overflowY={"auto"}
+    >
+      <Flex>
+        <WarningCircle size={24} color={"semantic.error"} aria-label={"Warning icon"} />
+        <Heading as="h3" fontSize="md" overflowWrap={"break-word"}>
+          {t("requirementTemplate.edit.errorsBox.title", { count: errorBox.length })}
+        </Heading>
+        <Button
+          onClick={onToggle}
+          rightIcon={isOpen ? <CaretUp /> : <CaretDown />}
+          variant={"unstyled"}
+          size={"sm"}
+          aria-label={"Open errors"}
+        ></Button>
+      </Flex>
+      <Collapse in={isOpen}>
+        <Text>{t("requirementTemplate.edit.errorsBox.instructions")}</Text>
+        <VStack alignItems={"flex-start"}>
+          {errorBox.map((error, index) => (
+            <ScrollLink key={error.id} to={error.id}>{`${index}. ${error.label}`}</ScrollLink>
+          ))}
+        </VStack>
+      </Collapse>
+    </Box>
+  )
+}

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -22,8 +22,10 @@ import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useMountStatus } from "../../../hooks/use-mount-status"
 import { IPermitApplication } from "../../../models/permit-application"
+import { IErrorsBoxData } from "../../../types/types"
 import { getCompletedSectionsFromForm } from "../../../utils/formio-component-traversal"
 import { handleScrollToTop } from "../../../utils/utility-funcitons"
+import { ErrorsBox } from "../../domains/permit-application/errors-box"
 import { Form } from "../chefs"
 
 interface IRequirementFormProps {
@@ -43,7 +45,7 @@ export const RequirementForm = observer(
     const boxRef = useRef<HTMLDivElement>(null)
 
     const [wrapperClickCount, setWrapperClickCount] = useState(0)
-
+    const [errorBoxData, setErrorBoxData] = useState<IErrorsBoxData[]>([]) //an array of Labels and links to the component
     const [allCollapsed, setAllCollapsed] = useState(false)
 
     const togglePanelCollapse = () => {
@@ -137,6 +139,11 @@ export const RequirementForm = observer(
       if (onCompletedSectionsChange) {
         onCompletedSectionsChange(getCompletedSectionsFromForm(containerComponent.root))
       }
+      setErrorBoxData(
+        containerComponent.root.errors.map((error) => {
+          return { label: error.component.label, id: error.component.id, class: error.component.class }
+        })
+      )
     }
 
     const formReady = (rootComponent) => {
@@ -151,6 +158,7 @@ export const RequirementForm = observer(
     return (
       <>
         <VStack position="relative" left="378px" right={0} w="calc(100% - 378px)" h={"full"}>
+          <ErrorsBox errorBox={errorBoxData} />
           <HStack spacing={10} w={"full"} h={"full"} alignItems={"flex-start"} pr={8}>
             <Box as={"section"} flex={1} className={"form-wrapper"} scrollMargin={96} ref={boxRef}>
               <Form

--- a/app/frontend/components/shared/permit-applications/scroll-link.tsx
+++ b/app/frontend/components/shared/permit-applications/scroll-link.tsx
@@ -1,0 +1,19 @@
+import { Link } from "@chakra-ui/react"
+import React from "react"
+
+export const ScrollLink = ({ to, children, ...props }) => {
+  const handleClick = (event) => {
+    event.preventDefault()
+    const targetElement = document.getElementById(to)
+
+    if (targetElement) {
+      targetElement.scrollIntoView({ behavior: "instant", block: "center" })
+    }
+  }
+
+  return (
+    <Link href={`#${to}`} onClick={handleClick} {...props}>
+      {children}
+    </Link>
+  )
+}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -428,6 +428,10 @@ const options = {
             emptyTemplateSectionText: "Start by clicking the Add Section button",
             goToTop: "Go to top",
             collapseAll: "Collapse All",
+            errorsBox: {
+              title: "There are {{count}} fields with errors on the page.",
+              instructions: "Please fix the following before submitting:",
+            },
           },
           fields: {
             status: "Status",

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -77,3 +77,9 @@ export interface IFormIORequirement {
 export interface ISubmissionData {
   data: any[]
 }
+
+export interface IErrorsBoxData {
+  id: string
+  label: string
+  class: string
+}


### PR DESCRIPTION
## Description

Added an errors box to the right to quickly allow you to scroll to the error.

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
[https://hous-bssb.atlassian.net/browse/BPHH-524](https://hous-bssb.atlassian.net/browse/BPHH-524)

## Steps to QA

Go to the submitter form and put in an invalid phone number or another field.  On blur the error should show on the right and you can click the link to go to the eror.

When there are no errors the box does not show.

## UI Accessibility Checklist

- [x ] Markup uses semantic HTML?
- [x ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ x] 📝 Use descriptive commit messages
- [ x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state
