### PR TITLE
[bphh-1058] Add user roles explanation modal

### DIFF
--- a/app/frontend/components/domains/users/invite-screen.tsx
+++ b/app/frontend/components/domains/users/invite-screen.tsx
@@ -13,7 +13,7 @@ import { ErrorScreen } from "../../shared/base/error-screen"
 import { CustomToast } from "../../shared/base/flash-message"
 import { UserInput } from "../../shared/base/inputs/user-input"
 import { LoadingScreen } from "../../shared/base/loading-screen"
-import { RouterLink } from "../../shared/navigation/router-link"
+import { UserRolesExplanationModal } from "../../shared/user-roles-explanation-modal"
 
 interface IInviteScreenProps {}
 
@@ -74,7 +74,7 @@ export const InviteScreen = observer(({}: IInviteScreenProps) => {
         <Flex direction="column">
           <Heading as="h1">{t("user.inviteTitle")}</Heading>
           <Text>
-            {t("user.inviteInstructions")} <RouterLink to="#">{t("user.rolesAndPermissions")}</RouterLink>
+            {t("user.inviteInstructions")} <UserRolesExplanationModal />
           </Text>
         </Flex>
         <Heading as="h2">{currentJurisdiction.name}</Heading>

--- a/app/frontend/components/shared/user-roles-explanation-modal.tsx
+++ b/app/frontend/components/shared/user-roles-explanation-modal.tsx
@@ -1,0 +1,47 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { EUserRoles } from "../../types/enums"
+
+export function UserRolesExplanationModal() {
+  const { t } = useTranslation()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const rolesToExplain = [EUserRoles.submitter, EUserRoles.reviewManager, EUserRoles.reviewer]
+  return (
+    <>
+      <Button onClick={onOpen} variant={"link"} textDecoration={"underline"}>
+        {t("user.rolesAndPermissions")}
+      </Button>
+      <Modal isOpen={isOpen} onClose={onClose} scrollBehavior="inside">
+        <ModalOverlay />
+        <ModalContent maxW={"container.md"}>
+          <ModalHeader>{t("user.rolesAndPermissions")}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Stack as={"ul"} listStyleType={"none"} spacing={4} pl={0} pb={4}>
+              {rolesToExplain.map((role) => (
+                <Text as={"li"} key={role}>
+                  <Text as={"span"} fontWeight={700} textTransform={"capitalize"}>
+                    {t(`user.roles.${role}`)}:
+                  </Text>{" "}
+                  {t(`user.rolesExplanation.${role}`)}
+                </Text>
+              ))}
+            </Stack>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -979,6 +979,17 @@ const options = {
             reviewer: "reviewer",
             super_admin: "super admin",
           },
+          rolesExplanation: {
+            submitter:
+              "The Submitter is typically an external user, such as a contractor, homeowner, or architect," +
+              " who initiates the building permit application process. They are responsible for providing all necessary documentation and information required for the permit application. Submitters need to ensure their submissions are complete, accurate, and comply with local regulations.",
+            review_manager:
+              "The Review Manager supervises the Reviewers and the entire building permit review operation. In addition to possessing all the permissions of a Reviewer, Review Managers are tasked with administrative oversight. Their responsibilities include the distribution of work among Reviewers, maintaining efficiency and consistency in the review processes, and ensuring that the quality of service meets established standards. Moreover, Review Managers have extended privileges to modify local government-specific configurations within the building permit application system, such as updating Step Code requirements, managing content on the 'About' page, and other application settings pertinent to their jurisdictional needs.",
+            reviewer:
+              "A Reviewer is typically an employee within the local government or a designated authority responsible for examining building permit applications submitted by the Submitter. Reviewers assess the documentation for compliance with building codes, zoning laws, and other regulatory requirements. They may request additional information, approve, reject, or provide comments on the applications.",
+            super_admin:
+              "The Super Admin is the highest-level user within the system, with overarching control over the entire permit application platform. They have the authority to manage user roles, including creating and removing user accounts, and to modify the system configuration. This role is responsible for the maintenance of the system, including updates and enhancements, and ensuring that the system meets the operational and strategic objectives of the local government or the organization.",
+          },
         },
         requirementTemplate: {
           edit: {

--- a/app/frontend/utils/utility-functions.ts
+++ b/app/frontend/utils/utility-functions.ts
@@ -92,7 +92,7 @@ export function handleScrollToTop() {
   document.body.scrollTop = 0 // For Safari
 }
 
-export function handleScrollToBottom(elementId: string) {
+export function handleScrollToBottom() {
   window.scrollTo(0, document.body.scrollHeight)
 }
 


### PR DESCRIPTION
## Description
- Add user roles explanation modal
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1145
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Got to any user invite screen and click the user roles and permissions link
- It should open up the explanation modal
<img width="1341" alt="Screenshot 2024-04-09 at 4 30 34 PM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/167287ea-82c1-465e-98b7-e8300718a368">
<img width="1511" alt="Screenshot 2024-04-09 at 4 30 41 PM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/c59998da-9331-4e42-81a2-c32c9c3dee0a">
