### PR TITLE
Bugfix/bphh 1113/Fixes bug with contact modal not populating with all contacts for permit application

### DIFF
--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -153,7 +153,7 @@ class RequirementFormJsonService
     return {} unless requirement.input_type_general_contact? || requirement.input_type_professional_contact?
 
     if requirement.input_options["can_add_multiple_contacts"].blank?
-      return(get_contact_field_set_form_json(requirement.key(requirement_block_key)))
+      return(get_contact_field_set_form_json("#{requirement.key(requirement_block_key)}|#{requirement.input_type}"))
     end
 
     get_multi_contact_datagrid_form_json(requirement_block_key)
@@ -210,11 +210,8 @@ class RequirementFormJsonService
     }
   end
 
-  def get_contact_field_set_form_json(key = nil, parent_key = nil)
+  def get_contact_field_set_form_json(key)
     return {} unless requirement.input_type_general_contact? || requirement.input_type_professional_contact?
-
-    key = "#{requirement.input_type}" if key.nil?
-    key = "#{parent_key}|#{key}" if parent_key.present?
 
     contact_components =
       (
@@ -284,6 +281,7 @@ class RequirementFormJsonService
   def get_multi_contact_datagrid_form_json(requirement_block_key = requirement&.requirement_block&.key)
     return {} unless requirement.input_type_general_contact? || requirement.input_type_professional_contact?
 
+    key = "#{requirement.key(requirement_block_key)}|multi_contact"
     {
       label: "Multi Contact",
       reorder: false,
@@ -295,24 +293,10 @@ class RequirementFormJsonService
       hideLabel: true,
       tableView: false,
       custom_class: "contact-data-grid",
-      defaultValue: [
-        {
-          firstName: "",
-          email: "",
-          lastName: "",
-          phone: "",
-          address: "", # TODO: address is a text now, replace with address type when implemented
-          businessName: "",
-          businessLicense: "",
-          organization: "",
-          professionalAssociation: "",
-          professionalNumber: "",
-        },
-      ],
-      key: requirement.key(requirement_block_key),
+      key: key,
       type: "datagrid",
       input: true,
-      components: [get_contact_field_set_form_json(nil, requirement_block_key)],
+      components: [get_contact_field_set_form_json("#{key}|#{requirement.input_type}")],
     }
   end
 
@@ -327,7 +311,7 @@ class RequirementFormJsonService
         {
           type: "simplefile",
           storage: "s3custom",
-          #fileMaxSize driven by front end defaults, do not set in requirements as it fixes it
+          # fileMaxSize driven by front end defaults, do not set in requirements as it fixes it
         }.tap do |file_hash|
           file_hash[:computedCompliance] = input_options["computed_compliance"] if input_options[
             "computed_compliance"


### PR DESCRIPTION
## Description
Bugfix/bphh 1113/Fixes bug with contact modal not populating with all contacts for permit application
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1113
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
Pre requisite: either start with a fresh db seed or publish a new template with a contact requirements
- Create a permit application with the above template and fill up all the details to submit
- As a review manager go to the permits screen and open the permit application
- Locate the contact modal and verify all contacts are listed

https://github.com/bcgov/HOUS-permit-portal/assets/32022335/f7380d91-9940-49e2-ac80-2f85d05bf297


