### PR TITLE
[bphh-935] Add warning banner for jurisdiction submission inbox if all contacts haven't been setup

### DIFF
--- a/app/frontend/components/domains/jurisdictions/submission-inbox/jurisdiction-submisson-inbox-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/jurisdiction-submisson-inbox-screen.tsx
@@ -8,6 +8,7 @@ import { useJurisdiction } from "../../../../hooks/resources/use-jurisdiction"
 import { useSearch } from "../../../../hooks/use-search"
 import { IPermitApplication } from "../../../../models/permit-application"
 import { useMst } from "../../../../setup/root"
+import { CalloutBanner } from "../../../shared/base/callout-banner"
 import { ErrorScreen } from "../../../shared/base/error-screen"
 import { Paginator } from "../../../shared/base/inputs/paginator"
 import { PerPageSelect } from "../../../shared/base/inputs/per-page-select"
@@ -38,6 +39,9 @@ export const JurisdictionSubmissionInboxScreen = observer(function JurisdictionS
   return (
     <Container maxW="container.lg" p={8} as={"main"}>
       <VStack align={"start"} spacing={5} w={"full"} h={"full"}>
+        {!currentJurisdiction.isSubmissionContactSetupComplete && (
+          <CalloutBanner type={"error"} title={t("permitApplication.submissionInbox.contactInviteWarning")} />
+        )}
         <Flex justify={"space-between"} w={"full"}>
           <Box>
             <Heading as="h1">{t("permitApplication.submissionInbox.title")}</Heading>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
@@ -12,7 +12,6 @@ import {
   useDisclosure,
 } from "@chakra-ui/react"
 import { resetForm } from "@formio/react"
-import { Warning } from "@phosphor-icons/react"
 import { autorun } from "mobx"
 import { observer } from "mobx-react-lite"
 import React, { useEffect } from "react"
@@ -21,6 +20,7 @@ import { useTranslation } from "react-i18next"
 import { IRequirementBlock } from "../../../../models/requirement-block"
 import { useMst } from "../../../../setup/root"
 import { IRequirementBlockParams } from "../../../../types/api-request"
+import { CalloutBanner } from "../../../shared/base/callout-banner"
 import { BlockSetup } from "./block-setup"
 import { FieldsSetup } from "./fields-setup"
 
@@ -145,19 +145,7 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
               </ModalHeader>
               <ModalBody px={"2.75rem"}>
                 {showEditWarning && (
-                  <HStack
-                    spacing={2}
-                    w={"full"}
-                    my={8}
-                    p={4}
-                    border={"1px solid"}
-                    borderColor={"semantic.warning"}
-                    bg={"semantic.warningLight"}
-                    borderRadius={"lg"}
-                  >
-                    <Warning aria-label={"Warning icon"} />
-                    <Text>{t("requirementsLibrary.modals.editWarning")}</Text>
-                  </HStack>
+                  <CalloutBanner type={"warning"} title={t("requirementsLibrary.modals.editWarning")} />
                 )}
                 <HStack spacing={9} w={"full"} h={"full"} alignItems={"flex-start"}>
                   <BlockSetup />

--- a/app/frontend/components/shared/base/callout-banner.tsx
+++ b/app/frontend/components/shared/base/callout-banner.tsx
@@ -1,0 +1,76 @@
+import { HStack, Stack, Text } from "@chakra-ui/react"
+import { CheckCircle, Info, Warning, WarningCircle } from "@phosphor-icons/react"
+import React from "react"
+
+interface IProps {
+  type: "warning" | "error" | "success" | "info"
+  title: string
+  body?: string
+}
+
+const iconProps = {
+  size: 16,
+  style: {
+    marginTop: "var(--chakra-space-1)",
+  },
+}
+
+function getTypeSpecificProps(type: IProps["type"]) {
+  switch (type) {
+    case "warning":
+      return {
+        icon: <Warning color={"var(--chakra-colors-semantic-warning)"} aria-label={"Warning icon"} {...iconProps} />,
+        backgroundColor: "semantic.warningLight",
+        mainColor: "semantic.warning",
+      }
+    case "error":
+      return {
+        icon: <WarningCircle color={"var(--chakra-colors-semantic-error)"} aria-label={"Error icon"} {...iconProps} />,
+        backgroundColor: "semantic.errorLight",
+        mainColor: "semantic.error",
+      }
+    case "success":
+      return {
+        icon: (
+          <CheckCircle color={"var(--chakra-colors-semantic-success)"} aria-label={"Success icon"} {...iconProps} />
+        ),
+        backgroundColor: "semantic.successLight",
+        mainColor: "semantic.success",
+      }
+    case "info":
+      return {
+        icon: <Info color={"var(--chakra-colors-semantic-info)"} aria-label={"Info icon"} {...iconProps} />,
+        backgroundColor: "semantic.infoLight",
+        mainColor: "semantic.info",
+      }
+  }
+}
+
+export function CalloutBanner({ type, title, body }: IProps) {
+  const typeSpecificProps = getTypeSpecificProps(type)
+  return (
+    <HStack
+      alignItems={"flex-start"}
+      spacing={2}
+      w={"full"}
+      my={8}
+      p={4}
+      border={"1px solid"}
+      borderColor={typeSpecificProps.mainColor}
+      bg={typeSpecificProps.backgroundColor}
+      borderRadius={"lg"}
+    >
+      {typeSpecificProps.icon}
+      {title && body ? (
+        <Stack spacing={1}>
+          <Text fontSize={"md"} fontWeight={700}>
+            {title}
+          </Text>
+          <Text>{body}</Text>
+        </Stack>
+      ) : (
+        <Text>{title}</Text>
+      )}
+    </HStack>
+  )
+}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -267,6 +267,7 @@ const options = {
             status: "Status",
           },
           submissionInbox: {
+            contactInviteWarning: "Please have a Review Manager setup the Submission Inbox for all permit types.",
             title: "Submissions Inbox",
             tableHeading: "Permit Applications",
             submissionsSentTo:


### PR DESCRIPTION
## Description
[bphh-935] Add warning banner for jurisdiction submission inbox if all contacts haven't been setup
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-935
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- log in as review manager or reviewer
- Go to submission inbox
- If all the contacts are not setup then there should be a warning banner
<img width="1601" alt="Screenshot 2024-03-21 at 5 42 05 PM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/ef6699b7-1ff1-4053-b7b8-8f907a16f8df">
