### PR TITLE
make useSearch reset currents and fix logout spinner

### DIFF
--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -155,7 +155,7 @@ const Footer = lazy(() => import("../../shared/base/footer").then((module) => ({
 
 export const Navigation = observer(() => {
   const { sessionStore, siteConfigurationStore } = useMst()
-  const { loggedIn } = sessionStore
+  const { isLoggingOut } = sessionStore
   const { displaySitewideMessage, sitewideMessage } = siteConfigurationStore
   const { validateToken, isValidating } = sessionStore
   const { t } = useTranslation()
@@ -163,6 +163,8 @@ export const Navigation = observer(() => {
   useEffect(() => {
     validateToken()
   }, [])
+
+  if (isLoggingOut) return <LoadingScreen />
 
   return (
     <BrowserRouter>

--- a/app/frontend/components/shared/base/not-found-screen.tsx
+++ b/app/frontend/components/shared/base/not-found-screen.tsx
@@ -3,21 +3,14 @@ import { ListMagnifyingGlass } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
-import { useMst } from "../../../setup/root"
 import { IHomeScreenProps } from "../../domains/home"
 import { RouterLink } from "../navigation/router-link"
 import { RouterLinkButton } from "../navigation/router-link-button"
-import { LoadingScreen } from "./loading-screen"
 
 interface INotFoundScreenProps extends IHomeScreenProps {}
 
 export const NotFoundScreen = observer(({ ...rest }: INotFoundScreenProps) => {
   const { t } = useTranslation()
-  const {
-    sessionStore: { isLoggingOut },
-  } = useMst()
-
-  if (isLoggingOut) return <LoadingScreen />
 
   return (
     <Container maxW="container.lg">

--- a/app/frontend/hooks/use-search.ts
+++ b/app/frontend/hooks/use-search.ts
@@ -1,12 +1,26 @@
 import { useEffect } from "react"
+import { useParams } from "react-router-dom"
 import { ISearch, TFilterableStatus } from "../lib/create-search-model"
+import { useMst } from "../setup/root"
 import { ESortDirection } from "../types/enums"
 import { parseBoolean } from "../utils/utility-functions"
 
 export const useSearch = (searchModel: ISearch, dependencyArray: any[] = []) => {
+  // Reset currents
+  const { jurisdictionId } = useParams()
+  const { permitApplicationId } = useParams()
+  const {
+    jurisdictionStore: { resetCurrentJurisdiction },
+    permitApplicationStore: { resetCurrentPermitApplication },
+  } = useMst()
+
+  useEffect(() => {
+    if (!jurisdictionId) resetCurrentJurisdiction()
+    if (!permitApplicationId) resetCurrentPermitApplication()
+  }, [jurisdictionId, permitApplicationId])
+
   useEffect(() => {
     // This is necessary for preventing failed calls, IE when the currentJursidiction for user search is undefined
-
     if (dependencyArray.some((dep) => dep == null)) return
 
     const queryParams = new URLSearchParams(location.search)

--- a/app/frontend/stores/jurisdiction-store.ts
+++ b/app/frontend/stores/jurisdiction-store.ts
@@ -109,6 +109,9 @@ export const JurisdictionStoreModel = types
     setCurrentJurisdiction(jurisdictionId) {
       self.currentJurisdiction = jurisdictionId
     },
+    resetCurrentJurisdiction() {
+      self.currentJurisdiction = null
+    },
     setCurrentJurisdictionBySlug(slug) {
       const j = self.jurisdictions.find((j) => j.slug == slug)
       self.currentJurisdiction = j?.id

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -156,6 +156,10 @@ export const PermitApplicationStoreModel = types
       self.currentPermitApplication &&
         self.rootStore.stepCodeStore.setCurrentStepCode(self.currentPermitApplication.stepCode)
     },
+    resetCurrentPermitApplication() {
+      self.currentPermitApplication = null
+      self.rootStore.stepCodeStore.setCurrentStepCode(null)
+    },
     processWebsocketChange: flow(function* (payload: IUserPushPayload) {
       //based on the eventType do stuff
       switch (payload.eventType) {


### PR DESCRIPTION
## Description

fix issue where previously set currentJurisdiction was causing searches to be performed against that jurisdiction by resetting store "currents" within the useSearch hook.

bonus: Render logout spinner from navigation route, not the 404 route