### PR TITLE
[bphh-786] Redirect to newly scheduled template version after schedule

### DIFF
--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -1,7 +1,8 @@
 class Api::RequirementTemplatesController < Api::ApplicationController
   include Api::Concerns::Search::RequirementTemplates
 
-  before_action :set_requirement_template, only: %i[show destroy restore update schedule]
+  before_action :set_requirement_template,
+                only: %i[show destroy restore update schedule]
   skip_after_action :verify_policy_scoped, only: [:index]
 
   def index
@@ -13,9 +14,9 @@ class Api::RequirementTemplatesController < Api::ApplicationController
                      meta: {
                        total_pages: @search.total_pages,
                        total_count: @search.total_count,
-                       current_page: @search.current_page,
+                       current_page: @search.current_page
                      },
-                     blueprint: RequirementTemplateBlueprint,
+                     blueprint: RequirementTemplateBlueprint
                    }
   end
 
@@ -24,11 +25,17 @@ class Api::RequirementTemplatesController < Api::ApplicationController
 
     render_success @requirement_template,
                    nil,
-                   { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
+                   {
+                     blueprint: RequirementTemplateBlueprint,
+                     blueprint_opts: {
+                       view: :extended
+                     }
+                   }
   end
 
   def create
-    @requirement_template = RequirementTemplate.build(requirement_template_params)
+    @requirement_template =
+      RequirementTemplate.build(requirement_template_params)
     authorize @requirement_template
 
     if @requirement_template.save
@@ -38,7 +45,8 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     else
       render_error "requirement_template.create_error",
                    message_opts: {
-                     error_message: @requirement_template.errors.full_messages.join(", "),
+                     error_message:
+                       @requirement_template.errors.full_messages.join(", ")
                    }
     end
   end
@@ -49,11 +57,17 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     if @requirement_template.update(requirement_template_params)
       render_success @requirement_template,
                      "requirement_template.update_success",
-                     { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
+                     {
+                       blueprint: RequirementTemplateBlueprint,
+                       blueprint_opts: {
+                         view: :extended
+                       }
+                     }
     else
       render_error "requirement_template.update_error",
                    message_opts: {
-                     error_message: @requirement_template.errors.full_messages.join(", "),
+                     error_message:
+                       @requirement_template.errors.full_messages.join(", ")
                    }
     end
   end
@@ -65,29 +79,47 @@ class Api::RequirementTemplatesController < Api::ApplicationController
       unless @requirement_template.update(requirement_template_params)
         render_error "requirement_template.schedule_error",
                      message_opts: {
-                       error_message: @requirement_template.errors.full_messages.join(", "),
+                       error_message:
+                         @requirement_template.errors.full_messages.join(", ")
                      }
       end
 
       begin
         scheduled_template_version =
-          TemplateVersioningService.schedule!(@requirement_template, Date.parse(schedule_params))
+          TemplateVersioningService.schedule!(
+            @requirement_template,
+            Date.parse(schedule_params)
+          )
       rescue StandardError => e
         # If there is an error in TemplateVersioningService.schedule!, rollback the transaction
-        render_error "requirement_template.schedule_error", message_opts: { error_message: e.message }
+        render_error "requirement_template.schedule_error",
+                     message_opts: {
+                       error_message: e.message
+                     }
         raise ActiveRecord::Rollback
       end
 
+      # A reload is required, otherwise the new template version is not ordered correctly
+      @requirement_template.reload
+
       render_success @requirement_template,
                      "requirement_template.schedule_success",
-                     { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
+                     {
+                       blueprint: RequirementTemplateBlueprint,
+                       blueprint_opts: {
+                         view: :extended
+                       }
+                     }
     end
   end
 
   def destroy
     authorize @requirement_template
     if @requirement_template.discard
-      render_success(@requirement_template, "requirement_template.destroy_success")
+      render_success(
+        @requirement_template,
+        "requirement_template.destroy_success"
+      )
     else
       render_error "requirement_template.destroy_error"
     end
@@ -96,7 +128,10 @@ class Api::RequirementTemplatesController < Api::ApplicationController
   def restore
     authorize @requirement_template
     if @requirement_template.update(discarded_at: nil)
-      render_success(@requirement_template, "requirement_template.restore_success")
+      render_success(
+        @requirement_template,
+        "requirement_template.restore_success"
+      )
     else
       render_error "requirement_template.restore_error", {}
     end
@@ -118,8 +153,13 @@ class Api::RequirementTemplatesController < Api::ApplicationController
         :name,
         :position,
         :_destroy,
-        template_section_blocks_attributes: %i[id requirement_block_id position _destroy],
-      ],
+        template_section_blocks_attributes: %i[
+          id
+          requirement_block_id
+          position
+          _destroy
+        ]
+      ]
     )
   end
 

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react"
 import { FormProvider, useFieldArray, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { RemoveScroll } from "react-remove-scroll"
+import { useNavigate } from "react-router-dom"
 import { v4 as uuidv4 } from "uuid"
 import { useRequirementTemplate } from "../../../../../hooks/resources/use-requirement-template"
 import { IRequirementTemplate } from "../../../../../models/requirement-template"
@@ -32,6 +33,7 @@ const scrollToIdPrefix = "template-builder-scroll-to-id-"
 export const formScrollToId = (id: string) => `${scrollToIdPrefix}${id}`
 
 export const EditRequirementTemplateScreen = observer(function EditRequirementTemplateScreen() {
+  const navigate = useNavigate()
   const { isOpen: isReorderMode, onClose: closeReorderMode, onOpen: openReorderMode } = useDisclosure()
   const { requirementTemplateStore, requirementBlockStore } = useMst()
   const { requirementTemplate, error } = useRequirementTemplate()
@@ -98,11 +100,22 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
     await handleSubmit(async (templateFormData) => {
       const formattedSubmitData = formatSubmitData(templateFormData)
 
-      return await requirementTemplateStore.scheduleRequirementTemplate(
+      const updatedRequirementTemplate = await requirementTemplateStore.scheduleRequirementTemplate(
         requirementTemplate.id,
         formattedSubmitData,
         date
       )
+
+      if (updatedRequirementTemplate) {
+        // the template versions are ordered by latest first, so this should return the newly scheduled template
+        // version
+        const scheduledTemplateVersion = (updatedRequirementTemplate as IRequirementTemplate)
+          .scheduledTemplateVersions?.[0]
+
+        scheduledTemplateVersion
+          ? navigate(`/template-versions/${scheduledTemplateVersion.id}`)
+          : navigate("/requirement-templates")
+      }
     })()
   }
 

--- a/app/frontend/stores/requirement-template-store.ts
+++ b/app/frontend/stores/requirement-template-store.ts
@@ -7,7 +7,7 @@ import { createSearchModel } from "../lib/create-search-model"
 import { withEnvironment } from "../lib/with-environment"
 import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
-import { RequirementTemplateModel } from "../models/requirement-template"
+import { IRequirementTemplate, RequirementTemplateModel } from "../models/requirement-template"
 import { IRequirementTemplateUpdateParams } from "../types/api-request"
 import { ERequirementTemplateSortFields } from "../types/enums"
 import { toCamelCase } from "../utils/utility-functions"
@@ -133,10 +133,10 @@ export const RequirementTemplateStoreModel = types
         templateData.isFullyLoaded = true
         self.mergeUpdate(templateData, "requirementTemplateMap")
 
-        return self.requirementTemplateMap.get(templateData.id)
+        return self.requirementTemplateMap.get(templateData.id) as IRequirementTemplate
       }
 
-      return response.ok
+      return false
     }),
   }))
 


### PR DESCRIPTION
## Description
[bphh-786] Redirect to newly scheduled template version after schedule
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ X] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-786
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Log in as super admin
- navigate to templates catalogue
- select any template to edit as draft
- schedule a publish
- after schedule succeeds, it should redirect to the read only template screen
