### PR TITLE
[bphh-750] Add rich text for helper text from super admin side

### DIFF
--- a/app/frontend/components/domains/requirements-library/requirement-field-display/generic-field-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/generic-field-display.tsx
@@ -1,8 +1,10 @@
-import { FormControl, FormHelperText, FormLabel, FormLabelProps } from "@chakra-ui/react"
+import { FormControl, FormLabel, FormLabelProps } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { getRequirementTypeLabel } from "../../../../constants"
+import { isQuillEmpty } from "../../../../utils/utility-functions"
+import { EditorWithPreview } from "../../../shared/editor/custom-extensions/editor-with-preview"
 import { TRequirementFieldDisplayProps } from "./index"
 
 interface IGroupedFieldProps extends Omit<TRequirementFieldDisplayProps, "options"> {
@@ -39,7 +41,14 @@ export const GenericFieldDisplay = observer(function GroupedFieldDisplay({
             : getRequirementTypeLabel(requirementType))}
       </FormLabel>
       {inputDisplay}
-      {helperText && <FormHelperText {...helperTextStyles}>{helperText}</FormHelperText>}
+      {!isQuillEmpty(helperText) && (
+        <EditorWithPreview
+          label={t("requirementsLibrary.modals.addHelpTextLabel")}
+          htmlValue={helperText}
+          containerProps={{ p: 0, ...helperTextStyles }}
+          isReadOnly
+        />
+      )}
     </FormControl>
   )
 })

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-helper-text.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-helper-text.tsx
@@ -1,31 +1,33 @@
+import { Button } from "@chakra-ui/react"
+import { Pencil } from "@phosphor-icons/react"
 import React from "react"
 import { FieldValues, useController } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import {
-  EditableInputWithControls,
-  IEditableInputWithControlsProps,
-} from "../../../shared/editable-input-with-controls"
+import { EditorWithPreview } from "../../../shared/editor/custom-extensions/editor-with-preview"
 import { IControlProps } from "./types"
 
-export type TEditableHelperTextProps<TFieldValues extends FieldValues> = IControlProps<TFieldValues> &
-  Partial<IEditableInputWithControlsProps>
+export type TEditableHelperTextProps<TFieldValues extends FieldValues> = IControlProps<TFieldValues>
 
 export function EditableHelperText<TFieldValues extends FieldValues>({
   controlProps,
-  ...editableHelperTextProps
 }: TEditableHelperTextProps<TFieldValues>) {
   const {
     field: { onChange, value },
   } = useController(controlProps)
   const { t } = useTranslation()
   return (
-    <EditableInputWithControls
-      initialHint={t("requirementsLibrary.modals.addHelpText")}
-      placeholder={t("requirementsLibrary.modals.helpTextPlaceHolder")}
-      defaultValue={(value as string) || ""}
-      onSubmit={onChange}
-      onCancel={onChange}
-      {...editableHelperTextProps}
+    <EditorWithPreview
+      label={t("requirementsLibrary.modals.addHelpTextLabel")}
+      htmlValue={value}
+      onChange={onChange}
+      renderInitialTrigger={(buttonProps) => (
+        <Button variant={"link"} rightIcon={<Pencil size={14} />} {...buttonProps}>
+          {t("requirementsLibrary.modals.addHelpText")}
+        </Button>
+      )}
+      editText={t("requirementsLibrary.modals.editHelpTextLabel")}
+      editTextButtonProps={{ rightIcon: <Pencil size={14} /> }}
+      containerProps={{ p: 0 }}
     />
   )
 }

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -165,18 +165,10 @@ export const FieldsSetup = observer(function FieldsSetup() {
                         "aria-label": "Edit Label",
                       }}
                       editableHelperTextProps={{
-                        getStateBasedEditableProps: (isEditing) =>
-                          isEditing
-                            ? {}
-                            : {
-                                color: !!watchedHint ? "text.secondary" : "text.link",
-                                textDecoration: watchedHint ? undefined : "underline",
-                              },
                         controlProps: {
                           control: control,
                           name: `requirementsAttributes.${index}.hint`,
                         },
-                        "aria-label": "Edit Helper Text",
                       }}
                       isOptionalCheckboxProps={{
                         controlProps: {

--- a/app/frontend/components/shared/editor/custom-extensions/editor-with-preview.tsx
+++ b/app/frontend/components/shared/editor/custom-extensions/editor-with-preview.tsx
@@ -5,12 +5,13 @@ import { useTranslation } from "react-i18next"
 import { isQuillEmpty } from "../../../../utils/utility-functions"
 import { Editor } from "../editor"
 
-type TProps = {
+export type TEditorWithPreviewProps = {
   label?: string
   htmlValue: string
   onChange?: (htmlValue: string) => void
   containerProps?: BoxProps
   editText?: string
+  editTextButtonProps?: ButtonProps
   onRemove?: (setEditMode: (editMode: boolean) => void) => void
   isReadOnly?: boolean
 } & (
@@ -30,9 +31,10 @@ export const EditorWithPreview = observer(function EditorWithPreview({
   renderInitialTrigger,
   initialTriggerText,
   editText,
+  editTextButtonProps,
   onRemove,
   isReadOnly,
-}: TProps) {
+}: TEditorWithPreviewProps) {
   const isEditorEmpty = isQuillEmpty(htmlValue)
   const [isEditMode, setIsEditMode] = useState(false)
   const { t } = useTranslation()
@@ -119,7 +121,7 @@ export const EditorWithPreview = observer(function EditorWithPreview({
       ) : (
         <>
           {editText && (
-            <Button variant={"link"} textDecoration={"underline"}>
+            <Button variant={"link"} textDecoration={"underline"} {...editTextButtonProps}>
               {editText}
             </Button>
           )}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -313,6 +313,8 @@ const options = {
             noFormFieldsAdded: "No form fields have been added yet, start by clicking the Add button.",
             defaultRequirementLabel: "Label",
             addHelpText: "Add help text",
+            addHelpTextLabel: "Help text",
+            editHelpTextLabel: "Edit help text",
             helpTextPlaceHolder: "Help text",
             optionalForSubmitters: "This field is optional for submitters",
             isAnElectiveField: "This is an elective field for Local Gov",


### PR DESCRIPTION
## Description
- Adds rich text capability for hint (helper text) of Requirement Field
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-750
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Log in as super admin
- Navigate to requirements library
- Select any requirement block to edit
- Click edit on any non contact requirement
- You should be able to edit/ add rich text for the input helper text

![Screenshot 2024-03-15 at 1 47 59 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/c98a9d47-0f7c-4f95-b010-eb14b18e38d7)
