### PR TITLE
Prevent new users from logging in with BCeID

### DIFF
--- a/app/controllers/api/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/omniauth_callbacks_controller.rb
@@ -5,15 +5,16 @@ class Api::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     auth = request.env["omniauth.auth"]
     invited_user&.accept_invitation_with_omniauth(auth)
     @user = invited_user || User.from_omniauth(auth)
-    if @user.valid? && @user.persisted?
+    if @user&.valid? && @user&.persisted?
       sign_in(resource_name, @user, store: false)
       redirect_to root_path
     else
+      error_key = @user ? "omniauth.failure_with_message" : "omniauth.unavailable"
       redirect_to login_path frontend_flash_message(
-                               "omniauth.failure_with_message",
+                               error_key,
                                "error",
                                message_opts: {
-                                 error_message: @user.errors.full_messages.join(","),
+                                 error_message: @user&.errors&.full_messages&.join(","),
                                },
                              )
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,10 +77,7 @@ class User < ApplicationRecord
   end
 
   def self.from_omniauth(auth)
-    find_or_create_by(provider: auth.provider, uid: auth.uid) do |user|
-      user.email = auth.info.email
-      user.password = Devise.friendly_token[0, 20]
-    end
+    find_by(provider: auth.provider, uid: auth.uid)
   end
 
   def accept_invitation_with_omniauth(auth)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,9 @@ en:
       failure_with_message:
         title: BCeID login failed
         message: "%{error_message}"
+      unavailable:
+        title: Sorry! BCeID login is not supported for new accounts
+        message: Please create an account and login with username and password
     geocoder:
       site_options_error:
         title: Oops


### PR DESCRIPTION
## Description

Currently, BCeID login is only available for reviewers who are invited via the invitation flow. This handles the case where a new user tries to login with BCeID.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Implements [BPHH-528](https://hous-bssb.atlassian.net/browse/BPHH-528)

## Steps to QA

1. Try to login with a BCeID that is not currently associated with a reviewer account - login fails with error
2. Invite a reviewer and accept the invitation with BCeID - the reviewer should be able to login with BCeID

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

N/A
