### PR TITLE
[bphh-918] Fix bug with requirement block failing to save when adding  a file requirement

### DIFF
--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -20,17 +20,31 @@ class Requirement < ApplicationRecord
          signature: 15,
          energy_step_code: 16,
          general_contact: 17,
-         professional_contact: 18,
+         professional_contact: 18
        },
        _prefix: true
 
-  before_create :set_requirement_code
-  before_save :convert_value_options, if: Proc.new { |req| TYPES_WITH_VALUE_OPTIONS.include?(req.input_type.to_s) }
-  validate :validate_value_options, if: Proc.new { |req| TYPES_WITH_VALUE_OPTIONS.include?(req.input_type.to_s) }
+  # This needs to run before validation because we have validations related to the requirement_code
+  before_validation :set_requirement_code
+  before_save :convert_value_options,
+              if:
+                Proc.new { |req|
+                  TYPES_WITH_VALUE_OPTIONS.include?(req.input_type.to_s)
+                }
+  validate :validate_value_options,
+           if:
+             Proc.new { |req|
+               TYPES_WITH_VALUE_OPTIONS.include?(req.input_type.to_s)
+             }
   validate :validate_unit_for_number_inputs
   validate :validate_can_add_multiple_contacts
-  validates_format_of :requirement_code, without: /\||\.|\=|\>/, message: "must not contain | or . or = or >"
-  validates_format_of :requirement_code, with: /\_file/, if: Proc.new { |req| req.input_type == "file" }
+  validates_format_of :requirement_code,
+                      without: /\||\.|\=|\>/,
+                      message: "must not contain | or . or = or >"
+  validates_format_of :requirement_code,
+                      with: /\_file/,
+                      if: Proc.new { |req| req.input_type == "file" },
+                      message: "must contain _file for file type"
 
   NUMBER_UNITS = %w[no_unit mm cm m in ft mi sqm sqft cad]
   TYPES_WITH_VALUE_OPTIONS = %w[multi_option_select select radio]
@@ -88,6 +102,10 @@ class Requirement < ApplicationRecord
           SecureRandom.uuid
         end
       )
+
+    return unless input_type == "file" && requirement_code.exclude?("_file")
+
+    self.requirement_code += "_file"
   end
 
   def formio_type_options
@@ -97,9 +115,11 @@ class Requirement < ApplicationRecord
   end
 
   def validate_value_options
-    if input_options.blank? || input_options["value_options"].blank? || !input_options["value_options"].is_a?(Array) ||
+    if input_options.blank? || input_options["value_options"].blank? ||
+         !input_options["value_options"].is_a?(Array) ||
          !input_options["value_options"].all? { |option|
-           option.is_a?(Hash) && (option.key?("label") && option["label"].is_a?(String)) &&
+           option.is_a?(Hash) &&
+             (option.key?("label") && option["label"].is_a?(String)) &&
              (option.key?("value") && option["value"].is_a?(String))
          }
       errors.add(:input_options, "must have value options defined")
@@ -107,27 +127,51 @@ class Requirement < ApplicationRecord
   end
 
   def validate_unit_for_number_inputs
-    return unless (input_options.present? && input_options["number_unit"].present?)
+    unless (input_options.present? && input_options["number_unit"].present?)
+      return
+    end
 
-    return(errors.add(:input_options, "number_unit is only allowed for number inputs")) if !input_type_number?
+    if !input_type_number?
+      return(
+        errors.add(
+          :input_options,
+          "number_unit is only allowed for number inputs"
+        )
+      )
+    end
 
     if !NUMBER_UNITS.include?(input_options["number_unit"])
-      errors.add(:input_options, "the number_unit must be one of #{NUMBER_UNITS.join(", ")}")
+      errors.add(
+        :input_options,
+        "the number_unit must be one of #{NUMBER_UNITS.join(", ")}"
+      )
     end
   end
 
   def convert_value_options
     # all values MUST be converted to camelCase to be compatible with rehyration on front end
-    input_options["value_options"] = input_options["value_options"].map do |option_json|
+    input_options["value_options"] = input_options[
+      "value_options"
+    ].map do |option_json|
       option_json.merge("value" => option_json["value"].camelize(:lower))
     end
   end
 
   def validate_can_add_multiple_contacts
-    return unless (input_options.present? && input_options["can_add_multiple_contacts"].present?)
+    unless (
+             input_options.present? &&
+               input_options["can_add_multiple_contacts"].present?
+           )
+      return
+    end
 
     unless CONTACT_TYPES.include?(input_type.to_s)
-      return(errors.add(:input_options, "can_add_multiple_contacts is only allowed for contact inputs"))
+      return(
+        errors.add(
+          :input_options,
+          "can_add_multiple_contacts is only allowed for contact inputs"
+        )
+      )
     end
 
     if !(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -177,7 +177,7 @@ en:
         message: "Something went wrong creating the requirement block"
       update_error:
         title: Oops
-        message: "Something went wrong updating the requirement block"
+        message: "%{error_message}"
       delete_error:
         title: Oops
         message: "Something went wrong deleting the requirement block"

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -101,14 +101,33 @@ RSpec.describe Requirement, type: :model do
     end
 
     context "files" do
-      it "enforces file valid when code ending in _file" do
-        file_requirement = build(:requirement, requirement_code: "test_file", input_type: "file")
+      it "enforces file valid and no additional _file is added to requirement_code if it's already ending in _file for
+ file types" do
+        code = "test_file"
+        file_requirement = build(:requirement, requirement_code: code, input_type: "file")
         expect(file_requirement.valid?).to eq(true)
+        expect(file_requirement.requirement_code).to eq(code)
       end
 
-      it "enforces file invalid when code not ending in _file" do
-        file_requirement = build(:requirement, requirement_code: "test_fail", input_type: "file")
-        expect(file_requirement.valid?).to eq(false)
+      it "enforces file valid and ensures _file is appended to requirement code if it doesn't end with it for file
+types" do
+        code = "test_incorrect_format"
+
+        file_requirement = build(:requirement, requirement_code: code, input_type: "file")
+
+        expect(file_requirement.valid?).to eq(true)
+        expect(file_requirement.requirement_code).to eq("#{code}_file")
+      end
+
+      it "enforces file valid and ensures _file is appended to requirement code if it includes _file but doesn't end
+with it for file
+types" do
+        code = "test_file_incorrect_format"
+
+        file_requirement = build(:requirement, requirement_code: code, input_type: "file")
+
+        expect(file_requirement.valid?).to eq(true)
+        expect(file_requirement.requirement_code).to eq("#{code}_file")
       end
     end
   end


### PR DESCRIPTION
## Description
Fixes a bug caused when trying to save a requirement block with a newly added file requirement. This happens because for file types we validate it has `_file` but do not include it automatically when the requirement_code is autogenerated
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-918
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Log in as super admin
- Navigate to requirements library
- Select any requirement block
- Add a new file requirement
- Save
- The block should save successfully 