### PR TITLE
add reindex callbacks for keeping jurisdiction size fields updated

### DIFF
--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -73,7 +73,7 @@ class Jurisdiction < ApplicationRecord
       review_managers_size: review_managers_size,
       reviewers_size: reviewers_size,
       permit_applications_size: permit_applications_size,
-      # templates_used: "TODO",
+      templates_used: templates_used_size,
     }
   end
 

--- a/app/models/jurisdiction_template_version_customization.rb
+++ b/app/models/jurisdiction_template_version_customization.rb
@@ -14,8 +14,16 @@ class JurisdictionTemplateVersionCustomization < ApplicationRecord
 
   before_save :sanitize_tip
   validates_uniqueness_of :template_version_id, scope: :jurisdiction_id
+  after_commit :reindex_jurisdiction_templates_used_size
 
   private
+
+  def reindex_jurisdiction_templates_used_size
+    return unless jurisdiction.present?
+    return unless new_record? || destroyed? || saved_change_to_jurisdiction_id?
+
+    jurisdiction.reindex
+  end
 
   def sanitize_tip
     return if customizations.blank? || customizations["requirement_block_changes"].blank?

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -38,6 +38,7 @@ class PermitApplication < ApplicationRecord
   before_validation :assign_unique_number, on: :create
   before_validation :set_template_version, on: :create
   before_save :set_submitted_at, if: :status_changed?
+  after_commit :reindex_jurisdiction_permit_application_size
 
   def search_data
     {
@@ -132,6 +133,13 @@ class PermitApplication < ApplicationRecord
   end
 
   private
+
+  def reindex_jurisdiction_permit_application_size
+    return unless jurisdiction.present?
+    return unless new_record? || destroyed? || saved_change_to_jurisdiction_id?
+
+    jurisdiction.reindex
+  end
 
   def set_submitted_at
     # Check if the status changed to 'submitted' and `submitted_at` is nil to avoid overwriting the timestamp.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,7 @@ class User < ApplicationRecord
   validates :email, presence: true
 
   after_commit :refresh_search_index, if: :saved_change_to_discarded_at
+  after_commit :reindex_jurisdiction_user_size
 
   # Stub this for now since we do not want to use IP Tracking at the moment - Jan 30, 2024
   attr_accessor :current_sign_in_ip, :last_sign_in_ip
@@ -90,6 +91,12 @@ class User < ApplicationRecord
   end
 
   private
+
+  def reindex_jurisdiction_user_size
+    return unless jurisdiction.present?
+
+    jurisdiction.reindex if saved_change_to_jurisdiction_id? || saved_change_to_role? || destroyed? || new_record?
+  end
 
   def refresh_search_index
     User.search_index.refresh


### PR DESCRIPTION
## Description

These new callbacks insure that jurisdiction is reindex with new sizes for the counts shown on the grid view (adding other associated records would not normally induce a reindex)

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-753

## Steps to QA

add or remove reviewers, managers, permit applications, and template customizations to jurisdictions and see that the counts in the jurisdictions index grid change.