### PR TITLE
[bphh-935] Refactor logic to only show jurisdiction setup call out warning banner only if there isn't at least one valid contact per permit type

### DIFF
--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/submissions-inbox-setup-screen/index.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/submissions-inbox-setup-screen/index.tsx
@@ -1,25 +1,18 @@
 import { Container, Heading, Text, VStack } from "@chakra-ui/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
-import React, { Suspense, useEffect } from "react"
+import React, { Suspense } from "react"
 import { useJurisdiction } from "../../../../../../hooks/resources/use-jurisdiction"
-import { useMst } from "../../../../../../setup/root"
+import { usePermitClassificationsLoad } from "../../../../../../hooks/resources/use-permit-classifications-load"
 import { ErrorScreen } from "../../../../../shared/base/error-screen"
 import { LoadingScreen } from "../../../../../shared/base/loading-screen"
 import { Form } from "./form"
 import { i18nPrefix } from "./i18n-prefix"
 
 export const SubmissionsInboxSetupScreen = observer(function SubmissionsInboxSetupScreen() {
-  const {
-    permitClassificationStore: { isLoaded, fetchPermitClassifications },
-  } = useMst()
+  const { isLoaded } = usePermitClassificationsLoad()
 
   const { currentJurisdiction, error } = useJurisdiction()
-
-  useEffect(() => {
-    const fetch = async () => await fetchPermitClassifications()
-    !isLoaded && fetch()
-  }, [isLoaded])
 
   return error ? (
     <ErrorScreen />

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/jurisdiction-submisson-inbox-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/jurisdiction-submisson-inbox-screen.tsx
@@ -5,6 +5,7 @@ import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { useJurisdiction } from "../../../../hooks/resources/use-jurisdiction"
+import { usePermitClassificationsLoad } from "../../../../hooks/resources/use-permit-classifications-load"
 import { useSearch } from "../../../../hooks/use-search"
 import { IPermitApplication } from "../../../../models/permit-application"
 import { useMst } from "../../../../setup/root"
@@ -27,6 +28,7 @@ export const JurisdictionSubmissionInboxScreen = observer(function JurisdictionS
   const { t } = useTranslation()
   const { permitApplicationStore } = useMst()
   const { currentJurisdiction, error } = useJurisdiction()
+  const { isLoaded: isPermitClassificationsLoaded } = usePermitClassificationsLoad()
 
   const { currentPage, totalPages, totalCount, countPerPage, handleCountPerPageChange, handlePageChange, isSearching } =
     permitApplicationStore
@@ -34,7 +36,7 @@ export const JurisdictionSubmissionInboxScreen = observer(function JurisdictionS
   useSearch(permitApplicationStore, [currentJurisdiction?.id])
 
   if (error) return <ErrorScreen error={error} />
-  if (!currentJurisdiction) return <LoadingScreen />
+  if (!currentJurisdiction || !isPermitClassificationsLoaded) return <LoadingScreen />
 
   return (
     <Container maxW="container.lg" p={8} as={"main"}>

--- a/app/frontend/hooks/resources/use-permit-classifications-load.ts
+++ b/app/frontend/hooks/resources/use-permit-classifications-load.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react"
+import { useMst } from "../../setup/root"
+
+export const usePermitClassificationsLoad = () => {
+  const {
+    permitClassificationStore: { isLoaded, fetchPermitClassifications },
+  } = useMst()
+
+  useEffect(() => {
+    const fetch = async () => await fetchPermitClassifications()
+    !isLoaded && fetch()
+  }, [isLoaded])
+
+  return { isLoaded }
+}

--- a/app/frontend/models/jurisdiction.ts
+++ b/app/frontend/models/jurisdiction.ts
@@ -60,16 +60,14 @@ export const JurisdictionModel = types
     get isSubmissionContactSetupComplete() {
       const permitTypes = self.rootStore.permitClassificationStore.permitTypes
 
-      const hasContactForAllPermitTypes = permitTypes.every((permitType) => {
-        return self.permitTypeSubmissionContacts.some((c) => c.permitTypeId == permitType.id)
+      const hasValidContactForAllPermitTypes = permitTypes.every((permitType) => {
+        //   checks if there is at least one confirmed email for each permit type
+        return self.permitTypeSubmissionContacts.some(
+          (c) => c.permitTypeId == permitType.id && c.email && c.confirmedAt
+        )
       })
 
-      if (!hasContactForAllPermitTypes) {
-        return false
-      }
-
-      // if there is a contact for all permit types, then check if all contacts have confirmed emails
-      return self.permitTypeSubmissionContacts.every((c) => c.email && c.confirmedAt)
+      return hasValidContactForAllPermitTypes
     },
   }))
   .actions((self) => ({


### PR DESCRIPTION
## Description
Refactors callout banner logic so that warning banner is shown only when there isn't at least one confirmed contact per permit type.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-935
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Log in a super admin and go to inbox screen
- If there is at least one **confirmed** contact per permit type then there won't be any banner 