### PR TITLE
Bugfix/bphh 803/wrong inbox load

### DIFF
--- a/app/controllers/api/concerns/search/permit_applications.rb
+++ b/app/controllers/api/concerns/search/permit_applications.rb
@@ -25,13 +25,18 @@ module Api::Concerns::Search::PermitApplications
     # Only add the jurisdiction_id condition if @jurisdiction is present
     if current_user.submitter?
       search_conditions[:where] = search_conditions[:where].merge({ submitter_id: current_user.id })
-    elsif @jurisdiction.present?
+    elsif current_user.review_staff?
+      raise StandardError unless @jurisdiction.present?
+
       search_conditions[:where] = {
         jurisdiction_id: @jurisdiction.id,
         # Overrides status filter, reorder the code if necessary
         status: %i[submitted],
       }
+    elsif current_user.super_admin?
+      return
     end
+
     @permit_application_search = PermitApplication.search(query, **search_conditions)
   end
 

--- a/app/frontend/hooks/resources/use-jurisdiction.ts
+++ b/app/frontend/hooks/resources/use-jurisdiction.ts
@@ -17,7 +17,7 @@ export const useJurisdiction = () => {
   useEffect(() => {
     ;(async () => {
       try {
-        setCurrentJurisdiction(null)
+        setCurrentJurisdiction(jurisdictionId)
         if (isUUID(jurisdictionId)) {
           await fetchJurisdiction(jurisdictionId)
           setCurrentJurisdiction(jurisdictionId)

--- a/app/frontend/stores/jurisdiction-store.ts
+++ b/app/frontend/stores/jurisdiction-store.ts
@@ -15,7 +15,7 @@ export const JurisdictionStoreModel = types
     types.model("JurisdictionStore").props({
       jurisdictionMap: types.map(JurisdictionModel),
       tableJurisdictions: types.array(types.safeReference(JurisdictionModel)),
-      currentJurisdiction: types.maybeNull(types.reference(JurisdictionModel)),
+      currentJurisdiction: types.maybeNull(types.maybe(types.reference(JurisdictionModel))),
       sort: types.maybeNull(types.frozen<ISort<EJurisdictionSortFields>>()),
     }),
     createSearchModel<EJurisdictionSortFields>("searchJurisdictions")


### PR DESCRIPTION
## Description

race condition was causing the jurisdiction to be set to null under some conditions
the fix uses the available jurisdiction ID when possible.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-803

## Steps to QA

log in as review manager
go to inbox
click home
click back
inbox should not load permit applications for null jurisdiction (ie submitter)
