### PR TITLE
allow properties with both pid and pin to fetch properly

### DIFF
--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -245,7 +245,7 @@ class PermitApplication < ApplicationRecord
   end
 
   def pid_or_pin_presence
-    if ((pid.present? && pin.present?) || (pin.blank? && pid.blank?))
+    if pin.blank? && pid.blank?
       errors.add(:base, I18n.t("activerecord.errors.models.permit_application.attributes.pid_or_pin"))
     end
   end

--- a/app/services/integrations/ltsa_parcel_map_bc.rb
+++ b/app/services/integrations/ltsa_parcel_map_bc.rb
@@ -78,7 +78,8 @@ class Integrations::LtsaParcelMapBc
   end
 
   def get_feature_attributes_by_pid_or_pin(pid:, pin:, fields: "*")
-    raise Errors::FeatureAttributesRetrievalError if ((pid.present? && pin.present?) || (pin.blank? && pid.blank?))
+    raise Errors::FeatureAttributesRetrievalError if pin.blank? && pid.blank?
+    #always prioritize pid over pin
     response =
       if pid
         get_details_by_pid(pid: pid, fields: fields)


### PR DESCRIPTION
## Description
its possible that certain properties have both pid and pin, we always start with a pid search if it exists

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
