### PR TITLE
Add confirmation on step code restart

### DIFF
--- a/app/frontend/components/domains/step-code/nav-links.tsx
+++ b/app/frontend/components/domains/step-code/nav-links.tsx
@@ -1,10 +1,10 @@
 import { Button, HStack } from "@chakra-ui/react"
-import { ArrowCounterClockwise } from "@phosphor-icons/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useNavigate } from "react-router-dom"
 import { useMst } from "../../../setup/root"
+import { RestartConfirmationModal } from "./restart-confirmation-modal"
 
 export const StepCodeNavLinks = observer(function StepCodeNavLinks() {
   const { stepCodeStore } = useMst()
@@ -30,14 +30,7 @@ export const StepCodeNavLinks = observer(function StepCodeNavLinks() {
           <Button variant="primary" onClick={handleSave}>
             {t("stepCode.saveAndGoBack")}
           </Button>
-          <Button
-            variant="tertiary"
-            // color="semantic.error"
-            rightIcon={<ArrowCounterClockwise />}
-            onClick={handleDeleteStepCode}
-          >
-            {t("stepCode.restart")}
-          </Button>
+          <RestartConfirmationModal />
         </>
       ) : (
         <Button variant="primary" onClick={() => navigate(-1)}>

--- a/app/frontend/components/domains/step-code/restart-confirmation-modal.tsx
+++ b/app/frontend/components/domains/step-code/restart-confirmation-modal.tsx
@@ -1,0 +1,57 @@
+import {
+  Button,
+  ButtonGroup,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { ArrowCounterClockwise } from "@phosphor-icons/react"
+import { t } from "i18next"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { useMst } from "../../../setup/root"
+
+export const RestartConfirmationModal = observer(function RestartStepCodeConfirmationModal() {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const { stepCodeStore } = useMst()
+
+  const handleDeleteStepCode = async () => {
+    await stepCodeStore.deleteStepCode()
+    onClose()
+  }
+
+  return (
+    <>
+      <Button variant="tertiary" rightIcon={<ArrowCounterClockwise />} onClick={onOpen}>
+        {t("stepCode.restart.trigger")}
+      </Button>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader fontSize={"2xl"} mt={2}>
+            {t("stepCode.restart.confirm.title")}
+          </ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>{t("stepCode.restart.confirm.body")}</ModalBody>
+
+          <ModalFooter justifyContent={"flex-start"}>
+            <ButtonGroup spacing={4}>
+              <Button variant={"primary"} onClick={handleDeleteStepCode} leftIcon={<ArrowCounterClockwise />}>
+                {t("stepCode.restart.trigger")}
+              </Button>
+              <Button variant={"secondary"} onClick={onClose}>
+                {t("ui.neverMind")}
+              </Button>
+            </ButtonGroup>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+})

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -498,7 +498,13 @@ const options = {
           checklistGuide: "See Checklist Guide",
           saveAndGoBack: "Save and Go Back",
           back: "Back to Permit Application",
-          restart: "Restart",
+          restart: {
+            trigger: "Restart",
+            confirm: {
+              title: "Are you sure?",
+              body: "Restarting will clear all checklist fields",
+            },
+          },
           info: {
             title: "BC Step Code Compliance Checklist - Part 9 Buildings",
             energy: "Energy Step Code",


### PR DESCRIPTION
[BPHH-990]

## Description

Adds confirmation modal when resetting step code checklist.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Implements [BPHH-990](https://hous-bssb.atlassian.net/browse/BPHH-990)

## Steps to QA

Restart button on step code checklist should trigger confirmation modal.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
