### PR TITLE
Put the font back on and check other areas on formio needs some tweaks

### DIFF
--- a/app/frontend/components/domains/permit-application/errors-box.tsx
+++ b/app/frontend/components/domains/permit-application/errors-box.tsx
@@ -37,7 +37,7 @@ export const ErrorsBox = ({ errorBox }: IErrorBoxProps) => {
         <Box color="semantic.error">
           <WarningCircle size={24} aria-label={"Warning icon"} />
         </Box>
-        <Heading as="h4" overflowWrap={"break-word"}>
+        <Heading as="h4" mb="0" overflowWrap={"break-word"}>
           {t("requirementTemplate.edit.errorsBox.title", { count: errorBox.length })}
         </Heading>
         <Button
@@ -49,7 +49,9 @@ export const ErrorsBox = ({ errorBox }: IErrorBoxProps) => {
         ></Button>
       </Flex>
       <Collapse in={isOpen}>
-        <Text fontSize="sm">{t("requirementTemplate.edit.errorsBox.instructions")}</Text>
+        <Text fontSize="sm" mt="2">
+          {t("requirementTemplate.edit.errorsBox.instructions")}
+        </Text>
 
         <OrderedList
           mt="2"

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
@@ -173,7 +173,7 @@ const requirementsComponentMap = {
           mb: 0,
           order: 2,
         }}
-        inputDisplay={<Checkbox mr={2} order={1} />}
+        inputDisplay={<Checkbox mr={2} order={1} alignItems="flex-start" pt="1.5" />}
         editorContainerProps={{ order: 3, gridColumn: "span 2" }}
         {...genericDisplayProps}
       />
@@ -190,7 +190,14 @@ const requirementsComponentMap = {
           <CheckboxGroup>
             <Stack>
               {options.map((option, index) => (
-                <Checkbox key={index} value={option}>
+                <Checkbox
+                  key={index}
+                  value={option}
+                  alignItems="flex-start"
+                  sx={{
+                    "& .chakra-checkbox__control": { marginTop: "1" },
+                  }}
+                >
                   {option}
                 </Checkbox>
               ))}

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -1,9 +1,15 @@
-@import url("https://fonts.googleapis.com/css?family=Material+Icons");
 @import url("https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css");
+// Font Awesome icons for: "fa-plus-square, fa-minus-square, fa-cloud
 @import url("https://unpkg.com/@phosphor-icons/web@2.0.3/src/fill/style.css");
+// Phosphor icon for the compliance lightning
 @import "bootstrap/dist/css/bootstrap.min.css";
 @import "formiojs/dist/formio.form.css";
 @import "../../../styles/global-theme-variables.scss";
+
+:root {
+  --bs-font-sans-serif: "BC Sans";
+  --bs-body-color: $bcgov-font;
+}
 
 /* ======================================
 
@@ -23,7 +29,7 @@
 
   // Typography
   .v-application {
-    font-family: -apple-system, "BlinkMacSystemFont", "BCSans", sans-serif !important;
+    font-family: "BCSans", sans-serif !important;
     line-height: 1.4;
     font-size: 0.875rem;
   }
@@ -391,7 +397,7 @@
 
     > .form-group:not(:empty) {
       // each form field inside a block
-      margin-bottom: var(--chakra-space-4);
+      margin-bottom: var(--chakra-space-6);
       max-width: var(--chakra-sizes-container-sm);
       a {
         text-decoration: underline;
@@ -483,6 +489,60 @@
       height: 24px;
       width: 24px;
       margin-right: 6px;
+    }
+  }
+
+  // File upload
+  .formio-component-file {
+    .list-group-header {
+      font-size: var(--chakra-fontSizes-sm);
+      background-color: var(--chakra-colors-greys-grey03);
+      color: var(--chakra-colors-text-secondary);
+      border: 0;
+      padding-top: var(--chakra-space-1);
+      padding-bottom: var(--chakra-space-1);
+    }
+
+    // upload area
+    .fileSelector {
+      background-color: var(--chakra-colors-theme-blueLight);
+      border-color: var(--chakra-colors-theme-blueShadedLight);
+      color: $bcgov-link;
+      font-size: var(--chakra-fontSizes-sm);
+      border-radius: var(--chakra-radii-md);
+      margin-bottom: 0.5rem;
+      transition:
+        background-color 200ms ease-in-out,
+        border-color 200ms ease-in-out;
+      a {
+        color: inherit;
+      }
+      &:hover {
+        background-color: var(--chakra-colors-semantic-infoLight);
+      }
+    }
+    .file {
+      border-radius: var(--chakra-radii-sm);
+      border: 1px solid var(--chakra-colors-border-light);
+      padding: 0 var(--chakra-space-2);
+      font-size: var(--chakra-fontSizes-sm);
+
+      .fileName {
+        [ref="fileStatusRemove"] {
+          color: $bcgov-font-error;
+          margin: 0 var(--chakra-space-1);
+          padding: 6px;
+          border-radius: var(--chakra-radii-full);
+          &:hover {
+            background-color: var(--chakra-colors-semantic-errorLight);
+            cursor: pointer;
+          }
+        }
+      }
+
+      .alert {
+        padding: var(--chakra-space-1) var(--chakra-space-2);
+      }
     }
   }
 

--- a/app/frontend/components/shared/editor/quill.css
+++ b/app/frontend/components/shared/editor/quill.css
@@ -3,6 +3,10 @@
 @import url("https://unpkg.com/react-quill@2.0.0/dist/quill.bubble.css");
 @import url("https://unpkg.com/quill-mention@3.1.0/dist/quill.mention.css");
 
+.ql-container {
+  font-family: inherit;
+}
+
 /* override default quill styles*/
 .quill .ql-container.ql-snow {
   border-bottom-left-radius: 0.25rem;

--- a/app/frontend/styles/global-theme-variables.scss
+++ b/app/frontend/styles/global-theme-variables.scss
@@ -3,7 +3,7 @@ $bcgov-blue: #003366;
 $bcgov-blue-secondary: #38598a;
 $bcgov-yellow: #fcba19;
 $bcgov-grey: #efefef;
-$bcgov-font: #313132;
+$bcgov-font: #292929;
 $bcgov-error: #d8292f;
 $bcgov-link: #1a5a96;
 $bcgov-link-hover: #3b99fc;


### PR DESCRIPTION
## Description
Bugfix: Set the page to use BC Sans as the main font for the chefs form page with bootstrap variables. Investigated what each of the imports are for, and keeping them for now. We're loading Font Awesome file but only actually using 3 of its icons, and loading Phosphor Fill but only using 1 icon (we may want to see if its further consolidating but it may hinder future maintenance). 
- Removed the unused Material Icons import.
- checkboxes were aligned to center instead of top which made the checkbox appear in the middle of the text that's long (making it hard to read)
 - improve the file upload component to match how the rest of app looks


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1128

## Steps to QA

- Log in as Submitter and look at the application form screen and it should be using "BC Sans" again.
- Log in as Super Admin and look at a template, and the checkbox now is aligned to top of its corresponding checkbox label (instead of in the middle)


