### PR TITLE
Feature/bphh 635/contact requirement types

### DIFF
--- a/app/controllers/api/requirement_blocks_controller.rb
+++ b/app/controllers/api/requirement_blocks_controller.rb
@@ -91,7 +91,7 @@ class Api::RequirementBlocksController < Api::ApplicationController
         :required_for_multiple_owners,
         :elective,
         :_destroy,
-        input_options: [:number_unit, value_options: [%i[value label]]],
+        input_options: [:number_unit, :can_add_multiple_contacts, value_options: [%i[value label]]],
       ],
     )
   end

--- a/app/frontend/components/domains/requirements-library/fields-setup-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/fields-setup-drawer.tsx
@@ -53,7 +53,7 @@ export const FieldsSetupDrawer = observer(function FieldsSetupMenu({
       )}
       <Drawer isOpen={isOpen} placement="left" onClose={onClose} finalFocusRef={btnRef}>
         <DrawerOverlay />
-        <DrawerContent maxW={"500px"}>
+        <DrawerContent maxW={"550px"}>
           <DrawerCloseButton fontSize={"xs"} />
           <DrawerHeader color={"greys.white"} backgroundColor={"theme.blueAlt"} p={6} pt={10} fontSize={"2xl"}>
             {t("ui.add")}...

--- a/app/frontend/components/domains/requirements-library/fields-setup-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/fields-setup-drawer.tsx
@@ -27,7 +27,7 @@ interface IProps {
 }
 
 // TODO: remove when backend for these types is implemented
-const DISABLED_TYPES = [ERequirementType.address, ERequirementType.generalContact]
+const DISABLED_TYPES = [ERequirementType.address]
 
 export const FieldsSetupDrawer = observer(function FieldsSetupMenu({
   defaultButtonProps,

--- a/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
@@ -190,6 +190,7 @@ export const RequirementBlockAccordion = observer(function RequirementBlockAccor
                         selectProps={{
                           maxW: "339px",
                         }}
+                        showAddPersonButton={!!requirement?.inputOptions?.canAddMultipleContacts}
                       />
                     </Box>
                   </Box>

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/contact-field-item-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/contact-field-item-display.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { getRequirementContactFieldItemLabel } from "../../../../constants"
+import { ERequirementContactFieldItemType, ERequirementType } from "../../../../types/enums"
+import { RequirementFieldDisplay, TRequirementFieldDisplayProps } from "./index"
+
+interface IContactFieldItemDisplayProps {
+  contactFieldItemType: ERequirementContactFieldItemType
+}
+
+export function ContactFieldItemDisplay({ contactFieldItemType }: IContactFieldItemDisplayProps) {
+  const defaultProps: Partial<TRequirementFieldDisplayProps> = {
+    label: getRequirementContactFieldItemLabel(contactFieldItemType),
+    requirementType: ERequirementType.text,
+  }
+
+  const propsByType = {
+    [ERequirementContactFieldItemType.email]: {
+      requirementType: ERequirementType.email,
+    },
+    [ERequirementContactFieldItemType.phone]: {
+      requirementType: ERequirementType.phone,
+    },
+    [ERequirementContactFieldItemType.address]: {
+      requirementType: ERequirementType.address,
+    },
+    [ERequirementContactFieldItemType.organization]: {
+      labelProps: { maxW: "full" },
+    },
+  }
+  return <RequirementFieldDisplay {...defaultProps} {...propsByType[contactFieldItemType]} />
+}

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/generic-contact-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/generic-contact-display.tsx
@@ -1,0 +1,72 @@
+import { Box, BoxProps, Heading, HeadingProps } from "@chakra-ui/react"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { getRequirementTypeLabel } from "../../../../constants"
+import { ERequirementContactFieldItemType } from "../../../../types/enums"
+import { ContactFieldItemDisplay } from "./contact-field-item-display"
+import { TRequirementFieldDisplayProps } from "./index"
+
+export function GenericContactDisplay({
+  contactFieldItems,
+  label,
+  labelProps,
+  showAddLabelIndicator,
+  requirementType,
+  containerProps,
+  renderHeading,
+}: {
+  contactFieldItems: Array<{
+    type: ERequirementContactFieldItemType
+    containerProps?: BoxProps
+  }>
+  containerProps?: BoxProps
+  renderHeading?: () => JSX.Element
+} & TRequirementFieldDisplayProps) {
+  const { t } = useTranslation()
+  return (
+    <Box
+      w={"full"}
+      as={"section"}
+      borderRadius={"sm"}
+      border={"1px solid"}
+      borderColor={"border.light"}
+      px={4}
+      py={3}
+      {...containerProps}
+    >
+      {renderHeading ? (
+        renderHeading()
+      ) : (
+        <Heading
+          as={"h4"}
+          fontSize={"md"}
+          {...(labelProps as HeadingProps)}
+          color={!label && showAddLabelIndicator ? "error" : "text.primary"}
+        >
+          {label ??
+            (showAddLabelIndicator
+              ? `${t("requirementsLibrary.modals.addLabel")} *`
+              : getRequirementTypeLabel(requirementType))}
+        </Heading>
+      )}
+      <Box w={"full"} display={"grid"} gridTemplateColumns={"repeat(2, calc(50% - 0.75rem))"} gap={"1rem 1.5rem"}>
+        {contactFieldItems.map(({ type, containerProps }) => (
+          <Box
+            key={type}
+            sx={{
+              ".chakra-form-control": {
+                display: "flex",
+                flexDir: "column",
+                justifyContent: "space-between",
+                h: "100%",
+              },
+            }}
+            {...containerProps}
+          >
+            <ContactFieldItemDisplay contactFieldItemType={type} />
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/generic-contact-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/generic-contact-display.tsx
@@ -1,10 +1,19 @@
-import { Box, BoxProps, Heading, HeadingProps } from "@chakra-ui/react"
+import { Box, BoxProps, FormControl, FormLabel, Heading, HeadingProps, Switch } from "@chakra-ui/react"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { getRequirementTypeLabel } from "../../../../constants"
 import { ERequirementContactFieldItemType } from "../../../../types/enums"
 import { ContactFieldItemDisplay } from "./contact-field-item-display"
 import { TRequirementFieldDisplayProps } from "./index"
+
+export type TGenericContactDisplayProps = {
+  contactFieldItems: Array<{
+    type: ERequirementContactFieldItemType
+    containerProps?: BoxProps
+  }>
+  containerProps?: BoxProps
+  renderHeading?: () => JSX.Element
+} & TRequirementFieldDisplayProps
 
 export function GenericContactDisplay({
   contactFieldItems,
@@ -14,59 +23,86 @@ export function GenericContactDisplay({
   requirementType,
   containerProps,
   renderHeading,
-}: {
-  contactFieldItems: Array<{
-    type: ERequirementContactFieldItemType
-    containerProps?: BoxProps
-  }>
-  containerProps?: BoxProps
-  renderHeading?: () => JSX.Element
-} & TRequirementFieldDisplayProps) {
+  addMultipleContactProps,
+}: TGenericContactDisplayProps) {
   const { t } = useTranslation()
   return (
-    <Box
-      w={"full"}
-      as={"section"}
-      borderRadius={"sm"}
-      border={"1px solid"}
-      borderColor={"border.light"}
-      px={4}
-      py={3}
-      {...containerProps}
-    >
-      {renderHeading ? (
-        renderHeading()
-      ) : (
-        <Heading
-          as={"h4"}
-          fontSize={"md"}
-          {...(labelProps as HeadingProps)}
-          color={!label && showAddLabelIndicator ? "error" : "text.primary"}
+    <>
+      <Box
+        w={"full"}
+        as={"section"}
+        borderRadius={"sm"}
+        border={"1px solid"}
+        borderColor={"border.light"}
+        borderBottomRadius={addMultipleContactProps?.shouldRender ? "none" : undefined}
+        px={4}
+        py={3}
+        {...containerProps}
+      >
+        {renderHeading ? (
+          renderHeading()
+        ) : (
+          <Heading
+            as={"h4"}
+            fontSize={"md"}
+            {...(labelProps as HeadingProps)}
+            color={!label && showAddLabelIndicator ? "error" : "text.primary"}
+          >
+            {label ??
+              (showAddLabelIndicator
+                ? `${t("requirementsLibrary.modals.addLabel")} *`
+                : getRequirementTypeLabel(requirementType))}
+          </Heading>
+        )}
+        <Box w={"full"} display={"grid"} gridTemplateColumns={"repeat(2, calc(50% - 0.75rem))"} gap={"1rem 1.5rem"}>
+          {contactFieldItems.map(({ type, containerProps }) => (
+            <Box
+              key={type}
+              sx={{
+                ".chakra-form-control": {
+                  display: "flex",
+                  flexDir: "column",
+                  justifyContent: "space-between",
+                  h: "100%",
+                },
+              }}
+              {...containerProps}
+            >
+              <ContactFieldItemDisplay contactFieldItemType={type} />
+            </Box>
+          ))}
+        </Box>
+      </Box>
+
+      {addMultipleContactProps?.shouldRender && (
+        <FormControl
+          bg={"greys.grey04"}
+          border={"1px solid"}
+          borderColor={"border.light"}
+          borderBottomRadius={"sm"}
+          borderTop={"none"}
+          w={"full"}
+          px={4}
+          py={3}
+          display="flex"
+          alignItems="center"
+          justifyContent={"space-between"}
+          {...addMultipleContactProps?.formControlProps}
         >
-          {label ??
-            (showAddLabelIndicator
-              ? `${t("requirementsLibrary.modals.addLabel")} *`
-              : getRequirementTypeLabel(requirementType))}
-        </Heading>
-      )}
-      <Box w={"full"} display={"grid"} gridTemplateColumns={"repeat(2, calc(50% - 0.75rem))"} gap={"1rem 1.5rem"}>
-        {contactFieldItems.map(({ type, containerProps }) => (
-          <Box
-            key={type}
+          <FormLabel htmlFor="can-add-label" mb="0">
+            {t("requirementsLibrary.modals.canAddMultipleContacts")}
+          </FormLabel>
+          <Switch
+            id="can-add-label"
             sx={{
-              ".chakra-form-control": {
-                display: "flex",
-                flexDir: "column",
-                justifyContent: "space-between",
-                h: "100%",
+              ".chakra-switch__track[aria-checked=true], .chakra-switch__track[data-checked]": {
+                "--switch-bg": "var(--chakra-colors-success)",
               },
             }}
-            {...containerProps}
-          >
-            <ContactFieldItemDisplay contactFieldItemType={type} />
-          </Box>
-        ))}
-      </Box>
-    </Box>
+            {...addMultipleContactProps?.switchProps}
+          />
+        </FormControl>
+      )}
+    </>
   )
 }

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/generic-contact-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/generic-contact-display.tsx
@@ -1,4 +1,5 @@
-import { Box, BoxProps, FormControl, FormLabel, Heading, HeadingProps, Switch } from "@chakra-ui/react"
+import { Box, BoxProps, Button, FormControl, FormLabel, Heading, HeadingProps, Switch } from "@chakra-ui/react"
+import { Plus } from "@phosphor-icons/react"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { getRequirementTypeLabel } from "../../../../constants"
@@ -24,6 +25,7 @@ export function GenericContactDisplay({
   containerProps,
   renderHeading,
   addMultipleContactProps,
+  showAddPersonButton,
 }: TGenericContactDisplayProps) {
   const { t } = useTranslation()
   return (
@@ -102,6 +104,27 @@ export function GenericContactDisplay({
             {...addMultipleContactProps?.switchProps}
           />
         </FormControl>
+      )}
+
+      {showAddPersonButton && (
+        <Button
+          variant={"secondary"}
+          leftIcon={<Plus />}
+          size={"sm"}
+          my={6}
+          isDisabled
+          // As it is a display component it should have the styles of
+          // a normal button but should be disabled to screen readers and not clickable
+          _disabled={{
+            bg: "transparent",
+            color: "text.primary",
+            borderWidth: 1,
+            borderColor: "border.dark",
+            cursor: "not-allowed",
+          }}
+        >
+          {t("requirementsLibrary.addAnotherPerson")}
+        </Button>
       )}
     </>
   )

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/generic-field-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/generic-field-display.tsx
@@ -1,0 +1,45 @@
+import { FormControl, FormHelperText, FormLabel, FormLabelProps } from "@chakra-ui/react"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { getRequirementTypeLabel } from "../../../../constants"
+import { TRequirementFieldDisplayProps } from "./index"
+
+interface IGroupedFieldProps extends Omit<TRequirementFieldDisplayProps, "options"> {
+  inputDisplay: JSX.Element
+}
+
+const defaultLabelProps: Partial<FormLabelProps> = {
+  color: "text.primary",
+}
+
+const helperTextStyles = {
+  color: "text.secondary",
+}
+
+export const GenericFieldDisplay = observer(function GroupedFieldDisplay({
+  inputDisplay,
+  label,
+  labelProps,
+  helperText,
+  showAddLabelIndicator,
+  requirementType,
+}: IGroupedFieldProps) {
+  const { t } = useTranslation()
+  return (
+    <FormControl w={"100%"} isReadOnly>
+      <FormLabel
+        {...defaultLabelProps}
+        {...(labelProps as FormLabelProps)}
+        color={!label && showAddLabelIndicator ? "error" : undefined}
+      >
+        {label ??
+          (showAddLabelIndicator
+            ? `${t("requirementsLibrary.modals.addLabel")} *`
+            : getRequirementTypeLabel(requirementType))}
+      </FormLabel>
+      {inputDisplay}
+      {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
+    </FormControl>
+  )
+})

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/generic-field-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/generic-field-display.tsx
@@ -1,4 +1,4 @@
-import { FormControl, FormHelperText, FormLabel, FormLabelProps } from "@chakra-ui/react"
+import { FormControl, FormControlProps, FormHelperText, FormLabel, FormLabelProps } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -7,6 +7,7 @@ import { TRequirementFieldDisplayProps } from "./index"
 
 interface IGroupedFieldProps extends Omit<TRequirementFieldDisplayProps, "options"> {
   inputDisplay: JSX.Element
+  containerProps?: Partial<FormControlProps>
 }
 
 const defaultLabelProps: Partial<FormLabelProps> = {
@@ -24,10 +25,11 @@ export const GenericFieldDisplay = observer(function GroupedFieldDisplay({
   helperText,
   showAddLabelIndicator,
   requirementType,
+  containerProps,
 }: IGroupedFieldProps) {
   const { t } = useTranslation()
   return (
-    <FormControl w={"100%"} isReadOnly>
+    <FormControl w={"100%"} isReadOnly {...containerProps}>
       <FormLabel
         {...defaultLabelProps}
         {...(labelProps as FormLabelProps)}

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
@@ -159,17 +159,16 @@ const requirementsComponentMap = {
   [ERequirementType.checkbox]({ options = defaultOptions, ...genericDisplayProps }: TRequirementFieldDisplayProps) {
     return (
       <GenericFieldDisplay
-        inputDisplay={
-          <CheckboxGroup>
-            <Stack>
-              {options.map((option, index) => (
-                <Checkbox key={index} value={option}>
-                  {option}
-                </Checkbox>
-              ))}
-            </Stack>
-          </CheckboxGroup>
-        }
+        containerProps={{
+          display: "flex",
+          flexDir: "row-reverse",
+          justifyContent: "flex-end",
+          alignItems: "center",
+          sx: {
+            label: { mb: 0 },
+          },
+        }}
+        inputDisplay={<Checkbox mr={2} />}
         {...genericDisplayProps}
       />
     )

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
@@ -265,9 +265,10 @@ const requirementsComponentMap = {
           },
         },
       },
+      { type: ERequirementContactFieldItemType.businessName },
+      { type: ERequirementContactFieldItemType.businessLicense },
       { type: ERequirementContactFieldItemType.professionalAssociation },
       { type: ERequirementContactFieldItemType.professionalNumber },
-      { type: ERequirementContactFieldItemType.organization },
     ]
 
     return <GenericContactDisplay contactFieldItems={contactFieldItemTypes} {...props} />

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
@@ -1,13 +1,8 @@
 import {
-  Box,
   BoxProps,
   Checkbox,
   CheckboxGroup,
-  FormControl,
-  FormHelperText,
-  FormLabel,
   FormLabelProps,
-  Heading,
   HeadingProps,
   Input,
   InputGroup,
@@ -23,15 +18,11 @@ import {
 import { CalendarBlank, Envelope, MapPin, Phone } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
-import { useTranslation } from "react-i18next"
-import { getRequirementContactFieldItemLabel, getRequirementTypeLabel } from "../../../constants"
-import { ENumberUnit, ERequirementContactFieldItemType, ERequirementType } from "../../../types/enums"
+import { ENumberUnit, ERequirementContactFieldItemType, ERequirementType } from "../../../../types/enums"
+import { GenericContactDisplay } from "./generic-contact-display"
+import { GenericFieldDisplay } from "./generic-field-display"
 
-const defaultLabelProps: Partial<FormLabelProps> = {
-  color: "text.primary",
-}
-
-type TRequirementFieldDisplayProps = {
+export type TRequirementFieldDisplayProps = {
   labelProps?: Partial<FormLabelProps | HeadingProps>
   label?: string
   options?: string[]
@@ -40,14 +31,6 @@ type TRequirementFieldDisplayProps = {
   selectProps?: Partial<SelectProps>
   requirementType: ERequirementType
   showAddLabelIndicator?: boolean
-}
-
-interface IGroupedFieldProps extends Omit<TRequirementFieldDisplayProps, "options"> {
-  inputDisplay: JSX.Element
-}
-
-const helperTextStyles = {
-  color: "text.secondary",
 }
 
 const defaultOptions = ["Option", "Option"]
@@ -239,7 +222,17 @@ const requirementsComponentMap = {
       { type: ERequirementContactFieldItemType.lastName },
       { type: ERequirementContactFieldItemType.email },
       { type: ERequirementContactFieldItemType.phone },
-      { type: ERequirementContactFieldItemType.address, containerProps: { gridColumn: "1 / span 2" } },
+      {
+        type: ERequirementContactFieldItemType.address,
+        containerProps: {
+          gridColumn: "1 / span 2",
+          sx: {
+            ".chakra-form-control input": {
+              maxW: "full",
+            },
+          },
+        },
+      },
       { type: ERequirementContactFieldItemType.organization },
     ]
 
@@ -252,7 +245,17 @@ const requirementsComponentMap = {
       { type: ERequirementContactFieldItemType.lastName },
       { type: ERequirementContactFieldItemType.email },
       { type: ERequirementContactFieldItemType.phone },
-      { type: ERequirementContactFieldItemType.address, containerProps: { gridColumn: "1 / span 2" } },
+      {
+        type: ERequirementContactFieldItemType.address,
+        containerProps: {
+          gridColumn: "1 / span 2",
+          sx: {
+            ".chakra-form-control input": {
+              maxW: "full",
+            },
+          },
+        },
+      },
       { type: ERequirementContactFieldItemType.professionalAssociation },
       { type: ERequirementContactFieldItemType.professionalNumber },
       { type: ERequirementContactFieldItemType.organization },
@@ -262,109 +265,10 @@ const requirementsComponentMap = {
   },
 }
 
-export function hasRequirementFieldDisplayComponent(requirementType: ERequirementType): boolean {
-  return !!requirementsComponentMap[requirementType]
-}
-
 export const RequirementFieldDisplay = observer(function RequirementFieldDisplay(props: TRequirementFieldDisplayProps) {
   return requirementsComponentMap[props.requirementType]?.(props) ?? null
 })
 
-export const GenericFieldDisplay = observer(function GroupedFieldDisplay({
-  inputDisplay,
-  label,
-  labelProps,
-  helperText,
-  showAddLabelIndicator,
-  requirementType,
-}: IGroupedFieldProps) {
-  const { t } = useTranslation()
-  return (
-    <FormControl w={"100%"} isReadOnly>
-      <FormLabel
-        {...defaultLabelProps}
-        {...(labelProps as FormLabelProps)}
-        color={!label && showAddLabelIndicator ? "error" : undefined}
-      >
-        {label ??
-          (showAddLabelIndicator
-            ? `${t("requirementsLibrary.modals.addLabel")} *`
-            : getRequirementTypeLabel(requirementType))}
-      </FormLabel>
-      {inputDisplay}
-      {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
-    </FormControl>
-  )
-})
-
-function GenericContactDisplay({
-  contactFieldItems,
-  label,
-  labelProps,
-  showAddLabelIndicator,
-  requirementType,
-}: {
-  contactFieldItems: Array<{ type: ERequirementContactFieldItemType; containerProps?: BoxProps }>
-} & TRequirementFieldDisplayProps) {
-  const { t } = useTranslation()
-  return (
-    <Box w={"full"} as={"section"} borderRadius={"sm"} border={"1px solid"} borderColor={"border.light"} px={4} py={3}>
-      <Heading
-        as={"h4"}
-        fontSize={"md"}
-        {...(labelProps as HeadingProps)}
-        color={!label && showAddLabelIndicator ? "error" : "text.primary"}
-      >
-        {label ??
-          (showAddLabelIndicator
-            ? `${t("requirementsLibrary.modals.addLabel")} *`
-            : getRequirementTypeLabel(requirementType))}
-      </Heading>
-      <Box w={"full"} display={"grid"} gridTemplateColumns={"repeat(2, calc(50% - 0.75rem))"} gap={"1rem 1.5rem"}>
-        {contactFieldItems.map(({ type, containerProps }) => (
-          <Box
-            key={type}
-            sx={{
-              ".chakra-form-control": {
-                display: "flex",
-                flexDir: "column",
-                justifyContent: "space-between",
-                h: "100%",
-              },
-            }}
-            {...containerProps}
-          >
-            <ContactFieldItemDisplay contactFieldItemType={type} />
-          </Box>
-        ))}
-      </Box>
-    </Box>
-  )
-}
-
-interface IContactFieldItemDisplayProps {
-  contactFieldItemType: ERequirementContactFieldItemType
-}
-
-function ContactFieldItemDisplay({ contactFieldItemType }: IContactFieldItemDisplayProps) {
-  const defaultProps: Partial<TRequirementFieldDisplayProps> = {
-    label: getRequirementContactFieldItemLabel(contactFieldItemType),
-    requirementType: ERequirementType.text,
-  }
-
-  const propsByType = {
-    [ERequirementContactFieldItemType.email]: {
-      requirementType: ERequirementType.email,
-    },
-    [ERequirementContactFieldItemType.phone]: {
-      requirementType: ERequirementType.phone,
-    },
-    [ERequirementContactFieldItemType.address]: {
-      requirementType: ERequirementType.address,
-    },
-    [ERequirementContactFieldItemType.organization]: {
-      labelProps: { maxW: "full" },
-    },
-  }
-  return <RequirementFieldDisplay {...defaultProps} {...propsByType[contactFieldItemType]} />
+export function hasRequirementFieldDisplayComponent(requirementType: ERequirementType): boolean {
+  return !!requirementsComponentMap[requirementType]
 }

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
@@ -2,6 +2,7 @@ import {
   BoxProps,
   Checkbox,
   CheckboxGroup,
+  FormControlProps,
   FormLabelProps,
   HeadingProps,
   Input,
@@ -13,6 +14,7 @@ import {
   Select,
   SelectProps,
   Stack,
+  SwitchProps,
   Textarea,
 } from "@chakra-ui/react"
 import { CalendarBlank, Envelope, MapPin, Phone } from "@phosphor-icons/react"
@@ -29,6 +31,13 @@ export type TRequirementFieldDisplayProps = {
   helperText?: string
   unit?: ENumberUnit | null
   selectProps?: Partial<SelectProps>
+  addMultipleContactProps?: {
+    shouldRender?: boolean
+    isChecked?: boolean
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+    formControlProps?: FormControlProps
+    switchProps?: SwitchProps
+  }
   requirementType: ERequirementType
   showAddLabelIndicator?: boolean
 }

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
@@ -38,6 +38,7 @@ export type TRequirementFieldDisplayProps = {
     formControlProps?: FormControlProps
     switchProps?: SwitchProps
   }
+  showAddPersonButton?: boolean
   requirementType: ERequirementType
   showAddLabelIndicator?: boolean
 }

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-group.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-group.tsx
@@ -1,0 +1,41 @@
+import { Stack } from "@chakra-ui/react"
+import React from "react"
+import { FieldValues } from "react-hook-form"
+import { EditableHelperText, TEditableHelperTextProps } from "./editable-helper-text"
+import { EditableLabel, TEditableLabelProps } from "./editable-label"
+import { IsElectiveCheckbox, TIsElectiveCheckboxProps } from "./is-elective-checkbox"
+import { IsOptionalCheckbox, TIsOptionalCheckboxProps } from "./is-optional-checkbox"
+
+export type TEditableGroupProps<TFieldValues extends FieldValues> = {
+  editableLabelProps?: TEditableLabelProps<TFieldValues>
+  editableHelperTextProps?: TEditableHelperTextProps<TFieldValues>
+  isOptionalCheckboxProps: TIsOptionalCheckboxProps<TFieldValues>
+  isElectiveCheckboxProps: TIsElectiveCheckboxProps<TFieldValues>
+  editableInput?: JSX.Element
+  multiOptionEditableInput?: JSX.Element
+}
+
+export function EditableGroup<TFieldValues>({
+  editableLabelProps,
+  editableHelperTextProps,
+  editableInput,
+  multiOptionEditableInput,
+  isOptionalCheckboxProps,
+  isElectiveCheckboxProps,
+}: TEditableGroupProps<TFieldValues>) {
+  return (
+    <Stack spacing={4}>
+      <EditableLabel {...editableLabelProps} />
+      {editableInput}
+      {editableInput && <EditableHelperText {...editableHelperTextProps} />}
+      {multiOptionEditableInput && (
+        <Stack>
+          {multiOptionEditableInput}
+          <EditableHelperText {...editableHelperTextProps} />
+        </Stack>
+      )}
+      <IsOptionalCheckbox {...isOptionalCheckboxProps} />
+      <IsElectiveCheckbox mt={"0.625rem"} {...isElectiveCheckboxProps} />
+    </Stack>
+  )
+}

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-group.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-group.tsx
@@ -1,4 +1,4 @@
-import { Stack } from "@chakra-ui/react"
+import { Stack, StackProps } from "@chakra-ui/react"
 import React from "react"
 import { FieldValues } from "react-hook-form"
 import { EditableHelperText, TEditableHelperTextProps } from "./editable-helper-text"
@@ -13,7 +13,7 @@ export type TEditableGroupProps<TFieldValues extends FieldValues> = {
   isElectiveCheckboxProps: TIsElectiveCheckboxProps<TFieldValues>
   editableInput?: JSX.Element
   multiOptionEditableInput?: JSX.Element
-}
+} & Partial<StackProps>
 
 export function EditableGroup<TFieldValues>({
   editableLabelProps,
@@ -22,9 +22,10 @@ export function EditableGroup<TFieldValues>({
   multiOptionEditableInput,
   isOptionalCheckboxProps,
   isElectiveCheckboxProps,
+  ...containerProps
 }: TEditableGroupProps<TFieldValues>) {
   return (
-    <Stack spacing={4}>
+    <Stack spacing={4} {...containerProps}>
       <EditableLabel {...editableLabelProps} />
       {editableInput}
       {editableInput && <EditableHelperText {...editableHelperTextProps} />}

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-helper-text.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-helper-text.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { FieldValues, useController } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import {
+  EditableInputWithControls,
+  IEditableInputWithControlsProps,
+} from "../../../shared/editable-input-with-controls"
+import { IControlProps } from "./types"
+
+export type TEditableHelperTextProps<TFieldValues extends FieldValues> = IControlProps<TFieldValues> &
+  Partial<IEditableInputWithControlsProps>
+
+export function EditableHelperText<TFieldValues extends FieldValues>({
+  controlProps,
+  ...editableHelperTextProps
+}: TEditableHelperTextProps<TFieldValues>) {
+  const {
+    field: { onChange, value },
+  } = useController(controlProps)
+  const { t } = useTranslation()
+  return (
+    <EditableInputWithControls
+      initialHint={t("requirementsLibrary.modals.addHelpText")}
+      placeholder={t("requirementsLibrary.modals.helpTextPlaceHolder")}
+      defaultValue={(value as string) || ""}
+      onSubmit={onChange}
+      onCancel={onChange}
+      {...editableHelperTextProps}
+    />
+  )
+}

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-label.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-label.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { FieldValues, useController } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import {
+  EditableInputWithControls,
+  IEditableInputWithControlsProps,
+} from "../../../shared/editable-input-with-controls"
+import { IControlProps } from "./types"
+
+export type TEditableLabelProps<TFieldValues extends FieldValues> = IControlProps<TFieldValues> &
+  Partial<IEditableInputWithControlsProps>
+
+export function EditableLabel<TFieldValues extends FieldValues>({
+  controlProps,
+  ...editableLabelProps
+}: TEditableLabelProps<TFieldValues>) {
+  const {
+    field: { onChange, value },
+  } = useController(controlProps)
+  const { t } = useTranslation()
+  return (
+    <EditableInputWithControls
+      initialHint={t("ui.clickToEdit")}
+      defaultValue={(value as string) || t("requirementsLibrary.modals.defaultRequirementLabel")}
+      onSubmit={onChange}
+      onCancel={onChange}
+      {...editableLabelProps}
+    />
+  )
+}

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/generic-contact-edit.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/generic-contact-edit.tsx
@@ -1,0 +1,39 @@
+import React from "react"
+import { useController } from "react-hook-form"
+import {
+  GenericContactDisplay,
+  TGenericContactDisplayProps,
+} from "../requirement-field-display/generic-contact-display"
+import { EditableLabel, TEditableLabelProps } from "./editable-label"
+import { IControlProps } from "./types"
+
+export type TGenericContactEditProps<TFieldValues> = {
+  editableLabelProps: TEditableLabelProps<TFieldValues>
+} & TGenericContactDisplayProps &
+  IControlProps<TFieldValues>
+
+export function GenericContactEdit<TFieldValues>({
+  controlProps,
+  editableLabelProps,
+  ...contactDisplayProps
+}: TGenericContactEditProps<TFieldValues>) {
+  const {
+    field: { value, ...restField },
+  } = useController(controlProps)
+  return (
+    <GenericContactDisplay
+      containerProps={{
+        borderBottomRadius: "none",
+      }}
+      renderHeading={() => <EditableLabel {...editableLabelProps} />}
+      addMultipleContactProps={{
+        switchProps: {
+          isChecked: !!value,
+          ...restField,
+        },
+        shouldRender: true,
+      }}
+      {...contactDisplayProps}
+    />
+  )
+}

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
@@ -11,7 +11,7 @@ import {
   Stack,
   Textarea,
 } from "@chakra-ui/react"
-import { CalendarBlank, MapPin, X } from "@phosphor-icons/react"
+import { CalendarBlank, Envelope, MapPin, Phone, X } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { Controller, FieldValues, useController, useFieldArray } from "react-hook-form"
@@ -59,7 +59,7 @@ const requirementsComponentMap = {
         editableInput={
           <InputGroup>
             <InputLeftElement pointerEvents="none">
-              <i className="fa fa-phone"></i>
+              <Phone />
             </InputLeftElement>
             <Input bg={"white"} isReadOnly />
           </InputGroup>
@@ -75,7 +75,7 @@ const requirementsComponentMap = {
         editableInput={
           <InputGroup>
             <InputLeftElement pointerEvents="none">
-              <i className="fa fa-envelope"></i>
+              <Envelope />
             </InputLeftElement>
             <Input bg={"white"} isReadOnly />
           </InputGroup>

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
@@ -1,51 +1,23 @@
-import {
-  Box,
-  Button,
-  Checkbox,
-  CheckboxProps,
-  HStack,
-  IconButton,
-  Input,
-  InputGroup,
-  InputLeftElement,
-  Stack,
-  Textarea,
-} from "@chakra-ui/react"
+import { Box, Button, HStack, IconButton, Input, InputGroup, InputLeftElement, Textarea } from "@chakra-ui/react"
 import { CalendarBlank, Envelope, MapPin, Phone, X } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
-import { Controller, FieldValues, useController, useFieldArray } from "react-hook-form"
-import { FieldPath, UseFieldArrayProps } from "react-hook-form/dist/types"
-import { UseControllerProps } from "react-hook-form/dist/types/controller"
+import { Controller, FieldValues, useFieldArray } from "react-hook-form"
+import { UseFieldArrayProps } from "react-hook-form/dist/types"
 import { useTranslation } from "react-i18next"
 import { ENumberUnit, ERequirementType } from "../../../../types/enums"
 import { IOption } from "../../../../types/types"
-import {
-  EditableInputWithControls,
-  IEditableInputWithControlsProps,
-} from "../../../shared/editable-input-with-controls"
 import { UnitSelect } from "../../../shared/select/selectors/unit-select"
+import { EditableGroup, TEditableGroupProps } from "./editable-group"
+import { IControlProps } from "./types"
 
-interface IControlProps<TFieldValues extends FieldValues> {
-  controlProps: Omit<UseControllerProps<TFieldValues, FieldPath<TFieldValues>>, "render">
-}
-
-type TRequirementEditProps<TFieldValues extends FieldValues> = TEditableGroupProps<TFieldValues> & {
+export type TRequirementEditProps<TFieldValues extends FieldValues> = TEditableGroupProps<TFieldValues> & {
   unitSelectProps?: IControlProps<TFieldValues>
   multiOptionProps?: {
     useFieldArrayProps: UseFieldArrayProps<TFieldValues>
     onOptionValueChange: (optionIndex: number, optionValue: string) => void
     getOptionValue: (idx: number) => IOption
   }
-}
-
-type TEditableGroupProps<TFieldValues extends FieldValues> = {
-  editableLabelProps?: IControlProps<TFieldValues> & Partial<IEditableInputWithControlsProps>
-  editableHelperTextProps?: IControlProps<TFieldValues> & Partial<IEditableInputWithControlsProps>
-  isOptionalCheckboxProps: IControlProps<TFieldValues> & Partial<CheckboxProps>
-  isElectiveCheckboxProps: IControlProps<TFieldValues> & Partial<CheckboxProps>
-  editableInput?: JSX.Element
-  multiOptionEditableInput?: JSX.Element
 }
 
 const requirementsComponentMap = {
@@ -390,110 +362,6 @@ export const RequirementFieldEdit = observer(function RequirementFieldEdit<TFiel
 }: TProps<TFieldValues>) {
   return requirementsComponentMap[requirementType]?.(rest) ?? null
 })
-
-function EditableLabel<TFieldValues extends FieldValues>({
-  controlProps,
-  ...editableLabelProps
-}: TRequirementEditProps<TFieldValues>["editableLabelProps"]) {
-  const {
-    field: { onChange, value },
-  } = useController(controlProps)
-  const { t } = useTranslation()
-  return (
-    <EditableInputWithControls
-      initialHint={t("ui.clickToEdit")}
-      defaultValue={(value as string) || t("requirementsLibrary.modals.defaultRequirementLabel")}
-      onSubmit={onChange}
-      onCancel={onChange}
-      {...editableLabelProps}
-    />
-  )
-}
-
-function EditableHelperText<TFieldValues extends FieldValues>({
-  controlProps,
-  ...editableHelperTextProps
-}: TRequirementEditProps<TFieldValues>["editableLabelProps"]) {
-  const {
-    field: { onChange, value },
-  } = useController(controlProps)
-  const { t } = useTranslation()
-  return (
-    <EditableInputWithControls
-      initialHint={t("requirementsLibrary.modals.addHelpText")}
-      placeholder={t("requirementsLibrary.modals.helpTextPlaceHolder")}
-      defaultValue={(value as string) || ""}
-      onSubmit={onChange}
-      onCancel={onChange}
-      {...editableHelperTextProps}
-    />
-  )
-}
-
-function IsOptionalCheckbox<TFieldValues extends FieldValues>({
-  controlProps,
-  ...checkboxProps
-}: TRequirementEditProps<TFieldValues>["isOptionalCheckboxProps"]) {
-  const {
-    field: { value, onChange, ...restField },
-  } = useController(controlProps)
-  const { t } = useTranslation()
-
-  return (
-    //   This is checked inverse of the boolean value. This is because the db field is for "required", instead of
-    //   optional, and by default it should be required
-    <Checkbox
-      {...checkboxProps}
-      isChecked={value === undefined ? value : !value}
-      onChange={(e) => {
-        onChange(!e.target.checked)
-      }}
-      {...restField}
-    >
-      {t("requirementsLibrary.modals.optionalForSubmitters")}
-    </Checkbox>
-  )
-}
-
-function IsElectiveCheckbox<TFieldValues extends FieldValues>({
-  controlProps,
-  ...checkboxProps
-}: TRequirementEditProps<TFieldValues>["isElectiveCheckboxProps"]) {
-  const {
-    field: { value, ...restField },
-  } = useController(controlProps)
-  const { t } = useTranslation()
-  return (
-    <Checkbox {...checkboxProps} isChecked={value} {...restField}>
-      {t("requirementsLibrary.modals.isAnElectiveField")}
-    </Checkbox>
-  )
-}
-
-function EditableGroup<TFieldValues>({
-  editableLabelProps,
-  editableHelperTextProps,
-  editableInput,
-  multiOptionEditableInput,
-  isOptionalCheckboxProps,
-  isElectiveCheckboxProps,
-}: TEditableGroupProps<TFieldValues>) {
-  return (
-    <Stack spacing={4}>
-      <EditableLabel {...editableLabelProps} />
-      {editableInput}
-      {editableInput && <EditableHelperText {...editableHelperTextProps} />}
-      {multiOptionEditableInput && (
-        <Stack>
-          {multiOptionEditableInput}
-          <EditableHelperText {...editableHelperTextProps} />
-        </Stack>
-      )}
-      <IsOptionalCheckbox {...isOptionalCheckboxProps} />
-      <IsElectiveCheckbox mt={"0.625rem"} {...isElectiveCheckboxProps} />
-    </Stack>
-  )
-}
 
 export function hasRequirementFieldEditComponent(requirementType: ERequirementType): boolean {
   return !!requirementsComponentMap[requirementType]

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
@@ -199,53 +199,23 @@ const requirementsComponentMap = {
     multiOptionProps,
     ...editableGroupProps
   }: TRequirementEditProps<TFieldValues>) {
-    const { t } = useTranslation()
-
-    if (!multiOptionProps) {
-      import.meta.env.DEV && console.error("multiOptionProps is required for checkbox requirement edit")
-      return null
-    }
-
-    const { useFieldArrayProps, onOptionValueChange, getOptionValue } = multiOptionProps
-
-    const { fields, append, remove } = useFieldArray<TFieldValues>(useFieldArrayProps)
-
     return (
       <EditableGroup
-        multiOptionEditableInput={
-          <>
-            {fields.map((field, idx) => (
-              <HStack key={field.id}>
-                <Box
-                  border={"1px solid"}
-                  borderColor={"border.light"}
-                  bg={"white"}
-                  w={"16px"}
-                  h={"16px"}
-                  borderRadius={"sm"}
-                />
-                <Input
-                  bg={"white"}
-                  size={"sm"}
-                  value={getOptionValue(idx).label}
-                  onChange={(e) => onOptionValueChange(idx, e.target.value)}
-                  w={"150px"}
-                />
-                <IconButton
-                  aria-label={"remove option"}
-                  variant={"unstyled"}
-                  icon={<X />}
-                  onClick={() => remove(idx)}
-                />
-              </HStack>
-            ))}
-
-            {/*  @ts-ignore*/}
-            <Button variant={"link"} textDecoration={"underline"} onClick={() => append({ value: "", label: "" })}>
-              {t("requirementsLibrary.modals.addOptionButton")}
-            </Button>
-          </>
-        }
+        sx={{
+          "& > div:first-child": {
+            alignItems: "center",
+            "&:before": {
+              content: "''",
+              border: "1px solid",
+              borderColor: "border.light",
+              bg: "white",
+              w: "16px",
+              h: "16px",
+              borderRadius: "sm",
+              mr: 2,
+            },
+          },
+        }}
         {...editableGroupProps}
       />
     )

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
@@ -1,14 +1,25 @@
-import { Box, Button, HStack, IconButton, Input, InputGroup, InputLeftElement, Textarea } from "@chakra-ui/react"
+import {
+  Box,
+  BoxProps,
+  Button,
+  HStack,
+  IconButton,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Textarea,
+} from "@chakra-ui/react"
 import { CalendarBlank, Envelope, MapPin, Phone, X } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { Controller, FieldValues, useFieldArray } from "react-hook-form"
 import { UseFieldArrayProps } from "react-hook-form/dist/types"
 import { useTranslation } from "react-i18next"
-import { ENumberUnit, ERequirementType } from "../../../../types/enums"
+import { ENumberUnit, ERequirementContactFieldItemType, ERequirementType } from "../../../../types/enums"
 import { IOption } from "../../../../types/types"
 import { UnitSelect } from "../../../shared/select/selectors/unit-select"
 import { EditableGroup, TEditableGroupProps } from "./editable-group"
+import { GenericContactEdit } from "./generic-contact-edit"
 import { IControlProps } from "./types"
 
 export type TRequirementEditProps<TFieldValues extends FieldValues> = TEditableGroupProps<TFieldValues> & {
@@ -18,6 +29,7 @@ export type TRequirementEditProps<TFieldValues extends FieldValues> = TEditableG
     onOptionValueChange: (optionIndex: number, optionValue: string) => void
     getOptionValue: (idx: number) => IOption
   }
+  canAddMultipleContactProps?: IControlProps<TFieldValues>
 }
 
 const requirementsComponentMap = {
@@ -349,6 +361,83 @@ const requirementsComponentMap = {
 
   [ERequirementType.energyStepCode]: function <TFieldValues>(props) {
     return <EditableGroup editableInput={<i className="fa fa-bolt"></i>} {...props} />
+  },
+  [ERequirementType.generalContact]: function <TFieldValues>({
+    editableLabelProps,
+    canAddMultipleContactProps,
+  }: TRequirementEditProps<TFieldValues>) {
+    const contactFieldItemTypes: Array<{ type: ERequirementContactFieldItemType; containerProps?: BoxProps }> = [
+      { type: ERequirementContactFieldItemType.firstName },
+      { type: ERequirementContactFieldItemType.lastName },
+      { type: ERequirementContactFieldItemType.email },
+      { type: ERequirementContactFieldItemType.phone },
+      {
+        type: ERequirementContactFieldItemType.address,
+        containerProps: {
+          gridColumn: "1 / span 2",
+          sx: {
+            ".chakra-form-control input": {
+              maxW: "full",
+            },
+          },
+        },
+      },
+      { type: ERequirementContactFieldItemType.organization },
+    ]
+
+    if (!canAddMultipleContactProps) {
+      import.meta.env.DEV && console.error("canAddMultipleContactProps is required for contact requirement edit")
+      return null
+    }
+
+    return (
+      <GenericContactEdit<TFieldValues>
+        requirementType={ERequirementType.generalContact}
+        contactFieldItems={contactFieldItemTypes}
+        editableLabelProps={editableLabelProps}
+        {...canAddMultipleContactProps}
+      />
+    )
+  },
+
+  [ERequirementType.professionalContact]: function <TFieldValues>({
+    editableLabelProps,
+    canAddMultipleContactProps,
+  }: TRequirementEditProps<TFieldValues>) {
+    if (!canAddMultipleContactProps) {
+      import.meta.env.DEV && console.error("multipleContactProps is required for contact requirement edit")
+      return null
+    }
+
+    const contactFieldItemTypes: Array<{ type: ERequirementContactFieldItemType; containerProps?: BoxProps }> = [
+      { type: ERequirementContactFieldItemType.firstName },
+      { type: ERequirementContactFieldItemType.lastName },
+      { type: ERequirementContactFieldItemType.email },
+      { type: ERequirementContactFieldItemType.phone },
+      {
+        type: ERequirementContactFieldItemType.address,
+        containerProps: {
+          gridColumn: "1 / span 2",
+          sx: {
+            ".chakra-form-control input": {
+              maxW: "full",
+            },
+          },
+        },
+      },
+      { type: ERequirementContactFieldItemType.professionalAssociation },
+      { type: ERequirementContactFieldItemType.professionalNumber },
+      { type: ERequirementContactFieldItemType.organization },
+    ]
+
+    return (
+      <GenericContactEdit<TFieldValues>
+        requirementType={ERequirementType.professionalContact}
+        contactFieldItems={contactFieldItemTypes}
+        editableLabelProps={editableLabelProps}
+        {...canAddMultipleContactProps}
+      />
+    )
   },
 }
 

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/is-elective-checkbox.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/is-elective-checkbox.tsx
@@ -1,0 +1,23 @@
+import { Checkbox, CheckboxProps } from "@chakra-ui/react"
+import React from "react"
+import { FieldValues, useController } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import { IControlProps } from "./types"
+
+export type TIsElectiveCheckboxProps<TFieldValues extends FieldValues> = IControlProps<TFieldValues> &
+  Partial<CheckboxProps>
+
+export function IsElectiveCheckbox<TFieldValues extends FieldValues>({
+  controlProps,
+  ...checkboxProps
+}: TIsElectiveCheckboxProps<TFieldValues>) {
+  const {
+    field: { value, ...restField },
+  } = useController(controlProps)
+  const { t } = useTranslation()
+  return (
+    <Checkbox {...checkboxProps} isChecked={value} {...restField}>
+      {t("requirementsLibrary.modals.isAnElectiveField")}
+    </Checkbox>
+  )
+}

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/is-optional-checkbox.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/is-optional-checkbox.tsx
@@ -1,0 +1,33 @@
+import { Checkbox, CheckboxProps } from "@chakra-ui/react"
+import React from "react"
+import { FieldValues, useController } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import { IControlProps } from "./types"
+
+export type TIsOptionalCheckboxProps<TFieldValues extends FieldValues> = IControlProps<TFieldValues> &
+  Partial<CheckboxProps>
+
+export function IsOptionalCheckbox<TFieldValues extends FieldValues>({
+  controlProps,
+  ...checkboxProps
+}: TIsOptionalCheckboxProps<TFieldValues>) {
+  const {
+    field: { value, onChange, ...restField },
+  } = useController(controlProps)
+  const { t } = useTranslation()
+
+  return (
+    //   This is checked inverse of the boolean value. This is because the db field is for "required", instead of
+    //   optional, and by default it should be required
+    <Checkbox
+      {...checkboxProps}
+      isChecked={value === undefined ? value : !value}
+      onChange={(e) => {
+        onChange(!e.target.checked)
+      }}
+      {...restField}
+    >
+      {t("requirementsLibrary.modals.optionalForSubmitters")}
+    </Checkbox>
+  )
+}

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/types.ts
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/types.ts
@@ -1,0 +1,7 @@
+import { FieldValues } from "react-hook-form"
+import { FieldPath } from "react-hook-form/dist/types"
+import { UseControllerProps } from "react-hook-form/dist/types/controller"
+
+export interface IControlProps<TFieldValues extends FieldValues> {
+  controlProps: Omit<UseControllerProps<TFieldValues, FieldPath<TFieldValues>>, "render">
+}

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "react-i18next"
 import { getRequirementTypeLabel } from "../../../../constants"
 import { IRequirementsAttribute } from "../../../../types/api-request"
 import { ENumberUnit, ERequirementType } from "../../../../types/enums"
-import { isMultiOptionRequirement } from "../../../../utils/utility-functions"
+import { isContactRequirement, isMultiOptionRequirement } from "../../../../utils/utility-functions"
 import { EditableInputWithControls } from "../../../shared/editable-input-with-controls"
 import { EditorWithPreview } from "../../../shared/editor/custom-extensions/editor-with-preview"
 import { FieldsSetupDrawer } from "../fields-setup-drawer"
@@ -49,6 +49,9 @@ export const FieldsSetup = observer(function FieldsSetup() {
   const onUseRequirement = (requirementType: ERequirementType) => {
     append({
       inputType: requirementType,
+      label: [ERequirementType.generalContact, ERequirementType.professionalContact].includes(requirementType)
+        ? t("requirementsLibrary.modals.defaultContactLabel")
+        : undefined,
       ...(isMultiOptionRequirement(requirementType)
         ? {
             inputOptions: {
@@ -186,7 +189,6 @@ export const FieldsSetup = observer(function FieldsSetup() {
                         controlProps: {
                           control: control,
                           name: `requirementsAttributes.${index}.elective`,
-                          // @ts-ignore
                         },
                       }}
                       unitSelectProps={
@@ -224,6 +226,16 @@ export const FieldsSetup = observer(function FieldsSetup() {
                             }
                           : undefined
                       }
+                      canAddMultipleContactProps={
+                        isContactRequirement(requirementType)
+                          ? {
+                              controlProps: {
+                                control: control,
+                                name: `requirementsAttributes.${index}.inputOptions.canAddMultipleContacts`,
+                              },
+                            }
+                          : undefined
+                      }
                     />
                   </Box>
                   <Box
@@ -245,6 +257,13 @@ export const FieldsSetup = observer(function FieldsSetup() {
                       )}
                       selectProps={{
                         maxW: "339px",
+                      }}
+                      addMultipleContactProps={{
+                        shouldRender: true,
+                        formControlProps: { isDisabled: true },
+                        switchProps: {
+                          isChecked: !!watch(`requirementsAttributes.${index}.inputOptions.canAddMultipleContacts`),
+                        },
                       }}
                       showAddLabelIndicator
                     />

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -388,6 +388,7 @@
 
     .tips-header {
       color: $bcgov-blue-secondary;
+
       .i {
         background-color: $bcgov-blue-secondary;
         height: 24px;
@@ -399,6 +400,7 @@
 
   .compliance {
     background-color: $blue-light !important;
+
     .i {
       background-color: $bcgov-blue-secondary;
       height: 24px;
@@ -455,18 +457,52 @@
     color: var(--chakra-colors-error);
     font-weight: 700;
   }
+
   .contact-data-grid {
     border: none;
-    max-width: 650px;
+    max-width: 700px;
 
     .contact-field-set {
       margin-top: 0;
+    }
+
+    td {
+      padding-left: 0;
     }
 
     table,
     td,
     tr {
       border: none !important;
+    }
+
+    .formio-button-add-row {
+      margin-top: 14px;
+      background: transparent;
+      color: var(--chakra-colors-text-primary);
+      border: 1px solid var(--chakra-colors-border-dark);
+
+      &:hover {
+        background: var(--chakra-colors-lighten-100);
+      }
+
+      &:disabled {
+        background: var(--chakra-colors-greys-grey03);
+        color: var(--chakra-colors-greys-grey01);
+        border-color: var(--chakra-colors-border-light);
+      }
+
+      &:active {
+        border-width: 2px;
+        border-color: var(--chakra-colors-focus);
+      }
+
+      i:before {
+        content: "+";
+        font-size: var(--chakra-fontSizes-xl);
+        margin-right: var(--chakra-space-1);
+      }
+
     }
 
     .formio-button-remove-row {

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -14,9 +14,9 @@
 
 // override formio form designer
 .form-designer,
-// override form viewer
+  // override form viewer
 .form-wrapper,
-// override preview panel in form builder component editor modal
+  // override preview panel in form builder component editor modal
 .component-preview {
   /*
   		moved from the main application
@@ -32,12 +32,15 @@
   h1 {
     font-size: 1.9em;
   }
+
   h2 {
     font-size: 1.7em;
   }
+
   h3 {
     font-size: 1.3em;
   }
+
   h4 {
     font-size: 1.05em;
   }
@@ -60,6 +63,7 @@
   // links
   a {
     color: $bcgov-link;
+
     &:hover {
       color: $bcgov-link-hover;
     }
@@ -68,6 +72,7 @@
   // Horizontal Rule
   hr {
     margin-bottom: 1em;
+
     .orange {
       border-top: 2px solid $bcgov-yellow;
     }
@@ -78,6 +83,7 @@
   .component-fade-leave-active {
     transition: opacity 0.3s ease;
   }
+
   .component-fade-enter,
   .component-fade-leave-to {
     opacity: 0;
@@ -97,14 +103,17 @@
     font-weight: bold;
     color: $bcgov-font;
     opacity: 1;
+
     .fa-minus-square-o::before,
     .fa-plus-square-o::before {
       font-size: 130%;
       color: black;
     }
+
     .fa-minus-square-o::before {
       content: "\f106";
     }
+
     .fa-plus-square-o::before {
       content: "\f107";
     }
@@ -127,6 +136,7 @@
         border-radius: 0;
       }
     }
+
     & > .card > .card-header {
       background: none;
 
@@ -180,6 +190,7 @@
       border-top-left-radius: 0.25rem;
       border-bottom-left-radius: 0.25rem;
     }
+
     // if validation error make borders red;
     &.is-invalid + .form-control.input {
       border: 1px solid #dc3545;
@@ -242,9 +253,11 @@
   .form-text {
     font-size: 0.85em;
   }
+
   .invalid-feedback {
     font-size: 100%; // reset this wrapper
   }
+
   .form-text.error {
     background: none !important;
     color: $bcgov-error;
@@ -263,6 +276,7 @@
       &:not(.is-selected) {
         color: $bcgov-font;
       }
+
       &:hover {
         background-color: $bcgov-link-hover;
         color: white;
@@ -275,11 +289,13 @@
       margin-bottom: 0;
       font-size: 90%;
     }
+
     .choices__item,
     .choices__button {
       background-color: white;
       color: $bcgov-link;
       border-color: $bcgov-link;
+
       &:hover {
         background-color: $bcgov-link-hover;
         border-color: $bcgov-link-hover;
@@ -297,12 +313,14 @@
   .form-radio {
     .form-check {
       margin-bottom: 5px;
+
       .form-check-label {
         font-size: 1em;
 
         .form-check-input {
           transform: scale(1.3);
         }
+
         span {
           margin-left: 5px;
         }
@@ -436,6 +454,60 @@
     margin-top: 16px;
     color: var(--chakra-colors-error);
     font-weight: 700;
+  }
+  .contact-data-grid {
+    border: none;
+    max-width: 650px;
+
+    .contact-field-set {
+      margin-top: 0;
+    }
+
+    table,
+    td,
+    tr {
+      border: none !important;
+    }
+
+    .formio-button-remove-row {
+      width: max-content;
+      background: inherit;
+      color: var(--chakra-colors-error);
+      border: none;
+      display: flex;
+      align-items: center;
+
+      i:before {
+        content: "\2715";
+        font-size: var(--chakra-fontSizes-xs);
+        margin-right: var(--chakra-space-2);
+      }
+
+      &:after {
+        content: "Remove";
+      }
+    }
+  }
+
+  .contact-field-set {
+    border: 1px solid var(--chakra-colors-border-light);
+    padding-inline: var(--chakra-space-4);
+    padding-block: var(--chakra-space-3);
+    border-radius: var(--chakra-radii-sm);
+    margin-top: var(--chakra-space-4);
+    max-width: 562px;
+
+    .formio-component-simpletextfield {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      height: 100%;
+    }
+
+    legend {
+      font-weight: 700;
+      font-size: var(--chakra-fontSizes-md);
+    }
   }
 }
 

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -18,7 +18,8 @@ import { ArrowUp } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 
 import { format } from "date-fns"
-import React, { useEffect, useRef, useState } from "react"
+import * as R from "ramda"
+import React, { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useLocation, useNavigate } from "react-router-dom"
 import { useMountStatus } from "../../../hooks/use-mount-status"
@@ -52,6 +53,8 @@ export const RequirementForm = observer(
     const [errorBoxData, setErrorBoxData] = useState<IErrorsBoxData[]>([]) //an array of Labels and links to the component
     const [allCollapsed, setAllCollapsed] = useState(false)
     const [imminentSubmission, setImminentSubmission] = useState(null)
+
+    const clonedSubmissionData = useMemo(() => R.clone(submissionData), [submissionData])
 
     useEffect(() => {
       // The box observers need to be re-registered whenever a panel is collapsed
@@ -210,7 +213,9 @@ export const RequirementForm = observer(
           <Form
             form={formattedFormJson}
             formReady={formReady}
-            submission={submissionData}
+            /* Needs cloned submissionData otherwise it's not possible to use data grid as mst props can't be
+                                     mutated*/
+            submission={clonedSubmissionData}
             onSubmit={onFormSubmit}
             options={isDraft ? {} : { readOnly: true }}
             onBlur={onBlur}

--- a/app/frontend/constants.ts
+++ b/app/frontend/constants.ts
@@ -1,5 +1,5 @@
 import { t } from "i18next"
-import { ENumberUnit, ERequirementType } from "./types/enums"
+import { ENumberUnit, ERequirementContactFieldItemType, ERequirementType } from "./types/enums"
 
 export const EMAIL_REGEX =
   /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
@@ -56,4 +56,8 @@ export function getRequirementTypeLabel(requirementType: ERequirementType) {
   })
 
   return t(`requirementsLibrary.requirementTypeLabels.${derivedTranslationKey}`)
+}
+
+export function getRequirementContactFieldItemLabel(contactFieldItemType: ERequirementContactFieldItemType) {
+  return t(`requirementsLibrary.contactFieldItemLabels.${contactFieldItemType}`)
 }

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -380,6 +380,18 @@ const options = {
             email: "E-mail",
             energyStepCode: "Energy Step Code",
           },
+          contactFieldItemLabels: {
+            firstName: "First Name",
+            lastName: "Last Name",
+            email: "Email",
+            phone: "Phone",
+            address: "Address",
+            organization: "Organization (optional)",
+            businessName: "Business Name",
+            businessLicense: "Business License",
+            professionalAssociation: "Professional Association",
+            professionalNumber: "Professional Number",
+          },
           descriptionMaxLength: "(Max length: 250 characters)",
           unitLabels: {
             option: {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -319,6 +319,8 @@ const options = {
             dummyOption: "Option",
           },
           modals: {
+            defaultContactLabel: "Contact",
+            canAddMultipleContacts: "Submitter can add multiple contacts",
             addLabel: "Add label",
             displayDescriptionLabel: "Instruction/Description (public)",
             addDescriptionTrigger: "Add instructions/description for this block",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -305,6 +305,7 @@ const options = {
           },
         },
         requirementsLibrary: {
+          addAnotherPerson: "Add another person",
           elective: "Elective",
           associationsInfo: "Sections, tags, etc...",
           index: {
@@ -388,7 +389,7 @@ const options = {
             email: "Email",
             phone: "Phone",
             address: "Address",
-            organization: "Organization (optional)",
+            organization: "Organization",
             businessName: "Business Name",
             businessLicense: "Business License",
             professionalAssociation: "Professional Association/Organization",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -391,7 +391,7 @@ const options = {
             organization: "Organization (optional)",
             businessName: "Business Name",
             businessLicense: "Business License",
-            professionalAssociation: "Professional Association",
+            professionalAssociation: "Professional Association/Organization",
             professionalNumber: "Professional Number",
           },
           descriptionMaxLength: "(Max length: 250 characters)",

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -11,6 +11,7 @@ export interface IRequirementsAttribute {
   inputOptions?: {
     valueOptions?: IOption[]
     numberUnit?: ENumberUnit
+    canAddMultipleContacts?: boolean
   }
 }
 

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -231,3 +231,16 @@ export enum ESZeroCarbonStep {
   three = "3",
   four = "4",
 }
+
+export enum ERequirementContactFieldItemType {
+  firstName = "firstName",
+  lastName = "lastName",
+  email = "email",
+  phone = "phone",
+  address = "address",
+  organization = "organization",
+  businessName = "businessName",
+  businessLicense = "businessLicense",
+  professionalAssociation = "professionalAssociation",
+  professionalNumber = "professionalNumber",
+}

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -60,6 +60,7 @@ export type TSearchParams<IModelSortFields> = {
 export interface IRequirementOptions {
   valueOptions?: IOption[]
   numberUnit?: ENumberUnit
+  canAddMultipleContacts?: boolean
 }
 
 export interface IFormJson {

--- a/app/frontend/utils/utility-functions.ts
+++ b/app/frontend/utils/utility-functions.ts
@@ -66,6 +66,11 @@ export function isMultiOptionRequirement(requirementType: ERequirementType): boo
   return multiOptionRequirementFields.includes(requirementType)
 }
 
+export function isContactRequirement(requirementType: ERequirementType): boolean {
+  const contactRequirementFields = [ERequirementType.generalContact, ERequirementType.professionalContact]
+  return contactRequirementFields.includes(requirementType)
+}
+
 export function isQuillEmpty(value: string) {
   if (!value || (value.replace(/<(.|\n)*?>/g, "").trim().length === 0 && !value.includes("<img"))) {
     return true

--- a/app/frontend/utils/utility-functions.ts
+++ b/app/frontend/utils/utility-functions.ts
@@ -59,7 +59,6 @@ export function setQueryParam(key: string, value: string) {
 export function isMultiOptionRequirement(requirementType: ERequirementType): boolean {
   const multiOptionRequirementFields = [
     ERequirementType.radio,
-    ERequirementType.checkbox,
     ERequirementType.select,
     ERequirementType.multiOptionSelect,
   ]

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -19,6 +19,8 @@ class Requirement < ApplicationRecord
          bcaddress: 14,
          signature: 15,
          energy_step_code: 16,
+         general_contact: 17,
+         professional_contact: 18,
        },
        _prefix: true
 

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -28,6 +28,7 @@ class Requirement < ApplicationRecord
   before_save :convert_value_options, if: Proc.new { |req| TYPES_WITH_VALUE_OPTIONS.include?(req.input_type.to_s) }
   validate :validate_value_options, if: Proc.new { |req| TYPES_WITH_VALUE_OPTIONS.include?(req.input_type.to_s) }
   validate :validate_unit_for_number_inputs
+  validate :validate_can_add_multiple_contacts
   validates_format_of :requirement_code, without: /\||\.|\=|\>/, message: "must not contain | or . or = or >"
   validates_format_of :requirement_code, with: /\_file/, if: Proc.new { |req| req.input_type == "file" }
 
@@ -113,6 +114,7 @@ class Requirement < ApplicationRecord
 
   NUMBER_UNITS = %w[no_unit mm cm m in ft mi sqm sqft cad]
   TYPES_WITH_VALUE_OPTIONS = %w[multi_option_select select radio]
+  CONTACT_TYPES = %w[general_contact professional_contact]
 
   def value_options
     return nil if input_options.blank? || input_options["value_options"].blank?
@@ -225,6 +227,14 @@ class Requirement < ApplicationRecord
   end
 
   def validate_value_options
+    unless TYPES_WITH_VALUE_OPTIONS.include?(input_type.to_s)
+      if input_options.present? && input_options["value_options"].present?
+        errors.add(:input_options, "value options are not allowed for #{input_type}")
+      end
+
+      return
+    end
+
     if input_options.blank? || input_options["value_options"].blank? || !input_options["value_options"].is_a?(Array) ||
          !input_options["value_options"].all? { |option|
            option.is_a?(Hash) && (option.key?("label") && option["label"].is_a?(String)) &&
@@ -235,7 +245,9 @@ class Requirement < ApplicationRecord
   end
 
   def validate_unit_for_number_inputs
-    return unless input_type_number? && (input_options.present? && input_options["number_unit"].present?)
+    return unless (input_options.present? && input_options["number_unit"].present?)
+
+    return(errors.add(:input_options, "number_unit is only allowed for number inputs")) if !input_type_number?
 
     if !NUMBER_UNITS.include?(input_options["number_unit"])
       errors.add(:input_options, "the number_unit must be one of #{NUMBER_UNITS.join(", ")}")
@@ -246,6 +258,21 @@ class Requirement < ApplicationRecord
     #all values MUST be converted to camelCase to be compatible with rehyration on front end
     input_options["value_options"] = input_options["value_options"].map do |option_json|
       option_json.merge("value" => option_json["value"].camelize(:lower))
+    end
+  end
+
+  def validate_can_add_multiple_contacts
+    return unless (input_options.present? && input_options["can_add_multiple_contacts"].present?)
+
+    unless CONTACT_TYPES.include?(input_type.to_s)
+      return(errors.add(:input_options, "can_add_multiple_contacts is only allowed for contact inputs"))
+    end
+
+    if !(
+         input_options["can_add_multiple_contacts"].is_a?(TrueClass) ||
+           input_options["can_add_multiple_contacts"].is_a?(FalseClass)
+       )
+      errors.add(:input_options, "can_add_multiple_contacts must be a boolean")
     end
   end
 end

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -32,86 +32,6 @@ class Requirement < ApplicationRecord
   validates_format_of :requirement_code, without: /\||\.|\=|\>/, message: "must not contain | or . or = or >"
   validates_format_of :requirement_code, with: /\_file/, if: Proc.new { |req| req.input_type == "file" }
 
-  DEFAULT_FORMIO_TYPE_TO_OPTIONS = {
-    text: {
-      type: "simpletextfield",
-    },
-    phone: {
-      type: "simplephonenumber",
-    },
-    email: {
-      type: "simpleemail",
-    },
-    # TODO: figure out why these address fields don't work
-    # address: {
-    #   type: "simpleaddressadvanced",
-    # },
-    address: {
-      type: "simpletextfield",
-    },
-    bcaddress: {
-      type: "bcaddress",
-    },
-    signature: {
-      type: "simplesignatureadvanced",
-    },
-    number: {
-      applyMaskOn: "change",
-      mask: false,
-      inputFormat: "plain",
-    },
-    date: {
-      enableTime: false,
-      datePicker: {
-        disableWeekends: false,
-        disableWeekdays: false,
-      },
-      enableMinDateInput: false,
-      enableMaxDateInput: false,
-      widget: {
-        type: "calendar",
-        displayInTimezone: "viewer",
-        locale: "en",
-        useLocaleSettings: false,
-        allowInput: true,
-        mode: "single",
-        enableTime: true,
-        noCalendar: false,
-        format: "yyyy-MM-dd",
-        hourIncrement: 1,
-        minuteIncrement: 1,
-        time_24hr: false,
-        minDate: nil,
-        disableWeekends: false,
-        disableWeekdays: false,
-        maxDate: nil,
-      },
-    },
-    select: {
-      widget: {
-        type: "choicesjs",
-      },
-    },
-    multi_option_select: {
-      type: "selectboxes",
-      inputType: "checkbox",
-      optionsLabelPosition: "right",
-      tableView: false,
-      # type: "select",
-      # multiple: true,
-      # widget: {
-      #   type: "choicesjs",
-      # },
-    },
-    energy_step_code: {
-      type: "button",
-      action: "custom",
-      title: I18n.t("formio.requirement_template.energy_step_code"),
-      label: I18n.t("formio.requirement_template.energy_step_code"),
-      custom: "document.dispatchEvent(new Event('openStepCode'));",
-    },
-  }
-
   NUMBER_UNITS = %w[no_unit mm cm m in ft mi sqm sqft cad]
   TYPES_WITH_VALUE_OPTIONS = %w[multi_option_select select radio]
   CONTACT_TYPES = %w[general_contact professional_contact]
@@ -133,49 +53,9 @@ class Requirement < ApplicationRecord
   end
 
   def to_form_json(requirement_block_key = requirement_block&.key)
-    json = {
-      id: id,
-      key: key(requirement_block_key),
-      type: input_type,
-      input: true,
-      label: label,
-      widget: {
-        type: "input",
-      },
-    }.merge!(formio_type_options)
+    form_json_service = RequirementFormJsonService.new(self)
 
-    json.merge!({ description: hint }) if hint
-
-    json.merge!({ validate: { required: true } }) if required
-
-    #assume all electives use a customConditional that defaults to false.  The customConditional works in tandem with the conditionals
-    json.merge!({ elective: elective }) if elective
-
-    json.merge!({ data: { values: input_options["value_options"] } }) if input_type_select?
-
-    json.merge!({ values: input_options["value_options"] }) if input_type_multi_option_select?
-
-    json.merge!({ computedCompliance: input_options["computed_compliance"] }) if computed_compliance?
-
-    json.merge!({ energyStepCode: input_options["energy_step_code"] }) if input_type.to_sym == :energy_step_code
-
-    if input_options["conditional"].present?
-      # assumption that conditional is only within the same requirement block for now
-      conditional = input_options["conditional"]
-      section = PermitApplication.section_from_key(requirement_block_key)
-      if conditional["when"].present?
-        conditional.merge!("when" => "#{section}.#{requirement_block_key}|#{conditional["when"]}")
-      end
-      json.merge!({ conditional: conditional })
-    end
-
-    #indicates code-based conditionals.  Always merge elective show = false to end.
-    if input_options["customConditional"].present?
-      json.merge!({ customConditional: input_options["customConditional"] })
-    end
-    json.merge!({ customConditional: "#{json[:customConditional]};show = false" }) if elective
-
-    json
+    form_json_service.to_form_json(requirement_block_key)
   end
 
   def lookup_props(requirement_block_key = requirement_block&.key)
@@ -201,29 +81,9 @@ class Requirement < ApplicationRecord
   end
 
   def formio_type_options
-    return unless input_type.present?
+    form_json_service = RequirementFormJsonService.new(self)
 
-    if (input_type.to_sym == :file)
-      return(
-        {
-          type: "file",
-          storage:
-            (
-              if (!Rails.env.test? && ENV["BCGOV_OBJECT_STORAGE_ACCESS_KEY_ID"].present?)
-                "s3custom"
-              else
-                nil
-              end
-            ),
-        }.tap do |file_hash|
-          file_hash["computedCompliance"] = input_options["computed_compliance"] if input_options[
-            "computed_compliance"
-          ].present?
-          file_hash["multiple"] = true if input_options["multiple"].present?
-        end
-      )
-    end
-    DEFAULT_FORMIO_TYPE_TO_OPTIONS[input_type.to_sym] || {}
+    form_json_service.formio_type_options
   end
 
   def validate_value_options

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -87,14 +87,6 @@ class Requirement < ApplicationRecord
   end
 
   def validate_value_options
-    unless TYPES_WITH_VALUE_OPTIONS.include?(input_type.to_s)
-      if input_options.present? && input_options["value_options"].present?
-        errors.add(:input_options, "value options are not allowed for #{input_type}")
-      end
-
-      return
-    end
-
     if input_options.blank? || input_options["value_options"].blank? || !input_options["value_options"].is_a?(Array) ||
          !input_options["value_options"].all? { |option|
            option.is_a?(Hash) && (option.key?("label") && option["label"].is_a?(String)) &&
@@ -115,7 +107,7 @@ class Requirement < ApplicationRecord
   end
 
   def convert_value_options
-    #all values MUST be converted to camelCase to be compatible with rehyration on front end
+    # all values MUST be converted to camelCase to be compatible with rehyration on front end
     input_options["value_options"] = input_options["value_options"].map do |option_json|
       option_json.merge("value" => option_json["value"].camelize(:lower))
     end

--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -1,0 +1,331 @@
+class RequirementFormJsonService
+  attr_accessor :requirement
+
+  DEFAULT_FORMIO_TYPE_TO_OPTIONS = {
+    text: {
+      type: "simpletextfield",
+    },
+    phone: {
+      type: "simplephonenumber",
+    },
+    email: {
+      type: "simpleemail",
+    },
+    # TODO: figure out why these address fields don't work
+    # address: {
+    #   type: "simpleaddressadvanced",
+    # },
+    address: {
+      type: "simpletextfield",
+    },
+    bcaddress: {
+      type: "bcaddress",
+    },
+    signature: {
+      type: "simplesignatureadvanced",
+    },
+    number: {
+      applyMaskOn: "change",
+      mask: false,
+      inputFormat: "plain",
+    },
+    date: {
+      enableTime: false,
+      datePicker: {
+        disableWeekends: false,
+        disableWeekdays: false,
+      },
+      enableMinDateInput: false,
+      enableMaxDateInput: false,
+      widget: {
+        type: "calendar",
+        displayInTimezone: "viewer",
+        locale: "en",
+        useLocaleSettings: false,
+        allowInput: true,
+        mode: "single",
+        enableTime: true,
+        noCalendar: false,
+        format: "yyyy-MM-dd",
+        hourIncrement: 1,
+        minuteIncrement: 1,
+        time_24hr: false,
+        minDate: nil,
+        disableWeekends: false,
+        disableWeekdays: false,
+        maxDate: nil,
+      },
+    },
+    select: {
+      widget: {
+        type: "choicesjs",
+      },
+    },
+    multi_option_select: {
+      type: "selectboxes",
+      inputType: "checkbox",
+      optionsLabelPosition: "right",
+      tableView: false,
+      # type: "select",
+      # multiple: true,
+      # widget: {
+      #   type: "choicesjs",
+      # },
+    },
+    energy_step_code: {
+      type: "button",
+      action: "custom",
+      title: I18n.t("formio.requirement_template.energy_step_code"),
+      label: I18n.t("formio.requirement_template.energy_step_code"),
+      custom: "document.dispatchEvent(new Event('openStepCode'));",
+    },
+  }
+
+  def initialize(requirement)
+    self.requirement = requirement
+  end
+
+  def to_form_json(requirement_block_key = requirement&.requirement_block&.key)
+    json =
+      if requirement.input_type_general_contact? || requirement.input_type_professional_contact?
+        get_contact_form_json(requirement_block_key)
+      else
+        {
+          id: requirement.id,
+          key: requirement.key(requirement_block_key),
+          type: requirement.input_type,
+          input: true,
+          label: requirement.label,
+          widget: {
+            type: "input",
+          },
+        }.merge!(formio_type_options)
+      end
+
+    json.merge!({ description: requirement.hint }) if requirement.hint
+
+    json.merge!({ validate: { required: true } }) if requirement.required
+
+    # assume all electives use a customConditional that defaults to false.  The customConditional works in tandem with the conditionals
+    json.merge!({ elective: requirement.elective }) if requirement.elective
+
+    json.merge!({ data: { values: requirement.input_options["value_options"] } }) if requirement.input_type_select?
+
+    json.merge!({ values: requirement.input_options["value_options"] }) if requirement.input_type_multi_option_select?
+
+    if requirement.computed_compliance?
+      json.merge!({ computedCompliance: requirement.input_options["computed_compliance"] })
+    end
+
+    if requirement.input_type.to_sym == :energy_step_code
+      json.merge!({ energyStepCode: requirement.input_options["energy_step_code"] })
+    end
+
+    if requirement.input_options["conditional"].present?
+      # assumption that conditional is only within the same requirement block for now
+      conditional = requirement.input_options["conditional"]
+      section = PermitApplication.section_from_key(requirement_block_key)
+      if conditional["when"].present?
+        conditional.merge!("when" => "#{section}.#{requirement_block_key}|#{conditional["when"]}")
+      end
+      json.merge!({ conditional: conditional })
+    end
+
+    # indicates code-based conditionals.  Always merge elective show = false to end.
+    if requirement.input_options["customConditional"].present?
+      json.merge!({ customConditional: requirement.input_options["customConditional"] })
+    end
+    json.merge!({ customConditional: "#{json[:customConditional]};show = false" }) if requirement.elective
+
+    json
+  end
+
+  private
+
+  def get_contact_form_json(requirement_block_key = requirement&.requirement_block&.key)
+    return {} unless requirement.input_type_general_contact? || requirement.input_type_professional_contact?
+
+    if requirement.input_options["can_add_multiple_contacts"].blank?
+      return(get_contact_field_set_form_json(requirement.key(requirement_block_key)))
+    end
+
+    get_multi_contact_datagrid_form_json(requirement_block_key)
+  end
+
+  def get_contact_field_form_json(field_key)
+    shared_form_json = {
+      applyMaskOn: "change",
+      tableView: true,
+      input: true,
+      # THe key needs to be camel case, otherwise there are issues in the front-end with data-grid
+      key: snake_to_camel(field_key.to_s),
+      label: I18n.t("formio.requirement.contact.#{field_key.to_s}"),
+      type: "textfield",
+      **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:text],
+    }
+
+    # TODO: address is a text now, replace with address type when implemented
+    field_to_form_json = {
+      email: {
+        **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:email],
+      },
+      phone: {
+        **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:phone],
+      },
+    }
+
+    form_json =
+      (
+        if field_to_form_json[field_key].present?
+          shared_form_json.merge!(field_to_form_json[field_key])
+        else
+          shared_form_json
+        end
+      )
+
+    form_json
+  end
+
+  def get_columns_form_json(key, column_components = [])
+    {
+      label: "Columns",
+      columns: column_components.map { |item| { components: [item] } },
+      key: key,
+      type: "columns",
+      input: false,
+      tableView: false,
+    }
+  end
+
+  def get_contact_field_set_form_json(key = nil)
+    return {} unless requirement.input_type_general_contact? || requirement.input_type_professional_contact?
+
+    key = requirement.input_type if key.nil?
+
+    contact_components =
+      (
+        if requirement.input_type_general_contact?
+          get_general_contact_field_components
+        else
+          get_professional_contact_field_components
+        end
+      )
+
+    {
+      legend: requirement.label,
+      key: key,
+      type: "fieldset",
+      label: requirement.label,
+      hideLabel: true,
+      input: false,
+      tableView: false,
+      components: contact_components,
+    }
+  end
+
+  def get_general_contact_field_components()
+    [
+      get_columns_form_json(
+        "name_columns",
+        [get_contact_field_form_json(:first_name), get_contact_field_form_json(:last_name)],
+      ),
+      get_columns_form_json(
+        "reach_columns",
+        [get_contact_field_form_json(:email), get_contact_field_form_json(:phone)],
+      ),
+      get_contact_field_form_json(:address),
+      get_columns_form_json("organization_columns", [get_contact_field_form_json(:organization)]),
+    ]
+  end
+
+  def get_professional_contact_field_components
+    [
+      get_columns_form_json(
+        "name_columns",
+        [get_contact_field_form_json(:first_name), get_contact_field_form_json(:last_name)],
+      ),
+      get_columns_form_json(
+        "reach_columns",
+        [get_contact_field_form_json(:email), get_contact_field_form_json(:phone)],
+      ),
+      get_contact_field_form_json(:address),
+      get_columns_form_json(
+        "business_columns",
+        [get_contact_field_form_json(:business_name), get_contact_field_form_json(:business_license)],
+      ),
+      get_columns_form_json(
+        "professional_columns",
+        [get_contact_field_form_json(:professional_association), get_contact_field_form_json(:professional_number)],
+      ),
+    ]
+  end
+
+  def get_multi_contact_datagrid_form_json(requirement_block_key = requirement&.requirement_block&.key)
+    return {} unless requirement.input_type_general_contact? || requirement.input_type_professional_contact?
+
+    {
+      label: "Multi Contact",
+      reorder: false,
+      addAnother: I18n.t("formio.requirement.contact.add_person_button"),
+      addAnotherPosition: "bottom",
+      layoutFixed: false,
+      enableRowGroups: false,
+      initEmpty: false,
+      hideLabel: true,
+      tableView: false,
+      defaultValue: [
+        {
+          firstName: "",
+          email: "",
+          lastName: "",
+          phone: "",
+          address: "", # TODO: address is a text now, replace with address type when implemented
+          businessName: "",
+          businessLicense: "",
+          organization: "",
+          professionalAssociation: "",
+          professionalNumber: "",
+        },
+      ],
+      key: requirement.key(requirement_block_key),
+      type: "datagrid",
+      input: true,
+      components: [get_contact_field_set_form_json],
+    }
+  end
+
+  def formio_type_options
+    return unless requirement.input_type.present?
+
+    input_type = requirement.input_type
+    input_options = requirement.input_options
+
+    if (input_type.to_sym == :file)
+      return(
+        {
+          type: "file",
+          storage:
+            (
+              if (!Rails.env.test? && ENV["BCGOV_OBJECT_STORAGE_ACCESS_KEY_ID"].present?)
+                "s3custom"
+              else
+                nil
+              end
+            ),
+        }.tap do |file_hash|
+          file_hash["computedCompliance"] = input_options["computed_compliance"] if input_options[
+            "computed_compliance"
+          ].present?
+          file_hash["multiple"] = true if input_options["multiple"].present?
+        end
+      )
+    end
+    DEFAULT_FORMIO_TYPE_TO_OPTIONS[input_type.to_sym] || {}
+  end
+
+  def snake_to_camel(snake_str)
+    components = snake_str.split("_")
+    # capitalize the first letter of each component except the first
+    components[0] + components[1..-1].map(&:capitalize).join
+  end
+end

--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -260,15 +260,15 @@ class RequirementFormJsonService
       get_columns_form_json(
         "business_columns",
         [
-          get_contact_field_form_json(:business_name, parent_key),
-          get_contact_field_form_json(:business_license, parent_key),
+          get_contact_field_form_json(:business_name, parent_key, false),
+          get_contact_field_form_json(:business_license, parent_key, false),
         ],
       ),
       get_columns_form_json(
         "professional_columns",
         [
           get_contact_field_form_json(:professional_association, parent_key, false),
-          get_contact_field_form_json(:professional_number, parent_key),
+          get_contact_field_form_json(:professional_number, parent_key, false),
         ],
       ),
     ]

--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -152,7 +152,7 @@ class RequirementFormJsonService
     get_multi_contact_datagrid_form_json(requirement_block_key)
   end
 
-  def get_contact_field_form_json(field_key)
+  def get_contact_field_form_json(field_key, required = true)
     shared_form_json = {
       applyMaskOn: "change",
       tableView: true,
@@ -161,6 +161,9 @@ class RequirementFormJsonService
       key: snake_to_camel(field_key.to_s),
       label: I18n.t("formio.requirement.contact.#{field_key.to_s}"),
       type: "textfield",
+      validate: {
+        required: required,
+      },
       **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:text],
     }
 
@@ -235,7 +238,7 @@ class RequirementFormJsonService
         [get_contact_field_form_json(:email), get_contact_field_form_json(:phone)],
       ),
       get_contact_field_form_json(:address),
-      get_columns_form_json("organization_columns", [get_contact_field_form_json(:organization)]),
+      get_columns_form_json("organization_columns", [get_contact_field_form_json(:organization, false)]),
     ]
   end
 
@@ -256,7 +259,10 @@ class RequirementFormJsonService
       ),
       get_columns_form_json(
         "professional_columns",
-        [get_contact_field_form_json(:professional_association), get_contact_field_form_json(:professional_number)],
+        [
+          get_contact_field_form_json(:professional_association, false),
+          get_contact_field_form_json(:professional_number),
+        ],
       ),
     ]
   end

--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -215,6 +215,7 @@ class RequirementFormJsonService
       legend: requirement.label,
       key: key,
       type: "fieldset",
+      custom_class: "contact-field-set",
       label: requirement.label,
       hideLabel: true,
       input: false,
@@ -273,6 +274,7 @@ class RequirementFormJsonService
       initEmpty: false,
       hideLabel: true,
       tableView: false,
+      custom_class: "contact-data-grid",
       defaultValue: [
         {
           firstName: "",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -283,6 +283,19 @@ en:
       energy_step_code: "Start"
     requirement_block:
       optional_block_confirmation_requirement_label: "I acknowledge that all fields in this block are either complete, or not applicable."
+    requirement:
+      contact:
+        first_name: "First name"
+        last_name: "Last name"
+        email: "Email"
+        phone: "Phone"
+        address: "Address"
+        business_name: "Business name"
+        business_license: "Business license"
+        professional_association: "Professional association/organization"
+        professional_number: "Professional number"
+        organization: "Organization (optional)"
+        add_person_button: "Add another person"
   step_code_building_characteristics_summary:
     performance_type:
       error: "%{field_name} performance type must be one of %{accepted_values}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,7 +294,7 @@ en:
         business_license: "Business license"
         professional_association: "Professional association/organization"
         professional_number: "Professional number"
-        organization: "Organization (optional)"
+        organization: "Organization"
         add_person_button: "Add another person"
   step_code_building_characteristics_summary:
     performance_type:


### PR DESCRIPTION
## Description
- Adds "General Contact" and "Professional Contact" requirement types
- Adds ability to configure the above from super admin side
- Adds the ability to render above requirements in the submitter flow
- Also refactors internal code fort better organization
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [X ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-635
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Super admin config
  - Log in as Super admin
  - Navigate to the requirements library and select a requirement block to edit
  - The new contact requirements should be available to add from the drawer and configurable
  - After adding, they should be visible in all requirement templates which use them
- Login as submitter
  - Select one draft permit (this is already seeded)
  - You should be able to see contact requirement types and fill them
  - They should persist on save
  - The multi addable contacts is not included in seeds so is not possible to test without manual changes 
