### PR TITLE
[bphh-834] Fix bug with next pagination button showing in table when there is an empty table

### DIFF
--- a/app/frontend/components/shared/base/inputs/paginator.tsx
+++ b/app/frontend/components/shared/base/inputs/paginator.tsx
@@ -76,7 +76,9 @@ export const Paginator = observer(({ handlePageChange, totalPages, ...pagination
           onClick={() => handlePageChange(pageToTransitionTo)}
           aria-label={"next page"}
           _after={{ display: "none !important" }}
-          isDisabled={totalPages === pageToTransitionTo && pageToTransitionTo === paginationProps.current}
+          isDisabled={
+            totalPages === 0 || (totalPages === pageToTransitionTo && pageToTransitionTo === paginationProps.current)
+          }
         ></IconButton>
       )
     }


### PR DESCRIPTION
## Description
[bphh-834] Fix bug with next pagination button showing in table when there is an empty table
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-834
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Go to any table view
- If there are no table results, then the paginate to next page button should be disabled
![Screenshot 2024-03-27 at 4 18 43 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/a8be9700-9dae-4fb6-9021-674a169e0deb)
