### PR TITLE
Fix issue triggering validations on file upload

### DIFF
--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -40,6 +40,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
   })
 
   const [completedBlocks, setCompletedBlocks] = useState({})
+  const [isDirty, setIsDirty] = useState(false)
 
   const { isOpen: isContactsOpen, onOpen: onContactsOpen, onClose: onContactsClose } = useDisclosure()
 
@@ -78,7 +79,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
     if (currentPermitApplication.isSubmitted || isStepCode || isContactsOpen) return
 
     const formio = formRef.current
-    if (formio.pristine) return true
+    if (formio.pristine && !isDirty) return true
 
     const submissionData = formio.data
     try {
@@ -92,6 +93,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
         //update file hashes that have been changed
       }
       formio.setPristine(true)
+      setIsDirty(false)
       return response.ok
     } catch (e) {
       return false
@@ -244,6 +246,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
               permitApplication={currentPermitApplication}
               onCompletedBlocksChange={setCompletedBlocks}
               triggerSave={handleSave}
+              setIsDirty={setIsDirty}
               showHelpButton
             />
           </Flex>

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -34,6 +34,7 @@ interface IRequirementFormProps {
   onCompletedBlocksChange?: (sections: any) => void
   formRef: any
   triggerSave?: () => void
+  setIsDirty?: (val: boolean) => void
   showHelpButton?: boolean
 }
 
@@ -43,6 +44,7 @@ export const RequirementForm = observer(
     onCompletedBlocksChange,
     formRef,
     triggerSave,
+    setIsDirty,
     showHelpButton = true,
   }: IRequirementFormProps) => {
     const {
@@ -207,8 +209,9 @@ export const RequirementForm = observer(
       }
       if (changedEvent?.changed?.component?.type == "simplefile") {
         //https://github.com/formio/formio.js/blob/4.19.x/src/components/file/File.unit.js
-        //no pristine sets for file upldates, but they are present in outher components, workaround this by dealing with change events
-        changedEvent?.changed?.instance?.root?.setPristine(false)
+        // formio `pristine` is not set for file upldates
+        // using `setPristine(false)` causes the entire form to validate so instead, we use a separate dirty state
+        setIsDirty(true)
       }
     }
 


### PR DESCRIPTION
## Description

Fix issue triggering validations on file upload.

Calling `setPristine` on file field change causes the entire form to validate and display the error box/message on each invalid field. Once another field is added, the form returns to its unvalidated state. This only happens if the form has not yet been saved when the file is uploaded. Once the form has been saved, the validation errors no longer appear on file input change.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Fixes [BPHH-1132](https://hous-bssb.atlassian.net/browse/BPHH-1132)

## Steps to QA

See ticket for reproduction steps. Verify the validation is not triggered on file input as per the Jira ticket.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
