### PR TITLE
[bphh-804] Add jurisdiction permit application default search to be ordered by application number descending

### DIFF
--- a/app/controllers/api/concerns/search/permit_applications.rb
+++ b/app/controllers/api/concerns/search/permit_applications.rb
@@ -53,8 +53,10 @@ module Api::Concerns::Search::PermitApplications
   def order
     if (sort = permit_application_search_params[:sort])
       { sort[:field] => { order: sort[:direction], unmapped_type: "long" } }
-    else
+    elsif current_user.submitter?
       { created_at: { order: :desc, unmapped_type: "long" } }
+    else
+      { number: { order: :desc, unmapped_type: "long" } }
     end
   end
 end


### PR DESCRIPTION
## Description
[bphh-804] Add jurisdiction permit application default search to be ordered by application number descending
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ X] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-804
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- login as reviewer or review manager
- go to submissions inbox
- default sort order should be highest application number top to lowest application number
