### PR TITLE
[bphh-884] Fix bug with page shifting due to scroll into view when adding first section to template

### DIFF
--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
@@ -109,9 +109,7 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
   const hasNoSections = watchedSectionsAttributes.length === 0
 
   return (
-    // the height 1px is needed other wise scroll does not work
-    // as it seems like the browser has issues calculating height for flex=1 containers
-    <RemoveScroll style={{ width: "100%", height: "100%" }}>
+    <RemoveScroll style={{ width: "100%", height: "calc(100% - 66px)", marginTop: "66px" }}>
       <Flex flexDir={"column"} w={"full"} maxW={"full"} h="full" as="main">
         <FormProvider {...formMethods}>
           <EditableBuilderHeader requirementTemplate={requirementTemplate} />
@@ -176,7 +174,7 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
     const element = document.getElementById(formScrollToId(id))
 
     if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "start" })
+      element.scrollIntoView({ behavior: "smooth", block: "nearest" })
     }
   }
 


### PR DESCRIPTION
## Description
[bphh-884] Fix bug with page shifting due to scroll into view when adding first section to template
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-884
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Log in as super admin
- Navigates to permit catalogue
- Select any template and edit in draft mode
- If already not empty, remove all sections
- Then add a new section
- Should work as expected without shifting non-scrollable container