### PR TITLE
BPHH-807 session and authentication fixes

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -29,7 +29,7 @@ class Api::ApplicationController < ActionController::API
   def user_not_authorized(exception)
     render_error(
       "misc.user_not_authorized_error",
-      { message_opts: { error_message: exception.message } },
+      { message_opts: { error_message: exception.message }, status: 403 },
       exception,
     ) and return
   end

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -1,8 +1,10 @@
 import { Box, Flex } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React, { useEffect } from "react"
-import { BrowserRouter, Route, Routes, useLocation } from "react-router-dom"
+import { useTranslation } from "react-i18next"
+import { BrowserRouter, Route, Routes, useLocation, useNavigate } from "react-router-dom"
 import { useMst } from "../../../setup/root"
+import { EFlashMessageStatus } from "../../../types/enums"
 import { FlashMessage } from "../../shared/base/flash-message"
 import { Footer } from "../../shared/base/footer"
 import { LoadingScreen } from "../../shared/base/loading-screen"
@@ -78,13 +80,24 @@ export const Navigation = observer(() => {
 })
 
 const AppRoutes = observer(() => {
-  const { sessionStore } = useMst()
-  const { loggedIn } = sessionStore
+  const { sessionStore, uiStore } = useMst()
+  const { loggedIn, tokenExpired } = sessionStore
   const location = useLocation()
   const background = location.state && location.state.background
 
   const { userStore } = useMst()
   const { currentUser } = userStore
+
+  const navigate = useNavigate()
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    if (tokenExpired) {
+      sessionStore.resetAuth()
+      navigate("/login")
+      uiStore.flashMessage.show(EFlashMessageStatus.warning, t("auth.tokenExpired"), null)
+    }
+  }, [tokenExpired])
 
   const superAdminOnlyRoutes = (
     <>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -40,6 +40,7 @@ const options = {
             "Must be between 8 - 64 characters long, at least one uppercase, one lowercase, one special character, and one number.",
           alreadyHaveAccount: "Already have an account?",
           checkYourEmail: "Please check your email inbox for the confirmation email to activate your account.",
+          tokenExpired: "Your session is no longer valid, please login again",
         },
         landing: {
           title: "Building Permit Hub",

--- a/app/frontend/setup/root.ts
+++ b/app/frontend/setup/root.ts
@@ -18,10 +18,11 @@ export const setupRootStore = () => {
   const rootStore = RootStoreModel.create(initialState, environment)
 
   const { api } = environment
-  const { uiStore } = rootStore
+  const { uiStore, sessionStore } = rootStore
 
   Monitors.addFlashMessageMonitor(api, uiStore)
   Monitors.addApiErrorMonitor(api, uiStore)
+  Monitors.addApiUnauthorizedError(api, sessionStore)
 
   return rootStore
 }

--- a/app/frontend/stores/root-store.ts
+++ b/app/frontend/stores/root-store.ts
@@ -56,4 +56,6 @@ export interface IRootStore extends IStateTreeNode {
   templateVersionStore: ITemplateVersionStoreModel
   geocoderStore: IGeocoderStore
   stepCodeStore: IStepCodeStore
+  subscribeToUserChannel: () => void
+  disconnectUserChannel: () => void
 }

--- a/app/frontend/stores/session-store.ts
+++ b/app/frontend/stores/session-store.ts
@@ -6,6 +6,7 @@ export const SessionStoreModel = types
   .model("SessionStoreModel")
   .props({
     loggedIn: types.optional(types.boolean, false),
+    tokenExpired: types.optional(types.boolean, false),
     isValidating: types.optional(types.boolean, true),
     isLoggingOut: types.optional(types.boolean, false),
   })
@@ -15,7 +16,9 @@ export const SessionStoreModel = types
   .actions((self) => ({
     resetAuth: flow(function* () {
       self.loggedIn = false
+      self.tokenExpired = false
       self.rootStore.userStore.unsetCurrentUser()
+      self.rootStore.disconnectUserChannel()
     }),
   }))
   .actions((self) => ({
@@ -53,7 +56,6 @@ export const SessionStoreModel = types
       self.isLoggingOut = true
       const response: any = yield self.environment.api.logout()
       if (response.ok) {
-        self.rootStore.disconnectUserChannel()
         self.resetAuth()
       }
       self.isLoggingOut = false
@@ -70,6 +72,9 @@ export const SessionStoreModel = types
         window.location.replace(response.meta.redirectUrl)
       }
     }),
+    setTokenExpired(isExpired: boolean) {
+      self.tokenExpired = isExpired
+    },
   }))
 
 export interface ISessionStore extends Instance<typeof SessionStoreModel> {}

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -11,7 +11,7 @@
 Devise.setup do |config|
   config.jwt do |jwt|
     jwt.secret = ENV["DEVISE_JWT_SECRET_KEY"]
-
+    jwt.expiration_time = ENV["SESSION_TIMEOUT_MINUTES"].to_i.minutes
     jwt.dispatch_requests = [
       ["POST", %r{^/api/login$}],
       ["PUT", %r{^/api/invitation$}],
@@ -257,11 +257,6 @@ Devise.setup do |config|
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
-
-  # ==> Configuration for :timeoutable
-  # The time you want to timeout the user session without activity. After this
-  # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = (ENV["SESSION_TIMEOUT_MINUTES"].to_i).minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
## Description

Session / Auth fixes
- Changes pundit errors to return 403
-  Adjusts timeout parameter properly (for devise-jwt and not base devise)
- Add some logic for detecting when an authentication error happens (401) when user takes an action when their token is already expired and redirect them to login instead with a friendly message. Ensure to disconnect all sockets / other stuff

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
