### PR TITLE
Bugfix/bphh 906/UI fixes

### DIFF
--- a/app/blueprints/jurisdiction_blueprint.rb
+++ b/app/blueprints/jurisdiction_blueprint.rb
@@ -15,6 +15,7 @@ class JurisdictionBlueprint < Blueprinter::Base
          :permit_applications_size,
          :templates_used_size,
          :map_position,
+         :map_zoom,
          :energy_step_required,
          :zero_carbon_step_required,
          :created_at,

--- a/app/controllers/api/jurisdictions_controller.rb
+++ b/app/controllers/api/jurisdictions_controller.rb
@@ -120,6 +120,7 @@ class Api::JurisdictionsController < Api::ApplicationController
       :contact_summary_html,
       :energy_step_required,
       :zero_carbon_step_required,
+      :map_zoom,
       map_position: [],
       users_attributes: %i[first_name last_name role email],
       contacts_attributes: %i[id name department title phone_number email],

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/index.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/index.tsx
@@ -1,15 +1,4 @@
-import {
-  Container,
-  FormControl,
-  FormLabel,
-  Grid,
-  GridItem,
-  HStack,
-  Heading,
-  Input,
-  Text,
-  VStack,
-} from "@chakra-ui/react"
+import { Container, Flex, FormControl, FormLabel, Grid, GridItem, Heading, Input, Text, VStack } from "@chakra-ui/react"
 import { FileText, Info, Tray } from "@phosphor-icons/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
@@ -37,7 +26,22 @@ export const ConfigurationManagementScreen = observer(function ConfigurationMana
             <Text fontSize="md">{t(`${i18nPrefix}.editPermission`)}</Text>
 
             <SectionBox>
-              <HStack>
+              <Flex align="flex-end">
+                <Text mb={2} mr={2}>
+                  The
+                </Text>
+                <FormControl>
+                  <FormLabel>{t(`${i18nPrefix}.jurisdictionLocalityTypeLabel`)}</FormLabel>
+                  <Input
+                    bg="greys.white"
+                    value={currentJurisdiction.localityType}
+                    isDisabled
+                    textTransform={"capitalize"}
+                  />
+                </FormControl>
+                <Text mb={2} mx={2}>
+                  of
+                </Text>
                 <FormControl>
                   <FormLabel>{t(`${i18nPrefix}.jurisdictionNameLabel`)}</FormLabel>
                   <Input bg="greys.white" value={currentJurisdiction.name} isDisabled />
@@ -47,7 +51,7 @@ export const ConfigurationManagementScreen = observer(function ConfigurationMana
               <FormLabel>{t(`${i18nPrefix}.jurisdictionLocationLabel`)}</FormLabel>
               <Input bg="greys.white" value={jurisdiction.boundryPoints} isDisabled />
             </FormControl> */}
-              </HStack>
+              </Flex>
             </SectionBox>
 
             <Grid templateColumns="repeat(2, 1fr)" gap={6}>

--- a/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
@@ -42,6 +42,7 @@ type TJurisdictionFieldValues = {
   lookOutHtml: string
   contactSummaryHtml: string
   mapPosition: TLatLngTuple
+  mapZoom: number
   contactsAttributes: IContact[]
 }
 
@@ -57,6 +58,7 @@ export const JurisdictionScreen = observer(() => {
       contactSummaryHtml: currentJurisdiction?.contactSummaryHtml,
       contactsAttributes: currentJurisdiction?.contacts as IContact[],
       mapPosition: currentJurisdiction?.mapPosition || [0, 0],
+      mapZoom: currentJurisdiction?.mapZoom || 13,
     }
   }
 
@@ -70,6 +72,7 @@ export const JurisdictionScreen = observer(() => {
   const { handleSubmit, control, reset, watch, formState } = formMethods
   const { isSubmitting, isValid } = formState
   const mapPositionWatch = watch("mapPosition")
+  const mapZoomWatch = watch("mapZoom")
 
   useEffect(() => {
     reset(getDefaultJurisdictionValues())
@@ -88,7 +91,7 @@ export const JurisdictionScreen = observer(() => {
     <Flex as="main" direction="column" w="full" bg="greys.white">
       <BlueTitleBar title={qualifiedName} />
       <Show below="md">
-        <JurisdictionMap mapPosition={mapPositionWatch} />
+        <JurisdictionMap mapPosition={mapPositionWatch} mapZoom={mapZoomWatch} />
       </Show>
       <Container maxW="container.lg" py={{ base: 6, md: 16 }} px={8}>
         <FormProvider {...formMethods}>
@@ -247,6 +250,7 @@ const EditableMap = ({ currentJurisdiction }: IEditableMapProps) => {
   const [isEditingMap, setIsEditingMap] = useState(false)
   const { control, watch, setValue } = useFormContext()
   const mapPositionWatch = watch("mapPosition")
+  const mapZoomWatch = watch("mapZoom")
 
   const editMapSteps = i18next.t("jurisdiction.edit.editMapSteps", { returnObjects: true }) as string[]
 
@@ -314,7 +318,9 @@ const EditableMap = ({ currentJurisdiction }: IEditableMapProps) => {
         )}
         <JurisdictionMap
           mapPosition={mapPositionWatch}
+          mapZoom={mapZoomWatch}
           onMapDrag={isEditingMap && ((latLng) => setValue("mapPosition", latLng))}
+          onZoomChange={isEditingMap && ((zoom) => setValue("mapZoom", zoom))}
           isEditingMap={isEditingMap}
         />
       </Flex>

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -9,6 +9,7 @@ import { FlashMessage } from "../../shared/base/flash-message"
 import { Footer } from "../../shared/base/footer"
 import { LoadingScreen } from "../../shared/base/loading-screen"
 import { NotFoundScreen } from "../../shared/base/not-found-screen"
+import { RedirectScreen } from "../../shared/base/redirect-screen"
 import { EULAModal } from "../../shared/eula-modal"
 import { EmailConfirmedScreen } from "../authentication/email-confirmed-screen"
 import { ForgotPasswordScreen } from "../authentication/forgot-password-screen"
@@ -162,9 +163,11 @@ const AppRoutes = observer(() => {
   return (
     <>
       <Routes location={background || location}>
+        <Route path="/welcome" element={<LandingScreen />} />
         {loggedIn ? (
           <>
             <Route path="/" element={<HomeScreen />} />
+            <Route path="/jurisdictions" element={<RedirectScreen />} />
             <Route path="/permit-applications" element={<PermitApplicationIndexScreen />} />
             <Route path="/permit-applications/new" element={<NewPermitApplicationScreen />} />
             <Route path="/profile" element={<ProfileScreen />} />
@@ -178,7 +181,7 @@ const AppRoutes = observer(() => {
           </>
         ) : (
           <>
-            <Route path="/" element={<LandingScreen />} />
+            <Route path="/" element={<RedirectScreen path="/welcome" />} />
             <Route path="/login" element={<LoginScreen />} />
             <Route path="/jurisdictions/:jurisdictionId" element={<JurisdictionScreen />} />
             <Route path="/accept-invitation" element={<AcceptInvitationScreen />} />

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -101,7 +101,7 @@ export const NavBar = observer(() => {
       >
         <Container maxW="container.lg">
           <Flex align="center" gap={2}>
-            <RouterLink to="/">
+            <RouterLink to="/welcome">
               <Image
                 fit="cover"
                 htmlHeight="64px"

--- a/app/frontend/components/domains/users/invite-screen.tsx
+++ b/app/frontend/components/domains/users/invite-screen.tsx
@@ -29,7 +29,7 @@ export const InviteScreen = observer(({}: IInviteScreenProps) => {
   } = useMst()
 
   const defaultUserValues = {
-    role: EUserRoles.reviewManager,
+    role: null,
     jurisdictionId: currentJurisdiction?.id,
     firstName: "",
     lastName: "",
@@ -60,7 +60,7 @@ export const InviteScreen = observer(({}: IInviteScreenProps) => {
   const { isSubmitting } = formState
 
   const onSubmit = async (formData) => {
-    invite(formData)
+    await invite(formData)
   }
 
   const navigate = useNavigate()

--- a/app/frontend/components/domains/users/profile-screen.tsx
+++ b/app/frontend/components/domains/users/profile-screen.tsx
@@ -50,6 +50,7 @@ export const ProfileScreen = observer(({}: IProfileScreenProps) => {
 
   const onSubmit = async (formData) => {
     await updateProfile(formData)
+    navigate("/")
   }
 
   return (

--- a/app/frontend/components/shared/base/inputs/user-input.tsx
+++ b/app/frontend/components/shared/base/inputs/user-input.tsx
@@ -1,11 +1,25 @@
-import { Button, Flex, FormControl, FormLabel, HStack, Input, InputGroup, Select, Tag, Text } from "@chakra-ui/react"
+import {
+  Box,
+  Button,
+  Flex,
+  FormControl,
+  FormLabel,
+  HStack,
+  Input,
+  InputGroup,
+  Select,
+  Tag,
+  Text,
+} from "@chakra-ui/react"
 import { CheckCircle, WarningCircle, X } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { Controller, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { useMst } from "../../../../setup/root"
+import { EUserRoles } from "../../../../types/enums"
 import { EmailFormControl } from "../../form/email-form-control"
+import { SharedSpinner } from "../shared-spinner"
 
 interface IUserInputProps {
   index: number
@@ -15,6 +29,7 @@ interface IUserInputProps {
 
 export const UserInput = observer(({ index, remove, jurisdictionId }: IUserInputProps) => {
   const { register, formState, control, watch } = useFormContext()
+  const { isSubmitting } = formState
   const { t } = useTranslation()
 
   const emailWatch = watch(`users.${index}.email`)
@@ -33,38 +48,44 @@ export const UserInput = observer(({ index, remove, jurisdictionId }: IUserInput
           <Controller
             name={`users.${index}.role`}
             control={control}
+            rules={{ required: true }} // Inline validation rule
             render={({ field }) => (
-              <Select bg="greys.white" {...field}>
-                <option value="review_manager">Review Manager</option>
-                <option value="reviewer">Reviewer</option>
-              </Select>
+              <>
+                <Select bg="greys.white" placeholder={t("ui.pleaseSelect")} {...field}>
+                  <option value="review_manager">{t(`user.roles.${EUserRoles.reviewManager}`)}</option>
+                  <option value="reviewer">{t(`user.roles.${EUserRoles.reviewer}`)}</option>
+                </Select>
+              </>
             )}
           />
         </FormControl>
         <EmailFormControl fieldName={`users.${index}.email`} flex={3} validate required />
         <NameFormControl label="First Name (optional)" index={index} subFieldName="firstName" />
         <NameFormControl label="Last Name (optional)" index={index} subFieldName="lastName" />
-        {invited && (
-          <Tag bg="semantic.successLight" border="1px solid" borderColor="semantic.success" alignSelf="center">
-            <HStack color="semantic.success">
-              <CheckCircle size={20} />
-              <Text>{t("user.inviteSuccess")}</Text>
-            </HStack>
-          </Tag>
-        )}
-        {taken && (
-          <Tag bg="semantic.errorLight" border="1px solid" borderColor="semantic.error" alignSelf="center">
-            <HStack color="semantic.error">
-              <WarningCircle size={20} />
-              <Text>{t("user.inviteError")}</Text>
-            </HStack>
-          </Tag>
-        )}
-        {!invited && !taken && remove && (
-          <Button onClick={() => remove(index)} variant="tertiary" leftIcon={<X size={16} />} alignSelf="center">
-            {t("ui.remove")}
-          </Button>
-        )}
+        <Box alignSelf="center">
+          {isSubmitting && <SharedSpinner />}
+          {invited && (
+            <Tag bg="semantic.successLight" border="1px solid" borderColor="semantic.success" alignSelf="center">
+              <HStack color="semantic.success">
+                <CheckCircle size={20} />
+                <Text>{t("user.inviteSuccess")}</Text>
+              </HStack>
+            </Tag>
+          )}
+          {taken && (
+            <Tag bg="semantic.errorLight" border="1px solid" borderColor="semantic.error" alignSelf="center">
+              <HStack color="semantic.error">
+                <WarningCircle size={20} />
+                <Text>{t("user.inviteError")}</Text>
+              </HStack>
+            </Tag>
+          )}
+          {!invited && !taken && remove && !isSubmitting && (
+            <Button onClick={() => remove(index)} variant="tertiary" leftIcon={<X size={16} />} alignSelf="center">
+              {t("ui.remove")}
+            </Button>
+          )}
+        </Box>
       </Flex>
     </Flex>
   )

--- a/app/frontend/components/shared/base/redirect-screen.tsx
+++ b/app/frontend/components/shared/base/redirect-screen.tsx
@@ -1,0 +1,29 @@
+import { observer } from "mobx-react-lite"
+import React, { useEffect } from "react"
+import { useLocation, useNavigate } from "react-router-dom"
+import { LoadingScreen } from "./loading-screen"
+
+interface IRedirectScreenProps {
+  path?: string
+}
+
+export const RedirectScreen = observer(({ path = null }: IRedirectScreenProps) => {
+  /*
+    This screen is used as a placeholder for links that appear in the breadcrumbs but dont have pages implemented
+    (ie when a review manager clicks /jurisdictions) - it is also optionally used when you want to redirect to a
+    spcific path for a given route.
+  */
+
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  useEffect(() => {
+    const currentPath = location.pathname
+    const pathSegments = currentPath.split("/").filter(Boolean) // Remove empty segments, especially the first one if path starts with '/'
+    pathSegments.pop() // Remove the last segment
+    const newPath = path ?? `/${pathSegments.join("/")}`
+    navigate(newPath, { replace: true }) // Navigate to the new path
+  }, [navigate, location.pathname])
+
+  return <LoadingScreen />
+})

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -454,8 +454,10 @@
   .help-block {
     display: block;
     margin-top: 16px;
-    color: var(--chakra-colors-error);
-    font-weight: 700;
+    border: 1px solid var(--chakra-colors-error);
+    border-radius: 8px;
+    background-color: var(--chakra-colors-semantic-errorLight);
+    padding: 12px;
   }
 
   .contact-data-grid {
@@ -502,7 +504,6 @@
         font-size: var(--chakra-fontSizes-xl);
         margin-right: var(--chakra-space-1);
       }
-
     }
 
     .formio-button-remove-row {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -798,6 +798,7 @@ const options = {
             title: "Configuration Management",
             description: "Customize content in one centralized place.",
             editPermission: "Only managers are able to edit.",
+            jurisdictionLocalityTypeLabel: "Locality type of local jurisdiction",
             jurisdictionNameLabel: "Name of local jurisdiction",
             jurisdictionLocationLabel: "Location",
             jurisdictionAbout: {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4,6 +4,13 @@ import { initReactI18next } from "react-i18next"
 export const defaultNS = "translation"
 export const fallbackNS = "translation"
 
+const fallbackTranslations = {
+  en: {
+    fallback: "Not found",
+  },
+  // You can add more fallback translations for other languages here
+}
+
 const options = {
   resources: {
     /* English translations */
@@ -151,6 +158,7 @@ const options = {
           failedToCopy: "Something went wrong while trying to copy",
           reset: "Reset",
           help: "Help",
+          pleaseSelect: "please select",
         },
         eula: {
           title: "End-User License Agreement",
@@ -1095,6 +1103,7 @@ const options = {
             energyStep: "Energy Step Code Requirements",
             submissionsInboxSetup: "Submissions Inbox Setup",
             confirmed: "Submission E-mail Confirmed",
+            welcome: "Welcome",
           },
           questionSupport: "Question Support",
         },
@@ -1109,6 +1118,9 @@ const options = {
   lng: "en", // default language
   fallbackLng: "en",
   interpolation: { escapeValue: false },
+  parseMissingKeyHandler: (key, defaultValue) => {
+    return fallbackTranslations.en.fallback
+  },
 }
 
 i18n.use(initReactI18next).init(options)

--- a/app/frontend/models/jurisdiction.ts
+++ b/app/frontend/models/jurisdiction.ts
@@ -34,6 +34,7 @@ export const JurisdictionModel = types
     tablePermitApplications: types.array(types.reference(PermitApplicationModel)),
     boundryPoints: types.optional(types.array(types.frozen<TLatLngTuple>()), []),
     mapPosition: types.frozen<TLatLngTuple>(),
+    mapZoom: types.maybeNull(types.number),
     energyStepRequired: types.maybeNull(types.number),
     zeroCarbonStepRequired: types.maybeNull(types.number),
   })

--- a/db/migrate/20240321224402_add_map_zoom_to_jurisdiction.rb
+++ b/db/migrate/20240321224402_add_map_zoom_to_jurisdiction.rb
@@ -1,0 +1,5 @@
+class AddMapZoomToJurisdiction < ActiveRecord::Migration[7.1]
+  def change
+    add_column :jurisdictions, :map_zoom, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_18_190718) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_21_224402) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -101,6 +101,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_18_190718) do
     t.integer "energy_step_required"
     t.integer "zero_carbon_step_required"
     t.string "slug"
+    t.integer "map_zoom"
     t.index ["prefix"], name: "index_jurisdictions_on_prefix", unique: true
     t.index ["regional_district_id"],
             name: "index_jurisdictions_on_regional_district_id"


### PR DESCRIPTION
## Description

A slew of UI/UX improvments inculding:

- [navigate home after updating profile](https://github.com/bcgov/HOUS-permit-portal/commit/59bbf69d7e4c93a21889f9eb15d2dbd14c3257ad)
- [make map zoom editable](https://github.com/bcgov/HOUS-permit-portal/commit/8bafe1af80f7ffb6ac40d291f9658ec6b4c6d7d2)
- [add a redirect screen for pages missing to certain roles ie jurisdiction page](https://github.com/bcgov/HOUS-permit-portal/commit/6844667f4d74b4a5e46c8b7e6c02f8ce39c7d4b4)
- [default invited role to null](https://github.com/bcgov/HOUS-permit-portal/commit/66c48eb84297b10f130da24047b3ab32c80ecfaa)

+ form submit error help box styles,
loading spinner on email invites

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [x ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-905
https://hous-bssb.atlassian.net/browse/BPHH-906
https://hous-bssb.atlassian.net/browse/BPHH-923
https://hous-bssb.atlassian.net/browse/BPHH-914
https://hous-bssb.atlassian.net/browse/BPHH-925
https://hous-bssb.atlassian.net/browse/BPHH-939
https://hous-bssb.atlassian.net/browse/BPHH-924
https://hous-bssb.atlassian.net/browse/BPHH-848

## Steps to QA

log in as review manager
go to invite users, see that user role is now unset and required for each. See that loading spinners now work on submit.
click jurisdiction in breadcrumbs, see that it goes to "/" route (home)
update profile and see it navigate home
go to jursidction config management, see the locality name.
go to content management, edit the map, follow the instructions and set the zoom. save and refresh to see map zoom is persisted.
log out , navigate to base path /
see it redirect to /welcome





