### PR TITLE
support address site options with empty string values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
   },
   "[erb]": {
     "editor.defaultFormatter": "elia.erb-formatter"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/app/frontend/components/domains/landing/index.tsx
+++ b/app/frontend/components/domains/landing/index.tsx
@@ -17,6 +17,7 @@ import {
 import { CaretRight, CheckCircle, ClipboardText, FileArrowUp, MapPin } from "@phosphor-icons/react"
 import i18next from "i18next"
 import { observer } from "mobx-react-lite"
+import * as R from "ramda"
 import React, { ReactNode, useEffect, useRef, useState } from "react"
 import { Controller, FormProvider, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
@@ -198,7 +199,11 @@ const JurisdictionSearch = observer(({}: IJurisdictionSearchProps) => {
   const siteWatch = watch("site")
 
   useEffect(() => {
-    if (!siteWatch?.value) return
+    // siteWatch.value may contain an empty string
+    // If this is the case, let through this conditional
+    // in order to let jurisdiction search fail and set manual mode
+    // empty string does not count as isNil but undefined does
+    if (R.isNil(siteWatch?.value)) return
     ;(async () => {
       const jurisdiction = await fetchGeocodedJurisdiction(siteWatch.value)
       if (jurisdiction) {

--- a/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
@@ -85,7 +85,14 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
   const jurisdictionWatch = watch("jurisdiction")
 
   useEffect(() => {
-    if (!siteWatch?.value) return
+    if (R.isNil(siteWatch?.value)) return
+
+    if (siteWatch.value == "") {
+      setPinMode(true)
+      setValue("jurisdiction", null)
+      return
+    }
+
     ;(async () => {
       const jurisdiction = await fetchGeocodedJurisdiction(siteWatch?.value)
       if (jurisdiction && !R.isEmpty(jurisdiction)) {

--- a/app/services/integrations/ltsa_parcel_map_bc.rb
+++ b/app/services/integrations/ltsa_parcel_map_bc.rb
@@ -28,7 +28,7 @@ class Integrations::LtsaParcelMapBc
     @client.get("#{ENV["GEO_LTSA_PARCELMAP_REST_URL"]}#{PARCEL_SERVICE}/query?f=json&#{query}")
   end
 
-  def search_pin_from_coordinates(coord_array: [], field: "*")
+  def search_pin_from_coordinates(coord_array: [], fields: "*")
     #assume we use SR4326 as geocoder defaults to that as its main coordinate version
     query = "returnIdsOnly=false&returnCountOnly=false"
     query += "&where=PIN+IS+NOT+NULL&geometry=#{coord_array.join("%2C")}"

--- a/app/services/wrappers/geocoder.rb
+++ b/app/services/wrappers/geocoder.rb
@@ -18,6 +18,12 @@ class Wrappers::Geocoder < Wrappers::Base
       brief: true,
       maxResults: 10,
       outputSRS: 4326,
+      # A few more params available for experimentation:
+      #   locationDescriptor: "any",
+      #   interpolation: "adaptive",
+      #   echo: true,
+      #   setBack: 0,
+      #   provinceCode: "BC"
     }
 
     site_params[:addressString] = address_string if address_string.present?
@@ -26,7 +32,7 @@ class Wrappers::Geocoder < Wrappers::Base
     r = get("/addresses.#{OUTPUT_FORMAT}", site_params)
     return(
       r["features"]
-        .filter { |f| f["properties"]["siteID"].present? }
+        .filter { |f| %w[CIVIC_NUMBER BLOCK].include?(f["properties"]["matchPrecision"]) }
         .map { |site| { label: site["properties"]["fullAddress"], value: site["properties"]["siteID"] } }
     )
   end


### PR DESCRIPTION
## Description

Need to be able to select addresses with no site ID
this will trigger the mode for manually entering jurisdiciton PIN

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-970

## Steps to QA

log in as submitter, start a new application

use the address 5670 KULLAHUN => pick it from the dropdown => this should trigger the mode that displays PIN and jurisdiction selection
check another normal address

do the same thing on the jurisdiction search on the landing welcome page
