### PR TITLE
[bphh-1163] Update draft permit applications with new template version on publish

### DIFF
--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -79,12 +79,24 @@ class TemplateVersioningService
           Rails.logger.error("Error copying customizations to new template version: #{e.message}")
         end
       end
+
+      #  updates draft permits with the new template version
+      update_draft_permits_with_new_template_version(previous_version, template_version)
     end
 
     return template_version
   end
 
   private
+
+  def self.update_draft_permits_with_new_template_version(previous_template_version, new_template_version)
+    return if new_template_version.status != "published"
+
+    previous_template_version
+      .permit_applications
+      .where(status: "draft")
+      .update_all(template_version_id: new_template_version.id)
+  end
 
   def self.previous_version(template_version)
     template_version


### PR DESCRIPTION
## Description
[bphh-1163] Update draft permit applications with new template version on publish
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1163
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
Short version: Run `bundle exec rspec ./spec/services/template_versioning_service_spec.rb`

Long version:
Start with fresh seed data
Submitter:
- Log in as submitter and create a permit application with template of choice
Super Admin
- Log in as super admin and navigate to Requirement Templates and edit the same template used by submitter
- Make any change e.g. Add a requirement block or remove one
- Schedule the template to be published
- Wait for it to publish or programatically force it

After it's published
- Log in as submitter and navigate to the permit application created before
- The new changes should be there