### PR TITLE
moves tips not inside child, but to override the panel template instead.

### DIFF
--- a/app/frontend/components/shared/chefs/additional-formio/templates/panel.js
+++ b/app/frontend/components/shared/chefs/additional-formio/templates/panel.js
@@ -1,0 +1,69 @@
+export const overridePanelTemplate = (ctx) => {
+  var __t,
+    __p = "",
+    __j = Array.prototype.join
+  function print() {
+    __p += __j.call(arguments, "")
+  }
+
+  __p += '<div class="mb-2 card border">\n  '
+  if (!ctx.component.hideLabel || ctx.builder || ctx.component.collapsible || ctx.component.tooltip) {
+    __p +=
+      '\n  <div class="card-header ' +
+      ((__t = ctx.transform("class", "bg-" + ctx.component.theme)) == null ? "" : __t) +
+      '"\n    '
+    if (ctx.component.collapsible) {
+      __p += '\n    tabindex="0"\n    '
+    }
+    __p +=
+      '\n    role="button"\n    aria-expanded="' +
+      ((__t = ctx.component.collapsible ? !ctx.collapsed : true) == null ? "" : __t) +
+      '"\n    aria-controls="' +
+      ((__t = ctx.instance.id) == null ? "" : __t) +
+      "-" +
+      ((__t = ctx.component.key) == null ? "" : __t) +
+      '"\n    ref="header"\n  >\n    <span class="mb-0 card-title '
+    if (ctx.component.theme && ctx.component.theme !== "default") {
+      __p += "text-light"
+    }
+    __p += '">\n      '
+    if (ctx.component.collapsible) {
+      __p +=
+        '\n        <i class="formio-collapse-icon ' +
+        ((__t = ctx.iconClass(ctx.collapsed ? "plus-square-o" : "minus-square-o")) == null ? "" : __t) +
+        ' text-muted" data-title="Collapse Panel"></i>\n      '
+    }
+    __p += "\n      "
+    if (!ctx.component.hideLabel || ctx.builder) {
+      __p += "\n      " + ((__t = ctx.t(ctx.component.title, { _userInput: true })) == null ? "" : __t) + "\n      "
+    }
+    __p += "\n      "
+    if (ctx.component.tooltip) {
+      __p +=
+        '\n        <i ref="tooltip" tabindex="0" class="' +
+        ((__t = ctx.iconClass("question-sign")) == null ? "" : __t) +
+        ' text-muted" data-tooltip="' +
+        ((__t = ctx.component.tooltip) == null ? "" : __t) +
+        '"></i>\n      '
+    }
+    __p += "\n    </span>\n  </div>\n  "
+  }
+  __p += "\n  "
+  if ((!ctx.collapsed || ctx.builder) && ctx.component?.tip) {
+    __p += `\n <div class="card-tips"><div class="tips"><h3 class="tips-header"><i class="ph-fill ph-seal-check"></i>Tip</h3>${ctx.component?.tip}</div></div>`
+  }
+  if (!ctx.collapsed || ctx.builder) {
+    __p +=
+      '\n  <div class="card-body" ref="' +
+      ((__t = ctx.nestedKey) == null ? "" : __t) +
+      '" id="' +
+      ((__t = ctx.instance.id) == null ? "" : __t) +
+      "-" +
+      ((__t = ctx.component.key) == null ? "" : __t) +
+      '">\n    ' +
+      ((__t = ctx.children) == null ? "" : __t) +
+      "\n  </div>\n  "
+  }
+  __p += "\n</div>\n"
+  return __p
+}

--- a/app/frontend/components/shared/chefs/index.tsx
+++ b/app/frontend/components/shared/chefs/index.tsx
@@ -3,26 +3,18 @@ import { Form, Formio, Templates } from "@formio/react"
 import "./styles.scss"
 
 import ChefsFormioComponents from "./additional-formio"
+import { overridePanelTemplate } from "./additional-formio/templates/panel"
 
 const defaultLabelTemplate = Templates.current.label.form
-const defaultComponentsTemplate = Templates.current.components.form
 const defaultButtonsTemplate = Templates.current.button.form
 
 //container - we can add for main headers like Contact Info
 //panels - are for section blocks, to put things inside panels, we need to target the components section under the body
 
 Templates.current = {
-  components: {
+  panel: {
     form: (ctx) => {
-      let template = ""
-      if (ctx?.component?.type == "panel") {
-        if (ctx?.component?.tip) {
-          template = template.concat(
-            `<div class="tips"><h3 class="tips-header"><i class="ph-fill ph-seal-check"></i>Tip</h3>${ctx?.component?.tip}</div>`
-          )
-        }
-      }
-      template = template.concat(defaultComponentsTemplate(ctx))
+      let template = overridePanelTemplate(ctx)
       return template
     },
   },
@@ -50,7 +42,6 @@ Templates.current = {
           ${computedComplianceText}</div>`
         )
       }
-
       template = template.concat(defaultLabelTemplate(ctx))
       return template
     },

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -351,6 +351,12 @@
     padding: 24px !important;
   }
 
+  .card-tips {
+    padding-top: 24px;
+    padding-right: 24px;
+    padding-left: 24px;
+  }
+
   .tips {
     border-left: 4px solid;
     border-color: $bcgov-blue-secondary;


### PR DESCRIPTION
## Description

Tips were children of panels, so it affected the way validations were being applied in formio.  

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-863

## Steps to QA
Add a tip to a region.
Check that the phone number / name fields do not interfere with each other
