### PR TITLE
Fix issue overriding text on autosave

### DIFF
--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -74,7 +74,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
   const nicknameWatch = watch("nickname")
   const isStepCode = R.test(/step-code/, window.location.pathname)
 
-  const handleSave = async () => {
+  const handleSave = async ({ autosave }: { autosave?: boolean } = {}) => {
     if (currentPermitApplication.isSubmitted || isStepCode || isContactsOpen) return
 
     const formio = formRef.current
@@ -85,6 +85,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
       const response = await currentPermitApplication.update({
         submissionData: { data: submissionData },
         nickname: nicknameWatch,
+        autosave,
       })
       if (response.ok && response.data.data.frontEndFormUpdate) {
         updateFormIoValues(formio, response.data.data.frontEndFormUpdate)
@@ -136,7 +137,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
     }
   }
 
-  useInterval(handleSave, 60000) // save progress every minute
+  useInterval(() => handleSave({ autosave: true }), 60000) // save progress every minute
 
   useEffect(() => {
     // sets the defaults subject to application load

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -166,11 +166,13 @@ export const PermitApplicationModel = types
       })
       self.rootStore.permitApplicationStore.permitApplicationMap.put(newData)
     },
-    update: flow(function* (params) {
+    update: flow(function* ({ autosave, ...params }) {
       const response = yield self.environment.api.updatePermitApplication(self.id, params)
       if (response.ok) {
         const { data: permitApplication } = response.data
-        self.rootStore.permitApplicationStore.mergeUpdate(permitApplication, "permitApplicationMap")
+        if (!autosave) {
+          self.rootStore.permitApplicationStore.mergeUpdate(permitApplication, "permitApplicationMap")
+        }
       }
       return response
     }),


### PR DESCRIPTION
## Description

Fix issue overriding text on autosave. If a user is actively typing while the form is autosaving, whatever the user types while the update API call is being made is dropped resulting in a jarring UI. To avoid this, we should only update the permit application in the MST store if we are NOT autosaving to avoid the form component from re-rendering and displaying stale form data.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Fixes [BPHH-1133](https://hous-bssb.atlassian.net/browse/BPHH-1133)

## Steps to QA

1. For ease of testing, update the autosave interval inside `edit-permit-application-screen.tsx` to `1000`
2. As a submitter, open a permit application and start typing in a text input. Keep typing while the autosave triggers - the autosave should not clear anything you type.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
