### PR TITLE
adding elective field rendering

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -16,8 +16,8 @@ class PermitApplicationBlueprint < Blueprinter::Base
          :front_end_form_update,
          :zipfile_size,
          :zipfile_name,
-         :zipfile_url
-  :form_customizations
+         :zipfile_url,
+         :form_customizations
   association :permit_type, blueprint: PermitClassificationBlueprint
   association :activity, blueprint: PermitClassificationBlueprint
   association :jurisdiction, blueprint: JurisdictionBlueprint

--- a/app/frontend/utils/formio-component-traversal.ts
+++ b/app/frontend/utils/formio-component-traversal.ts
@@ -48,6 +48,21 @@ export const combineComplianceHints = (
   const blocksList = findPanelComponents(updatedJson.components)
   blocksList.forEach((panelComponent) => {
     if (blocksLookups[panelComponent.id]) {
+      if (blocksLookups[panelComponent.id]?.tip) {
+        panelComponent["tip"] = blocksLookups[panelComponent.id].tip
+      }
+      if (blocksLookups[panelComponent.id]?.["enabledElectiveFieldIds"]) {
+        panelComponent.components.forEach((subComp) => {
+          if (subComp.elective) {
+            subComp["conditional"] = {
+              show: blocksLookups[panelComponent.id]?.enabledElectiveFieldIds?.includes(subComp.id),
+              when: null,
+              eq: "",
+            }
+          }
+        })
+      }
+
       for (const [key, value] of Object.entries(blocksLookups[panelComponent.id])) {
         panelComponent[key] = value
       }

--- a/app/frontend/utils/formio-component-traversal.ts
+++ b/app/frontend/utils/formio-component-traversal.ts
@@ -53,12 +53,9 @@ export const combineComplianceHints = (
       }
       if (blocksLookups[panelComponent.id]?.["enabledElectiveFieldIds"]) {
         panelComponent.components.forEach((subComp) => {
-          if (subComp.elective) {
-            subComp["conditional"] = {
-              show: blocksLookups[panelComponent.id]?.enabledElectiveFieldIds?.includes(subComp.id),
-              when: null,
-              eq: "",
-            }
+          if (subComp.elective && subComp.customConditional.endsWith(";show = false")) {
+            //remove the ;show = false at the end of the conditional
+            subComp.customConditional = subComp.customConditional.slice(0, -13)
           }
         })
       }

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -143,6 +143,8 @@ class Requirement < ApplicationRecord
     json.merge!({ description: hint }) if hint
 
     json.merge!({ validate: { required: true } }) if required
+    
+    json.merge!({ elective: elective }) if elective
 
     json.merge!({ data: { values: input_options["value_options"] } }) if input_type_select?
 

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -143,7 +143,8 @@ class Requirement < ApplicationRecord
     json.merge!({ description: hint }) if hint
 
     json.merge!({ validate: { required: true } }) if required
-    
+
+    #assume all electives use a customConditional that defaults to false.  The customConditional works in tandem with the conditionals
     json.merge!({ elective: elective }) if elective
 
     json.merge!({ data: { values: input_options["value_options"] } }) if input_type_select?
@@ -161,6 +162,12 @@ class Requirement < ApplicationRecord
       end
       json.merge!({ conditional: conditional })
     end
+
+    #indicates code-based conditionals.  Always merge elective show = false to end.
+    if input_options["customConditional"].present?
+      json.merge!({ customConditional: input_options["customConditional"] })
+    end
+    json.merge!({ customConditional: "#{json[:customConditional]};show = false" }) if elective
 
     json
   end

--- a/db/templates/Core Permit Requirements List.xlsx
+++ b/db/templates/Core Permit Requirements List.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:290ca4c6eebd0d1328b610ab91fb2ea45b055c1752b3a0b7be1d9b1d50cd0417
-size 636362
+oid sha256:6f66c34c3378b5db0f6a716ad45565a914f4c72dfa9e15bfbb448d56721feacc
+size 640707

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -312,6 +312,98 @@ RSpec.describe Requirement, type: :model do
 
         expect(form_json).to eq(expected_form_json)
       end
+
+      context "electives" do
+        it "returns a hidden field for an elective requirement" do
+          requirement =
+            create(
+              :requirement,
+              requirement_code: "text_requirement",
+              label: "Text Requirement",
+              input_type: "text",
+              elective: true,
+            )
+          form_json = requirement.to_form_json.reject { |key| key == :id }
+          expected_form_json = {
+            key: "#{requirement.requirement_block.key}|#{requirement.requirement_code}",
+            type: "simpletextfield",
+            elective: true,
+            input: true,
+            label: "Text Requirement",
+            widget: {
+              type: "input",
+            },
+            customConditional: ";show = false",
+          }
+          expect(form_json).to eq(expected_form_json)
+        end
+
+        it "merges the show condition for an elective with other conditional logic" do
+          requirement =
+            create(
+              :requirement,
+              requirement_code: "text_requirement",
+              label: "Text Requirement",
+              input_type: "text",
+              elective: true,
+              input_options: {
+                "conditional" => {
+                  show: true,
+                  when: "test",
+                  eq: "customValue",
+                },
+              },
+            )
+          form_json = requirement.to_form_json.reject { |key| key == :id }
+          expected_form_json = {
+            key: "#{requirement.requirement_block.key}|#{requirement.requirement_code}",
+            type: "simpletextfield",
+            elective: true,
+            input: true,
+            label: "Text Requirement",
+            widget: {
+              type: "input",
+            },
+            conditional: {
+              show: true,
+              when: "test",
+              eq: "customValue",
+            },
+            customConditional: ";show = false",
+          }
+        end
+
+        it "merges the show condition for an elective with customConditional" do
+          requirement =
+            create(
+              :requirement,
+              requirement_code: "text_requirement",
+              label: "Text Requirement",
+              input_type: "text",
+              elective: true,
+              input_options: {
+                "customConditional" => "show = true",
+              },
+            )
+          form_json = requirement.to_form_json.reject { |key| key == :id }
+          expected_form_json = {
+            key: "#{requirement.requirement_block.key}|#{requirement.requirement_code}",
+            type: "simpletextfield",
+            elective: true,
+            input: true,
+            label: "Text Requirement",
+            widget: {
+              type: "input",
+            },
+            customConditional: "show = true;show = false",
+          }
+        end
+      end
+
+      context "validations" do
+        it "returns a validation for required if it is a required field" do
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

Seed some elective fields, make sure you publish them. 
Ensure the local jurisdiction modifies the electives and adds them and publishes it.

Open a permit applicaiton in jurisidction without an elective - verify
Open a permit applicaiton in jurisidction with an elective - verify

[BPHH-747](https://hous-bssb.atlassian.net/browse/BPHH-747)