### PR TITLE
Add link to setup from submission inbox

### DIFF
--- a/app/controllers/api/permit_type_submission_contacts_controller.rb
+++ b/app/controllers/api/permit_type_submission_contacts_controller.rb
@@ -1,7 +1,4 @@
-class Api::PermitTypeSubmissionContactsController < Api::ApplicationController
-  skip_after_action :verify_authorized
-  skip_after_action :verify_policy_scoped
-
+class Api::PermitTypeSubmissionContactsController < ActionController::API
   # GET /permit_type_submission_contacts/confirm?confirmation_token=abcdef
   # use a special redirect with a frontend flash message here
   def confirm

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/jurisdiction-submisson-inbox-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/jurisdiction-submisson-inbox-screen.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Container, Flex, Heading, IconButton, Text, VStack } from "@chakra-ui/react"
+import { Box, Button, Center, Container, Flex, Heading, IconButton, Text, VStack } from "@chakra-ui/react"
 import { ArrowSquareOut, Download } from "@phosphor-icons/react"
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
@@ -18,6 +18,7 @@ import { SearchGridItem } from "../../../shared/grid/search-grid-item"
 import { RouterLink } from "../../../shared/navigation/router-link"
 import { RouterLinkButton } from "../../../shared/navigation/router-link-button"
 import { PermitApplicationViewedAtTag } from "../../../shared/permit-applications/permit-application-viewed-at-tag"
+import { Can } from "../../../shared/user/can"
 import { SubmissionDownloadModal } from "../../permit-application/submission-download-modal"
 import { GridHeaders } from "./grid-header"
 
@@ -36,23 +37,25 @@ export const JurisdictionSubmissionInboxScreen = observer(function JurisdictionS
 
   return (
     <Container maxW="container.lg" p={8} as={"main"} flexGrow={1}>
-      <VStack alignItems={"flex-start"} spacing={5} w={"full"} h={"full"}>
-        <Flex justifyContent={"space-between"} w={"full"} alignItems={"flex-end"}>
-          <Flex direction="column">
+      <VStack align={"start"} spacing={5} w={"full"} h={"full"}>
+        <Flex justify={"space-between"} w={"full"}>
+          <Box>
             <Heading as="h1" fontSize={"4xl"} color={"text.primary"}>
               {t("permitApplication.submissionInbox.title")}
             </Heading>
-            <Flex>
-              <Text mr={2}>
-                {t("permitApplication.submissionInbox.submissionsSentTo", {
-                  email: currentJurisdiction?.submissionEmail || t("ui.notAvailable"),
-                })}
-              </Text>
-              <RouterLink to={`/jurisdictions/${currentJurisdiction.id}/configuration-management`}>
-                {t("ui.change")}
-              </RouterLink>
-            </Flex>
-          </Flex>
+            <Text fontSize="sm" color="text.secondary">
+              {t("permitApplication.submissionInbox.submissionsSentTo")}
+            </Text>
+          </Box>
+          <Can action="jurisdiction:manage" data={{ jurisdiction: currentJurisdiction }}>
+            <Button
+              as={RouterLink}
+              to={`/jurisdictions/${currentJurisdiction.id}/configuration-management/submissions-inbox-setup`}
+              variant="secondary"
+            >
+              {t("ui.setup")}
+            </Button>
+          </Can>
         </Flex>
 
         <SearchGrid templateColumns="170px 2fr 2fr repeat(3, 1fr)">

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -972,6 +972,7 @@ const options = {
             configurationManagement: "Configuration Management",
             energyStep: "Energy Step Code Requirements",
             submissionsInboxSetup: "Submissions Inbox Setup",
+            confirmed: "Submission E-mail Confirmed",
           },
           questionSupport: "Question Support",
         },

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -92,7 +92,7 @@ const options = {
           no: "No",
           show: "Show",
           hide: "Hide",
-          change: "Change",
+          setup: "Setup",
           search: "Search",
           loading: "Loading...",
           invalidInput: "Invalid input",
@@ -234,7 +234,8 @@ const options = {
           submissionInbox: {
             title: "Submissions Inbox",
             tableHeading: "Permit Applications",
-            submissionsSentTo: "All submissions are sent to: {{email}}",
+            submissionsSentTo:
+              "A copy of all submitted applications are also sent to one or more email addresses configured by the review manager.",
           },
           fields: {
             number: "Application #",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -971,6 +971,7 @@ const options = {
             contact: "Contact Us",
             configurationManagement: "Configuration Management",
             energyStep: "Energy Step Code Requirements",
+            submissionsInboxSetup: "Submissions Inbox Setup",
           },
           questionSupport: "Question Support",
         },


### PR DESCRIPTION
[BPHH-765]

## Description

Allow review managers to access the setup page from the submission inbox

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Implements [BPHH765](https://hous-bssb.atlassian.net/browse/BPHH-765).

## Steps to QA

1. Login as review manager & navigate to submission inbox. See link to "Setup" that goes to the submission inbox setup screen
2. Login as reviewer - note the setup button is not present on the submission inbox screen

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

N/A