### PR TITLE
use domparser instead of regex in quill empty check

### DIFF
--- a/app/frontend/utils/utility-functions.ts
+++ b/app/frontend/utils/utility-functions.ts
@@ -71,10 +71,22 @@ export function isContactRequirement(requirementType: ERequirementType): boolean
 }
 
 export function isQuillEmpty(value: string) {
-  if (!value || (value.replace(/<(.|\n)*?>/g, "").trim().length === 0 && !value.includes("<img"))) {
+  if (!value) {
     return true
   }
-  return false
+
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(value, "text/html")
+
+  // Check if there are any image tags
+  const hasImage = doc.querySelector("img") !== null
+
+  // Check for non-empty text nodes or other elements
+  const hasTextOrElements = Array.from(doc.body.childNodes).some((node) => {
+    return node.nodeType === Node.TEXT_NODE ? node.textContent.trim().length > 0 : node.nodeType === Node.ELEMENT_NODE
+  })
+
+  return !hasImage && !hasTextOrElements
 }
 
 export function parseBoolean(value: string): boolean {


### PR DESCRIPTION
## Description

This code:
```
export function isQuillEmpty(value: string) {
  if (!value || (value.replace(/<(.|\n)*?>/g, "")
```

was giving the SonarCloud warning:

"Make sure the regex used here, which is vulnerable to super-linear runtime due to backtracking, cannot lead to denial of service."

This alternative implementation removes the use of regex to prevent mischief from bandits, vandals, and ne'rdowells

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-722

