### PR TITLE
Bugfixes - Jurisdictions screen navigation and templates used column removal

### DIFF
--- a/app/blueprints/jurisdiction_blueprint.rb
+++ b/app/blueprints/jurisdiction_blueprint.rb
@@ -13,7 +13,6 @@ class JurisdictionBlueprint < Blueprinter::Base
          :review_managers_size,
          :reviewers_size,
          :permit_applications_size,
-         :templates_used_size,
          :map_position,
          :map_zoom,
          :energy_step_required,

--- a/app/frontend/components/domains/jurisdictions/grid-header.tsx
+++ b/app/frontend/components/domains/jurisdictions/grid-header.tsx
@@ -18,7 +18,7 @@ export const GridHeaders = observer(function GridHeaders() {
       <Box display={"contents"} role={"row"}>
         <GridItem
           as={Flex}
-          gridColumn={"span 6"}
+          gridColumn={"span 5"}
           p={6}
           bg={"greys.grey10"}
           justifyContent={"space-between"}

--- a/app/frontend/components/domains/jurisdictions/index.tsx
+++ b/app/frontend/components/domains/jurisdictions/index.tsx
@@ -43,7 +43,7 @@ export const JurisdictionIndexScreen = observer(function JurisdictionIndex() {
           </RouterLinkButton>
         </Flex>
 
-        <SearchGrid templateColumns="3fr repeat(4, 1fr) 1fr">
+        <SearchGrid templateColumns="3fr repeat(3, 1fr) 1fr">
           <GridHeaders />
 
           {isSearching ? (
@@ -58,7 +58,6 @@ export const JurisdictionIndexScreen = observer(function JurisdictionIndex() {
                   <SearchGridItem>{j.reviewManagersSize}</SearchGridItem>
                   <SearchGridItem>{j.reviewersSize}</SearchGridItem>
                   <SearchGridItem>{j.permitApplicationsSize}</SearchGridItem>
-                  <SearchGridItem>{j.templatesUsedSize}</SearchGridItem>
                   <SearchGridItem>
                     <Flex justify="center" w="full" gap={3}>
                       <RouterLink to={`${j.slug}/users/invite`}>{t("user.invite")}</RouterLink>

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -167,7 +167,7 @@ const AppRoutes = observer(() => {
         {loggedIn ? (
           <>
             <Route path="/" element={<HomeScreen />} />
-            <Route path="/jurisdictions" element={<RedirectScreen />} />
+            {currentUser?.isSuperAdmin ? null : <Route path="/jurisdictions" element={<RedirectScreen />} />}
             <Route path="/permit-applications" element={<PermitApplicationIndexScreen />} />
             <Route path="/permit-applications/new" element={<NewPermitApplicationScreen />} />
             <Route path="/profile" element={<ProfileScreen />} />

--- a/app/frontend/models/jurisdiction.ts
+++ b/app/frontend/models/jurisdiction.ts
@@ -21,7 +21,6 @@ export const JurisdictionModel = types
     qualifier: types.string,
     reviewManagersSize: types.number,
     reviewersSize: types.number,
-    templatesUsedSize: types.number,
     permitApplicationsSize: types.number,
     descriptionHtml: types.maybeNull(types.string),
     checklistHtml: types.maybeNull(types.string),

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -52,7 +52,6 @@ export enum EJurisdictionSortFields {
   reviewManagersSize = "review_managers_size",
   reviewersSize = "reviewers_size",
   permitApplicationsSize = "permit_applications_size",
-  templatesUsed = "templates_used",
 }
 
 export enum EUserSortFields {

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -80,7 +80,6 @@ class Jurisdiction < ApplicationRecord
       review_managers_size: review_managers_size,
       reviewers_size: reviewers_size,
       permit_applications_size: permit_applications_size,
-      templates_used: templates_used_size,
     }
   end
 
@@ -110,10 +109,6 @@ class Jurisdiction < ApplicationRecord
 
   def permit_applications_size
     permit_applications&.size || 0
-  end
-
-  def templates_used_size
-    jurisdiction_template_version_customizations&.size || 0
   end
 
   def unviewed_permit_applications


### PR DESCRIPTION
## Description
Has two bug fixes:
1.[ Fixes bug with not being able to navigate to jurisdictions screen when logged in as super admin](https://github.com/bcgov/HOUS-permit-portal/commit/73527a6e13c477b79200d7843a392a82aeb8953e)
2. [Removes templates used sort column for jurisdictions index page as it is no longer required](https://github.com/bcgov/HOUS-permit-portal/commit/693fc37df97a32af9d65b6484d0005ebac4ae18b)
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
1. [ Fixes bug with not being able to navigate to jurisdictions screen when logged in as super admin](https://github.com/bcgov/HOUS-permit-portal/commit/73527a6e13c477b79200d7843a392a82aeb8953e)
    - Log in as super admin
    - Click jurisdictions link
    - Should successfully navigate to jurisdictions index screen
2. [Removes templates used sort column for jurisdictions index page as it is no longer required](https://github.com/bcgov/HOUS-permit-portal/commit/693fc37df97a32af9d65b6484d0005ebac4ae18b)
    - Log in as super admin
    - Click jurisdictions link
    - There should no longer be any templates used column