### PR TITLE
Bugfix/bphh 752/completed blocks

### DIFF
--- a/app/frontend/components/domains/permit-application/checklist-sidebar.tsx
+++ b/app/frontend/components/domains/permit-application/checklist-sidebar.tsx
@@ -6,10 +6,10 @@ import { IPermitApplication } from "../../../models/permit-application"
 
 interface IChecklistSideBarProps {
   permitApplication: IPermitApplication
-  completedSections: object
+  completedBlocks: object
 }
 
-export const ChecklistSideBar = observer(({ permitApplication, completedSections }: IChecklistSideBarProps) => {
+export const ChecklistSideBar = observer(({ permitApplication, completedBlocks }: IChecklistSideBarProps) => {
   const { formJson } = permitApplication
   const { selectedTabIndex, setSelectedTabIndex, indexOfBlockId, getBlockClass } = permitApplication
 
@@ -57,7 +57,7 @@ export const ChecklistSideBar = observer(({ permitApplication, completedSections
                       >
                         <Flex align="center">
                           <Box w={5} mr={2}>
-                            {completedSections[block.key] ? (
+                            {completedBlocks[block.key] ? (
                               <CheckCircle color="#2E8540" size={18} />
                             ) : (
                               <CircleDashed color="#A19F9D" size={18} />

--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -41,7 +41,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
   const nicknameWatch = watch("nickname")
   const isStepCode = R.test(/step-code/, window.location.pathname)
 
-  const [completedSections, setCompletedSections] = useState({})
+  const [completedBlocks, setCompletedBlocks] = useState({})
 
   const { isOpen: isContactsOpen, onOpen: onContactsOpen, onClose: onContactsClose } = useDisclosure()
 
@@ -172,13 +172,13 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
         )}
       </Flex>
       <Flex w="full" h="calc(100% - 96px)" overflow="auto" id="permitApplicationFieldsContainer">
-        <ChecklistSideBar permitApplication={currentPermitApplication} completedSections={completedSections} />
+        <ChecklistSideBar permitApplication={currentPermitApplication} completedBlocks={completedBlocks} />
         {formJson && (
           <Flex flex={1} direction="column" p={24}>
             <RequirementForm
               formRef={formRef}
               permitApplication={currentPermitApplication}
-              onCompletedSectionsChange={setCompletedSections}
+              onCompletedBlocksChange={setCompletedBlocks}
               triggerSave={handleSave}
             />
           </Flex>

--- a/app/frontend/components/domains/permit-application/review-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/review-permit-application-screen.tsx
@@ -20,7 +20,7 @@ export const ReviewPermitApplicationScreen = observer(() => {
   const formRef = useRef(null)
   const navigate = useNavigate()
 
-  const [completedSections, setCompletedSections] = useState({})
+  const [completedBlocks, setCompletedBlocks] = useState({})
 
   const { isOpen: isContactsOpen, onOpen: onContactsOpen, onClose: onContactsClose } = useDisclosure()
 
@@ -66,13 +66,13 @@ export const ReviewPermitApplicationScreen = observer(() => {
         </Stack>
       </Flex>
       <Flex w="full" h="calc(100% - 96px)" overflow="auto" id="permitApplicationFieldsContainer">
-        <ChecklistSideBar permitApplication={currentPermitApplication} completedSections={completedSections} />
+        <ChecklistSideBar permitApplication={currentPermitApplication} completedBlocks={completedBlocks} />
         {formJson && (
           <Flex flex={1} direction="column" p={24}>
             <RequirementForm
               formRef={formRef}
               permitApplication={currentPermitApplication}
-              onCompletedSectionsChange={setCompletedSections}
+              onCompletedBlocksChange={setCompletedBlocks}
             />
           </Flex>
         )}

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -400,4 +400,21 @@ $blue-light: #f6f9fc;
       margin-right: 6px;
     }
   }
+
+  .optional-block-confirmation-checkbox {
+    font-weight: 700;
+
+    &:before {
+      content: "";
+      display: block;
+      height: 1px;
+      background-color: gray;
+      width: 100%;
+      margin-top: 24px;
+      margin-bottom: 24px;
+      // position: absolute;
+      top: 0;
+      left: 0;
+    }
+  }
 }

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -122,6 +122,11 @@ export const RequirementForm = observer(
       setAllCollapsed((cur) => !cur)
     }
 
+    const mapErrorBoxData = (errors) =>
+      errors.map((error) => {
+        return { label: error.component.label, id: error.component.id, class: error.component.class }
+      })
+
     function handleBlockIntersection(entries: IntersectionObserverEntry[]) {
       const entry = entries.filter((en) => en.isIntersecting)[0]
       if (!entry) return
@@ -152,15 +157,21 @@ export const RequirementForm = observer(
       if (onCompletedSectionsChange) {
         onCompletedSectionsChange(getCompletedSectionsFromForm(containerComponent.root))
       }
-      setErrorBoxData(
-        containerComponent.root.errors.map((error) => {
-          return { label: error.component.label, id: error.component.id, class: error.component.class }
-        })
-      )
+      setErrorBoxData(mapErrorBoxData(containerComponent.root.errors))
+    }
+
+    const onChange = () => {
+      if (!formRef.current) return
+
+      if (onCompletedSectionsChange) {
+        onCompletedSectionsChange(getCompletedSectionsFromForm(formRef.current))
+      }
+      setErrorBoxData(mapErrorBoxData(formRef.current.errors))
     }
 
     const formReady = (rootComponent) => {
       formRef.current = rootComponent
+
       if (onCompletedSectionsChange) {
         onCompletedSectionsChange(getCompletedSectionsFromForm(rootComponent))
       }
@@ -204,6 +215,7 @@ export const RequirementForm = observer(
             onSubmit={onFormSubmit}
             options={isDraft ? {} : { readOnly: true }}
             onBlur={onBlur}
+            onChange={onChange}
           />
         </Flex>
         <VStack align="end" position="sticky" bottom={24} left={"100%"} zIndex={11} gap={4} w="fit-content">

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -23,7 +23,7 @@ import { Link, useLocation, useNavigate } from "react-router-dom"
 import { useMountStatus } from "../../../hooks/use-mount-status"
 import { IPermitApplication } from "../../../models/permit-application"
 import { IErrorsBoxData } from "../../../types/types"
-import { getCompletedSectionsFromForm } from "../../../utils/formio-component-traversal"
+import { getCompletedBlocksFromForm } from "../../../utils/formio-component-traversal"
 import { handleScrollToTop } from "../../../utils/utility-functions"
 import { ErrorsBox } from "../../domains/permit-application/errors-box"
 import { CustomToast } from "../base/flash-message"
@@ -31,13 +31,13 @@ import { Form } from "../chefs"
 
 interface IRequirementFormProps {
   permitApplication?: IPermitApplication
-  onCompletedSectionsChange?: (sections: any) => void
+  onCompletedBlocksChange?: (sections: any) => void
   formRef: any
   triggerSave?: () => void
 }
 
 export const RequirementForm = observer(
-  ({ permitApplication, onCompletedSectionsChange, formRef, triggerSave }: IRequirementFormProps) => {
+  ({ permitApplication, onCompletedBlocksChange, formRef, triggerSave }: IRequirementFormProps) => {
     const { submissionData, setSelectedTabIndex, indexOfBlockId, formJson, blockClasses, formattedFormJson, isDraft } =
       permitApplication
     const isMounted = useMountStatus()
@@ -154,8 +154,8 @@ export const RequirementForm = observer(
     }
 
     const onBlur = (containerComponent) => {
-      if (onCompletedSectionsChange) {
-        onCompletedSectionsChange(getCompletedSectionsFromForm(containerComponent.root))
+      if (onCompletedBlocksChange) {
+        onCompletedBlocksChange(getCompletedBlocksFromForm(containerComponent.root))
       }
       setErrorBoxData(mapErrorBoxData(containerComponent.root.errors))
     }
@@ -163,8 +163,8 @@ export const RequirementForm = observer(
     const onChange = () => {
       if (!formRef.current) return
 
-      if (onCompletedSectionsChange) {
-        onCompletedSectionsChange(getCompletedSectionsFromForm(formRef.current))
+      if (onCompletedBlocksChange) {
+        onCompletedBlocksChange(getCompletedBlocksFromForm(formRef.current))
       }
       setErrorBoxData(mapErrorBoxData(formRef.current.errors))
     }
@@ -172,8 +172,8 @@ export const RequirementForm = observer(
     const formReady = (rootComponent) => {
       formRef.current = rootComponent
 
-      if (onCompletedSectionsChange) {
-        onCompletedSectionsChange(getCompletedSectionsFromForm(rootComponent))
+      if (onCompletedBlocksChange) {
+        onCompletedBlocksChange(getCompletedBlocksFromForm(rootComponent))
       }
     }
     const scrollToTop = () => {

--- a/app/frontend/utils/formio-component-traversal.ts
+++ b/app/frontend/utils/formio-component-traversal.ts
@@ -22,9 +22,9 @@ const findPanelComponents = (components) => {
   return panelComponents
 }
 
-export const getCompletedSectionsFromForm = (rootComponent) => {
+export const getCompletedBlocksFromForm = (rootComponent) => {
   const blocksList = findPanelComponents(rootComponent.components)
-  let completedSections = {}
+  let completedBlocks = {}
   blocksList.forEach((panelComponent) => {
     const incompleteComponents = panelComponent.components.filter(
       (comp) =>
@@ -33,9 +33,9 @@ export const getCompletedSectionsFromForm = (rootComponent) => {
 
     const complete = incompleteComponents.length == 0 //if there are any components with errors OR required fields with no value
 
-    return (completedSections[panelComponent?.component?.key] = complete)
+    return (completedBlocks[panelComponent?.component?.key] = complete)
   })
-  return completedSections
+  return completedBlocks
 }
 
 export const combineComplianceHints = (

--- a/app/frontend/utils/formio-component-traversal.ts
+++ b/app/frontend/utils/formio-component-traversal.ts
@@ -26,10 +26,12 @@ export const getCompletedSectionsFromForm = (rootComponent) => {
   const blocksList = findPanelComponents(rootComponent.components)
   let completedSections = {}
   blocksList.forEach((panelComponent) => {
-    const complete =
-      panelComponent.components.filter(
-        (comp) => comp.error || (comp.component.validate?.required && R.isEmpty(comp.dataValue))
-      ).length == 0 //if there are any components with errors OR required fields with no value
+    const incompleteComponents = panelComponent.components.filter(
+      (comp) =>
+        comp.error || (comp.component.validate?.required && (R.isEmpty(comp.dataValue) || R.isNil(comp.dataValue)))
+    )
+
+    const complete = incompleteComponents.length == 0 //if there are any components with errors OR required fields with no value
 
     return (completedSections[panelComponent?.component?.key] = complete)
   })

--- a/app/frontend/utils/formio-component-traversal.ts
+++ b/app/frontend/utils/formio-component-traversal.ts
@@ -27,8 +27,7 @@ export const getCompletedBlocksFromForm = (rootComponent) => {
   let completedBlocks = {}
   blocksList.forEach((panelComponent) => {
     const incompleteComponents = panelComponent.components.filter(
-      (comp) =>
-        comp.error || (comp.component.validate?.required && (R.isEmpty(comp.dataValue) || R.isNil(comp.dataValue)))
+      (comp) => comp.error || (comp.component.validate?.required && (R.isEmpty(comp.dataValue) || !comp.dataValue))
     )
 
     const complete = incompleteComponents.length == 0 //if there are any components with errors OR required fields with no value

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -44,7 +44,6 @@ class RequirementBlock < ApplicationRecord
   end
 
   def components_form_json(section_key)
-    # binding.pry
     optional_block = requirements.all? { |req| !req.required }
     requirement_map = requirements.map { |r| r.to_form_json(key(section_key)) }
 

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -39,7 +39,34 @@ class RequirementBlock < ApplicationRecord
       title: name,
       collapsible: true,
       collapsed: false,
-      components: requirements.map { |r| r.to_form_json(key(section_key)) },
+      components: components_form_json(section_key),
+    }
+  end
+
+  def components_form_json(section_key)
+    # binding.pry
+    optional_block = requirements.all? { |req| !req.required }
+    requirement_map = requirements.map { |r| r.to_form_json(key(section_key)) }
+
+    requirement_map.push(optional_block_confirmation_requirement(section_key)) if optional_block
+
+    requirement_map
+  end
+
+  def optional_block_confirmation_requirement(section_key)
+    {
+      id: "#{id}-confirmation",
+      key: "#{key(section_key)}|confirmation",
+      type: "checkbox",
+      custom_class: "optional-block-confirmation-checkbox",
+      validate: {
+        required: true,
+      },
+      input: true,
+      label: I18n.t("formio.requirement_block.optional_block_confirmation_requirement_label"),
+      widget: {
+        type: "input",
+      },
     }
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -261,6 +261,8 @@ en:
       signoff_checkbox_label: "I acknowledge that by checking this box and providing my digital signature, I am electronically signing."
       signoff_submit_title: "Submit"
       energy_step_code: "Use Energy Step Code Tool"
+    requirement_block:
+      optional_block_confirmation_requirement_label: "I acknowledge that all fields in this block are either complete, or not applicable."
   step_code_building_characteristics_summary:
     performance_type:
       error: "%{field_name} performance type must be one of %{accepted_values}"

--- a/spec/models/requirement_block_spec.rb
+++ b/spec/models/requirement_block_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe RequirementBlock, type: :model do
   end
 
   describe "enums" do
-    # TODO: remove xit tests when roles will be defined
     it { should define_enum_for(:sign_off_role).with_prefix(true).with_values(any: 0) }
     it { should define_enum_for(:reviewer_role).with_prefix(true).with_values(any: 0) }
   end
@@ -42,8 +41,8 @@ RSpec.describe RequirementBlock, type: :model do
              collapsed: false,
            }
          )
-
-      expect(form_json[:components].count).to eq 6
+      # expect 7 because a block that is all optional requirements gets one extra required component
+      expect(form_json[:components].count).to eq 7
     end
   end
 


### PR DESCRIPTION
## Description

Fixes busted checklist sidebar (under assumption of using old requirement seeds that arent broken)
Also add required checkbox for optional-only blocks

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-752

https://hous-bssb.atlassian.net/browse/BPHH-837

## Steps to QA

Run this line to obtain a requirements XLSS file that isn't busted:

```
git checkout -f 1445b26 "db/templates/Core Permit Requirements List.xlsx"
```

change this line:

```
json.merge!({ validate: { required: !Rails.env.development? } }) if required
```

to

```  
json.merge!({ validate: { required: [true, false].sample } }) if required
```

and re-seed


create a new permit application and see that the blocks get marked as complete as you fill them. Ensure that all blocks without any incomplete required fields are marked with a green check on the sidebar. save and reload the form.

