### PR TITLE
Bugfix/bphh 1137/multi select requirement selection saving

### DIFF
--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -124,9 +124,20 @@ class Requirement < ApplicationRecord
   end
 
   def convert_value_options
-    # all values MUST be converted to camelCase to be compatible with rehyration on front end
+    return unless attribute_changed?(:input_options)
+    # all values MUST be converted to camelCase and stripped of white space to be compatible with rehyration on front
+    # end
     input_options["value_options"] = input_options["value_options"].map do |option_json|
-      option_json.merge("value" => option_json["value"].camelize(:lower))
+      # camelize the value
+      # this is a two step process as camelize only camelizes individual words and ignores spaces
+
+      # remove spaces to make one word and capitalize each word
+      value = option_json["value"]
+      words = value.split(" ").map(&:capitalize)
+
+      # join the words together and then run camelize
+      formatted_value = words.join("").strip.camelize(:lower)
+      option_json.merge("value" => formatted_value)
     end
   end
 

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -163,6 +163,22 @@ types" do
       expect(select_requirement.value_options).to eq(camel_select_options)
     end
 
+    it "removes spaces from values on input types" do
+      select_options = [{ "label" => "test", "value" => "needs trim" }]
+      select_requirement =
+        create(:requirement, input_type: "select", input_options: { "value_options" => select_options })
+      formatted_select_options = [{ "label" => "test", "value" => "needsTrim" }]
+      expect(select_requirement.value_options).to eq(formatted_select_options)
+    end
+
+    it "removes spaces and camelizes values on input types" do
+      select_options = [{ "label" => "test", "value" => "new option_2" }]
+      select_requirement =
+        create(:requirement, input_type: "select", input_options: { "value_options" => select_options })
+      formatted_select_options = [{ "label" => "test", "value" => "newOption2" }]
+      expect(select_requirement.value_options).to eq(formatted_select_options)
+    end
+
     it "returns the number unit for number input with a unit" do
       number_unit = "m"
       number_requirement_with_unit =


### PR DESCRIPTION
## Description
- Fixes issue with multi select checbox selection not saving for manually created requirements
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1137
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Add a multi select checkbox requirement to a requirement block and enter options with spaces
- Add it to a template and publish it
- Once published template is available, create a permit application with it as a submitter
- Select a checkbox
- Save application 
- Return to application
- The selected checkbox should persist

https://github.com/bcgov/HOUS-permit-portal/assets/32022335/6c9564cd-e33a-4427-b186-23c93d85fa4e

