### PR TITLE
Only autosave if form is dirty

### DIFF
--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -78,6 +78,8 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
     if (currentPermitApplication.isSubmitted || isStepCode || isContactsOpen) return
 
     const formio = formRef.current
+    if (formio.pristine) return
+
     const submissionData = formio.data
     try {
       const response = await currentPermitApplication.update({
@@ -88,6 +90,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
         updateFormIoValues(formio, response.data.data.frontEndFormUpdate)
         //update file hashes that have been changed
       }
+      formio.setPristine(true)
       return response.ok
     } catch (e) {
       return false


### PR DESCRIPTION
## Description

Prevent permit application autosave API call if the form has not changed.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Implements [BPHH-1105](https://hous-bssb.atlassian.net/browse/BPHH-1105).

## Steps to QA

Verify form only autosaves if it has changed.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
