### PR TITLE
reset pristine when files change

### DIFF
--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -205,6 +205,11 @@ export const RequirementForm = observer(
         }
         setErrorBoxData(mapErrorBoxData(changedEvent?.changed?.instance?.root?.errors))
       }
+      if (changedEvent?.changed?.component?.type == "simplefile") {
+        //https://github.com/formio/formio.js/blob/4.19.x/src/components/file/File.unit.js
+        //no pristine sets for file upldates, but they are present in outher components, workaround this by dealing with change events
+        changedEvent?.changed?.instance?.root?.setPristine(false)
+      }
     }
 
     const onInitialized = (event) => {


### PR DESCRIPTION
## Description

When a file is uploaded or deleted, the save should be enabled since the form is now dirty.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1120