### PR TITLE
[bphh-1164] Fix bug with all electives showing on a requirement block of permit form when only some are enabled

### DIFF
--- a/app/frontend/utils/formio-component-traversal.ts
+++ b/app/frontend/utils/formio-component-traversal.ts
@@ -75,9 +75,15 @@ export const combineComplianceHints = (
       if (blocksLookups[panelComponent.id]?.tip) {
         panelComponent["tip"] = blocksLookups[panelComponent.id].tip
       }
-      if (blocksLookups[panelComponent.id]?.["enabledElectiveFieldIds"]) {
+      const enabledElectiveIds = blocksLookups[panelComponent.id]?.["enabledElectiveFieldIds"]
+
+      if (enabledElectiveIds) {
         panelComponent.components.forEach((subComp) => {
-          if (subComp.elective && subComp.customConditional.endsWith(";show = false")) {
+          if (
+            enabledElectiveIds?.includes(subComp?.id) &&
+            subComp.elective &&
+            subComp.customConditional.endsWith(";show =" + " false")
+          ) {
             //remove the ;show = false at the end of the conditional
             subComp.customConditional = subComp.customConditional.slice(0, -13)
           }

--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -222,7 +222,7 @@ class RequirementFormJsonService
         end
       )
 
-    {
+    form_json = {
       legend: requirement.label,
       key: key,
       type: "fieldset",
@@ -233,6 +233,10 @@ class RequirementFormJsonService
       tableView: false,
       components: contact_components,
     }
+
+    form_json[:id] = requirement.id if requirement.input_options["can_add_multiple_contacts"].blank?
+
+    form_json
   end
 
   def get_general_contact_field_components(parent_key = nil)
@@ -284,6 +288,7 @@ class RequirementFormJsonService
     key = "#{requirement.key(requirement_block_key)}|multi_contact"
     {
       label: "Multi Contact",
+      id: requirement.id,
       reorder: false,
       addAnother: I18n.t("formio.requirement.contact.add_person_button"),
       addAnotherPosition: "bottom",


### PR DESCRIPTION
[bphh-1164] Fix bug with all electives showing on a requirement block of permit form when only some are enabled

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1164
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
Pre req: work with fresh db or seed
Review Manager side:
- Log in as  seed review manager of North Vancouver
- Go to building permits and click "Low Residential" to edit
- Go down to "Owner Contact Details" requirement block and click edit
- The requirement block should have two elective fields
- enable any ONE of the elective fields and publish

Submitter:
- Create a permit application with the same building permit that the review manager edited
- Scroll down to relevant requirement block
- Only the enabled elective field should be visible

https://github.com/bcgov/HOUS-permit-portal/assets/32022335/567a5386-bc2c-46a0-90c9-51a6ee3eca3d

