### PR TITLE
Feature/bphh 760/edit requirement block elective fields

### DIFF
--- a/app/controllers/api/requirement_blocks_controller.rb
+++ b/app/controllers/api/requirement_blocks_controller.rb
@@ -89,6 +89,7 @@ class Api::RequirementBlocksController < Api::ApplicationController
         :related_content,
         :required_for_in_person_hint,
         :required_for_multiple_owners,
+        :elective,
         :_destroy,
         input_options: [:number_unit, value_options: [%i[value label]]],
       ],

--- a/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/jurisdiction-requirement-block-edit-sidebar.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/jurisdiction-requirement-block-edit-sidebar.tsx
@@ -259,6 +259,7 @@ const ManageElectiveFieldsView = ({
               py={2}
             >
               <Checkbox
+                borderColor={"border.input"}
                 isChecked={enabledFieldIds.includes(requirementField.id)}
                 onChange={(e) => onFieldEnableChange(requirementField.id, e.target.checked)}
               />

--- a/app/frontend/components/domains/requirements-library/requirement-field-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display.tsx
@@ -182,7 +182,7 @@ const requirementsComponentMap = {
     return (
       <FormControl isReadOnly>
         <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.multiSelectCheckbox")}
+          {label ?? t("requirementsLibrary.requirementTypeLabels.multiOptionSelect")}
         </FormLabel>
         <CheckboxGroup>
           <Stack>

--- a/app/frontend/components/domains/requirements-library/requirement-field-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display.tsx
@@ -250,7 +250,7 @@ export const GenericFieldDisplay = observer(function GroupedFieldDisplay({
 }: IGroupedFieldProps) {
   const { t } = useTranslation()
   return (
-    <FormControl isReadOnly>
+    <FormControl w={"100%"} isReadOnly>
       <FormLabel {...defaultLabelProps} {...labelProps} color={!label && showAddLabelIndicator ? "error" : undefined}>
         {label ??
           (showAddLabelIndicator

--- a/app/frontend/components/domains/requirements-library/requirement-field-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display.tsx
@@ -20,19 +20,26 @@ import { CalendarBlank, MapPin } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
+import { getRequirementTypeLabel } from "../../../constants"
 import { ENumberUnit, ERequirementType } from "../../../types/enums"
 
 const defaultLabelProps: Partial<FormLabelProps> = {
   color: "text.primary",
 }
 
-type TRequirementProps = {
+type TRequirementFieldDisplayProps = {
   labelProps?: Partial<FormLabelProps>
   label?: string
   options?: string[]
   helperText?: string
   unit?: ENumberUnit | null
   selectProps?: Partial<SelectProps>
+  requirementType: ERequirementType
+  showAddLabelIndicator?: boolean
+}
+
+interface IGroupedFieldProps extends Omit<TRequirementFieldDisplayProps, "options"> {
+  inputDisplay: JSX.Element
 }
 
 const helperTextStyles = {
@@ -42,241 +49,216 @@ const helperTextStyles = {
 const defaultOptions = ["Option", "Option"]
 
 const requirementsComponentMap = {
-  [ERequirementType.text]({ label, helperText, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
+  [ERequirementType.text](props: TRequirementFieldDisplayProps) {
+    return <GenericFieldDisplay inputDisplay={<Input bg={"white"} />} {...props} />
+  },
+
+  [ERequirementType.phone](props: TRequirementFieldDisplayProps) {
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.shortText")}
-        </FormLabel>
-        <Input bg={"white"} />
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <GenericFieldDisplay
+        inputDisplay={
+          <InputGroup>
+            <InputLeftElement pointerEvents="none">
+              <i className="fa fa-phone"></i>
+            </InputLeftElement>
+            <Input bg={"white"} />
+          </InputGroup>
+        }
+        {...props}
+      />
     )
   },
 
-  [ERequirementType.phone]({ label, helperText, labelProps }: TRequirementProps) {
+  [ERequirementType.email](props: TRequirementFieldDisplayProps) {
     const { t } = useTranslation()
+
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.phone")}
-        </FormLabel>
-        <InputGroup>
-          <InputLeftElement pointerEvents="none">
-            <i className="fa fa-phone"></i>
-          </InputLeftElement>
-          <Input bg={"white"} />
-        </InputGroup>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <GenericFieldDisplay
+        inputDisplay={
+          <InputGroup>
+            <InputLeftElement pointerEvents="none">
+              <i className="fa fa-envelope"></i>
+            </InputLeftElement>
+            <Input bg={"white"} />
+          </InputGroup>
+        }
+        {...props}
+      />
     )
   },
 
-  [ERequirementType.email]({ label, helperText, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
+  [ERequirementType.address](props: TRequirementFieldDisplayProps) {
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.email")}
-        </FormLabel>
-        <InputGroup>
-          <InputLeftElement pointerEvents="none">
-            <i className="fa fa-envelope"></i>
-          </InputLeftElement>
-          <Input bg={"white"} />
-        </InputGroup>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <GenericFieldDisplay
+        inputDisplay={
+          <InputGroup>
+            <InputLeftElement>
+              <MapPin />
+            </InputLeftElement>
+            <Input bg={"white"} />
+          </InputGroup>
+        }
+        {...props}
+      />
     )
   },
 
-  [ERequirementType.address]({ label, helperText, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
+  [ERequirementType.date](props: TRequirementFieldDisplayProps) {
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.address")}
-        </FormLabel>
-        <InputGroup>
-          <InputLeftElement>
-            <MapPin />
-          </InputLeftElement>
-          <Input bg={"white"} />
-        </InputGroup>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <GenericFieldDisplay
+        inputDisplay={
+          <InputGroup w={"166px"}>
+            <InputLeftElement>
+              <CalendarBlank />
+            </InputLeftElement>
+            <Input bg={"white"} />
+          </InputGroup>
+        }
+        {...props}
+      />
     )
   },
 
-  [ERequirementType.date]({ label, helperText, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
+  [ERequirementType.number]({ unit, ...genericieldDisplayProps }: TRequirementFieldDisplayProps) {
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.date")}
-        </FormLabel>
-        <InputGroup w={"166px"}>
-          <InputLeftElement>
-            <CalendarBlank />
-          </InputLeftElement>
-          <Input bg={"white"} />
-        </InputGroup>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <GenericFieldDisplay
+        inputDisplay={
+          <InputGroup w={"130px"}>
+            <InputRightElement mr={2}>{unit === undefined ? "unit" : unit}</InputRightElement>
+            <Input bg={"white"} />
+          </InputGroup>
+        }
+        {...genericieldDisplayProps}
+      />
     )
   },
 
-  [ERequirementType.number]({ label, helperText, unit, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
+  [ERequirementType.textArea](props: TRequirementFieldDisplayProps) {
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.number")}
-        </FormLabel>
-        <InputGroup w={"130px"}>
-          <InputRightElement mr={2}>{unit === undefined ? "unit" : unit}</InputRightElement>
-          <Input bg={"white"} />
-        </InputGroup>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <GenericFieldDisplay
+        inputDisplay={<Textarea bg={"white"} _hover={{ borderColor: "border.base" }} />}
+        {...props}
+      />
     )
   },
 
-  [ERequirementType.textArea]({ label, helperText, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
+  [ERequirementType.radio]({ options = defaultOptions, ...genericDisplayProps }: TRequirementFieldDisplayProps) {
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.textArea")}
-        </FormLabel>
-        <Textarea bg={"white"} _hover={{ borderColor: "border.base" }} />
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <GenericFieldDisplay
+        inputDisplay={
+          <RadioGroup defaultValue="1">
+            <Stack>
+              {options.map((option, index) => (
+                <Radio key={index} value={option}>
+                  {option}
+                </Radio>
+              ))}
+            </Stack>
+          </RadioGroup>
+        }
+        {...genericDisplayProps}
+      />
     )
   },
 
-  [ERequirementType.radio]({ label, options = defaultOptions, helperText, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
+  [ERequirementType.checkbox]({ options = defaultOptions, ...genericDisplayProps }: TRequirementFieldDisplayProps) {
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.radio")}
-        </FormLabel>
-        <RadioGroup defaultValue="1">
-          <Stack>
-            {options.map((option, index) => (
-              <Radio key={index} value={option}>
-                {option}
-              </Radio>
-            ))}
-          </Stack>
-        </RadioGroup>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <GenericFieldDisplay
+        inputDisplay={
+          <CheckboxGroup>
+            <Stack>
+              {options.map((option, index) => (
+                <Checkbox key={index} value={option}>
+                  {option}
+                </Checkbox>
+              ))}
+            </Stack>
+          </CheckboxGroup>
+        }
+        {...genericDisplayProps}
+      />
     )
   },
 
-  [ERequirementType.checkbox]({ label, helperText, options = defaultOptions, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
+  [ERequirementType.multiOptionSelect]({
+    options = defaultOptions,
+    ...genericDisplayProps
+  }: TRequirementFieldDisplayProps) {
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.multiOptionSelect")}
-        </FormLabel>
-        <CheckboxGroup>
-          <Stack>
-            {options.map((option, index) => (
-              <Checkbox key={index} value={option}>
-                {option}
-              </Checkbox>
-            ))}
-          </Stack>
-        </CheckboxGroup>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
-    )
-  },
-
-  [ERequirementType.multiOptionSelect]({ label, helperText, options = defaultOptions, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
-    return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.multiOptionSelect")}
-        </FormLabel>
-        <CheckboxGroup>
-          <Stack>
-            {options.map((option, index) => (
-              <Checkbox key={index} value={option}>
-                {option}
-              </Checkbox>
-            ))}
-          </Stack>
-        </CheckboxGroup>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <GenericFieldDisplay
+        inputDisplay={
+          <CheckboxGroup>
+            <Stack>
+              {options.map((option, index) => (
+                <Checkbox key={index} value={option}>
+                  {option}
+                </Checkbox>
+              ))}
+            </Stack>
+          </CheckboxGroup>
+        }
+        {...genericDisplayProps}
+      />
     )
   },
 
   [ERequirementType.select]({
-    label,
-    helperText,
-    options = defaultOptions,
-    labelProps,
     selectProps,
-  }: TRequirementProps) {
-    const { t } = useTranslation()
+    options = defaultOptions,
+    ...genericDisplayProps
+  }: TRequirementFieldDisplayProps) {
     return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.select")}
-        </FormLabel>
-        <Select placeholder={"Select"} color={"greys.grey01"} value={""} isReadOnly {...selectProps}>
-          {options.map((option, index) => (
-            <option key={index} value={option} style={{ width: "100%" }}>
-              {option}
-            </option>
-          ))}
-        </Select>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
+      <GenericFieldDisplay
+        inputDisplay={
+          <Select placeholder={"Select"} color={"greys.grey01"} value={""} isReadOnly {...selectProps}>
+            {options.map((option, index) => (
+              <option key={index} value={option} style={{ width: "100%" }}>
+                {option}
+              </option>
+            ))}
+          </Select>
+        }
+        {...genericDisplayProps}
+      />
     )
   },
 
-  [ERequirementType.file]({ label, helperText, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
-    return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.fileUpload")}
-        </FormLabel>
-        <i className="fa fa-cloud-upload"></i>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
-    )
+  [ERequirementType.file](props: TRequirementFieldDisplayProps) {
+    return <GenericFieldDisplay inputDisplay={<i className="fa fa-cloud-upload"></i>} {...props} />
   },
 
-  [ERequirementType.energyStepCode]({ label, helperText, labelProps }: TRequirementProps) {
-    const { t } = useTranslation()
-    return (
-      <FormControl isReadOnly>
-        <FormLabel {...defaultLabelProps} {...labelProps}>
-          {label ?? t("requirementsLibrary.requirementTypeLabels.energyStepCode")}
-        </FormLabel>
-        <i className="fa fa-bolt"></i>
-        {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-      </FormControl>
-    )
+  [ERequirementType.energyStepCode](props: TRequirementFieldDisplayProps) {
+    return <GenericFieldDisplay inputDisplay={<i className="fa fa-bolt"></i>} {...props} />
   },
 }
-
-type TProps = { requirementType: ERequirementType } & TRequirementProps
 
 export function hasRequirementFieldDisplayComponent(requirementType: ERequirementType): boolean {
   return !!requirementsComponentMap[requirementType]
 }
 
-export const RequirementFieldDisplay = observer(function RequirementFieldDisplay({ requirementType, ...rest }: TProps) {
-  return requirementsComponentMap[requirementType]?.(rest) ?? null
+export const RequirementFieldDisplay = observer(function RequirementFieldDisplay(props: TRequirementFieldDisplayProps) {
+  return requirementsComponentMap[props.requirementType]?.(props) ?? null
+})
+
+export const GenericFieldDisplay = observer(function GroupedFieldDisplay({
+  inputDisplay,
+  label,
+  labelProps,
+  helperText,
+  showAddLabelIndicator,
+  requirementType,
+}: IGroupedFieldProps) {
+  const { t } = useTranslation()
+  return (
+    <FormControl isReadOnly>
+      <FormLabel {...defaultLabelProps} {...labelProps} color={!label && showAddLabelIndicator ? "error" : undefined}>
+        {label ??
+          (showAddLabelIndicator
+            ? `${t("requirementsLibrary.modals.addLabel")} *`
+            : getRequirementTypeLabel(requirementType))}
+      </FormLabel>
+      {inputDisplay}
+      {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
+    </FormControl>
+  )
 })

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
@@ -384,7 +384,7 @@ type TProps<TFieldValues> = {
   requirementType: ERequirementType
 } & TRequirementEditProps<TFieldValues>
 
-export const RequirementFieldEdit = observer(function RequirementFieldDisplay<TFieldValues>({
+export const RequirementFieldEdit = observer(function RequirementFieldEdit<TFieldValues>({
   requirementType,
   ...rest
 }: TProps<TFieldValues>) {

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
@@ -39,6 +39,15 @@ type TRequirementEditProps<TFieldValues extends FieldValues> = TEditableGroupPro
   }
 }
 
+type TEditableGroupProps<TFieldValues extends FieldValues> = {
+  editableLabelProps?: IControlProps<TFieldValues> & Partial<IEditableInputWithControlsProps>
+  editableHelperTextProps?: IControlProps<TFieldValues> & Partial<IEditableInputWithControlsProps>
+  isOptionalCheckboxProps: IControlProps<TFieldValues> & Partial<CheckboxProps>
+  isElectiveCheckboxProps: IControlProps<TFieldValues> & Partial<CheckboxProps>
+  editableInput?: JSX.Element
+  multiOptionEditableInput?: JSX.Element
+}
+
 const requirementsComponentMap = {
   [ERequirementType.text]: function <TFieldValues>(props: TRequirementEditProps<TFieldValues>) {
     return <EditableGroup editableInput={<Input bg={"white"} isReadOnly />} {...props} />
@@ -425,21 +434,40 @@ function IsOptionalCheckbox<TFieldValues extends FieldValues>({
   controlProps,
   ...checkboxProps
 }: TRequirementEditProps<TFieldValues>["isOptionalCheckboxProps"]) {
-  const { field } = useController(controlProps)
+  const {
+    field: { value, onChange, ...restField },
+  } = useController(controlProps)
   const { t } = useTranslation()
+
   return (
-    <Checkbox {...checkboxProps} {...field}>
+    //   This is checked inverse of the boolean value. This is because the db field is for "required", instead of
+    //   optional, and by default it should be required
+    <Checkbox
+      {...checkboxProps}
+      isChecked={value === undefined ? value : !value}
+      onChange={(e) => {
+        onChange(!e.target.checked)
+      }}
+      {...restField}
+    >
       {t("requirementsLibrary.modals.optionalForSubmitters")}
     </Checkbox>
   )
 }
 
-type TEditableGroupProps<TFieldValues extends FieldValues> = {
-  editableLabelProps?: IControlProps<TFieldValues> & Partial<IEditableInputWithControlsProps>
-  editableHelperTextProps?: IControlProps<TFieldValues> & Partial<IEditableInputWithControlsProps>
-  isOptionalCheckboxProps: IControlProps<TFieldValues> & Partial<CheckboxProps>
-  editableInput?: JSX.Element
-  multiOptionEditableInput?: JSX.Element
+function IsElectiveCheckbox<TFieldValues extends FieldValues>({
+  controlProps,
+  ...checkboxProps
+}: TRequirementEditProps<TFieldValues>["isElectiveCheckboxProps"]) {
+  const {
+    field: { value, ...restField },
+  } = useController(controlProps)
+  const { t } = useTranslation()
+  return (
+    <Checkbox {...checkboxProps} isChecked={value} {...restField}>
+      {t("requirementsLibrary.modals.isAnElectiveField")}
+    </Checkbox>
+  )
 }
 
 function EditableGroup<TFieldValues>({
@@ -448,6 +476,7 @@ function EditableGroup<TFieldValues>({
   editableInput,
   multiOptionEditableInput,
   isOptionalCheckboxProps,
+  isElectiveCheckboxProps,
 }: TEditableGroupProps<TFieldValues>) {
   return (
     <Stack spacing={4}>
@@ -461,6 +490,7 @@ function EditableGroup<TFieldValues>({
         </Stack>
       )}
       <IsOptionalCheckbox {...isOptionalCheckboxProps} />
+      <IsElectiveCheckbox mt={"0.625rem"} {...isElectiveCheckboxProps} />
     </Stack>
   )
 }

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -167,7 +167,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
                         },
                         "aria-label": "Edit Helper Text",
                       }}
-                      checkboxProps={{
+                      isOptionalCheckboxProps={{
                         controlProps: {
                           control: control,
                           rules: {

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -1,9 +1,10 @@
-import { Box, Button, Flex, HStack, Text, VStack } from "@chakra-ui/react"
+import { Box, Button, Flex, HStack, Tag, Text, VStack } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
 import React, { useState } from "react"
 import { Controller, useController, useFieldArray, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
+import { getRequirementTypeLabel } from "../../../../constants"
 import { IRequirementsAttribute } from "../../../../types/api-request"
 import { ENumberUnit, ERequirementType } from "../../../../types/enums"
 import { isMultiOptionRequirement } from "../../../../utils/utility-functions"
@@ -15,6 +16,15 @@ import { RequirementFieldEdit } from "../requirement-field-edit"
 import { OptionsMenu } from "../requirement-field-edit/options-menu"
 import { IRequirementBlockForm } from "./index"
 
+const fieldContainerSharedProps = {
+  w: "full",
+  sx: {
+    "& input": {
+      maxW: "339px",
+    },
+  },
+  mt: 7,
+}
 export const FieldsSetup = observer(function FieldsSetup() {
   const { t } = useTranslation()
   const { setValue, control, register, watch } = useFormContext<IRequirementBlockForm>()
@@ -108,6 +118,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
           <VStack w={"full"} alignItems={"flex-start"} spacing={2} px={3}>
             {fields.map((field, index) => {
               const watchedHint = watch(`requirementsAttributes.${index}.hint`)
+              const watchedElective = watch(`requirementsAttributes.${index}.elective`)
               const requirementType = (field as IRequirementsAttribute).inputType
               return (
                 <Box
@@ -116,14 +127,20 @@ export const FieldsSetup = observer(function FieldsSetup() {
                   borderRadius={"sm"}
                   _hover={{
                     bg: "theme.blueLight",
-                    "& .requirement-edit-btn": {
-                      visibility: "visible",
+                    "& .requirement-edit-controls-container": {
+                      flexFlow: "row",
+                      ".requirement-edit-controls": {
+                        visibility: "visible",
+                      },
                     },
                   }}
                   _focus={{
                     bg: "theme.blueLight",
-                    "& .requirement-edit-btn": {
-                      visibility: "visible",
+                    "& .requirement-edit-controls-container": {
+                      flexFlow: "row",
+                      ".requirement-edit-controls": {
+                        visibility: "visible",
+                      },
                     },
                   }}
                   tabIndex={0}
@@ -132,15 +149,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
                   pb={5}
                   pos={"relative"}
                 >
-                  <Box
-                    w={"full"}
-                    sx={{
-                      "& input": {
-                        maxW: "339px",
-                      },
-                    }}
-                    display={isRequirementInEditMode(field.id) ? "block" : "none"}
-                  >
+                  <Box {...fieldContainerSharedProps} display={isRequirementInEditMode(field.id) ? "block" : "none"}>
                     <RequirementFieldEdit<IRequirementBlockForm>
                       requirementType={requirementType}
                       editableLabelProps={{
@@ -150,7 +159,6 @@ export const FieldsSetup = observer(function FieldsSetup() {
                           rules: { required: true },
                         },
                         color: "text.link",
-                        w: `calc(100% - 220px)`,
                         "aria-label": "Edit Label",
                       }}
                       editableHelperTextProps={{
@@ -219,21 +227,14 @@ export const FieldsSetup = observer(function FieldsSetup() {
                     />
                   </Box>
                   <Box
-                    w={"full"}
-                    sx={{
-                      "& input": {
-                        maxW: "339px",
-                      },
-                    }}
+                    className={"requirement-display"}
                     display={!isRequirementInEditMode(field.id) ? "block" : "none"}
+                    {...fieldContainerSharedProps}
                   >
                     <RequirementFieldDisplay
                       requirementType={requirementType}
                       label={watch(`requirementsAttributes.${index}.label`)}
                       helperText={watchedHint}
-                      labelProps={{
-                        w: `calc(100% - 60px})`,
-                      }}
                       unit={
                         requirementType === ERequirementType.number
                           ? watch(`requirementsAttributes.${index}.inputOptions.numberUnit`) ?? null
@@ -257,17 +258,42 @@ export const FieldsSetup = observer(function FieldsSetup() {
                         onRemove={() => remove(index)}
                       />
                     )}
-                    <Button
-                      className={"requirement-edit-btn"}
-                      visibility={isRequirementInEditMode(field.id) ? "visible" : "hidden"}
-                      variant={"primary"}
-                      size={"sm"}
-                      onClick={() => {
-                        toggleRequirementToEdit(field.id)
-                      }}
-                    >
-                      {t(isRequirementInEditMode(field.id) ? "ui.done" : "ui.edit")}
-                    </Button>
+                    <HStack className={"requirement-edit-controls-container"} flexFlow={"row-reverse"}>
+                      {watchedElective && !isRequirementInEditMode(field.id) && (
+                        <Tag
+                          bg={"theme.yellowLight"}
+                          color={"text.secondary"}
+                          fontWeight={700}
+                          fontSize={"xs"}
+                          visibility={isRequirementInEditMode(field.id) ? "hidden" : "visible"}
+                        >
+                          {t("requirementsLibrary.elective")}
+                        </Tag>
+                      )}
+                      {!isRequirementInEditMode(field.id) && (
+                        <Tag
+                          bg={"greys.grey03"}
+                          color={"text.secondary"}
+                          fontWeight={700}
+                          fontSize={"xs"}
+                          className={"requirement-edit-controls"}
+                          visibility={"hidden"}
+                        >
+                          {getRequirementTypeLabel(requirementType)}
+                        </Tag>
+                      )}
+                      <Button
+                        variant={"primary"}
+                        size={"sm"}
+                        onClick={() => {
+                          toggleRequirementToEdit(field.id)
+                        }}
+                        className={"requirement-edit-controls"}
+                        visibility={isRequirementInEditMode(field.id) ? "visible" : "hidden"}
+                      >
+                        {t(isRequirementInEditMode(field.id) ? "ui.done" : "ui.edit")}
+                      </Button>
+                    </HStack>
                   </HStack>
                 </Box>
               )

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -245,6 +245,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
                       selectProps={{
                         maxW: "339px",
                       }}
+                      showAddLabelIndicator
                     />
                   </Box>
                   <HStack pos={"absolute"} right={0} top={0} spacing={4}>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -170,12 +170,15 @@ export const FieldsSetup = observer(function FieldsSetup() {
                       isOptionalCheckboxProps={{
                         controlProps: {
                           control: control,
-                          rules: {
-                            onChange: (e) => setValue(`requirementsAttributes.${index}.required`, !e.target.value),
-                          },
                           name: `requirementsAttributes.${index}.required`,
-                          // @ts-ignore
                           defaultValue: true,
+                        },
+                      }}
+                      isElectiveCheckboxProps={{
+                        controlProps: {
+                          control: control,
+                          name: `requirementsAttributes.${index}.elective`,
+                          // @ts-ignore
                         },
                       }}
                       unitSelectProps={

--- a/app/frontend/constants.ts
+++ b/app/frontend/constants.ts
@@ -1,5 +1,5 @@
 import { t } from "i18next"
-import { ENumberUnit } from "./types/enums"
+import { ENumberUnit, ERequirementType } from "./types/enums"
 
 export const EMAIL_REGEX =
   /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
@@ -41,3 +41,15 @@ export const unitGroups: { [key: string]: ENumberUnit[] } = {
 }
 
 export const datefnsAppDateFormat = "yyyy/MM/dd"
+
+export function getRequirementTypeLabel(requirementType: ERequirementType) {
+  let derivedTranslationKey: keyof typeof ERequirementType
+
+  Object.entries(ERequirementType).forEach(([key, value]: [keyof typeof ERequirementType, ERequirementType]) => {
+    if (value === requirementType) {
+      derivedTranslationKey = key
+    }
+  })
+
+  return t(`requirementsLibrary.requirementTypeLabels.${derivedTranslationKey}`)
+}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -293,6 +293,7 @@ const options = {
             addHelpText: "Add help text",
             helpTextPlaceHolder: "Help text",
             optionalForSubmitters: "This field is optional for submitters",
+            isAnElectiveField: "This is an elective field for Local Gov",
             optionsMenu: {
               triggerButton: "Options",
               remove: "Remove",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -262,6 +262,7 @@ const options = {
           },
         },
         requirementsLibrary: {
+          elective: "Elective",
           associationsInfo: "Sections, tags, etc...",
           index: {
             title: "Requirements Library",
@@ -325,7 +326,7 @@ const options = {
             date: "Date",
             number: "Number",
             textArea: "Text Area",
-            radio: "Select Radio Options",
+            radio: "Radio Options",
             multiOptionSelect: "Multi-Select Checkboxes",
             select: "Single Select Dropdown",
             signature: "Signature",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -275,6 +275,7 @@ const options = {
             dummyOption: "Option",
           },
           modals: {
+            addLabel: "Add label",
             displayDescriptionLabel: "Instruction/Description (public)",
             addDescriptionTrigger: "Add instructions/description for this block",
             create: {
@@ -317,8 +318,10 @@ const options = {
             requirementSku: "Generated unique identifier",
           },
           requirementTypeLabels: {
-            shortText: "Short Text",
+            text: "Short Text",
+            checkbox: "Checkbox",
             address: "Address",
+            bcaddress: "BC Address",
             date: "Date",
             number: "Number",
             textArea: "Text Area",
@@ -327,7 +330,8 @@ const options = {
             select: "Single Select Dropdown",
             signature: "Signature",
             generalContact: "General Contact",
-            fileUpload: "File Upload",
+            professionalContact: "Professional Contact",
+            file: "File Upload",
             phone: "Phone",
             email: "E-mail",
             energyStepCode: "Energy Step Code",

--- a/app/frontend/models/requirement.ts
+++ b/app/frontend/models/requirement.ts
@@ -10,6 +10,7 @@ export const RequirementModel = types
     inputType: types.enumeration<ERequirementType[]>(Object.values(ERequirementType)),
     inputOptions: types.frozen<IRequirementOptions>({}),
     elective: types.boolean,
+    required: types.boolean,
     createdAt: types.Date,
     updatedAt: types.Date,
   })

--- a/app/frontend/styles/theme/foundations/colors.ts
+++ b/app/frontend/styles/theme/foundations/colors.ts
@@ -11,6 +11,7 @@ export const colors = {
     blueGradient:
       "var(--Gradient-Blue-Background, linear-gradient(125deg, #142B43 -52.7%, #142B43 -52.68%, #054277 47.38%, #142B43 137.55%));",
     yellow: "#FCBA19",
+    yellowLight: "#FEF2D6",
   },
   greys: {
     white: "#FFFFFF",

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -7,6 +7,7 @@ export interface IRequirementsAttribute {
   inputType?: ERequirementType
   hint?: string
   required?: boolean
+  elective?: boolean
   inputOptions?: {
     valueOptions?: IOption[]
     numberUnit?: ENumberUnit

--- a/app/services/requirements_from_xlsx_seeder.rb
+++ b/app/services/requirements_from_xlsx_seeder.rb
@@ -157,7 +157,7 @@ class RequirementsFromXlsxSeeder
               ), # if parse fails it will raise error
             # required_for_in_person_hint - text
             # reusable - boolean
-            required_for_multiple_owners: row["required_for_multiple_owners"].present?,
+            elective: row["elective"].present?,
             position: req_position_incrementer,
           )
           req_position_incrementer += 1


### PR DESCRIPTION
## Description
- Adds ability of super admins to mark fields as elective
- Adds tag to show input type on hover
- Adds tag to display field as elective
- Fixes bug with the state of "optional for submitter" not saving on page reload
- - Refactors `RequirementFieldEdit and `RequirementFieldDisplay` components to use reusable components to reduce duplication
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-760
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Login as super admin
- Navigate to requirement block page
- Click on any to edit
- Add a requirement field if one does now already exist
- Verify you can see the input type tag
- Click Edit button and mark the checkbox to denote the field as elective
- Click done
- The elective tag should be visible
- Refresh page to confirm changes persisted