### PR TITLE
[bphh-754] Add back-end logic to copy over jurisdiction changes to new template version

### DIFF
--- a/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/index.tsx
@@ -191,6 +191,15 @@ export const JurisdictionEditDigitalPermitScreen = observer(function Jurisdictio
                 )
               }}
               requirementBlockCustomizations={watchedCustomizations?.requirementBlockChanges}
+              hideElectiveField={(requirementBlockId, requirement) => {
+                const customization = watchedCustomizations.requirementBlockChanges[requirementBlockId]
+
+                if (!customization || !customization.enabledElectiveFieldIds) {
+                  return true
+                }
+
+                return !customization?.enabledElectiveFieldIds?.includes(requirement.id)
+              }}
             />
           </Flex>
         </Flex>

--- a/app/frontend/components/domains/requirement-template/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/sections-display.tsx
@@ -2,6 +2,7 @@ import { Box, HStack, Stack, Text } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import {
+  IDenormalizedRequirement,
   IDenormalizedRequirementBlock,
   IDenormalizedRequirementTemplateSection,
   IRequirementBlockCustomization,
@@ -32,6 +33,7 @@ interface ISectionDisplayProps {
   formScrollToId: (recordId: string) => string
   renderEdit?: (props: { denormalizedRequirementBlock: IDenormalizedRequirementBlock }) => JSX.Element
   requirementBlockCustomizations?: Record<string, IRequirementBlockCustomization>
+  hideElectiveField?: (requirementBlockId: string, requirement: IDenormalizedRequirement) => boolean
 }
 
 const SectionDisplay = observer(
@@ -42,6 +44,7 @@ const SectionDisplay = observer(
     formScrollToId,
     renderEdit,
     requirementBlockCustomizations,
+    hideElectiveField,
   }: ISectionDisplayProps) => {
     const sectionBlocks = section.templateSectionBlocks
     const sectionName = section.name
@@ -64,6 +67,7 @@ const SectionDisplay = observer(
           {sectionBlocks.map((sectionBlock) => (
             <RequirementBlockAccordion
               as={"section"}
+              hideElectiveField={hideElectiveField}
               id={formScrollToId(sectionBlock.id)}
               key={sectionBlock.id}
               requirementBlock={sectionBlock.requirementBlock}

--- a/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
@@ -33,6 +33,7 @@ type TProps = {
   triggerForceCollapse?: boolean
   renderEdit?: () => JSX.Element
   requirementBlockCustomization?: IRequirementBlockCustomization
+  hideElectiveField?: (requirementBlockId: string, requirement: IDenormalizedRequirement) => boolean
 } & Partial<AccordionProps> &
   (
     | { isEditable?: never; showEditWarning?: never }
@@ -51,6 +52,7 @@ export const RequirementBlockAccordion = observer(function RequirementBlockAccor
   triggerForceCollapse,
   renderEdit,
   requirementBlockCustomization,
+  hideElectiveField,
   ...accordionProps
 }: TProps) {
   const { t } = useTranslation()
@@ -142,43 +144,57 @@ export const RequirementBlockAccordion = observer(function RequirementBlockAccor
                 : 0
             }
           >
-            {requirementBlock.requirements.map((requirement: IDenormalizedRequirement, index) => {
-              const requirementType = requirement.inputType
-              return (
-                <Box
-                  key={requirement.id}
-                  w={"full"}
-                  borderRadius={"sm"}
-                  pt={index !== 0 ? 1 : 0}
-                  pb={5}
-                  pos={"relative"}
-                >
+            {requirementBlock.requirements
+              .filter((requirement) => {
+                if (!requirement.elective) {
+                  return true
+                }
+
+                if (!hideElectiveField) {
+                  return true
+                }
+
+                if (hideElectiveField) {
+                  return !hideElectiveField(requirementBlock.id, requirement)
+                }
+              })
+              .map((requirement: IDenormalizedRequirement, index) => {
+                const requirementType = requirement.inputType
+                return (
                   <Box
+                    key={requirement.id}
                     w={"full"}
-                    sx={{
-                      "& input": {
-                        maxW: "339px",
-                      },
-                    }}
+                    borderRadius={"sm"}
+                    pt={index !== 0 ? 1 : 0}
+                    pb={5}
+                    pos={"relative"}
                   >
-                    <RequirementFieldDisplay
-                      requirementType={requirementType}
-                      label={requirement.label}
-                      helperText={requirement?.hint}
-                      unit={
-                        requirementType === ERequirementType.number
-                          ? requirement?.inputOptions?.numberUnit ?? null
-                          : undefined
-                      }
-                      options={requirement?.inputOptions?.valueOptions?.map((option) => option.label)}
-                      selectProps={{
-                        maxW: "339px",
+                    <Box
+                      w={"full"}
+                      sx={{
+                        "& input": {
+                          maxW: "339px",
+                        },
                       }}
-                    />
+                    >
+                      <RequirementFieldDisplay
+                        requirementType={requirementType}
+                        label={requirement.label}
+                        helperText={requirement?.hint}
+                        unit={
+                          requirementType === ERequirementType.number
+                            ? requirement?.inputOptions?.numberUnit ?? null
+                            : undefined
+                        }
+                        options={requirement?.inputOptions?.valueOptions?.map((option) => option.label)}
+                        selectProps={{
+                          maxW: "339px",
+                        }}
+                      />
+                    </Box>
                   </Box>
-                </Box>
-              )
-            })}
+                )
+              })}
           </VStack>
         </AccordionPanel>
       </AccordionItem>

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -68,6 +68,8 @@ class TemplateVersioningService
 
       previous_version = previous_version(template_version)
 
+      return template_version if previous_version.blank?
+
       previous_version.jurisdiction_template_version_customizations.each do |customization|
         begin
           copy_jurisdiction_customizations_to_template_version(customization, template_version)

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -65,12 +65,105 @@ class TemplateVersioningService
       deprecate_versions_before_template(template_version)
 
       raise StandardError.new(template_version.errors.full_messages.join(", ")) if !template_version.save
+
+      previous_version = previous_version(template_version)
+
+      previous_version.jurisdiction_template_version_customizations.each do |customization|
+        begin
+          copy_jurisdiction_customizations_to_template_version(customization, template_version)
+        rescue => e
+          # we want to know if an error is happening
+          # but don't want to fail the whole publish process because of it
+          Rails.logger.error("Error copying customizations to new template version: #{e.message}")
+        end
+      end
     end
 
     return template_version
   end
 
   private
+
+  def self.previous_version(template_version)
+    template_version
+      .requirement_template
+      .template_versions
+      .where("version_date <=?", template_version.version_date)
+      .where.not(id: template_version.id)
+      .order(version_date: :desc)
+      .first
+  end
+
+  def self.copy_jurisdiction_customizations_to_template_version(
+    jurisdiction_template_version_customization,
+    new_template_version
+  )
+    return if jurisdiction_template_version_customization.blank? || new_template_version.blank?
+
+    modified_copied_customizations = jurisdiction_template_version_customization.customizations.deep_dup
+    existing_customization_for_template =
+      new_template_version.jurisdiction_template_version_customizations.find_by(
+        jurisdiction_id: jurisdiction_template_version_customization.jurisdiction_id,
+      )
+    does_new_template_already_have_customization = existing_customization_for_template.present?
+
+    return if modified_copied_customizations["requirement_block_changes"].blank?
+
+    # Remove any requirement_block_changes if the requirement_block is not present in the new template version
+    modified_copied_customizations["requirement_block_changes"].delete_if do |key, _value|
+      !new_template_version.requirement_blocks_json.key?(key)
+    end
+
+    # Remove any enabled_elective_field_ids that are not present in the new template version's requirement_blocks
+    modified_copied_customizations["requirement_block_changes"].each do |key, current_requirement_block_change|
+      next if current_requirement_block_change["enabled_elective_field_ids"].blank?
+
+      available_elective_field_ids =
+        new_template_version.requirement_blocks_json[key]["requirements"]
+          .select { |r| r["elective"] }
+          .map { |r| r["id"] }
+
+      modified_copied_customizations["requirement_block_changes"][key]["enabled_elective_field_ids"].delete_if do |id|
+        !available_elective_field_ids.include?(id)
+      end
+
+      if !does_new_template_already_have_customization ||
+           existing_customization_for_template
+             .customizations
+             .dig("requirement_block_changes", key, "enabled_elective_field_ids")
+             .blank?
+        next
+      end
+
+      # Combine the enabled_elective_field_ids from the old and new template versions and remove any duplicates
+      modified_copied_customizations["requirement_block_changes"][key][
+        "enabled_elective_field_ids"
+      ] = existing_customization_for_template.customizations.dig(
+        "requirement_block_changes",
+        key,
+        "enabled_elective_field_ids",
+      ) | modified_copied_customizations.dig("requirement_block_changes", key, "enabled_elective_field_ids")
+    end
+
+    copied_jurisdiction_template_version_customization = nil
+
+    if does_new_template_already_have_customization
+      copied_jurisdiction_template_version_customization = existing_customization_for_template
+      copied_jurisdiction_template_version_customization.customizations = modified_copied_customizations
+    else
+      copied_jurisdiction_template_version_customization =
+        new_template_version.jurisdiction_template_version_customizations.build(
+          jurisdiction_id: jurisdiction_template_version_customization.jurisdiction_id,
+          customizations: modified_copied_customizations,
+        )
+    end
+
+    if !copied_jurisdiction_template_version_customization.save
+      raise StandardError.new(
+              "Old jurisdiction customizations could not be copied to new template version for jurisdiction_id:#{jurisdiction_template_version_customization.jurisdiction_id}",
+            )
+    end
+  end
 
   def self.deprecate_versions_before_template(template_version)
     template_version


### PR DESCRIPTION
## Description
- This PR sets up the `TemplateVersioningService` so that it copies over the jurisdiction changes from last version to new template version published

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
**https://hous-bssb.atlassian.net/browse/BPHH-754**
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Unfortunately this happens in the background and cannot be manually tested easily
- Specs will be added later
<!--
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.
Provide any relevant screenshots here.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
