### PR TITLE
Feature/bphh 724/view only conditionals and required field asterisk

### DIFF
--- a/app/frontend/components/domains/requirements-library/grid-header.tsx
+++ b/app/frontend/components/domains/requirements-library/grid-header.tsx
@@ -20,14 +20,20 @@ export const GridHeaders = observer(function GridHeaders() {
       <Box display={"contents"} role={"row"}>
         <GridItem
           as={Flex}
-          gridColumn={"span 5"}
+          gridColumn={"span 6"}
           p={6}
           bg={"greys.grey10"}
           justifyContent={"space-between"}
           align="center"
         >
           <Text role={"heading"}>{t("requirementsLibrary.index.tableHeading")}</Text>
-          <SearchInput searchModel={requirementBlockStore as ISearch} />
+          <SearchInput
+            inputGroupProps={{
+              position: "sticky",
+              right: 6,
+            }}
+            searchModel={requirementBlockStore as ISearch}
+          />
         </GridItem>
       </Box>
       <Box display={"contents"} role={"row"}>

--- a/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
@@ -191,6 +191,7 @@ export const RequirementBlockAccordion = observer(function RequirementBlockAccor
                           maxW: "339px",
                         }}
                         showAddPersonButton={!!requirement?.inputOptions?.canAddMultipleContacts}
+                        required={requirement.required}
                       />
                     </Box>
                   </Box>

--- a/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
@@ -20,8 +20,10 @@ import { useMst } from "../../../setup/root"
 import { Paginator } from "../../shared/base/inputs/paginator"
 import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
 import { SharedSpinner } from "../../shared/base/shared-spinner"
+import { ElectiveTag } from "../../shared/elective-tag"
 import { SearchGrid } from "../../shared/grid/search-grid"
 import { SearchGridItem } from "../../shared/grid/search-grid-item"
+import { HasConditionalTag } from "../../shared/has-conditional-tag"
 import { GridHeaders } from "./grid-header"
 import { RequirementsBlockModal } from "./requirements-block-modal"
 
@@ -48,7 +50,7 @@ export const RequirementBlocksTable = observer(function RequirementBlocksTable({
   useSearch(requirementBlockStore as ISearch)
   return (
     <VStack as={"article"} spacing={5} {...containerProps}>
-      <SearchGrid templateColumns="repeat(4, 1fr) 85px">
+      <SearchGrid templateColumns="repeat(4, 1fr) max(200px) 85px" pos={"relative"}>
         <GridHeaders />
 
         {isSearching ? (
@@ -86,6 +88,12 @@ export const RequirementBlocksTable = observer(function RequirementBlocksTable({
                   </UnorderedList>
                 </SearchGridItem>
                 <SearchGridItem fontSize={"sm"}>{format(requirementBlock.updatedAt, "yyyy-MM-dd")}</SearchGridItem>
+                <SearchGridItem>
+                  <HStack flexWrap={"wrap"} maxW={"full"} alignSelf={"flex-start"}>
+                    {requirementBlock.hasAnyElective && <ElectiveTag />}
+                    {requirementBlock.hasAnyConditional && <HasConditionalTag />}
+                  </HStack>
+                </SearchGridItem>
                 <SearchGridItem justifyContent={"center"}>
                   {renderActionButton ? (
                     renderActionButton({ requirementBlock })

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/contact-field-item-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/contact-field-item-display.tsx
@@ -11,7 +11,15 @@ export function ContactFieldItemDisplay({ contactFieldItemType }: IContactFieldI
   const defaultProps: Partial<TRequirementFieldDisplayProps> = {
     label: getRequirementContactFieldItemLabel(contactFieldItemType),
     requirementType: ERequirementType.text,
+    required: true,
   }
+  const required = [
+    ERequirementContactFieldItemType.firstName,
+    ERequirementContactFieldItemType.lastName,
+    ERequirementContactFieldItemType.email,
+    ERequirementContactFieldItemType.phone,
+    ERequirementContactFieldItemType.address,
+  ].includes(contactFieldItemType)
 
   const propsByType = {
     [ERequirementContactFieldItemType.email]: {
@@ -27,5 +35,5 @@ export function ContactFieldItemDisplay({ contactFieldItemType }: IContactFieldI
       labelProps: { maxW: "full" },
     },
   }
-  return <RequirementFieldDisplay {...defaultProps} {...propsByType[contactFieldItemType]} />
+  return <RequirementFieldDisplay {...defaultProps} {...propsByType[contactFieldItemType]} required={required} />
 }

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/generic-field-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/generic-field-display.tsx
@@ -7,6 +7,7 @@ import { TRequirementFieldDisplayProps } from "./index"
 
 interface IGroupedFieldProps extends Omit<TRequirementFieldDisplayProps, "options"> {
   inputDisplay: JSX.Element
+  required?: boolean
   containerProps?: Partial<FormControlProps>
 }
 
@@ -26,10 +27,11 @@ export const GenericFieldDisplay = observer(function GroupedFieldDisplay({
   showAddLabelIndicator,
   requirementType,
   containerProps,
+  required,
 }: IGroupedFieldProps) {
   const { t } = useTranslation()
   return (
-    <FormControl w={"100%"} isReadOnly {...containerProps}>
+    <FormControl w={"100%"} isReadOnly isRequired={required} {...containerProps}>
       <FormLabel
         {...defaultLabelProps}
         {...(labelProps as FormLabelProps)}

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
@@ -41,6 +41,7 @@ export type TRequirementFieldDisplayProps = {
   showAddPersonButton?: boolean
   requirementType: ERequirementType
   showAddLabelIndicator?: boolean
+  required?: boolean
 }
 
 const defaultOptions = ["Option", "Option"]

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/conditional-setup-modal.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/conditional-setup-modal.tsx
@@ -1,0 +1,89 @@
+import {
+  Button,
+  ButtonGroup,
+  ButtonProps,
+  HStack,
+  MenuItem,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { SlidersHorizontal } from "@phosphor-icons/react"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { IRequirementAttributes } from "../../../../types/api-request"
+
+interface IProps {
+  triggerButtonProps?: Partial<ButtonProps>
+  renderTriggerButton?: (props: ButtonProps) => JSX.Element
+  conditional: IRequirementAttributes["inputOptions"]["conditional"]
+}
+
+export function ConditionalSetupModal({ triggerButtonProps, renderTriggerButton, conditional }: IProps) {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const { t } = useTranslation()
+  return (
+    <>
+      {renderTriggerButton ? (
+        renderTriggerButton({ onClick: onOpen })
+      ) : (
+        <MenuItem color={"text.primary"} onClick={onOpen} isDisabled={!conditional} {...triggerButtonProps}>
+          <HStack spacing={2} fontSize={"sm"}>
+            <SlidersHorizontal />
+            <Text as={"span"}>{t("requirementsLibrary.modals.optionsMenu.conditionalLogic")}</Text>
+          </HStack>
+        </MenuItem>
+      )}
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent maxW={"600px"} fontSize={"sm"} color={"text.secondary"}>
+          <ModalCloseButton />
+          <ModalHeader
+            display={"flex"}
+            justifyContent={"center"}
+            alignItems={"center"}
+            bg={"greys.grey03"}
+            borderTopRadius={"md"}
+          >
+            <SlidersHorizontal style={{ marginRight: "var(--chakra-space-2)" }} />
+            {t("requirementsLibrary.modals.optionsMenu.conditionalLogic")}
+          </ModalHeader>
+          <ModalBody
+            py={4}
+            sx={{
+              pre: {
+                bg: "greys.grey03",
+                px: 4,
+                py: 3,
+                borderRadius: "sm",
+                color: "text.primary",
+              },
+            }}
+          >
+            <pre>{JSON.stringify(conditional, null, 2)}</pre>
+          </ModalBody>
+
+          <ModalFooter justifyContent={"flex-start"}>
+            <ButtonGroup>
+              <Button variant={"primary"} isDisabled>
+                {t("ui.onlySave")}
+              </Button>
+              <Button variant={"secondary"} onClick={onClose}>
+                {t("ui.cancel")}
+              </Button>
+              <Button variant={"ghost"} isDisabled>
+                {t("ui.reset")}
+              </Button>
+            </ButtonGroup>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
@@ -10,18 +10,26 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react"
-import { CaretDown, SlidersHorizontal, Warning, X } from "@phosphor-icons/react"
+import { CaretDown, Warning, X } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React, { useEffect } from "react"
 import { useTranslation } from "react-i18next"
+import { IRequirementAttributes } from "../../../../types/api-request"
+import { ConditionalSetupModal } from "./conditional-setup-modal"
 
 interface IProps {
   menuButtonProps?: Partial<ButtonProps>
   onRemove?: () => void
   emitOpenState?: (isOpen: boolean) => void
+  conditional: IRequirementAttributes["inputOptions"]["conditional"]
 }
 
-export const OptionsMenu = observer(function UnitSelect({ menuButtonProps, onRemove, emitOpenState }: IProps) {
+export const OptionsMenu = observer(function UnitSelect({
+  conditional,
+  menuButtonProps,
+  onRemove,
+  emitOpenState,
+}: IProps) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
 
@@ -46,26 +54,17 @@ export const OptionsMenu = observer(function UnitSelect({ menuButtonProps, onRem
         rightIcon={<CaretDown />}
         {...menuButtonProps}
       >
-        <HStack justifyContent={"space-between"} w={"full"}>
-          <Text color={"text.primary"} as={"span"} flex={1} w={"full"}>
-            {t("requirementsLibrary.modals.optionsMenu.triggerButton")}
-          </Text>
-          <CaretDown />
-        </HStack>
+        {t("requirementsLibrary.modals.optionsMenu.triggerButton")}
       </MenuButton>
       <MenuList w={"220px"}>
-        <MenuItem color={"text,primary"} isDisabled>
+        <MenuItem color={"text.primary"} isDisabled>
           <HStack spacing={2} fontSize={"sm"}>
             <Warning />
             <Text as={"span"}>{t("requirementsLibrary.modals.optionsMenu.dataValidation")}</Text>
           </HStack>
         </MenuItem>
-        <MenuItem color={"text,primary"} isDisabled>
-          <HStack spacing={2} fontSize={"sm"}>
-            <SlidersHorizontal />
-            <Text as={"span"}>{t("requirementsLibrary.modals.optionsMenu.conditionalLogic")}</Text>
-          </HStack>
-        </MenuItem>
+        <ConditionalSetupModal conditional={conditional} />
+
         <MenuDivider />
         <MenuItem color={"semantic.error"} onClick={onRemove}>
           <HStack spacing={2} fontSize={"sm"}>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
@@ -1,0 +1,86 @@
+import { Button, HStack, Tag } from "@chakra-ui/react"
+import { SlidersHorizontal } from "@phosphor-icons/react"
+import React from "react"
+import { useFieldArray, useFormContext } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import { getRequirementTypeLabel } from "../../../../constants"
+import { OptionsMenu } from "../requirement-field-edit/options-menu"
+import { IRequirementBlockForm } from "./index"
+
+interface IProps {
+  requirementIndex: number
+  isRequirementInEditMode: boolean
+  toggleRequirementToEdit: () => void
+}
+
+export function FieldControlsHeader({ requirementIndex, isRequirementInEditMode, toggleRequirementToEdit }: IProps) {
+  const { t } = useTranslation()
+  const { watch, control } = useFormContext<IRequirementBlockForm>()
+  const { remove } = useFieldArray<IRequirementBlockForm>({
+    control,
+    name: "requirementsAttributes",
+  })
+  const watchedElective = watch(`requirementsAttributes.${requirementIndex}.elective`)
+  const watchedConditional = watch(`requirementsAttributes.${requirementIndex}.inputOptions.conditional`)
+  const watchedRequirementType = watch(`requirementsAttributes.${requirementIndex}.inputType`)
+
+  return (
+    <HStack pos={"absolute"} right={0} top={0} spacing={4}>
+      {isRequirementInEditMode && (
+        <OptionsMenu
+          menuButtonProps={{
+            size: "sm",
+          }}
+          onRemove={() => remove(requirementIndex)}
+          conditional={watchedConditional}
+        />
+      )}
+      <HStack className={"requirement-edit-controls-container"}>
+        {watchedElective && !isRequirementInEditMode && (
+          <Tag
+            bg={"theme.yellowLight"}
+            color={"text.secondary"}
+            fontWeight={700}
+            fontSize={"xs"}
+            display={isRequirementInEditMode ? "none" : "flex"}
+          >
+            {t("requirementsLibrary.elective")}
+          </Tag>
+        )}
+        {watchedConditional && !isRequirementInEditMode && (
+          <Tag
+            bg={"semantic.infoLight"}
+            color={"text.secondary"}
+            fontWeight={700}
+            fontSize={"xs"}
+            display={isRequirementInEditMode ? "none" : "flex"}
+          >
+            <SlidersHorizontal style={{ marginRight: "var(--chakra-space-1)" }} />
+            {t("requirementsLibrary.hasConditionalLogic")}
+          </Tag>
+        )}
+        {!isRequirementInEditMode && (
+          <Tag
+            bg={"greys.grey03"}
+            color={"text.secondary"}
+            fontWeight={700}
+            fontSize={"xs"}
+            className={"requirement-edit-controls"}
+            display={"none"}
+          >
+            {getRequirementTypeLabel(watchedRequirementType)}
+          </Tag>
+        )}
+        <Button
+          variant={"primary"}
+          size={"sm"}
+          onClick={toggleRequirementToEdit}
+          className={"requirement-edit-controls"}
+          display={isRequirementInEditMode ? "flex" : "none"}
+        >
+          {t(isRequirementInEditMode ? "ui.done" : "ui.edit")}
+        </Button>
+      </HStack>
+    </HStack>
+  )
+}

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
@@ -1,9 +1,10 @@
-import { Button, HStack, Tag } from "@chakra-ui/react"
-import { SlidersHorizontal } from "@phosphor-icons/react"
+import { Button, HStack } from "@chakra-ui/react"
 import React from "react"
 import { useFieldArray, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { getRequirementTypeLabel } from "../../../../constants"
+import { ElectiveTag } from "../../../shared/elective-tag"
+import { HasConditionalTag } from "../../../shared/has-conditional-tag"
+import { RequirementTypeTag } from "../../../shared/requirement-type-tag"
 import { OptionsMenu } from "../requirement-field-edit/options-menu"
 import { IRequirementBlockForm } from "./index"
 
@@ -37,39 +38,13 @@ export function FieldControlsHeader({ requirementIndex, isRequirementInEditMode,
       )}
       <HStack className={"requirement-edit-controls-container"}>
         {watchedElective && !isRequirementInEditMode && (
-          <Tag
-            bg={"theme.yellowLight"}
-            color={"text.secondary"}
-            fontWeight={700}
-            fontSize={"xs"}
-            display={isRequirementInEditMode ? "none" : "flex"}
-          >
-            {t("requirementsLibrary.elective")}
-          </Tag>
+          <ElectiveTag display={isRequirementInEditMode ? "none" : "flex"} />
         )}
         {watchedConditional && !isRequirementInEditMode && (
-          <Tag
-            bg={"semantic.infoLight"}
-            color={"text.secondary"}
-            fontWeight={700}
-            fontSize={"xs"}
-            display={isRequirementInEditMode ? "none" : "flex"}
-          >
-            <SlidersHorizontal style={{ marginRight: "var(--chakra-space-1)" }} />
-            {t("requirementsLibrary.hasConditionalLogic")}
-          </Tag>
+          <HasConditionalTag display={isRequirementInEditMode ? "none" : "flex"} />
         )}
         {!isRequirementInEditMode && (
-          <Tag
-            bg={"greys.grey03"}
-            color={"text.secondary"}
-            fontWeight={700}
-            fontSize={"xs"}
-            className={"requirement-edit-controls"}
-            display={"none"}
-          >
-            {getRequirementTypeLabel(watchedRequirementType)}
-          </Tag>
+          <RequirementTypeTag type={watchedRequirementType} className={"requirement-edit-controls"} display={"none"} />
         )}
         <Button
           variant={"primary"}

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -1,11 +1,10 @@
-import { Box, Button, Flex, HStack, Tag, Text, VStack } from "@chakra-ui/react"
+import { Box, Flex, Text, VStack } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
 import React, { useState } from "react"
 import { Controller, useController, useFieldArray, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { getRequirementTypeLabel } from "../../../../constants"
-import { IRequirementsAttribute } from "../../../../types/api-request"
+import { IRequirementAttributes } from "../../../../types/api-request"
 import { ENumberUnit, ERequirementType } from "../../../../types/enums"
 import { isContactRequirement, isMultiOptionRequirement } from "../../../../utils/utility-functions"
 import { EditableInputWithControls } from "../../../shared/editable-input-with-controls"
@@ -13,7 +12,7 @@ import { EditorWithPreview } from "../../../shared/editor/custom-extensions/edit
 import { FieldsSetupDrawer } from "../fields-setup-drawer"
 import { RequirementFieldDisplay } from "../requirement-field-display"
 import { RequirementFieldEdit } from "../requirement-field-edit"
-import { OptionsMenu } from "../requirement-field-edit/options-menu"
+import { FieldControlsHeader } from "./field-controls-header"
 import { IRequirementBlockForm } from "./index"
 
 const fieldContainerSharedProps = {
@@ -122,7 +121,8 @@ export const FieldsSetup = observer(function FieldsSetup() {
             {fields.map((field, index) => {
               const watchedHint = watch(`requirementsAttributes.${index}.hint`)
               const watchedElective = watch(`requirementsAttributes.${index}.elective`)
-              const requirementType = (field as IRequirementsAttribute).inputType
+              const watchedConditional = watch(`requirementsAttributes.${index}.inputOptions.conditional`)
+              const requirementType = (field as IRequirementAttributes).inputType
               return (
                 <Box
                   key={field.id}
@@ -131,9 +131,8 @@ export const FieldsSetup = observer(function FieldsSetup() {
                   _hover={{
                     bg: "theme.blueLight",
                     "& .requirement-edit-controls-container": {
-                      flexFlow: "row",
                       ".requirement-edit-controls": {
-                        visibility: "visible",
+                        display: "flex",
                       },
                     },
                   }}
@@ -268,52 +267,11 @@ export const FieldsSetup = observer(function FieldsSetup() {
                       showAddLabelIndicator
                     />
                   </Box>
-                  <HStack pos={"absolute"} right={0} top={0} spacing={4}>
-                    {isRequirementInEditMode(field.id) && (
-                      <OptionsMenu
-                        menuButtonProps={{
-                          size: "sm",
-                        }}
-                        onRemove={() => remove(index)}
-                      />
-                    )}
-                    <HStack className={"requirement-edit-controls-container"} flexFlow={"row-reverse"}>
-                      {watchedElective && !isRequirementInEditMode(field.id) && (
-                        <Tag
-                          bg={"theme.yellowLight"}
-                          color={"text.secondary"}
-                          fontWeight={700}
-                          fontSize={"xs"}
-                          visibility={isRequirementInEditMode(field.id) ? "hidden" : "visible"}
-                        >
-                          {t("requirementsLibrary.elective")}
-                        </Tag>
-                      )}
-                      {!isRequirementInEditMode(field.id) && (
-                        <Tag
-                          bg={"greys.grey03"}
-                          color={"text.secondary"}
-                          fontWeight={700}
-                          fontSize={"xs"}
-                          className={"requirement-edit-controls"}
-                          visibility={"hidden"}
-                        >
-                          {getRequirementTypeLabel(requirementType)}
-                        </Tag>
-                      )}
-                      <Button
-                        variant={"primary"}
-                        size={"sm"}
-                        onClick={() => {
-                          toggleRequirementToEdit(field.id)
-                        }}
-                        className={"requirement-edit-controls"}
-                        visibility={isRequirementInEditMode(field.id) ? "visible" : "hidden"}
-                      >
-                        {t(isRequirementInEditMode(field.id) ? "ui.done" : "ui.edit")}
-                      </Button>
-                    </HStack>
-                  </HStack>
+                  <FieldControlsHeader
+                    requirementIndex={index}
+                    isRequirementInEditMode={isRequirementInEditMode(field.id)}
+                    toggleRequirementToEdit={() => toggleRequirementToEdit(field.id)}
+                  />
                 </Box>
               )
             })}

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -120,8 +120,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
           <VStack w={"full"} alignItems={"flex-start"} spacing={2} px={3}>
             {fields.map((field, index) => {
               const watchedHint = watch(`requirementsAttributes.${index}.hint`)
-              const watchedElective = watch(`requirementsAttributes.${index}.elective`)
-              const watchedConditional = watch(`requirementsAttributes.${index}.inputOptions.conditional`)
+              const watchedRequired = watch(`requirementsAttributes.${index}.required`)
               const requirementType = (field as IRequirementAttributes).inputType
               return (
                 <Box
@@ -264,6 +263,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
                           isChecked: !!watch(`requirementsAttributes.${index}.inputOptions.canAddMultipleContacts`),
                         },
                       }}
+                      required={watchedRequired}
                       showAddLabelIndicator
                     />
                   </Box>

--- a/app/frontend/components/shared/elective-tag.tsx
+++ b/app/frontend/components/shared/elective-tag.tsx
@@ -1,0 +1,12 @@
+import { Tag, TagProps } from "@chakra-ui/react"
+import React from "react"
+import { useTranslation } from "react-i18next"
+
+export function ElectiveTag(props: Partial<TagProps>) {
+  const { t } = useTranslation()
+  return (
+    <Tag bg={"theme.yellowLight"} color={"text.secondary"} fontWeight={700} fontSize={"xs"} {...props}>
+      {t("requirementsLibrary.elective")}
+    </Tag>
+  )
+}

--- a/app/frontend/components/shared/has-conditional-tag.tsx
+++ b/app/frontend/components/shared/has-conditional-tag.tsx
@@ -1,0 +1,14 @@
+import { Tag, TagProps } from "@chakra-ui/react"
+import { SlidersHorizontal } from "@phosphor-icons/react"
+import React from "react"
+import { useTranslation } from "react-i18next"
+
+export function HasConditionalTag(props: Partial<TagProps>) {
+  const { t } = useTranslation()
+  return (
+    <Tag bg={"semantic.infoLight"} color={"text.secondary"} fontWeight={700} fontSize={"xs"} {...props}>
+      <SlidersHorizontal style={{ marginRight: "var(--chakra-space-1)" }} />
+      {t("requirementsLibrary.hasConditionalLogic")}
+    </Tag>
+  )
+}

--- a/app/frontend/components/shared/requirement-type-tag.tsx
+++ b/app/frontend/components/shared/requirement-type-tag.tsx
@@ -1,0 +1,12 @@
+import { Tag, TagProps } from "@chakra-ui/react"
+import React from "react"
+import { getRequirementTypeLabel } from "../../constants"
+import { ERequirementType } from "../../types/enums"
+
+export function RequirementTypeTag({ type, ...tagProps }: { type: ERequirementType } & Partial<TagProps>) {
+  return (
+    <Tag bg={"greys.grey03"} color={"text.secondary"} fontWeight={700} fontSize={"xs"} {...tagProps}>
+      {getRequirementTypeLabel(type)}
+    </Tag>
+  )
+}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -145,6 +145,7 @@ const options = {
           returnHome: "Return to home",
           copied: "Copied!",
           failedToCopy: "Something went wrong while trying to copy",
+          reset: "Reset",
         },
         eula: {
           title: "End-User License Agreement",
@@ -313,6 +314,7 @@ const options = {
         requirementsLibrary: {
           addAnotherPerson: "Add another person",
           elective: "Elective",
+          hasConditionalLogic: "Has Conditional Logic",
           associationsInfo: "Sections, tags, etc...",
           index: {
             title: "Requirements Library",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -367,6 +367,7 @@ const options = {
             updatedAt: "Updated At",
             requirementSku: "Requirement SKU",
           },
+          configurationsColumn: "Configurations",
           fieldDescriptions: {
             description: "Provide some context for admins and managers for this fieldset.",
             associations: "Assign a tag to help organize and find this requirement block easier.",

--- a/app/frontend/models/requirement-block.ts
+++ b/app/frontend/models/requirement-block.ts
@@ -23,6 +23,15 @@ export const RequirementBlockModel = types
     hasRequirement(id: string) {
       return self.requirements.findIndex((requirement) => requirement.id === id) !== -1
     },
+    get hasAnyElective() {
+      return self.requirements.some((requirement) => requirement.elective)
+    },
+    get hasAnyConditional() {
+      return self.requirements.some((requirement) => !!requirement.conditional)
+    },
+    get hasAnyDataValidation() {
+      return self.requirements.some((requirement) => !!requirement.dataValidation)
+    },
   }))
   .actions((self) => ({
     update: flow(function* (requirementParams: IRequirementBlockParams) {

--- a/app/frontend/models/requirement.ts
+++ b/app/frontend/models/requirement.ts
@@ -21,6 +21,12 @@ export const RequirementModel = types
     get numberUnit(): ENumberUnit | undefined {
       return self.inputOptions?.numberUnit
     },
+    get conditional(): Object | undefined {
+      return self.inputOptions?.conditional
+    },
+    get dataValidation(): Object | undefined {
+      return self.inputOptions?.dataValidation
+    },
   }))
 
 export interface IRequirement extends Instance<typeof RequirementModel> {}

--- a/app/frontend/stores/requirement-block-store.ts
+++ b/app/frontend/stores/requirement-block-store.ts
@@ -34,6 +34,8 @@ export const RequirementBlockStoreModel = types
           return t("requirementsLibrary.fields.formFields")
         case ERequirementLibrarySortFields.updatedAt:
           return t("requirementsLibrary.fields.updatedAt")
+        case ERequirementLibrarySortFields.configurations:
+          return t("requirementsLibrary.configurationsColumn")
       }
     },
   }))

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -1,7 +1,7 @@
 import { ENumberUnit, ERequirementType, ETagType } from "./enums"
 import { IOption } from "./types"
 
-export interface IRequirementsAttribute {
+export interface IRequirementAttributes {
   id?: string
   label?: string
   inputType?: ERequirementType
@@ -12,6 +12,7 @@ export interface IRequirementsAttribute {
     valueOptions?: IOption[]
     numberUnit?: ENumberUnit
     canAddMultipleContacts?: boolean
+    conditional?: Object
   }
 }
 
@@ -21,7 +22,7 @@ export interface IRequirementBlockParams {
   displayDescription: string
   description?: string
   associationList?: string[]
-  requirementsAttributes: IRequirementsAttribute[]
+  requirementsAttributes: IRequirementAttributes[]
 }
 
 export interface ITemplateSectionBlockAttributes {

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -44,6 +44,7 @@ export enum ERequirementLibrarySortFields {
   associations = "associations",
   requirementLabels = "requirement_labels",
   updatedAt = "updated_at",
+  configurations = "configurations",
 }
 
 export enum EJurisdictionSortFields {

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -114,6 +114,7 @@ export interface IDenormalizedRequirement {
   inputOptions: IRequirementOptions
   hint?: string | null
   elective?: boolean
+  required?: boolean
 }
 
 export interface IDenormalizedRequirementBlock {

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -61,6 +61,8 @@ export interface IRequirementOptions {
   valueOptions?: IOption[]
   numberUnit?: ENumberUnit
   canAddMultipleContacts?: boolean
+  conditional?: Object
+  dataValidation?: Object
 }
 
 export interface IFormJson {

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -66,6 +66,16 @@ class Requirement < ApplicationRecord
     input_options["computed_compliance"].present?
   end
 
+  def has_conditional?
+    input_options["conditional"].present?
+  end
+
+  def has_data_validation?
+    # TODO: false for now, but will be implemented in the future when
+    # custom data validation is added
+    false
+  end
+
   private
 
   # requirement codes should not be auto generated during seeding.  Use uuid if not provided

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -1,5 +1,6 @@
 class RequirementBlock < ApplicationRecord
-  searchkick searchable: %i[name requirement_labels associations], word_start: %i[name requirement_labels associations]
+  searchkick searchable: %i[name requirement_labels associations configurations],
+             word_start: %i[name requirement_labels associations configurations]
 
   has_many :requirements, -> { order(position: :asc) }, dependent: :destroy
 
@@ -24,6 +25,7 @@ class RequirementBlock < ApplicationRecord
       name: name,
       requirement_labels: requirements.pluck(:label),
       associations: association_list,
+      configurations: configurations_search_list,
     }
   end
 
@@ -74,6 +76,19 @@ class RequirementBlock < ApplicationRecord
   end
 
   private
+
+  def configurations_search_list
+    configurations = []
+    has_any_elective = requirements.any?(&:elective?)
+    has_any_conditional = requirements.any?(&:has_conditional?)
+    has_any_data_validation = requirements.any?(&:has_data_validation?)
+
+    configurations << "elective" if has_any_elective
+    configurations << "conditional" if has_any_conditional
+    configurations << "data_validation" if has_any_data_validation
+
+    configurations
+  end
 
   # sku should be auto generated. Use uuid if not provided
   def set_sku


### PR DESCRIPTION
## Description
- Add basic ability to view conditionals for super admins
- Adds configuration column to requirement table. Shows if block has any electives or conditionals
- Adds required asterisk for requirement display
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
- https://hous-bssb.atlassian.net/browse/BPHH-724
- https://hous-bssb.atlassian.net/browse/BPHH-648
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
<img width="1264" alt="Screenshot 2024-03-19 at 3 20 53 PM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/c2976692-a06a-4362-887a-84777de44306">
<img width="1328" alt="Screenshot 2024-03-19 at 3 21 04 PM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/7ac43ae7-6a86-4087-b259-b3d1e5d8107e">
<img width="1188" alt="Screenshot 2024-03-19 at 3 21 16 PM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/c06f0a1f-f304-42de-99dd-9ba568925c99">
<img width="1516" alt="Screenshot 2024-03-19 at 3 21 27 PM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/8170d111-20d5-443c-a6da-587e27b9e173">
