### PR TITLE
ad foippa warning and fix pid selector

### DIFF
--- a/app/frontend/components/domains/requirement-template/builder-floating-buttons.tsx
+++ b/app/frontend/components/domains/requirement-template/builder-floating-buttons.tsx
@@ -15,7 +15,7 @@ export function BuilderFloatingButtons({ onScrollToTop, onCollapseAll }: IProps)
         {t("requirementTemplate.edit.goToTop")}
       </Button>
       <Button variant={"greyButton"} onClick={onCollapseAll}>
-        {t("requirementTemplate.edit.collapseAll")}
+        {t("ui.collapseAll")}
       </Button>
     </Stack>
   )

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -19,7 +19,7 @@ import { observer } from "mobx-react-lite"
 import { format } from "date-fns"
 import React, { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { useLocation, useNavigate } from "react-router-dom"
+import { Link, useLocation, useNavigate } from "react-router-dom"
 import { useMountStatus } from "../../../hooks/use-mount-status"
 import { IPermitApplication } from "../../../models/permit-application"
 import { IErrorsBoxData } from "../../../types/types"
@@ -191,6 +191,12 @@ export const RequirementForm = observer(
               status="info"
             />
           )}
+          <Box bg="greys.grey03" p={3} borderRadius="sm">
+            <Text fontStyle="italic">
+              {t("site.foippaWarning")}
+              <Link to={"mailto:digital.codes.permits@gov.bc.ca"}>digital.codes.permits@gov.bc.ca</Link>
+            </Text>
+          </Box>
           <Form
             form={formattedFormJson}
             formReady={formReady}
@@ -200,7 +206,7 @@ export const RequirementForm = observer(
             onBlur={onBlur}
           />
         </Flex>
-        <VStack align="end" position="sticky" bottom={24} right={0} zIndex={11} gap={4}>
+        <VStack align="end" position="sticky" bottom={24} left={"100%"} zIndex={11} gap={4} w="fit-content">
           <Button w="136px" onClick={togglePanelCollapse} variant="greyButton">
             {allCollapsed ? t("ui.expandAll") : t("ui.collapseAll")}
           </Button>

--- a/app/frontend/components/shared/select/selectors/sites-select.tsx
+++ b/app/frontend/components/shared/select/selectors/sites-select.tsx
@@ -52,13 +52,14 @@ export const SitesSelect = observer(function ({
   }
 
   const handleChange = (option: IOption) => {
+    setPidOptions([])
     onChange(option)
+    setValue(pidName, null)
     if (option) {
       fetchPids(option.value).then((pids: string[]) => {
         setPidOptions(pids.map((pid) => ({ value: pid, label: pid })))
       })
     }
-    setValue(pidName, null)
     const selectControl = pidSelectRef.current.controlRef
     if (selectControl) {
       selectControl.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }))
@@ -124,7 +125,7 @@ export const SitesSelect = observer(function ({
                   <Select
                     options={pidOptions}
                     ref={pidSelectRef}
-                    value={pidOptions.find((option) => option.value === value?.value)}
+                    value={pidOptions.find((option) => option.value === value) ?? { label: null, value: null }}
                     onChange={(option) => {
                       onChange(option.value)
                     }}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -170,7 +170,7 @@ const options = {
             nextStep: "The next step is to invite users",
           },
           index: {
-            title: "Manage Jurisdictions",
+            title: "Jurisdictions",
             description: "Below is a list of all jurisdictions in the system",
             createButton: "Create New Jurisdiction",
             tableHeading: "Local Governments",
@@ -889,6 +889,8 @@ const options = {
           seeConsoleForDetails: "See the browser console for details",
           accessibility: "Accessibility",
           copyright: "Copyright",
+          foippaWarning:
+            "We are collecting your personal information for the purpose of creating and submitting a building permit application. We are collecting your personal information under section 26(c) of the Freedom of Information and Protection of Privacy Act. If you have questions about our collection of your information, please contact us at ",
           breadcrumb: {
             profile: "Profile",
             jurisdictions: "Manage Jurisdictions",

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -39,6 +39,13 @@ class PermitApplication < ApplicationRecord
   before_validation :set_template_version, on: :create
   before_save :set_submitted_at, if: :status_changed?
 
+  def force_update_published_template_version
+    return unless Rails.env.development?
+    # for development purposes only
+
+    current_template_version.update(form_json: current_template_version.requirement_template.to_form_json)
+  end
+
   def search_data
     {
       number: number,


### PR DESCRIPTION
## Description

PID selector fix
FOIPPA warning
also fix breadcrumb
added a dev helper function for refreshing form json

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-725
https://hous-bssb.atlassian.net/browse/BPHH-741
https://hous-bssb.atlassian.net/browse/BPHH-691

## Steps to QA

create a new pa
pick a address, pick another adddress
PID resets appropriately
start it, see the new information collection warning
