### PR TITLE
Bugfix/bphh 846/refactor lookups

### DIFF
--- a/app/models/concerns/automated_compliance_utils.rb
+++ b/app/models/concerns/automated_compliance_utils.rb
@@ -1,14 +1,19 @@
 module AutomatedComplianceUtils
   extend ActiveSupport::Concern
 
-  def requirements_lookups #a flattened list of requiements with the right information
-    # template_version&.lookup_props
-    template_version&.requirement_template&.lookup_props
+  def requirements_lookups
+    #a flattened list of requiements with the right information, the key is the file field, the rest is the actual requirement hash
+
+    #we utilize this to search by key in special cases like energy stepcode
+    #we utilize the lookup to see if the field has computed compliances
+    #for electives they will try to lookup and run compliance values regardless in case those do get turned on
+
+    template_version&.lookup_props
   end
 
   def automated_compliance_requirements
     #check which fields in requirement have custom compliance components
-    requirements_lookups.select { |field_id, req| req.computed_compliance? }
+    requirements_lookups.select { |field_id, req| req["computedCompliance"].present? }
   end
 
   def automated_compliance_unfilled_requirements
@@ -16,7 +21,7 @@ module AutomatedComplianceUtils
   end
 
   def submission_field_is_empty?(field_id, requirement)
-    if requirement.input_options.dig("computed_compliance", "module") == "DigitalSealValidator"
+    if requirement.dig("computedCompliance", "module") == "DigitalSealValidator"
       #if there is no related supporting document, consider this okay and not run the autopopulate again
       #if there is a supporting document, check if the compliance has a result, if not, let it know as unfilled
       doc = active_supporting_documents.find_by(data_key: field_id)
@@ -33,15 +38,12 @@ module AutomatedComplianceUtils
   end
 
   def automated_compliance_unique_unfilled_modules
-    automated_compliance_unfilled_requirements
-      .values
-      .map { |req| req.input_options.dig("computed_compliance", "module") }
-      .uniq
+    automated_compliance_unfilled_requirements.values.map { |req| req.dig("computedCompliance", "module") }.uniq
   end
 
   def automated_compliance_requirements_for_module(compliance_module_name)
     automated_compliance_requirements.select do |field_id, req|
-      req.input_options.dig("computed_compliance", "module") == compliance_module_name
+      req.dig("computedCompliance", "module") == compliance_module_name
     end
   end
 end

--- a/app/models/concerns/step_code_field_extraction.rb
+++ b/app/models/concerns/step_code_field_extraction.rb
@@ -42,6 +42,6 @@ module StepCodeFieldExtraction
 
   def requirement_energy_step_code_key_value
     #energy stepcode is a unique field, look at the published form_json to find item with lookup_type: "energy_step_code"
-    requirements_lookups.find { |k, v| v.input_type == "energy_step_code" }
+    requirements_lookups.find { |k, v| v["requirementInputType"] == "energy_step_code" }
   end
 end

--- a/app/models/concerns/traverse_data_json.rb
+++ b/app/models/concerns/traverse_data_json.rb
@@ -24,4 +24,15 @@ module TraverseDataJson
     end
     files
   end
+
+  def flatten_requirements_from_form_hash(data_hash)
+    return [] if data_hash.blank? && data_hash&.dig("components").blank?
+    #assume the layering is template containing sections, sections containing blocks, blocks contining requirements
+    #requirements may have nesting (like general contact, etc),  but in our purpose we skip this
+    #TODO: explore performanc edifference to move this straight into jsonb functions
+    data_hash["components"]
+      .map { |section_json| section_json["components"].map { |blocks_json| blocks_json["components"].flatten }.flatten }
+      .flatten
+      .reduce({}) { |obj, requirement| obj.merge({ requirement["key"] => requirement }) }
+  end
 end

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -65,10 +65,6 @@ class Requirement < ApplicationRecord
     form_json_service.to_form_json(requirement_block_key)
   end
 
-  def lookup_props(requirement_block_key = requirement_block&.key)
-    { key(requirement_block_key) => self }
-  end
-
   def computed_compliance?
     input_options["computed_compliance"].present?
   end

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -75,10 +75,6 @@ class RequirementBlock < ApplicationRecord
     }
   end
 
-  def lookup_props(section_key = nil)
-    requirements.map { |r| r.lookup_props(key(section_key)) }
-  end
-
   private
 
   def configurations_search_list

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -108,14 +108,6 @@ class RequirementTemplate < ApplicationRecord
     rails.logger.error e.message
   end
 
-  def lookup_props
-    array_of_req_pairs = requirement_template_sections.map(&:lookup_props).flatten
-    array_of_req_pairs.reduce({}) do |obj, pair|
-      key, value = pair.flatten
-      obj.merge({ key => value })
-    end
-  end
-
   def search_data
     {
       description: description,

--- a/app/models/requirement_template_section.rb
+++ b/app/models/requirement_template_section.rb
@@ -24,8 +24,4 @@ class RequirementTemplateSection < ApplicationRecord
       components: requirement_blocks.map { |rb| rb.to_form_json(key) },
     }
   end
-
-  def lookup_props
-    requirement_blocks.map { |rb| rb.lookup_props(key) }.flatten
-  end
 end

--- a/app/models/template_version.rb
+++ b/app/models/template_version.rb
@@ -1,4 +1,5 @@
 class TemplateVersion < ApplicationRecord
+  include TraverseDataJson
   belongs_to :requirement_template
   has_many :jurisdiction_template_version_customizations
   has_many :permit_applications
@@ -9,6 +10,11 @@ class TemplateVersion < ApplicationRecord
   enum status: { scheduled: 0, published: 1, deprecated: 2 }, _default: 0
 
   after_save :reindex_requirement_template_if_published, if: :status_changed?
+
+  def lookup_props
+    #form_json starts at root template
+    flatten_requirements_from_form_hash(form_json)
+  end
 
   private
 

--- a/app/services/automated_compliance/historic_site.rb
+++ b/app/services/automated_compliance/historic_site.rb
@@ -10,7 +10,7 @@ class AutomatedCompliance::HistoricSite < AutomatedCompliance::Base
         permit_application
           .automated_compliance_requirements_for_module("HistoricSite")
           .each do |field_id, req|
-            if attributes[req.input_options.dig("computed_compliance", "value")] == "Y"
+            if attributes[req.dig("computedCompliance", "value")] == "Y"
               permit_application.compliance_data[field_id] = "yes"
             end
           end

--- a/app/services/automated_compliance/parcel_info_extractor.rb
+++ b/app/services/automated_compliance/parcel_info_extractor.rb
@@ -14,7 +14,7 @@ class AutomatedCompliance::ParcelInfoExtractor < AutomatedCompliance::Base
       permit_application
         .automated_compliance_requirements_for_module("ParcelInfoExtractor")
         .each do |field_id, req|
-          value = attributes[req.input_options.dig("computed_compliance", "value")]
+          value = attributes[req.dig("computedCompliance", "value")]
           permit_application.compliance_data[field_id] = value if value
         end
       permit_application.save!

--- a/app/services/automated_compliance/permit_application.rb
+++ b/app/services/automated_compliance/permit_application.rb
@@ -7,8 +7,8 @@ class AutomatedCompliance::PermitApplication < AutomatedCompliance::Base
     permit_application
       .automated_compliance_requirements_for_module("PermitApplication")
       .each do |field_id, req|
-        if WHITELISTED_ATTRIBUTES.include?(req.input_options.dig("computed_compliance", "value"))
-          value = permit_application.try(req.input_options.dig("computed_compliance", "value"))
+        if WHITELISTED_ATTRIBUTES.include?(req.dig("computedCompliance", "value"))
+          value = permit_application.try(req.dig("computedCompliance", "value"))
           if value
             updated = true
             permit_application.compliance_data[field_id] = value

--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -98,6 +98,7 @@ class RequirementFormJsonService
           id: requirement.id,
           key: requirement.key(requirement_block_key),
           type: requirement.input_type,
+          requirementInputType: requirement.input_type,
           input: true,
           label: requirement.label,
           widget: {
@@ -328,11 +329,11 @@ class RequirementFormJsonService
           storage: "s3custom",
           #fileMaxSize driven by front end defaults, do not set in requirements as it fixes it
         }.tap do |file_hash|
-          file_hash["computedCompliance"] = input_options["computed_compliance"] if input_options[
+          file_hash[:computedCompliance] = input_options["computed_compliance"] if input_options[
             "computed_compliance"
           ].present?
-          file_hash["multiple"] = true if input_options["multiple"].present?
-          file_hash["custom_class"] = "formio-component-file" if file_hash[:type] != "file"
+          file_hash[:multiple] = true if input_options["multiple"].present?
+          file_hash[:custom_class] = "formio-component-file" if file_hash[:type] != "file"
         end
       )
     end

--- a/spec/factories/requirement_templates.rb
+++ b/spec/factories/requirement_templates.rb
@@ -73,6 +73,7 @@ FactoryBot.define do
         end
         #publish a template_version
         create(:template_version, requirement_template: template, form_json: template.to_form_json, status: "published")
+        template.reload
       end
     end
 
@@ -98,6 +99,7 @@ FactoryBot.define do
         end
         #publish a template version
         create(:template_version, requirement_template: template, form_json: template.to_form_json, status: "published")
+        template.reload
       end
     end
   end

--- a/spec/factories/template_versions.rb
+++ b/spec/factories/template_versions.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     requirement_blocks_json { "{}" }
     version_diff { "{}" }
     version_date { "2024-02-15" }
-    status { 0 }
+    status { 1 }
     requirement_template { RequirementTemplate.first || association(:requirement_template) }
   end
 end

--- a/spec/jobs/automated_compliance/autopopulate_job_spec.rb
+++ b/spec/jobs/automated_compliance/autopopulate_job_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe AutomatedCompliance::AutopopulateJob, type: :job do
   let(:permit_application) { create(:permit_application) }
 
+  before :each do
+    allow_any_instance_of(PermitApplication).to receive(:formatted_compliance_data) { {} }
+  end
+
   context "valid compliance requirements" do
     before :each do
       #use any instance of since sidekiq takes inthe id and does a find
@@ -10,6 +14,7 @@ RSpec.describe AutomatedCompliance::AutopopulateJob, type: :job do
         %w[DigitalSealValidator ParcelInfoExtractor]
       }
 
+      expect(WebsocketBroadcaster).to receive(:push_update_to_relevant_users)
       #calls a module if no job
       expect_any_instance_of(AutomatedCompliance::ParcelInfoExtractor).to receive(:call)
     end

--- a/spec/models/concerns/automated_compliance_utils_spec.rb
+++ b/spec/models/concerns/automated_compliance_utils_spec.rb
@@ -20,10 +20,13 @@ RSpec.describe AutomatedComplianceUtils do
       expect(
         permit_application
           .automated_compliance_requirements
-          .select { |key, req| req&.input_options&.dig("computed_compliance").present? }
-          .map { |key, req| req },
+          .select { |key, req| req&.dig("computedCompliance").present? }
+          .map { |key, req| req["id"] },
       ).to eq(
-        requirement_template.requirements.select { |req| req&.input_options&.dig("computed_compliance").present? },
+        requirement_template
+          .requirements
+          .select { |req| req&.input_options&.dig("computed_compliance").present? }
+          .map(&:id),
       )
     end
   end

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -180,6 +180,7 @@ types" do
         form_json = requirement.to_form_json.reject { |key| key == :id }
         expected_form_json = {
           key: "#{requirement.requirement_block.key}|#{requirement.requirement_code}",
+          requirementInputType: "text",
           type: "simpletextfield",
           input: true,
           label: "Text Requirement",
@@ -205,6 +206,7 @@ types" do
           },
           applyMaskOn: "change",
           mask: false,
+          requirementInputType: "number",
           inputFormat: "plain",
         }
 
@@ -219,6 +221,7 @@ types" do
           type: "checkbox",
           input: true,
           label: "Checkbox Requirement",
+          requirementInputType: "checkbox",
           widget: {
             type: "input",
           },
@@ -236,6 +239,7 @@ types" do
           tableView: false,
           input: true,
           label: "Date  Requirement",
+          requirementInputType: "date",
           enableTime: false,
           datePicker: {
             disableWeekends: false,
@@ -283,6 +287,7 @@ types" do
           type: "select",
           input: true,
           label: "select Requirement",
+          requirementInputType: "select",
           widget: {
             type: "choicesjs",
           },
@@ -312,6 +317,7 @@ types" do
           key: "#{requirement.requirement_block.key}|multiOptionSelectRequirement",
           label: "Multi option select Requirement",
           optionsLabelPosition: "right",
+          requirementInputType: "multi_option_select",
           tableView: false,
           type: "selectboxes",
           widget: {
@@ -319,6 +325,25 @@ types" do
           },
           optionsLabelPosition: "right",
           values: select_options,
+        }
+
+        expect(form_json).to eq(expected_form_json)
+      end
+
+      it "returns correct form json for file requirement" do
+        requirement = create(:requirement, label: "File Requirement", input_type: "file")
+        form_json = requirement.to_form_json.reject { |key| key == :id }
+        expected_form_json = {
+          key: "#{requirement.requirement_block.key}|fileRequirement_file",
+          storage: "s3custom",
+          type: "simplefile",
+          custom_class: "formio-component-file",
+          input: true,
+          label: "File Requirement",
+          requirementInputType: "file",
+          widget: {
+            type: "input",
+          },
         }
 
         expect(form_json).to eq(expected_form_json)
@@ -337,6 +362,7 @@ types" do
           form_json = requirement.to_form_json.reject { |key| key == :id }
           expected_form_json = {
             key: "#{requirement.requirement_block.key}|#{requirement.requirement_code}",
+            requirementInputType: "text",
             type: "simpletextfield",
             elective: true,
             input: true,


### PR DESCRIPTION
## Description

Lookups are now refactored to utilize the template_versions json instead of the underlying requirement template in case things change.
Lookups are used by automated compliance to figure out what things to automatically check and trigger against.
This was not noticed before as we have not been publishing templates that change compliance methods.

A new property was added to requirements json so we need to ensure templates are either republished or seed is updated.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

(https://hous-bssb.atlassian.net/browse/BPHH-846)

## Steps to QA
You should be able to use automated compliance as it originally works.
If you upload a file and have websockets that has compliance, it will run on the next autosave.
