### PR TITLE
Prevent upload screen flash on load

### DIFF
--- a/app/frontend/components/domains/step-code/index.tsx
+++ b/app/frontend/components/domains/step-code/index.tsx
@@ -1,6 +1,7 @@
 import { Center, Container, Flex, VStack } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React, { Suspense, useEffect } from "react"
+import { usePermitApplication } from "../../../hooks/resources/use-permit-application"
 import { useMst } from "../../../setup/root"
 import { SharedSpinner } from "../../shared/base/shared-spinner"
 import { StepCodeChecklistForm } from "./checklist"
@@ -13,6 +14,8 @@ export const StepCodeForm = observer(function NewStepCodeForm() {
   const {
     stepCodeStore: { isLoaded, fetchStepCodes, currentStepCode },
   } = useMst()
+
+  const { currentPermitApplication } = usePermitApplication()
 
   const navHeight = document.getElementById("mainNav").offsetHeight
 
@@ -40,7 +43,7 @@ export const StepCodeForm = observer(function NewStepCodeForm() {
           </Center>
         }
       >
-        {isLoaded && (
+        {isLoaded && currentPermitApplication && (
           <Container my={10} maxW="780px" px={0}>
             {!currentStepCode ? (
               <VStack spacing={8} align="start" w="full" pb={20}>


### PR DESCRIPTION
Wait until permit application is loaded so we can go directly to the step code checklist without flashing the import screen first.