### PR TITLE
add custom locality type input and locality type / name normalization

### DIFF
--- a/app/frontend/components/domains/jurisdictions/new-jurisdiction-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/new-jurisdiction-screen.tsx
@@ -1,4 +1,17 @@
-import { Box, Button, Center, Container, Flex, HStack, Heading, Text, VStack } from "@chakra-ui/react"
+import {
+  Box,
+  Button,
+  Center,
+  Container,
+  Flex,
+  FormControl,
+  FormLabel,
+  HStack,
+  Heading,
+  Switch,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React, { useState } from "react"
 import { FormProvider, useForm } from "react-hook-form"
@@ -18,6 +31,7 @@ export type TCreateJurisdictionFormData = {
 export const NewJurisdictionScreen = observer(() => {
   const { t } = useTranslation()
   const [jurisdiction, setJurisdiction] = useState<IJurisdiction>()
+  const [useCustom, setUseCustom] = useState<boolean>(false)
   const {
     jurisdictionStore: { createJurisdiction, fetchLocalityTypeOptions },
   } = useMst()
@@ -41,6 +55,9 @@ export const NewJurisdictionScreen = observer(() => {
       setJurisdiction(createdJurisdiction)
     }
   }
+
+  const handleToggleCustom = () => setUseCustom(!useCustom)
+
   return (
     <Container maxW="container.lg" p={8} as="main">
       <FormProvider {...formMethods}>
@@ -82,16 +99,31 @@ export const NewJurisdictionScreen = observer(() => {
                 >
                   <Flex gap={8}>
                     <Center w="50%">
-                      <AsyncRadioGroup
-                        label={t("jurisdiction.fields.localityType")}
-                        fetchOptions={fetchLocalityTypeOptions}
-                        fieldName={"localityType"}
-                      />
+                      {useCustom ? (
+                        <TextFormControl
+                          label={t("jurisdiction.fields.localityType")}
+                          fieldName={"localityType"}
+                          required
+                        />
+                      ) : (
+                        <AsyncRadioGroup
+                          label={t("jurisdiction.fields.localityType")}
+                          fetchOptions={fetchLocalityTypeOptions}
+                          fieldName={"localityType"}
+                        />
+                      )}
                     </Center>
                     <Box w="50%">
                       <TextFormControl label={t("jurisdiction.new.nameLabel")} fieldName={"name"} required />
                     </Box>
                   </Flex>
+
+                  <FormControl display="flex" alignItems="center">
+                    <FormLabel htmlFor="email-alerts" mb="0">
+                      {t("jurisdiction.new.useCustom")}
+                    </FormLabel>
+                    <Switch id="use-custom" isChecked={useCustom} onChange={handleToggleCustom} />
+                  </FormControl>
                 </Flex>
                 <Flex gap={4}>
                   <Button

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -218,6 +218,7 @@ const options = {
             createButton: "Create jurisdiction",
             nameLabel: "Name of local jurisdiction",
             nextStep: "The next step is to invite users",
+            useCustom: "Use a custom locality type",
           },
           index: {
             title: "Jurisdictions",

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -19,9 +19,11 @@ class Jurisdiction < ApplicationRecord
   has_many :requirement_templates, through: :template_versions
   has_many :permit_type_submission_contacts
 
-  validates :name, uniqueness: { scope: :locality_type }
+  validates :name, uniqueness: { scope: :locality_type, case_sensitive: false }
   validates :locality_type, presence: true
 
+  before_validation :normalize_locality_type
+  before_validation :normalize_name
   before_validation :set_type_based_on_locality
   before_save :sanitize_html_fields
 
@@ -132,5 +134,41 @@ class Jurisdiction < ApplicationRecord
     else
       self.type = "SubDistrict"
     end
+  end
+
+  def normalize_name
+    # binding.pry
+    # Replace underscores with spaces
+    normalized = name.gsub("_", " ")
+
+    # Remove commas and periods
+    normalized.gsub(/[,.]/, "")
+
+    # Remove leading and trailing whitespaces
+    normalized.strip!
+
+    self.name = normalized
+  end
+
+  def normalize_locality_type
+    # Convert to lowercase
+    normalized = locality_type.downcase
+
+    # Replace underscores with spaces
+    normalized.gsub("_", " ")
+
+    # Remove commas and periods
+    normalized.gsub(/[,.]/, "")
+
+    # Remove leading and trailing whitespaces
+    normalized.strip!
+
+    # Remove leading "the" or "of", case insensitive
+    normalized.sub!(/\A(the|of)\s+/, "")
+
+    # Remove trailing "the" or "of", case insensitive
+    normalized.sub!(/\s+(the|of)\z/, "")
+
+    self.locality_type = normalized
   end
 end


### PR DESCRIPTION
## Description

Lets super admins create new locality types
normalization was added to locality types and names for jurisdictions to prevent near-identical duplicates.
note that case insensitivity was added to the name
