### PR TITLE
[bphh-1019] Refactor jurisdiction customization update/create endpoint to single endpoint

### DIFF
--- a/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen/index.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useJurisdictionTemplateVersionCustomization } from "../../../../../hooks/resources/use-jurisdiction-template-version-customization"
 import { useTemplateVersion } from "../../../../../hooks/resources/use-template-version"
-import { IJurisdiction } from "../../../../../models/jurisdiction"
 import { IJurisdictionTemplateVersionCustomization } from "../../../../../models/jurisdiction-template-version-customization"
 import { useMst } from "../../../../../setup/root"
 import { IRequirementBlockCustomization, ITemplateCustomization } from "../../../../../types/types"
@@ -30,12 +29,10 @@ export interface IJurisdictionTemplateVersionCustomizationForm {
 }
 
 function formFormDefaults(
-  jurisdictionTemplateVersionCustomization: IJurisdictionTemplateVersionCustomization | undefined,
-  jurisdiction: IJurisdiction
+  jurisdictionTemplateVersionCustomization: IJurisdictionTemplateVersionCustomization | undefined
 ): IJurisdictionTemplateVersionCustomizationForm {
   if (!jurisdictionTemplateVersionCustomization) {
     return {
-      jurisdictionId: jurisdiction?.id,
       customizations: {
         requirementBlockChanges: {},
       },
@@ -43,7 +40,6 @@ function formFormDefaults(
   }
 
   return {
-    jurisdictionId: jurisdiction?.jurisdictionId,
     customizations: { requirementBlockChanges: {}, ...jurisdictionTemplateVersionCustomization.customizations },
   }
 }
@@ -71,7 +67,7 @@ export const JurisdictionEditDigitalPermitScreen = observer(function Jurisdictio
     })
 
   const formMethods = useForm<IJurisdictionTemplateVersionCustomizationForm>({
-    defaultValues: formFormDefaults(jurisdictionTemplateVersionCustomization, currentUser?.jurisdiction),
+    defaultValues: formFormDefaults(jurisdictionTemplateVersionCustomization),
   })
   const { formState, handleSubmit, setValue, reset, watch } = formMethods
 
@@ -84,7 +80,7 @@ export const JurisdictionEditDigitalPermitScreen = observer(function Jurisdictio
   }
 
   useEffect(() => {
-    reset(formFormDefaults(jurisdictionTemplateVersionCustomization, currentUser?.jurisdiction))
+    reset(formFormDefaults(jurisdictionTemplateVersionCustomization))
   }, [jurisdictionTemplateVersionCustomization?.customizations])
 
   if (!currentUser?.jurisdiction) return <ErrorScreen error={new Error(t("errors.fetchJurisdiction"))} />
@@ -104,11 +100,7 @@ export const JurisdictionEditDigitalPermitScreen = observer(function Jurisdictio
   }
 
   const onSubmit = handleSubmit((data) => {
-    const submitMethod = jurisdictionTemplateVersionCustomization
-      ? templateVersion.updateJurisdictionTemplateVersionCustomization
-      : templateVersion.createJurisdictionTemplateVersionCustomization
-
-    return submitMethod(currentUser.jurisdiction.id, data)
+    return templateVersion.createOrUpdateJurisdictionTemplateVersionCustomization(currentUser.jurisdiction.id, data)
   })
 
   return (

--- a/app/frontend/models/template-version.ts
+++ b/app/frontend/models/template-version.ts
@@ -60,31 +60,12 @@ export const TemplateVersionModel = types
 
       return response
     }),
-    createJurisdictionTemplateVersionCustomization: flow(function* (
+    createOrUpdateJurisdictionTemplateVersionCustomization: flow(function* (
       jurisdictionId: string,
       params: IJurisdictionTemplateVersionCustomizationForm
     ) {
       const response = yield* toGenerator(
-        self.environment.api.createJurisdictionTemplateVersionCustomization(self.id, jurisdictionId, params)
-      )
-      if (!response.ok) {
-        return response.ok
-      }
-
-      const customization = response.data.data
-
-      if (customization) {
-        self.templateVersionCustomizationsByJurisdiction.set(jurisdictionId, customization)
-      }
-
-      return self.getJurisdictionTemplateVersionCustomization(jurisdictionId)
-    }),
-    updateJurisdictionTemplateVersionCustomization: flow(function* (
-      jurisdictionId: string,
-      params: IJurisdictionTemplateVersionCustomizationForm
-    ) {
-      const response = yield* toGenerator(
-        self.environment.api.updateJurisdictionTemplateVersionCustomization(self.id, jurisdictionId, params)
+        self.environment.api.createOrUpdateJurisdictionTemplateVersionCustomization(self.id, jurisdictionId, params)
       )
       if (!response.ok) {
         return response.ok

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -287,23 +287,12 @@ export class Api {
     )
   }
 
-  async createJurisdictionTemplateVersionCustomization(
+  async createOrUpdateJurisdictionTemplateVersionCustomization(
     templateId: string,
     jurisdictionId: string,
     jurisdictionTemplateVersionCustomization: IJurisdictionTemplateVersionCustomizationForm
   ) {
     return this.client.post<ApiResponse<IJurisdictionTemplateVersionCustomization>>(
-      `/template_versions/${templateId}/jurisdictions/${jurisdictionId}/jurisdiction_template_version_customization`,
-      { jurisdictionTemplateVersionCustomization }
-    )
-  }
-
-  async updateJurisdictionTemplateVersionCustomization(
-    templateId: string,
-    jurisdictionId: string,
-    jurisdictionTemplateVersionCustomization: IJurisdictionTemplateVersionCustomizationForm
-  ) {
-    return this.client.put<ApiResponse<IJurisdictionTemplateVersionCustomization>>(
       `/template_versions/${templateId}/jurisdictions/${jurisdictionId}/jurisdiction_template_version_customization`,
       { jurisdictionTemplateVersionCustomization }
     )
@@ -336,7 +325,7 @@ export class Api {
   async updateSiteConfiguration(siteConfiguration) {
     return this.client.put<ApiResponse<ISiteConfiguration>>(`/site_configuration`, { siteConfiguration })
   }
-    
+
   async updateUser(id: string, user: IUser) {
     return this.client.patch<ApiResponse<IUser>>(`/users/${id}`, { user })
   }

--- a/app/policies/template_version_policy.rb
+++ b/app/policies/template_version_policy.rb
@@ -11,12 +11,8 @@ class TemplateVersionPolicy < ApplicationPolicy
     true
   end
 
-  def update_jurisdiction_template_version_cutomization?
-    show_jurisdiction_template_version_cutomization?
-  end
-
-  def create_jurisdiction_template_version_cutomization?
-    show_jurisdiction_template_version_cutomization?
+  def create_or_update_jurisdiction_template_version_cutomization?
+    user.review_manager? && record.jurisdiction_id == user.jurisdiction_id
   end
 
   class Scope < Scope

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -291,15 +291,9 @@ en:
         title: "Error"
         message: 404 - The requested resource could not be found
     jurisdiction_template_version_customization:
-      create_success:
-        title: ""
-        message: "Jurisdiction Template Customization created!"
       update_success:
         title: ""
         message: "Jurisdiction Template Customization updated!"
-      create_error:
-        title: Error
-        message: "Something went wrong creating Jurisdiction Customization"
       update_error:
         title: Error
         message: "Something went wrong updating Jurisdiction Customization"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,10 +67,8 @@ Rails.application.routes.draw do
 
     get "template_versions/:id/jurisdictions/:jurisdiction_id/jurisdiction_template_version_customization" =>
           "template_versions#show_jurisdiction_template_version_cutomization"
-    put "template_versions/:id/jurisdictions/:jurisdiction_id/jurisdiction_template_version_customization" =>
-          "template_versions#update_jurisdiction_template_version_cutomization"
     post "template_versions/:id/jurisdictions/:jurisdiction_id/jurisdiction_template_version_customization" =>
-           "template_versions#create_jurisdiction_template_version_cutomization"
+           "template_versions#create_or_update_jurisdiction_template_version_cutomization"
 
     resources :jurisdictions, only: %i[index update show create] do
       post "search", on: :collection, to: "jurisdictions#index"


### PR DESCRIPTION
## Description
[bphh-1019] Refactor jurisdiction customization to use singular endpoint to create or update, and adds a lock to prevent errors when multiple review managers are trying to add customization for the first time
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1019
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Pre req: ensure there is a published template version, but no customizations has been added yet. If there is a customization, manually delete for testing purposes
- Log in as two different review managers for the same jurisdiction in different browser instances
- Navigate to the edit permit page and make some changes to electives by both review managers
- Click publish one after another
- There should be no errors