### PR TITLE
[bphh-940] Update disabled state styles for formio inputs to app colours and ensure select, checkbox inputs have  disabled state styles

### DIFF
--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -178,6 +178,18 @@
     }
   }
 
+
+  // disabled form inputs
+  .form-control, .form-check-input:not(:checked) {
+    &:disabled,
+    &[disabled="disabled"] {
+      background-color: var(--chakra-colors-greys-grey03);
+      border-color: var(--chakra-colors-greys-grey02);
+      cursor: not-allowed;
+    }
+  }
+
+
   // remove alert icons from invalid fields
   .form-control.is-invalid,
   .was-validated .form-control:invalid {
@@ -420,6 +432,7 @@
     padding-right: var(--chakra-space-6);
     margin-top: 4px;
     margin-bottom: 4px;
+
     .i {
       background-color: $error;
       height: 24px;


### PR DESCRIPTION
## Description
[bphh-940] Update disabled state styles for formio inputs to app colours and ensure select, checkbox inputs have  disabled state styles
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ X] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-940
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
Pre req: Ensure you have submitted permits
- login as review manger
- go to submission inbox
- view any submission
- the inputs should have disabled styles to app grey colour
- select inputs and checkbox inputs should have disabled styles

![Screenshot 2024-03-25 at 4 35 21 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/b3df8374-a7ea-4318-b5e8-88dac098b38e)
