### PR TITLE
[bphh-885] Bugfix - Adding same requirement block to same section after removing

### DIFF
--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
@@ -194,7 +194,13 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
         // from another section, then we set the id to null so that it gets created
         // on the new section by rails.
         if (!existingMSTSection || !existingMSTSection.hasTemplateSectionBlock(sectionBlockAttributes.id)) {
-          sectionBlockAttributes.id = null
+          // this is to handle case if the same requirementBlock was removed then re-added during edit
+          const existingSectionAndRequirementBlockCombo =
+            existingMSTSection?.getTemplateSectionBlockByRequirementBlockId(sectionBlockAttributes.requirementBlockId)
+
+          sectionBlockAttributes.id = existingSectionAndRequirementBlockCombo
+            ? existingSectionAndRequirementBlockCombo.id
+            : null
         }
         sectionBlockAttributes.position = blockIndex
       })

--- a/app/frontend/models/requirement-template-section.ts
+++ b/app/frontend/models/requirement-template-section.ts
@@ -1,5 +1,5 @@
 import { Instance, types } from "mobx-state-tree"
-import { TemplateSectionBlockModel } from "./template-section-block"
+import { ITemplateSectionBlockModel, TemplateSectionBlockModel } from "./template-section-block"
 
 function preProcessor(snapshot) {
   const processedSnapShot = { ...snapshot }
@@ -27,6 +27,13 @@ export const RequirementTemplateSectionModel = types.snapshotProcessor(
     .views((self) => ({
       hasTemplateSectionBlock(id: string) {
         return self.templateSectionBlockMap.has(id)
+      },
+      getTemplateSectionBlockByRequirementBlockId(requirementBlockId: string) {
+        const templateSectionBlock: ITemplateSectionBlockModel | undefined = Array.from(
+          self.templateSectionBlockMap.values()
+        ).find((sectionBlock) => sectionBlock.requirementBlockId === requirementBlockId)
+
+        return templateSectionBlock
       },
       getTemplateSectionBlockById(id: string) {
         return self.templateSectionBlockMap.get(id)


### PR DESCRIPTION
## Description
[bphh-885] Fix bug when trying to save a requirement template after removing and then adding the same requirement block to the same section
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-885
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Log in as super admin
- Go to templates catalogue
- Edit draft of template which alreay has some persisted requirement blocks
- Remove a requirement block and then add it back to same section
- Click save as draft button
- The save should be successfull
