### PR TITLE
[bphh-1162] Fix issue with auto compliance result from websocket not updating permit application form

### DIFF
--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
-import { requirementTypeToFomionType } from "../../../constants"
+import { requirementTypeToFormioType } from "../../../constants"
 import { usePermitApplication } from "../../../hooks/resources/use-permit-application"
 import { useInterval } from "../../../hooks/use-interval"
 import { ICustomEventMap } from "../../../types/dom"
@@ -43,7 +43,6 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
   })
 
   const [completedBlocks, setCompletedBlocks] = useState({})
-  const [isDirty, setIsDirty] = useState(false)
 
   const { isOpen: isContactsOpen, onOpen: onContactsOpen, onClose: onContactsClose } = useDisclosure()
 
@@ -81,11 +80,18 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
   const nicknameWatch = watch("nickname")
   const isStepCode = R.test(/step-code/, window.location.pathname)
 
-  const handleSave = async ({ autosave, skipDirtyCheck }: { autosave?: boolean; skipDirtyCheck?: boolean } = {}) => {
+  const handleSave = async ({
+    autosave,
+    skipPristineCheck,
+  }: {
+    autosave?: boolean
+    skipPristineCheck?: boolean
+  } = {}) => {
     if (currentPermitApplication.isSubmitted || isStepCode || isContactsOpen) return
 
     const formio = formRef.current
-    if (formio.pristine && !isDirty && !skipDirtyCheck) return true
+
+    if (formio.pristine && !skipPristineCheck) return true
 
     const submissionData = formio.data
     try {
@@ -99,7 +105,6 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
         //update file hashes that have been changed
       }
       formio.setPristine(true)
-      setIsDirty(false)
       return response.ok
     } catch (e) {
       return false
@@ -151,7 +156,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
     if (
       !componentToSet ||
       componentToSet?.component?.type === "file" ||
-      componentToSet?.component?.type === requirementTypeToFomionType[ERequirementType.file]
+      componentToSet?.component?.type === requirementTypeToFormioType[ERequirementType.file]
     ) {
       return
     }
@@ -278,7 +283,6 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
               permitApplication={currentPermitApplication}
               onCompletedBlocksChange={setCompletedBlocks}
               triggerSave={handleSave}
-              setIsDirty={setIsDirty}
               showHelpButton
             />
           </Flex>

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -33,8 +33,7 @@ interface IRequirementFormProps {
   permitApplication?: IPermitApplication
   onCompletedBlocksChange?: (sections: any) => void
   formRef: any
-  triggerSave?: (params?: { autosave?: boolean; skipDirtyCheck?: boolean }) => void
-  setIsDirty?: (val: boolean) => void
+  triggerSave?: (params?: { autosave?: boolean; skipPristineCheck?: boolean }) => void
   showHelpButton?: boolean
 }
 
@@ -44,7 +43,6 @@ export const RequirementForm = observer(
     onCompletedBlocksChange,
     formRef,
     triggerSave,
-    setIsDirty,
     showHelpButton = true,
   }: IRequirementFormProps) => {
     const {
@@ -211,9 +209,8 @@ export const RequirementForm = observer(
         //https://github.com/formio/formio.js/blob/4.19.x/src/components/file/File.unit.js
         // formio `pristine` is not set for file upldates
         // using `setPristine(false)` causes the entire form to validate so instead, we use a separate dirty state
-        setIsDirty(true)
         // trigger save to rerun compliance and save file
-        triggerSave?.({ autosave: true, skipDirtyCheck: true })
+        triggerSave?.({ autosave: true, skipPristineCheck: true })
       }
     }
 
@@ -303,7 +300,7 @@ export const RequirementForm = observer(
             form={formattedFormJson}
             formReady={formReady}
             /* Needs cloned submissionData otherwise it's not possible to use data grid as mst props can't be
-                                                                                                                                                                         mutated*/
+                                                                                                                                                                                                                         mutated*/
             submission={clonedSubmissionData}
             onSubmit={onFormSubmit}
             options={permitAppOptions}

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -33,7 +33,7 @@ interface IRequirementFormProps {
   permitApplication?: IPermitApplication
   onCompletedBlocksChange?: (sections: any) => void
   formRef: any
-  triggerSave?: () => void
+  triggerSave?: (params?: { autosave?: boolean; skipDirtyCheck?: boolean }) => void
   setIsDirty?: (val: boolean) => void
   showHelpButton?: boolean
 }
@@ -212,6 +212,8 @@ export const RequirementForm = observer(
         // formio `pristine` is not set for file upldates
         // using `setPristine(false)` causes the entire form to validate so instead, we use a separate dirty state
         setIsDirty(true)
+        // trigger save to rerun compliance and save file
+        triggerSave?.({ autosave: true, skipDirtyCheck: true })
       }
     }
 
@@ -301,7 +303,7 @@ export const RequirementForm = observer(
             form={formattedFormJson}
             formReady={formReady}
             /* Needs cloned submissionData otherwise it's not possible to use data grid as mst props can't be
-                                     mutated*/
+                                                                                                                                                                         mutated*/
             submission={clonedSubmissionData}
             onSubmit={onFormSubmit}
             options={permitAppOptions}

--- a/app/frontend/constants.ts
+++ b/app/frontend/constants.ts
@@ -28,6 +28,10 @@ export const getUnitOptionLabel = (unit?: ENumberUnit) => {
   return unit === undefined ? t("requirementsLibrary.unitLabels.option.noUnit") : unitToLabel[unit]
 }
 
+export const requirementTypeToFomionType = {
+  [ERequirementType.file]: "simplefile",
+} as const
+
 export const getUnitDisplayLabel = (unit?: ENumberUnit) => {
   const unitToLabel = {
     mm: t("requirementsLibrary.unitLabels.display.mm"),

--- a/app/frontend/constants.ts
+++ b/app/frontend/constants.ts
@@ -28,7 +28,7 @@ export const getUnitOptionLabel = (unit?: ENumberUnit) => {
   return unit === undefined ? t("requirementsLibrary.unitLabels.option.noUnit") : unitToLabel[unit]
 }
 
-export const requirementTypeToFomionType = {
+export const requirementTypeToFormioType = {
   [ERequirementType.file]: "simplefile",
 } as const
 

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -9,7 +9,7 @@ import { withRootStore } from "../lib/with-root-store"
 import { IJurisdiction } from "../models/jurisdiction"
 import { IPermitApplication, PermitApplicationModel } from "../models/permit-application"
 import { IUser } from "../models/user"
-import { EPermitApplicationSortFields, ESocketEventTypes } from "../types/enums"
+import { ECustomEvents, EPermitApplicationSortFields, ESocketEventTypes } from "../types/enums"
 import { IPermitApplicationUpdate, IUserPushPayload } from "../types/types"
 
 export const PermitApplicationStoreModel = types
@@ -167,7 +167,7 @@ export const PermitApplicationStoreModel = types
       switch (payload.eventType) {
         case ESocketEventTypes.update:
           const payloadData = payload.data as IPermitApplicationUpdate
-          const event = new CustomEvent("handlePermitApplicationUpdate", { detail: payloadData })
+          const event = new CustomEvent(ECustomEvents.handlePermitApplicationUpdate, { detail: payloadData })
 
           self.permitApplicationMap
             .get(payloadData?.id)

--- a/app/frontend/types/dom.d.ts
+++ b/app/frontend/types/dom.d.ts
@@ -1,0 +1,20 @@
+// modified from https://stackoverflow.com/questions/43001679/how-do-you-create-custom-event-in-typescript
+import { ECustomEvents } from "./enums"
+import { IPermitApplicationUpdate } from "./types"
+
+export interface ICustomEventMap {
+  [ECustomEvents.handlePermitApplicationUpdate]: CustomEvent<IPermitApplicationUpdate>
+}
+
+declare global {
+  interface Document {
+    //adds definition to Document, but you can do the same with HTMLElement
+    addEventListener<K extends keyof ICustomEventMap>(
+      type: K,
+      listener: (this: Document, ev: ICustomEventMap[K]) => void
+    ): void
+
+    dispatchEvent<K extends keyof ICustomEventMap>(ev: ICustomEventMap[K]): void
+  }
+}
+export {} //needed for TS compiler.

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -282,3 +282,7 @@ export enum EEnabledElectiveFieldReason {
   zoning = "zoning",
   policy = "policy",
 }
+
+export enum ECustomEvents {
+  handlePermitApplicationUpdate = "handlePermitApplicationUpdate",
+}

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -203,7 +203,7 @@ export interface INotification {
 
 export interface IPermitApplicationUpdate {
   id
-  frontEndFromUpdate: Object
+  frontEndFormUpdate: Object
   formattedComplianceData: Object
 }
 


### PR DESCRIPTION
## Description
[bphh-1162] Fix issue with auto compliance result from websocket not updating permit application form
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1162
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
Start with fresh seed, and ensure you have sidekiq and  websockets running and `RUN_COMPLIANCE_ON_SAVE` env variable set to true
- Login as submitter and navigate to create permit application
- Chose an address without PID e.g. 1214 st george ave north
- Enter relevant details and choose North Vancouver for jurisdiction
- Click create and wait to auto navigate to form
- Give it a second for websockets to kick in
- The form should be updated with auto compliance result. Note the yellow sections, which should be update to auto compliance fail
- Scroll down to a file input which has auto compliance capability
- Upload an invalidly signed file
- After websockets kicks in the banner should be updated


https://github.com/bcgov/HOUS-permit-portal/assets/32022335/4eac8ed0-7932-4c06-a6fe-5f68493dfb5e
