### PR TITLE
Add support for LG configured energy steps

### DIFF
--- a/app/blueprints/step_code/zero_carbon/compliance_blueprint.rb
+++ b/app/blueprints/step_code/zero_carbon/compliance_blueprint.rb
@@ -5,7 +5,7 @@ class StepCode::ZeroCarbon::ComplianceBlueprint < Blueprinter::Base
   transform RoundDecimalsTransformer
 
   field :proposed_zero_carbon_step do |compliance, _options|
-    "EL#{compliance.step}"
+    compliance.step && "EL#{compliance.step}"
   end
 
   field :required_zero_carbon_step do |compliance, _options|

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/energy-step-select.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/energy-step-select.tsx
@@ -2,7 +2,6 @@ import {
   Flex,
   Input,
   InputGroup,
-  InputProps,
   InputRightElement,
   Popover,
   PopoverContent,
@@ -22,10 +21,10 @@ import { i18nPrefix } from "../i18n-prefix"
 interface IProps {
   onChange: (event: any) => void
   value: EEnergyStep
-  inputProps?: InputProps
+  isDisabled?: boolean
 }
 
-export const EnergyStepSelect = observer(function EnergyStepSelect({ onChange, value, inputProps }: IProps) {
+export const EnergyStepSelect = observer(function EnergyStepSelect({ onChange, value, isDisabled }: IProps) {
   const {
     stepCodeStore: { selectOptions },
   } = useMst()
@@ -35,7 +34,7 @@ export const EnergyStepSelect = observer(function EnergyStepSelect({ onChange, v
       {({ onClose }) => (
         <>
           <PopoverTrigger>
-            <InputGroup>
+            <InputGroup pointerEvents={isDisabled ? "none" : "auto"}>
               <Input
                 as={Flex}
                 bg="white"
@@ -45,7 +44,7 @@ export const EnergyStepSelect = observer(function EnergyStepSelect({ onChange, v
                 borderWidth={1}
                 rounded="base"
                 shadow="base"
-                {...inputProps}
+                isDisabled={isDisabled}
               >
                 {value ? t(`${i18nPrefix}.stepRequired.energy.options.${value}`) : t(`ui.selectPlaceholder`)}
               </Input>

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/index.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/index.tsx
@@ -50,7 +50,7 @@ const Form = function JursidictionEnergyStepRequirementsForm({ jurisdiction }) {
               control={control}
               name="energyStepRequired"
               render={({ field: { onChange, value } }) => {
-                return <EnergyStepSelect onChange={onChange} value={value} inputProps={{ isDisabled: !isEditing }} />
+                return <EnergyStepSelect onChange={onChange} value={value} isDisabled={!isEditing} />
               }}
             />
           </FormControl>
@@ -60,9 +60,7 @@ const Form = function JursidictionEnergyStepRequirementsForm({ jurisdiction }) {
               control={control}
               name="zeroCarbonStepRequired"
               render={({ field: { onChange, value } }) => {
-                return (
-                  <ZeroCarbonStepSelect onChange={onChange} value={value} inputProps={{ isDisabled: !isEditing }} />
-                )
+                return <ZeroCarbonStepSelect onChange={onChange} value={value} isDisabled={!isEditing} />
               }}
             />
           </FormControl>

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/zero-carbon-step-select.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/zero-carbon-step-select.tsx
@@ -2,7 +2,6 @@ import {
   Flex,
   Input,
   InputGroup,
-  InputProps,
   InputRightElement,
   Popover,
   PopoverContent,
@@ -22,10 +21,10 @@ import { i18nPrefix } from "../i18n-prefix"
 interface IProps {
   onChange: (event: any) => void
   value: ESZeroCarbonStep
-  inputProps?: InputProps
+  isDisabled?: boolean
 }
 
-export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({ onChange, value, inputProps }: IProps) {
+export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({ onChange, value, isDisabled }: IProps) {
   const {
     stepCodeStore: { selectOptions },
   } = useMst()
@@ -35,7 +34,7 @@ export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({ onC
       {({ onClose }) => (
         <>
           <PopoverTrigger>
-            <InputGroup>
+            <InputGroup pointerEvents={isDisabled ? "none" : "auto"}>
               <Input
                 as={Flex}
                 bg="white"
@@ -45,7 +44,7 @@ export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({ onC
                 borderWidth={1}
                 rounded="base"
                 shadow="base"
-                {...inputProps}
+                isDisabled={isDisabled}
               >
                 {value ? t(`${i18nPrefix}.stepRequired.zeroCarbon.options.${value}`) : t(`ui.selectPlaceholder`)}
               </Input>

--- a/app/frontend/components/domains/step-code/checklist/energy-step-code-compliance/compliance-grid/energy-step.tsx
+++ b/app/frontend/components/domains/step-code/checklist/energy-step-code-compliance/compliance-grid/energy-step.tsx
@@ -16,9 +16,7 @@ export const EnergyStep = function EnergyStep({ checklist }: IProps) {
     <>
       <GridRowHeader>{t(`${translationPrefix}.step`)}</GridRowHeader>
       <GridData>
-        <TextFormControl
-          inputProps={{ isDisabled: true, textAlign: "center", value: checklist.proposedEnergyStep || "-" }}
-        />
+        <TextFormControl inputProps={{ isDisabled: true, textAlign: "center", value: checklist.requiredEnergyStep }} />
       </GridData>
       <GridPlaceholder colSpan={2} />
     </>

--- a/app/frontend/components/domains/step-code/checklist/zero-carbon-step-code-compliance/compliance-grid/zero-carbon-step.tsx
+++ b/app/frontend/components/domains/step-code/checklist/zero-carbon-step-code-compliance/compliance-grid/zero-carbon-step.tsx
@@ -17,7 +17,7 @@ export const ZeroCarbonStep = function ZeroCarbonStep({ checklist }: IProps) {
       <GridRowHeader>{t(`${translationPrefix}.step`)}</GridRowHeader>
       <GridData>
         <TextFormControl
-          inputProps={{ isDisabled: true, textAlign: "center", value: checklist.proposedZeroCarbonStep || "-" }}
+          inputProps={{ isDisabled: true, textAlign: "center", value: checklist.requiredZeroCarbonStep }}
         />
       </GridData>
       <GridPlaceholder colSpan={2} />

--- a/app/services/step_code/compliance/check_requirements/zero_carbon/base.rb
+++ b/app/services/step_code/compliance/check_requirements/zero_carbon/base.rb
@@ -10,7 +10,7 @@ class StepCode::Compliance::CheckRequirements::ZeroCarbon::Base
 
   def initialize(checklist:, step:)
     @checklist = checklist
-    @step = step
+    @step = step || checklist.step_code.zero_carbon_step_required || ENV["MIN_ZERO_CARBON_STEP"].to_i
   end
 
   def total_ghg

--- a/app/services/step_code/compliance/propose_step/zero_carbon.rb
+++ b/app/services/step_code/compliance/propose_step/zero_carbon.rb
@@ -1,6 +1,6 @@
 class StepCode::Compliance::ProposeStep::ZeroCarbon < StepCode::Compliance::ProposeStep::Base
   def min_required_step
-    @min_required_step ||= checklist.step_code.energy_step_required || min_step
+    @min_required_step ||= checklist.step_code.zero_carbon_step_required || min_step
   end
 
   def max_step


### PR DESCRIPTION
[BPHH-763]

## Description

Fixes some bugs with the zero carbon compliance when the minimum step is not met and required metrics were not visible.

Fixes issue with LG energy step configuration being editable when not in edit mode.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Implements [BPHH-763](https://hous-bssb.atlassian.net/browse/BPHH-763)

## Steps to QA

1. Login as Review Manager and update the minimum energy and zero carbon steps to something above the default minimum
2. Login as a Submitter and upload an energy step code. Note that the two test h2k files now fail to pass the step requirements and the details on what failed are visible under the energy and zero carbon compliance sections at the bottom of the checklist.

## UI Accessibility Checklist

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

N/A
