### PR TITLE
Feature/bphh 1047/auto compliance not found handling

### DIFF
--- a/app/frontend/components/shared/chefs/index.tsx
+++ b/app/frontend/components/shared/chefs/index.tsx
@@ -41,27 +41,28 @@ Templates.current = {
         let result = ctx?.component?.computedComplianceResult
 
         let computedComplianceText
+        let showWarning = false
         if (result) {
           if (ctx?.component?.computedCompliance?.module == "DigitalSealValidator") {
             //assume an array of one response or an array of responses for multiple files
             //utilize id in the compliance messge to check if the front end id matches the file
-            const parsedMessage = result
-              .filter((fileMessage) => ctx.value.find((v) => v.id == fileMessage.id))
-              .map((fileMessage) => fileMessage.message)
-              .join(",")
+            const currentFileMessages = result.filter((fileMessage) => ctx.value.find((v) => v.id == fileMessage.id))
+            const parsedMessage = currentFileMessages.map((fileMessage) => fileMessage.message).join(",")
+            showWarning = currentFileMessages.some((fileMessage) => fileMessage.error)
             computedComplianceText = parsedMessage || t(`automatedCompliance.baseMessage`)
           } else {
             //assume all complianes are default values except for seal validators
             computedComplianceText = t("automatedCompliance.defaultValueMessage", { defaultValue: result })
           }
         } else if ("computedComplianceResult" in ctx.component) {
+          showWarning = true
           computedComplianceText = t("automatedCompliance.failedValueMessage")
         } else {
           computedComplianceText = t(`automatedCompliance.baseMessage`)
         }
 
         template = template.concat(
-          `<div key={'${ctx?.id}-compliance'} class="compliance" data-compliance='${ctx?.component?.computedCompliance?.module}'><span><i class="ph-fill ph-lightning-a"></i>
+          `<div key={'${ctx?.id}-compliance'} class="compliance ${showWarning ? "compliance-warning" : ""}" data-compliance='${ctx?.component?.computedCompliance?.module}'><span><i class="ph-fill ph-lightning-a"></i>
           ${computedComplianceText}</span></div>`
         )
       }

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -123,6 +123,7 @@
       content: "\f107";
     }
   }
+
   .card-body {
     border-top: 1px solid var(--chakra-colors-border-light);
   }
@@ -295,12 +296,15 @@
   .choices__list {
     vertical-align: middle;
   }
+
   .choices {
     overflow: visible;
+
     &:focus {
       box-shadow: 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
     }
   }
+
   .choices__list--dropdown {
     .choices__item {
       &:not(.is-selected) {
@@ -373,9 +377,11 @@
     min-height: var(--chakra-space-10);
     border-bottom: 0;
   }
+
   .card-title {
     display: flex;
     justify-content: space-between;
+
     i {
       order: 2;
     }
@@ -399,12 +405,15 @@
       // each form field inside a block
       margin-bottom: var(--chakra-space-6);
       max-width: var(--chakra-sizes-container-sm);
+
       a {
         text-decoration: underline;
       }
+
       &:not(.contact-field-set):focus-within label:not(.form-check-label) {
         font-weight: bold;
       }
+
       &.contact-field-set .form-group:focus-within .col-form-label {
         font-weight: bold;
       }
@@ -448,11 +457,13 @@
     margin-top: calc(-1 * var(--chakra-space-1));
     margin-bottom: 6px;
 
+
     span {
       background-color: $bcgov-alert-info !important;
       display: inline-block;
       padding: var(--chakra-space-1);
       position: relative;
+
       &:after {
         content: "";
         display: inline-block;
@@ -462,6 +473,12 @@
         border-top: 6px solid $bcgov-alert-info !important;
         border-left: 6px solid transparent;
         border-right: 6px solid transparent;
+      }
+    }
+
+    &.compliance-warning {
+      span {
+        background-color: $bcgov-alert-warning !important;
       }
     }
 
@@ -511,16 +528,18 @@
       font-size: var(--chakra-fontSizes-sm);
       border-radius: var(--chakra-radii-md);
       margin-bottom: 0.5rem;
-      transition:
-        background-color 200ms ease-in-out,
-        border-color 200ms ease-in-out;
+      transition: background-color 200ms ease-in-out,
+      border-color 200ms ease-in-out;
+
       a {
         color: inherit;
       }
+
       &:hover {
         background-color: var(--chakra-colors-semantic-infoLight);
       }
     }
+
     .file {
       border-radius: var(--chakra-radii-sm);
       border: 1px solid var(--chakra-colors-border-light);
@@ -533,6 +552,7 @@
           margin: 0 var(--chakra-space-1);
           padding: 6px;
           border-radius: var(--chakra-radii-full);
+
           &:hover {
             background-color: var(--chakra-colors-semantic-errorLight);
             cursor: pointer;
@@ -670,10 +690,12 @@
       font-weight: 700;
       font-size: var(--chakra-fontSizes-md);
     }
+
     .formio-error-wrapper {
       padding-left: var(--chakra-space-3) !important;
       margin-left: 0 !important;
       width: 100%;
+
       &::before {
         margin-left: calc(-1 * var(--chakra-space-8)) !important;
       }
@@ -767,6 +789,7 @@
     opacity: 1;
     transform: translateX(0);
   }
+
   &.float-off #floating-error-alert-box {
     opacity: 0;
     transform: translateX(200px);

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1186,7 +1186,7 @@ const options = {
         automatedCompliance: {
           baseMessage: `This field has Auto-Compliance capability`,
           defaultValueMessage: `Auto-Compliance found the default value to be "{{defaultValue}}".`,
-          failedValueMessage: `Auto-Compliance could not find a value for this parameter.`,
+          failedValueMessage: `Auto-Compliance was unable fill this field, please check with your local jurisdiction if this is required.`,
         },
       },
     },

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -227,6 +227,9 @@ export const PermitApplicationModel = types
       })
       self.rootStore.permitApplicationStore.permitApplicationMap.put(newData)
     },
+    setFormattedComplianceData(data: Record<string, any>) {
+      self.formattedComplianceData = data
+    },
     update: flow(function* ({ autosave, ...params }) {
       const response = yield self.environment.api.updatePermitApplication(self.id, params)
       if (response.ok) {

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -10,7 +10,7 @@ import { IJurisdiction } from "../models/jurisdiction"
 import { IPermitApplication, PermitApplicationModel } from "../models/permit-application"
 import { IUser } from "../models/user"
 import { EPermitApplicationSortFields, ESocketEventTypes } from "../types/enums"
-import { IUserPushPayload } from "../types/types"
+import { IPermitApplicationUpdate, IUserPushPayload } from "../types/types"
 
 export const PermitApplicationStoreModel = types
   .compose(
@@ -166,7 +166,12 @@ export const PermitApplicationStoreModel = types
       //based on the eventType do stuff
       switch (payload.eventType) {
         case ESocketEventTypes.update:
-          const event = new CustomEvent("handlePermitApplicationUpdate", { detail: payload.data })
+          const payloadData = payload.data as IPermitApplicationUpdate
+          const event = new CustomEvent("handlePermitApplicationUpdate", { detail: payloadData })
+
+          self.permitApplicationMap
+            .get(payloadData?.id)
+            ?.setFormattedComplianceData(payloadData?.formattedComplianceData)
           document.dispatchEvent(event)
           break
         default:

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -204,6 +204,7 @@ export interface INotification {
 export interface IPermitApplicationUpdate {
   id
   frontEndFromUpdate: Object
+  formattedComplianceData: Object
 }
 
 export interface IUserPushPayload {

--- a/app/models/errors/parcel_error.rb
+++ b/app/models/errors/parcel_error.rb
@@ -1,0 +1,2 @@
+class Errors::ParcelError < StandardError
+end

--- a/app/models/supporting_document.rb
+++ b/app/models/supporting_document.rb
@@ -5,7 +5,7 @@ class SupportingDocument < ApplicationRecord
   validate :unique_data_key
 
   scope :file_ids_with_regex, ->(regex_pattern) { where("file_data ->> 'id' ~ ?", regex_pattern) }
-  scope :without_compliance, -> { where("compliance_data = '{}' OR compliance_data is NULL") }
+  scope :without_compliance, -> { where("compliance_data = '{}' OR compliance_data IS NULL") }
 
   def last_signer
     if compliance_data["result"] &&
@@ -29,7 +29,7 @@ class SupportingDocument < ApplicationRecord
 
       { "id" => file_id, "data_key" => data_key, "message" => "Signers validated: #{signers.join(",")}" }
     else
-      { "id" => file_id, "data_key" => data_key, "message" => compliance_data["error"] }
+      { "id" => file_id, "data_key" => data_key, "message" => compliance_data["error"], "error" => true }
     end
   end
 
@@ -81,6 +81,7 @@ class SupportingDocument < ApplicationRecord
   end
 
   UNIQUE_DATA_KEYS = %i[permit_application_pdf step_code_checklist_pdf]
+
   def unique_data_key
     return unless UNIQUE_DATA_KEYS.include?(data_key)
     return if !permit_application.supporting_documents.not(self).find_by(data_key: data_key)

--- a/app/services/automated_compliance/parcel_info_extractor.rb
+++ b/app/services/automated_compliance/parcel_info_extractor.rb
@@ -1,23 +1,48 @@
 class AutomatedCompliance::ParcelInfoExtractor < AutomatedCompliance::Base
   def call(permit_application)
-    return if permit_application.pid.blank? && permit_application.pin.blank?
-    #extraction of parcel data can be done via LTSA base
-    attributes =
-      Integrations::LtsaParcelMapBc.new.get_feature_attributes_by_pid_or_pin(
-        pid: permit_application.pid,
-        pin: permit_application.pin,
-      )
+    begin
+      raise Errors::ParcelError if permit_application.pid.blank? && permit_application.pin.blank?
 
-    #automation sets up the extracted data into compliance_data, the front end will allow the user to see what was extracted and override the result
-    #lock this while it is updating in case mulitple automated compliances run at once
-    permit_application.with_lock do
-      permit_application
-        .automated_compliance_requirements_for_module("ParcelInfoExtractor")
-        .each do |field_id, req|
-          value = attributes[req.dig("computedCompliance", "value")]
-          permit_application.compliance_data[field_id] = value if value
-        end
-      permit_application.save!
-    end if attributes
+      # extraction of parcel data can be done via LTSA base
+      attributes =
+        Integrations::LtsaParcelMapBc.new.get_feature_attributes_by_pid_or_pin(
+          pid: permit_application.pid,
+          pin: permit_application.pin,
+        )
+
+      raise Errors::ParcelError if attributes.nil?
+
+      # automation sets up the extracted data into compliance_data, the front end will allow the user to see what was extracted and override the result
+      # lock this while it is updating in case mulitple automated compliances run at once
+      permit_application.with_lock do
+        updated = false
+        permit_application
+          .automated_compliance_requirements_for_module("ParcelInfoExtractor")
+          .each do |field_id, req|
+            value = attributes[req.dig("computedCompliance", "value")]
+
+            if value != permit_application.compliance_data[field_id]
+              updated = true
+              permit_application.compliance_data[field_id] = value
+            end
+          end
+        permit_application.save! if updated
+      end
+    rescue Errors::ParcelError
+      permit_application.with_lock do
+        updated = false
+        permit_application
+          .automated_compliance_requirements_for_module("ParcelInfoExtractor")
+          .each do |field_id, req|
+            # set to nil if there is no existing value to indicate
+            # a valid value was not found
+            if !permit_application.compliance_data.has_key?(field_id)
+              updated = true
+              permit_application.compliance_data[field_id] = nil
+            end
+          end
+        permit_application.save! if updated
+      end
+    end
   end
 end

--- a/app/services/automated_compliance/permit_application.rb
+++ b/app/services/automated_compliance/permit_application.rb
@@ -1,20 +1,23 @@
 class AutomatedCompliance::PermitApplication < AutomatedCompliance::Base
   WHITELISTED_ATTRIBUTES = ["full_address"]
+
   def call(permit_application)
     return if permit_application.full_address.blank?
 
     updated = false
-    permit_application
-      .automated_compliance_requirements_for_module("PermitApplication")
-      .each do |field_id, req|
-        if WHITELISTED_ATTRIBUTES.include?(req.dig("computedCompliance", "value"))
-          value = permit_application.try(req.dig("computedCompliance", "value"))
-          if value
-            updated = true
-            permit_application.compliance_data[field_id] = value
+    permit_application.with_lock do
+      permit_application
+        .automated_compliance_requirements_for_module("PermitApplication")
+        .each do |field_id, req|
+          if WHITELISTED_ATTRIBUTES.include?(req.dig("computedCompliance", "value"))
+            value = permit_application.try(req.dig("computedCompliance", "value"))
+            if value != permit_application.compliance_data[field_id]
+              updated = true
+              permit_application.compliance_data[field_id] = value
+            end
           end
         end
-      end
-    permit_application.save! if updated
+      permit_application.save! if updated
+    end
   end
 end


### PR DESCRIPTION
## Description
[bphh-1047] Fix bug with auto compliance failure message not showing after auto compliance ran and no value was found
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1047
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- The easiest way to recreate a auto compliance failure is to create a permit application without a pid. This can be done using the address "1214 St George Ave, North Vancouver"
- Create a permit application with the above address
- Got to permit application. Give it a second for web-socket to return compliance result or alternatively if web socket is not setup, then input anything in any field then click save
- Return to permit application. You should be able to see at least one field where auto compliance failed and there is a yellow warning message

![Screenshot 2024-04-10 at 4 06 27 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/7d300d67-dbad-451d-99a0-1d7912210ead)
