### PR TITLE
[bphh-1121] Fix lagging section text input in requirement builder

### DIFF
--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/sections-display.tsx
@@ -2,7 +2,7 @@ import { Box, Button, HStack, Stack } from "@chakra-ui/react"
 import { X } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
-import React from "react"
+import React, { useEffect } from "react"
 import { useFieldArray, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { v4 as uuidv4 } from "uuid"
@@ -74,6 +74,12 @@ const SectionDisplay = observer(
     )
 
     const watchedSectionName = watch(`requirementTemplateSectionsAttributes.${sectionIndex}.name`)
+    const [editableSectionName, setEditableSectionName] = React.useState<string>(watchedSectionName ?? "")
+
+    useEffect(() => {
+      setEditableSectionName(watchedSectionName)
+    }, [watchedSectionName])
+
     return (
       <Box
         ref={(el) => setSectionRef(el, section.id)}
@@ -95,15 +101,15 @@ const SectionDisplay = observer(
             fontSize={"2xl"}
             className="edit-template-yellowBarHeader"
             initialHint={t("ui.clickToEdit")}
-            value={watchedSectionName || ""}
-            editableInputProps={{
-              ...register(`requirementTemplateSectionsAttributes.${sectionIndex}.name`, { required: true }),
-              "aria-label": "Edit Section Name",
+            value={editableSectionName}
+            onChange={setEditableSectionName}
+            onSubmit={(nextValue) => {
+              setValue(`requirementTemplateSectionsAttributes.${sectionIndex}.name`, nextValue)
             }}
-            color={R.isEmpty(watchedSectionName) ? "text.link" : undefined}
+            color={R.isEmpty(editableSectionName) ? "text.link" : undefined}
             aria-label={"Edit Section Name"}
             onCancel={(previousValue) => {
-              setValue(`requirementTemplateSectionsAttributes.${sectionIndex}.name`, previousValue)
+              setEditableSectionName(previousValue)
             }}
           />
 


### PR DESCRIPTION
## Description
[bphh-1121] Fixes lagging section text input in requirement builder
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
- https://hous-bssb.atlassian.net/browse/BPHH-1121
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Log in as super admin
- Navigate to templates catalogue
- Open a long permit template in Draft mode
- Edit any section title
- There shouldn't be any significant lag

https://github.com/bcgov/HOUS-permit-portal/assets/32022335/66486d52-3d90-4a5a-8420-19a25d67d761

