### PR TITLE
Feature/bphh 365/jurisdiction elective fields

### DIFF
--- a/app/blueprints/requirement_blueprint.rb
+++ b/app/blueprints/requirement_blueprint.rb
@@ -11,6 +11,7 @@ class RequirementBlueprint < Blueprinter::Base
          :related_content,
          :required_for_in_person_hint,
          :required_for_multiple_owners,
+         :elective,
          :updated_at,
          :created_at
 

--- a/app/blueprints/requirement_template_blueprint.rb
+++ b/app/blueprints/requirement_template_blueprint.rb
@@ -1,6 +1,6 @@
 class RequirementTemplateBlueprint < Blueprinter::Base
   identifier :id
-  fields :status, :description, :scheduled_for, :discarded_at, :created_at, :updated_at
+  fields :description, :discarded_at, :created_at, :updated_at
 
   association :permit_type, blueprint: PermitClassificationBlueprint
   association :activity, blueprint: PermitClassificationBlueprint

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -34,6 +34,12 @@ function isTemplateEditPath(path: string): boolean {
   return regex.test(path)
 }
 
+function isDigitalPermitEditPath(path: string): boolean {
+  const regex = /^\/digital-building-permits\/([a-f\d-]+)\/edit$/
+
+  return regex.test(path)
+}
+
 function isTemplateVersionPath(path: string): boolean {
   const regex = /^\/template-versions\/([a-f\d-]+)$/
   return regex.test(path)
@@ -56,6 +62,7 @@ function shouldHideSubNavbarForPath(path: string): boolean {
     isTemplateVersionPath,
     isPermitApplicationEditPath,
     isPermitApplicationPath,
+    isDigitalPermitEditPath,
   ]
 
   return matchers.some((matcher) => matcher(path))

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/builder-header.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/builder-header.tsx
@@ -13,6 +13,7 @@ interface IProps {
   renderDescription?: () => JSX.Element
   status?: ETemplateVersionStatus
   versionDate?: Date
+  breadCrumbs?: { href: string; title: string }[]
 }
 
 export const BuilderHeader = observer(function BuilderHeader({
@@ -20,26 +21,9 @@ export const BuilderHeader = observer(function BuilderHeader({
   status,
   versionDate,
   renderDescription,
+  breadCrumbs = [],
 }: IProps) {
   const { t } = useTranslation()
-  const breadCrumbs =
-    status === ETemplateVersionStatus.draft
-      ? [
-          {
-            href: "/requirement-templates",
-            title: t("site.breadcrumb.requirementTemplates"),
-          },
-          {
-            href: `/requirements-template${requirementTemplate.id}/edit`,
-            title: t("site.breadcrumb.editTemplate"),
-          },
-        ]
-      : [
-          {
-            href: "/template-versions",
-            title: t("site.breadcrumb.templateVersions"),
-          },
-        ]
 
   return (
     <Container as={"header"} maxW={"container.lg"} px={8}>

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/editable-builder-header.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/editable-builder-header.tsx
@@ -19,6 +19,16 @@ export const EditableBuilderHeader = observer(function EditableBuilderHeader({ r
   const watchedDescription = watch("description")
   return (
     <BuilderHeader
+      breadCrumbs={[
+        {
+          href: "/requirement-templates",
+          title: t("site.breadcrumb.requirementTemplates"),
+        },
+        {
+          href: `/requirements-template${requirementTemplate.id}/edit`,
+          title: t("site.breadcrumb.editTemplate"),
+        },
+      ]}
       requirementTemplate={requirementTemplate}
       status={ETemplateVersionStatus.draft}
       renderDescription={() => (

--- a/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/index.tsx
@@ -182,6 +182,11 @@ export const JurisdictionEditDigitalPermitScreen = observer(function Jurisdictio
                     triggerButtonProps={{
                       isDisabled: isSubmitting,
                     }}
+                    onResetDefault={(requirementBlockId) =>
+                      jurisdictionTemplateVersionCustomization?.customizations?.requirementBlockChanges?.[
+                        requirementBlockId
+                      ]
+                    }
                   />
                 )
               }}

--- a/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/index.tsx
@@ -117,6 +117,16 @@ export const JurisdictionEditDigitalPermitScreen = observer(function Jurisdictio
     <RemoveScroll style={{ width: "100%", height: "100%" }}>
       <Flex flexDir={"column"} w={"full"} maxW={"full"} h="full" as="main">
         <BuilderHeader
+          breadCrumbs={[
+            {
+              href: "/digital-building-permits",
+              title: t("site.breadcrumb.digitalBuildingPermits"),
+            },
+            {
+              href: `/digital-building-permits/${templateVersion.id}/edit`,
+              title: t("site.breadcrumb.editPermit"),
+            },
+          ]}
           requirementTemplate={denormalizedTemplate}
           status={templateVersion.status}
           versionDate={templateVersion.versionDate}

--- a/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/jurisdiction-requirement-block-edit-sidebar.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/jurisdiction-requirement-block-edit-sidebar.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   ButtonGroup,
   ButtonProps,
+  Checkbox,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
@@ -14,28 +15,34 @@ import {
   useDisclosure,
 } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
-import React, { useEffect } from "react"
-import { useController, useForm } from "react-hook-form"
+import React, { useEffect, useState } from "react"
+import { FormProvider, useController, useForm, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { IDenormalizedRequirementBlock, IRequirementBlockCustomization } from "../../../../../types/types"
+import {
+  IDenormalizedRequirement,
+  IDenormalizedRequirementBlock,
+  IRequirementBlockCustomization,
+} from "../../../../../types/types"
 import { Editor } from "../../../../shared/editor/editor"
-
-interface IProps {
-  requirementBlock: IDenormalizedRequirementBlock
-}
 
 interface ICustomizationForm extends IRequirementBlockCustomization {}
 
 interface IProps {
+  requirementBlock: IDenormalizedRequirementBlock
   requirementBlockCustomization?: IRequirementBlockCustomization
   triggerButtonProps?: Partial<ButtonProps>
   onSave?: (requirementBlockId: string, customization: ICustomizationForm) => void
 }
 
-function formFormDefaults(customization: IRequirementBlockCustomization | undefined): ICustomizationForm {
+function formFormDefaults(
+  availableElectiveFields: IDenormalizedRequirement[],
+  customization: IRequirementBlockCustomization | undefined
+): ICustomizationForm {
   return {
     tip: customization?.tip,
-    enabledElectiveFieldIds: customization?.enabledElectiveFieldIds,
+    enabledElectiveFieldIds: customization?.enabledElectiveFieldIds?.filter(
+      (id) => !!availableElectiveFields.find((f) => f.id === id)
+    ),
   }
 }
 
@@ -48,26 +55,31 @@ export const JurisdictionRequirementBlockEditSidebar = observer(function Jurisdi
   const { isOpen, onOpen, onClose } = useDisclosure()
   const btnRef = React.useRef()
   const { t } = useTranslation()
-  const { reset, handleSubmit, control } = useForm<ICustomizationForm>({
-    defaultValues: formFormDefaults(requirementBlockCustomization),
+  const electiveFields = requirementBlock?.requirements?.filter((req) => req.elective) ?? []
+  const formMethods = useForm<ICustomizationForm>({
+    defaultValues: formFormDefaults(electiveFields, requirementBlockCustomization),
   })
-  const {
-    field: { value: tipValue, onChange: onTipChange },
-  } = useController({ control, name: "tip" })
+  const { watch, setValue, reset, handleSubmit, control } = formMethods
+  const [showManageFieldsView, setShowManageFieldsView] = useState(false)
+
+  const watchedEnabledElectiveFieldIds = watch("enabledElectiveFieldIds") ?? []
 
   useEffect(() => {
     if (isOpen) {
-      reset(formFormDefaults(requirementBlockCustomization))
+      reset(formFormDefaults(electiveFields, requirementBlockCustomization))
     }
   }, [requirementBlockCustomization, isOpen])
 
   const handleCancel = () => {
-    reset(formFormDefaults(requirementBlockCustomization))
+    reset(formFormDefaults(electiveFields, requirementBlockCustomization))
+    setShowManageFieldsView(false)
     onClose()
   }
 
   const onSubmit = handleSubmit((data) => {
     onSave(requirementBlock.id, data)
+
+    setShowManageFieldsView(false)
     onClose()
   })
 
@@ -100,33 +112,149 @@ export const JurisdictionRequirementBlockEditSidebar = observer(function Jurisdi
           </DrawerHeader>
 
           <DrawerBody px={8}>
-            <Stack w={"full"} spacing={6}>
-              <Text color={"text.secondary"} fontSize={"sm"}>
-                {t("digitalBuildingPermits.edit.requirementBlockSidebar.description")}
-              </Text>
-              <Box sx={{ ".ql-container": { h: "112px" } }}>
-                <Text mb={1}>{t("digitalBuildingPermits.edit.requirementBlockSidebar.tipLabel")}</Text>
-                <Editor htmlValue={tipValue} onChange={onTipChange} />
-              </Box>
-              <ButtonGroup size={"md"}>
-                <Button
-                  variant={"primary"}
-                  flex={1}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onSubmit()
+            <FormProvider {...formMethods}>
+              {showManageFieldsView ? (
+                <ManageElectiveFieldsView
+                  existingEnabledElectiveFieldIds={watchedEnabledElectiveFieldIds}
+                  electiveFields={electiveFields}
+                  onCancel={() => setShowManageFieldsView(false)}
+                  onAddFields={(fieldIds) => {
+                    setValue("enabledElectiveFieldIds", fieldIds)
+                    setShowManageFieldsView(false)
                   }}
-                >
-                  {t("ui.done")}
-                </Button>
-                <Button variant={"secondary"} flex={1} onClick={handleCancel}>
-                  {t("ui.cancel")}
-                </Button>
-              </ButtonGroup>
-            </Stack>
+                />
+              ) : (
+                <MainView
+                  electiveFields={electiveFields}
+                  onDone={onSubmit}
+                  onCancel={handleCancel}
+                  onManageElectiveFields={() => setShowManageFieldsView(true)}
+                />
+              )}
+            </FormProvider>
           </DrawerBody>
         </DrawerContent>
       </Drawer>
     </>
   )
 })
+
+const MainView = ({
+  electiveFields,
+  onDone,
+  onCancel,
+  onManageElectiveFields,
+}: {
+  electiveFields: IDenormalizedRequirement[]
+  onDone: () => void
+  onCancel: () => void
+  onManageElectiveFields: () => void
+}) => {
+  const { t } = useTranslation()
+  const { control, watch } = useFormContext<ICustomizationForm>()
+  const {
+    field: { value: tipValue, onChange: onTipChange },
+  } = useController({ control, name: "tip" })
+  const watchedEnabledElectiveFieldIds = watch("enabledElectiveFieldIds") ?? []
+
+  return (
+    <Stack as={"section"} w={"full"} spacing={6}>
+      <Text color={"text.secondary"} fontSize={"sm"}>
+        {t("digitalBuildingPermits.edit.requirementBlockSidebar.description")}
+      </Text>
+      <Box sx={{ ".ql-container": { h: "112px" } }}>
+        <Text mb={1}>{t("digitalBuildingPermits.edit.requirementBlockSidebar.tipLabel")}</Text>
+        <Editor htmlValue={tipValue} onChange={onTipChange} />
+      </Box>
+
+      <Box w={"full"}>
+        <Text color={"text.secondary"} fontWeight={700}>
+          {t("digitalBuildingPermits.edit.requirementBlockSidebar.electiveFormFields")}
+        </Text>
+        <Stack w={"full"} spacing={2} mt={3}>
+          {watchedEnabledElectiveFieldIds.map((requirementFieldId) => {
+            const requirementField = electiveFields.find((req) => req.id === requirementFieldId)
+            return (
+              <Box key={requirementField.id} borderRadius={"md"} bg={"theme.blueLight"} px={4} py={1}>
+                {requirementField.label}
+              </Box>
+            )
+          })}
+        </Stack>
+      </Box>
+      <Button variant={"link"} textDecoration={"underline"} onClick={onManageElectiveFields}>
+        {t("digitalBuildingPermits.edit.requirementBlockSidebar.manageFieldsButton")}
+      </Button>
+      <ButtonGroup size={"md"}>
+        <Button variant={"primary"} flex={1} onClick={onDone}>
+          {t("ui.done")}
+        </Button>
+        <Button variant={"secondary"} flex={1} onClick={onCancel}>
+          {t("ui.cancel")}
+        </Button>
+      </ButtonGroup>
+    </Stack>
+  )
+}
+
+const ManageElectiveFieldsView = ({
+  existingEnabledElectiveFieldIds,
+  onCancel,
+  electiveFields,
+  onAddFields,
+}: {
+  existingEnabledElectiveFieldIds: string[]
+  electiveFields: IDenormalizedRequirement[]
+  onAddFields: (fieldIds: string[]) => void
+  onCancel: () => void
+}) => {
+  const { t } = useTranslation()
+  const [enabledFieldIds, setEnabledFieldIds] = useState<string[]>([...existingEnabledElectiveFieldIds])
+
+  const onFieldEnableChange = (fieldId: string, isEnabled: boolean) => {
+    if (isEnabled) {
+      setEnabledFieldIds((prev) => [...prev, fieldId])
+    } else {
+      setEnabledFieldIds((prev) => prev.filter((id) => id !== fieldId))
+    }
+  }
+  return (
+    <Stack as={"section"} w={"full"} spacing={6} mt={7}>
+      <Text color={"text.secondary"} fontWeight={700}>
+        {t("digitalBuildingPermits.edit.requirementBlockSidebar.selectFieldsTitle")}
+      </Text>
+      <Stack w={"full"} spacing={4}>
+        {electiveFields.map((requirementField) => {
+          return (
+            <Stack
+              key={requirementField.id}
+              flexDir={"row"}
+              spacing={2}
+              borderRadius={"md"}
+              border={"1px solid"}
+              borderColor={"border.light"}
+              bg={"theme.blueLight"}
+              px={4}
+              py={2}
+            >
+              <Checkbox
+                isChecked={enabledFieldIds.includes(requirementField.id)}
+                onChange={(e) => onFieldEnableChange(requirementField.id, e.target.checked)}
+              />
+              <Text fontWeight={700}>{requirementField.label}</Text>
+            </Stack>
+          )
+        })}
+      </Stack>
+
+      <ButtonGroup size={"md"} justifyContent={"flex-start"} gap={6}>
+        <Button variant={"primary"} onClick={() => onAddFields([...new Set(enabledFieldIds)])}>
+          {t("digitalBuildingPermits.edit.requirementBlockSidebar.addSelectedButton")}
+        </Button>
+        <Button variant={"secondary"} onClick={onCancel}>
+          {t("ui.cancel")}
+        </Button>
+      </ButtonGroup>
+    </Stack>
+  )
+}

--- a/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/jurisdiction-requirement-block-edit-sidebar.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/jurisdiction-requirement-block-edit-sidebar.tsx
@@ -32,6 +32,7 @@ interface IProps {
   requirementBlockCustomization?: IRequirementBlockCustomization
   triggerButtonProps?: Partial<ButtonProps>
   onSave?: (requirementBlockId: string, customization: ICustomizationForm) => void
+  onResetDefault?: (requirementBlockId: string) => ICustomizationForm | undefined
 }
 
 function formFormDefaults(
@@ -51,6 +52,7 @@ export const JurisdictionRequirementBlockEditSidebar = observer(function Jurisdi
   requirementBlockCustomization,
   triggerButtonProps,
   onSave,
+  onResetDefault,
 }: IProps) {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const btnRef = React.useRef()
@@ -129,6 +131,10 @@ export const JurisdictionRequirementBlockEditSidebar = observer(function Jurisdi
                   onDone={onSubmit}
                   onCancel={handleCancel}
                   onManageElectiveFields={() => setShowManageFieldsView(true)}
+                  onResetDefault={() => {
+                    const defaultCustomization = onResetDefault(requirementBlock.id)
+                    defaultCustomization && reset(formFormDefaults(electiveFields, defaultCustomization))
+                  }}
                 />
               )}
             </FormProvider>
@@ -144,11 +150,13 @@ const MainView = ({
   onDone,
   onCancel,
   onManageElectiveFields,
+  onResetDefault,
 }: {
   electiveFields: IDenormalizedRequirement[]
   onDone: () => void
   onCancel: () => void
   onManageElectiveFields: () => void
+  onResetDefault?: () => void
 }) => {
   const { t } = useTranslation()
   const { control, watch } = useFormContext<ICustomizationForm>()
@@ -182,17 +190,30 @@ const MainView = ({
           })}
         </Stack>
       </Box>
-      <Button variant={"link"} textDecoration={"underline"} onClick={onManageElectiveFields}>
-        {t("digitalBuildingPermits.edit.requirementBlockSidebar.manageFieldsButton")}
-      </Button>
+      {electiveFields?.length > 0 && (
+        <Button variant={"link"} textDecoration={"underline"} onClick={onManageElectiveFields}>
+          {t("digitalBuildingPermits.edit.requirementBlockSidebar.manageFieldsButton")}
+        </Button>
+      )}
       <ButtonGroup size={"md"}>
-        <Button variant={"primary"} flex={1} onClick={onDone}>
+        <Button
+          variant={"primary"}
+          flex={1}
+          onClick={(e) => {
+            e.stopPropagation()
+            onDone()
+          }}
+        >
           {t("ui.done")}
         </Button>
         <Button variant={"secondary"} flex={1} onClick={onCancel}>
           {t("ui.cancel")}
         </Button>
       </ButtonGroup>
+
+      <Button variant={"link"} textDecoration={"underline"} onClick={onResetDefault}>
+        {t("digitalBuildingPermits.edit.requirementBlockSidebar.resetToDefaults")}
+      </Button>
     </Stack>
   )
 }

--- a/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
@@ -44,6 +44,12 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
     <RemoveScroll style={{ width: "100%", height: "100%" }}>
       <Flex flexDir={"column"} w={"full"} maxW={"full"} h="full" as="main">
         <BuilderHeader
+          breadCrumbs={[
+            {
+              href: "/template-versions",
+              title: t("site.breadcrumb.templateVersions"),
+            },
+          ]}
           requirementTemplate={denormalizedTemplate}
           status={templateVersion.status}
           versionDate={templateVersion.versionDate}

--- a/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
+++ b/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
@@ -65,17 +65,19 @@ export const TemplateVersionsSidebar = observer(function TemplateVersionsSidebar
                   }
                 />
               </Box>
-              <Box>
-                <Text as="h3" fontSize={"xl"} fontWeight={700} mb={2}>
-                  {t("requirementTemplate.versionSidebar.listTitles.draft")}
-                </Text>
+              {!requirementTemplate.isDiscarded && (
+                <Box>
+                  <Text as="h3" fontSize={"xl"} fontWeight={700} mb={2}>
+                    {t("requirementTemplate.versionSidebar.listTitles.draft")}
+                  </Text>
 
-                <VersionCard
-                  viewRoute={`/requirement-templates/${requirementTemplate.id}/edit`}
-                  status={ETemplateVersionStatus.draft}
-                  updatedAt={requirementTemplate.updatedAt}
-                />
-              </Box>
+                  <VersionCard
+                    viewRoute={`/requirement-templates/${requirementTemplate.id}/edit`}
+                    status={ETemplateVersionStatus.draft}
+                    updatedAt={requirementTemplate.updatedAt}
+                  />
+                </Box>
+              )}
 
               <VersionsList
                 type={ETemplateVersionStatus.scheduled}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -795,6 +795,10 @@ const options = {
               description:
                 "Local jurisdictions can change building permit applications to fit their needs by adding elective fields and offering submitters practical tips. This helps make the application forms reflect the distinct regulations, standards, and requirements of each jurisdiction, so applicants provide the correct information needed by their area.",
               tipLabel: "Tip for submitters (optional)",
+              manageFieldsButton: "Manage elective field(s)",
+              selectFieldsTitle: "Select elective fields",
+              electiveFormFields: "Elective Form Fields",
+              addSelectedButton: "Add selected",
             },
           },
         },

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -796,6 +796,7 @@ const options = {
                 "Local jurisdictions can change building permit applications to fit their needs by adding elective fields and offering submitters practical tips. This helps make the application forms reflect the distinct regulations, standards, and requirements of each jurisdiction, so applicants provide the correct information needed by their area.",
               tipLabel: "Tip for submitters (optional)",
               manageFieldsButton: "Manage elective field(s)",
+              resetToDefaults: "Reset to defaults",
               selectFieldsTitle: "Select elective fields",
               electiveFormFields: "Elective Form Fields",
               addSelectedButton: "Add selected",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -839,6 +839,7 @@ const options = {
             edit: "Edit",
             users: "Users",
             editTemplate: "Edit template",
+            editPermit: "Edit Permit",
             permitApplications: "Permit Applications",
             submissionInbox: "Submission Inbox",
             configuration: "Configure Jurisdiction",

--- a/app/frontend/models/requirement-template.ts
+++ b/app/frontend/models/requirement-template.ts
@@ -2,7 +2,7 @@ import { addDays, isAfter, isSameDay, max } from "date-fns"
 import { Instance, flow, types } from "mobx-state-tree"
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
-import { ERequirementTemplateStatus, ETemplateVersionStatus } from "../types/enums"
+import { ETemplateVersionStatus } from "../types/enums"
 import { IActivity, IPermitType } from "./permit-classification"
 import { RequirementTemplateSectionModel } from "./requirement-template-section"
 import { TemplateVersionModel } from "./template-version"
@@ -34,7 +34,6 @@ export const RequirementTemplateModel = types.snapshotProcessor(
   types
     .model("RequirementTemplateModel", {
       id: types.identifier,
-      status: types.enumeration(Object.values(ERequirementTemplateStatus)),
       description: types.maybeNull(types.string),
       jurisdictionsSize: types.optional(types.number, 0),
       publishedTemplateVersion: types.maybeNull(types.safeReference(TemplateVersionModel)),
@@ -42,7 +41,6 @@ export const RequirementTemplateModel = types.snapshotProcessor(
       permitType: types.frozen<IPermitType>(),
       activity: types.frozen<IActivity>(),
       formJson: types.frozen<IRequirementTemplateFormJson>(),
-      scheduledFor: types.maybeNull(types.Date),
       discardedAt: types.maybeNull(types.Date),
       requirementTemplateSectionMap: types.map(RequirementTemplateSectionModel),
       sortedRequirementTemplateSections: types.array(types.safeReference(RequirementTemplateSectionModel)),

--- a/app/frontend/models/requirement.ts
+++ b/app/frontend/models/requirement.ts
@@ -9,6 +9,7 @@ export const RequirementModel = types
     hint: types.maybeNull(types.string),
     inputType: types.enumeration<ERequirementType[]>(Object.values(ERequirementType)),
     inputOptions: types.frozen<IRequirementOptions>({}),
+    elective: types.boolean,
     createdAt: types.Date,
     updatedAt: types.Date,
   })

--- a/app/frontend/stores/template-version-store.ts
+++ b/app/frontend/stores/template-version-store.ts
@@ -34,8 +34,10 @@ export const TemplateVersionStoreModel = types
       if (response.ok) {
         const templateVersions = response.data.data
 
-        templateVersions.forEach((version) => (version.isFullyLoaded = true)),
-          self.mergeUpdateAll(templateVersions, "templateVersionMap")
+        templateVersions.forEach((version) => {
+          version.isFullyLoaded = true
+        })
+        self.mergeUpdateAll(templateVersions, "templateVersionMap")
 
         !!activityId &&
           self.templateVersionsByActivityId.set(

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -1,4 +1,4 @@
-import { ENumberUnit, ERequirementTemplateStatus, ERequirementType, ETagType } from "./enums"
+import { ENumberUnit, ERequirementType, ETagType } from "./enums"
 import { IOption } from "./types"
 
 export interface IRequirementsAttribute {
@@ -39,7 +39,6 @@ export interface IRequirementTemplateSectionAttributes {
 }
 
 export interface IRequirementTemplateUpdateParams {
-  status?: ERequirementTemplateStatus
   description?: string | null
   requirementTemplateSectionsAttributes?: IRequirementTemplateSectionAttributes[]
 }

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -16,12 +16,6 @@ export enum EPermitApplicationStatus {
   viewed = "viewed",
 }
 
-export enum ERequirementTemplateStatus {
-  published = "published",
-  scheduled = "scheduled",
-  draft = "draft",
-}
-
 export enum ETemplateVersionStatus {
   published = "published",
   scheduled = "scheduled",
@@ -74,6 +68,7 @@ export enum EContactSortFields {
   phone = "phone",
   address = "address",
 }
+
 export enum EPermitApplicationSortFields {
   number = "number",
   permitClassification = "permit_classification",

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -95,6 +95,7 @@ export interface IDenormalizedRequirement {
   inputType: ERequirementType
   inputOptions: IRequirementOptions
   hint?: string | null
+  elective?: boolean
 }
 
 export interface IDenormalizedRequirementBlock {

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -11,7 +11,7 @@ class PermitApplication < ApplicationRecord
   belongs_to :permit_type
   belongs_to :activity
 
-  #The front end form update provides a json paylioad of items we want to force update on the front-end since form io maintains its own state and does not 'rerender' if we send the form data back
+  # The front end form update provides a json paylioad of items we want to force update on the front-end since form io maintains its own state and does not 'rerender' if we send the form data back
   attr_accessor :front_end_form_update
   has_one :step_code
 
@@ -51,8 +51,8 @@ class PermitApplication < ApplicationRecord
   end
 
   def form_json
-    #TODO: add versioning for requirement templates, etc.  for now just stub the return of the requirement template to use and its form data
-    #need to look up jurisidcitional version and enablement as well
+    # TODO: add versioning for requirement templates, etc.  for now just stub the return of the requirement template to use and its form data
+    # need to look up jurisidcitional version and enablement as well
     jurisdiction.template_form_json(activity, permit_type)
   end
 

--- a/db/migrate/20240305204740_add_elective_to_requirement.rb
+++ b/db/migrate/20240305204740_add_elective_to_requirement.rb
@@ -1,0 +1,5 @@
+class AddElectiveToRequirement < ActiveRecord::Migration[7.1]
+  def change
+    add_column :requirements, :elective, :boolean, default: false
+  end
+end

--- a/db/migrate/20240305210153_remove_unused_fields_from_requirement_template.rb
+++ b/db/migrate/20240305210153_remove_unused_fields_from_requirement_template.rb
@@ -1,0 +1,7 @@
+class RemoveUnusedFieldsFromRequirementTemplate < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :requirement_templates, :version
+    remove_column :requirement_templates, :scheduled_for
+    remove_column :requirement_templates, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,10 +153,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_06_190337) do
     t.uuid "permit_type_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "status", default: 0
     t.string "description"
-    t.string "version"
-    t.date "scheduled_for"
     t.datetime "discarded_at"
     t.index ["activity_id"], name: "index_requirement_templates_on_activity_id"
     t.index ["discarded_at"], name: "index_requirement_templates_on_discarded_at"
@@ -177,7 +174,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_06_190337) do
     t.datetime "updated_at", null: false
     t.uuid "requirement_block_id", null: false
     t.integer "position"
-    t.index ["requirement_block_id"], name: "index_requirements_on_requirement_block_id"
+    t.boolean "elective", default: false
+    t.index ["requirement_block_id"],
+            name: "index_requirements_on_requirement_block_id"
   end
 
   create_table "step_code_checklists", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/requirement_templates.rb
+++ b/spec/factories/requirement_templates.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :requirement_template do
     association :activity, factory: :activity
     association :permit_type, factory: :permit_type
-    status { :published }
 
     factory :requirement_template_with_sections do
       transient { sections_count { 5 } }


### PR DESCRIPTION
## Description
- Adds ability for review managers to a make customizations to a published template and add a elective fields for a requirement block

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-79
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
(Ping me if testing locally as it will require some setup as elective fields aren't seeded yet)
- Login as review manager
- Navigate to building permits page
- Click manage on any available permit template
- Click edit on any requirement block that has elective fields, and wait for the side bar to open
- Click Manage fields
- Check fields to enable
- Click Add fields
- Click done
- Click publish to save the changes

