### PR TITLE
[bphh-956] Fix bug with jurisdiction inbox page crashing when there is a submitted permit application

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -19,14 +19,25 @@ class PermitApplicationBlueprint < Blueprinter::Base
     association :activity, blueprint: PermitClassificationBlueprint
   end
 
+  view :jurisdiction_review_inbox do
+    include_view :base
+
+    association :submitter, blueprint: UserBlueprint
+    association :supporting_documents, blueprint: SupportingDocumentBlueprint
+  end
+
   view :extended do
     include_view :base
-    fields :form_json, :submission_data, :formatted_compliance_data, :front_end_form_update, :form_customizations
+    fields :form_json,
+           :submission_data,
+           :formatted_compliance_data,
+           :front_end_form_update,
+           :form_customizations
 
-    association :jurisdiction, blueprint: JurisdictionBlueprint
     association :submitter, blueprint: UserBlueprint
-    association :step_code, blueprint: StepCodeBlueprint
     association :supporting_documents, blueprint: SupportingDocumentBlueprint
+    association :jurisdiction, blueprint: JurisdictionBlueprint
+    association :step_code, blueprint: StepCodeBlueprint
   end
 
   view :compliance_update do

--- a/app/controllers/api/jurisdictions_controller.rb
+++ b/app/controllers/api/jurisdictions_controller.rb
@@ -103,7 +103,7 @@ class Api::JurisdictionsController < Api::ApplicationController
                      },
                      blueprint: PermitApplicationBlueprint,
                      blueprint_opts: {
-                       view: :base,
+                       view: :jurisdiction_review_inbox,
                      },
                    }
   end


### PR DESCRIPTION
## Description
Fix bug with jurisdiction inbox page crashing when there is a submitted permit application
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-956
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Ensure there is a submitted permit application for the jurisdiction, and if not create one as a submitter
- Log in as reviewer or review manager
- Navigate to permit application inbox screen
- There should be no crash 
