### PR TITLE
Bugfix/bphh 1155/expired invites

### DIFF
--- a/app/controllers/api/invitations_controller.rb
+++ b/app/controllers/api/invitations_controller.rb
@@ -20,6 +20,9 @@ class Api::InvitationsController < Devise::InvitationsController
   def update
     raw_invitation_token = update_resource_params["invitation_token"]
     user = User.find_by_invitation_token(raw_invitation_token, true)
+
+    render_error "user.accept_invite_error" and return unless user.present?
+
     user.update(user_params)
 
     self.resource = accept_resource if user&.errors.empty?
@@ -40,7 +43,6 @@ class Api::InvitationsController < Devise::InvitationsController
       ) and return
     else
       resource.invitation_token = raw_invitation_token
-      # resource.errors.full_messages is full here probably with "Invitation token is invalid", lets just craft our own message for now
       render_error "user.accept_invite_error",
                    message_opts: {
                      error_message: resource.errors.full_messages.join(", "),

--- a/app/frontend/components/shared/select/selectors/address-select.tsx
+++ b/app/frontend/components/shared/select/selectors/address-select.tsx
@@ -65,7 +65,7 @@ export const AddressSelect = observer(function ({
   }
 
   return (
-    <FormControl w="full">
+    <FormControl w="full" zIndex={2}>
       <FormLabel>{t("landing.addressSelectLabel")}</FormLabel>
       <InputGroup w="full">
         <AsyncSelect<IOption, boolean>

--- a/app/frontend/components/shared/select/selectors/jurisdiction-select.tsx
+++ b/app/frontend/components/shared/select/selectors/jurisdiction-select.tsx
@@ -70,7 +70,7 @@ export const JurisdictionSelect = observer(function ({
   }
 
   return (
-    <FormControl w="full">
+    <FormControl w="full" zIndex={1}>
       <FormLabel>{title ?? t("jurisdiction.index.title")}</FormLabel>
       <InputGroup w="full">
         <AsyncSelect<IOption<IJurisdiction>, boolean>


### PR DESCRIPTION
## Description

Fix expired invite error message

BONUS: fix z index on landing page selectors

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1155

## Steps to QA

in devise rb set config.invite_for = 2.seconds, reboot server

log in as review manager
go to users, invite
invite a user, wait 2 seconds
open the link in the email in an incognito window
fill and submit the form
should toast:
"The invitation link is invalid or has expired. Please ask your administrator to re-invite you to the workspace."

-----
to test z index go to landing
first put in a failing address like 1988 wylie
then put in a search with lots of options like 1234 as
the list should properly cover the form ocntrol below now.
