### PR TITLE
[bphh-955] Fix bug with not navigating to building permits page when closing jurisdiction permit editor

### DIFF
--- a/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/index.tsx
@@ -97,7 +97,7 @@ export const JurisdictionEditDigitalPermitScreen = observer(function Jurisdictio
   const hasNoSections = templateSections.length === 0
 
   const onClose = () => {
-    window.history.state && window.history.state.idx > 0 ? navigate(-1) : navigate(`/requirement-templates`)
+    window.history.state && window.history.state.idx > 0 ? navigate(-1) : navigate(`/digital-building-permits`)
   }
 
   const onBlockEditSave = (requirementBlockId: string, data: IRequirementBlockCustomization) => {


### PR DESCRIPTION
## Description
[bphh-955] Fix bug with not navigating to building permits page when closing jurisdiction permit editor
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-955
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- log in as jurisdiction review manager
- navigate to digital building permits page
- select any permit to edit
- click close button
- should go back to digital building permits page
- go back into editing a permit
- refresh page
- should go back to building permits page