### PR TITLE
[bphh-907] Add ability to force publish template version, turned on by an env flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,13 @@ MAX_ZERO_CARBON_STEP=4
 ########################################################################
 RUN_COMPLIANCE_ON_SAVE=false
 
+
+########################################################################
+# Dev Only, we allow force publish to make testing easier
+########################################################################
+ENABLE_TEMPLATE_FORCE_PUBLISH="true"
+VITE_ENABLE_TEMPLATE_FORCE_PUBLISH="true"
+
 # Sidekiq
 REDIS_URL="redis://localhost:6379/0"
 ANYCABLE_DEV_REDIS_URL="redis://localhost:6379/1"

--- a/app/errors/template_version_force_publish_now_error.rb
+++ b/app/errors/template_version_force_publish_now_error.rb
@@ -1,0 +1,2 @@
+class TemplateVersionForcePublishNowError < StandardError
+end

--- a/app/errors/template_version_publish_error.rb
+++ b/app/errors/template_version_publish_error.rb
@@ -1,0 +1,2 @@
+class TemplateVersionPublishError < StandardError
+end

--- a/app/errors/template_version_schedule_error.rb
+++ b/app/errors/template_version_schedule_error.rb
@@ -1,0 +1,2 @@
+class TemplateVersionScheduleError < StandardError
+end

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/controls-header.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/controls-header.tsx
@@ -11,6 +11,7 @@ import { PublishScheduleModal } from "./publish-schedule-modal"
 
 interface IProps {
   onScheduleDate?: (date: Date) => void
+  onForcePublishNow?: () => void
   onSaveDraft: () => void
   onAddSection: () => void
   requirementTemplate: IRequirementTemplate
@@ -21,6 +22,7 @@ export const ControlsHeader = observer(function ControlsHeader({
   onScheduleDate,
   onSaveDraft,
   onAddSection,
+  onForcePublishNow,
 }: IProps) {
   const navigate = useNavigate()
   const { t } = useTranslation()
@@ -57,6 +59,7 @@ export const ControlsHeader = observer(function ControlsHeader({
         <PublishScheduleModal
           minDate={requirementTemplate.nextAvailableScheduleDate}
           onScheduleConfirm={onScheduleDate}
+          onForcePublishNow={onForcePublishNow}
           triggerButtonProps={{
             isDisabled: isSubmitDisabled,
           }}

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/publish-schedule-modal.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/publish-schedule-modal.tsx
@@ -23,10 +23,11 @@ import { DatePicker } from "../../../../shared/date-picker"
 interface IProps {
   minDate: Date
   onScheduleConfirm: (date: Date) => void
+  onForcePublishNow?: () => void
   triggerButtonProps?: Partial<ButtonProps>
 }
 
-export function PublishScheduleModal({ minDate, onScheduleConfirm, triggerButtonProps }: IProps) {
+export function PublishScheduleModal({ minDate, onScheduleConfirm, triggerButtonProps, onForcePublishNow }: IProps) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [scheduleDate, setScheduleDate] = React.useState(null)
@@ -53,7 +54,7 @@ export function PublishScheduleModal({ minDate, onScheduleConfirm, triggerButton
       </Button>
       <Modal isOpen={isOpen} onClose={onClose} autoFocus={false}>
         <ModalOverlay />
-        <ModalContent w={"436px"}>
+        <ModalContent w={onForcePublishNow ? "container.sm" : "436px"}>
           <ModalHeader fontSize={"2xl"} mt={2}>
             {t("requirementTemplate.edit.scheduleModalTitle")}
           </ModalHeader>
@@ -75,6 +76,11 @@ export function PublishScheduleModal({ minDate, onScheduleConfirm, triggerButton
               <Button variant={"secondary"} onClick={onCancel}>
                 {t("ui.neverMind")}
               </Button>
+              {onForcePublishNow && (
+                <Button variant={"secondary"} color={"error"} borderColor={"error"} onClick={onForcePublishNow}>
+                  {t("requirementTemplate.edit.forcePublishNow")}
+                </Button>
+              )}
             </ButtonGroup>
           </ModalFooter>
         </ModalContent>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1019,6 +1019,7 @@ const options = {
               "Once you publish, local jurisdictions and submitters will be able to see and use this new version of the form.",
             scheduleModalHelperText: "Schedule to publish (at 00:01 PST)",
             scheduleModalCancelMessage: "Changes were not scheduled.",
+            forcePublishNow: "Force publish!",
             errorsBox: {
               title: "There are {{count}} fields with errors on the page",
               instructions: "Please fix the following before submitting:",

--- a/app/frontend/models/requirement-template-section.ts
+++ b/app/frontend/models/requirement-template-section.ts
@@ -22,7 +22,7 @@ export const RequirementTemplateSectionModel = types.snapshotProcessor(
       id: types.identifier,
       name: types.maybeNull(types.string),
       templateSectionBlockMap: types.map(TemplateSectionBlockModel),
-      sortedTemplateSectionBlocks: types.array(types.safeReference(TemplateSectionBlockModel)),
+      sortedTemplateSectionBlocks: types.array(types.reference(TemplateSectionBlockModel)),
     })
     .views((self) => ({
       hasTemplateSectionBlock(id: string) {

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -262,6 +262,15 @@ export class Api {
     })
   }
 
+  async forcePublishRequirementTemplate(templateId: string, requirementTemplate: IRequirementTemplateUpdateParams) {
+    return this.client.post<ApiResponse<IRequirementTemplate>>(
+      `/requirement_templates/${templateId}/force_publish_now`,
+      {
+        requirementTemplate,
+      }
+    )
+  }
+
   async fetchSiteOptions(address: string, pid: string = null) {
     return this.client.get<IOptionResponse>(`/geocoder/site_options`, { address, pid })
   }

--- a/app/frontend/stores/requirement-template-store.ts
+++ b/app/frontend/stores/requirement-template-store.ts
@@ -46,9 +46,7 @@ export const RequirementTemplateStoreModel = types
       }
 
       if (requirementTemplate.templateVersions?.length > 0) {
-        requirementTemplate.templateVersions.forEach((templateVersion) =>
-          self.rootStore.templateVersionStore.mergeUpdate(templateVersion, "templateVersionMap")
-        )
+        self.rootStore.templateVersionStore.mergeUpdateAll(requirementTemplate.templateVersions, "templateVersionMap")
       }
 
       return requirementTemplate
@@ -109,6 +107,7 @@ export const RequirementTemplateStoreModel = types
       if (response.ok) {
         const templateData = response.data.data
         templateData.isFullyLoaded = true
+
         self.mergeUpdate(templateData, "requirementTemplateMap")
 
         return self.requirementTemplateMap.get(templateData.id)
@@ -126,6 +125,24 @@ export const RequirementTemplateStoreModel = types
           requirementTemplate: requirementParams,
           versionDate: format(scheduleDate, datefnsAppDateFormat),
         })
+      )
+
+      if (response.ok) {
+        const templateData = response.data.data
+        templateData.isFullyLoaded = true
+        self.mergeUpdate(templateData, "requirementTemplateMap")
+
+        return self.requirementTemplateMap.get(templateData.id) as IRequirementTemplate
+      }
+
+      return false
+    }),
+    forcePublishRequirementTemplate: flow(function* (
+      templateId: string,
+      requirementParams: IRequirementTemplateUpdateParams
+    ) {
+      const response = yield* toGenerator(
+        self.environment.api.forcePublishRequirementTemplate(templateId, requirementParams)
       )
 
       if (response.ok) {

--- a/app/policies/requirement_template_policy.rb
+++ b/app/policies/requirement_template_policy.rb
@@ -19,6 +19,10 @@ class RequirementTemplatePolicy < ApplicationPolicy
     create?
   end
 
+  def force_publish_now?
+    create? && ENV["ENABLE_TEMPLATE_FORCE_PUBLISH"] == "true"
+  end
+
   def destroy?
     create?
   end

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -33,7 +33,9 @@ class TemplateVersioningService
 
   def self.schedule!(requirement_template, version_date)
     if !is_valid_schedule_version_date?(requirement_template, version_date)
-      raise StandardError.new("Version date must be in the future and after latest scheduled version date")
+      raise TemplateVersionScheduleError.new(
+              "Version date must be in the future and after latest scheduled version date",
+            )
     end
 
     template_version =
@@ -47,16 +49,45 @@ class TemplateVersioningService
         status: "scheduled",
       )
 
-    raise StandardError.new(template_version.errors.full_messages.join(", ")) if !template_version.save
+    raise TemplateVersionScheduleError.new(template_version.errors.full_messages.join(", ")) if !template_version.save
 
     template_version
   end
 
-  def self.publish_version!(template_version)
+  def self.force_publish_now!(requirement_template)
+    unless ENV["ENABLE_TEMPLATE_FORCE_PUBLISH"] == "true"
+      raise TemplateVersionForcePublishNowError.new("Force publish is not enabled")
+    end
+
+    version_date = Date.current
+
+    template_version =
+      requirement_template.template_versions.build(
+        denormalized_template_json:
+          RequirementTemplateBlueprint.render_as_hash(requirement_template, view: :template_snapshot),
+        form_json: requirement_template.to_form_json,
+        requirement_blocks_json: form_requirement_blocks_hash(requirement_template),
+        version_diff: diff_of_current_changes_and_last_version,
+        version_date: version_date,
+        status: "scheduled",
+      )
+
+    raise TemplateVersionScheduleError.new(template_version.errors.full_messages.join(", ")) if !template_version.save
+
+    template_version.reload
+
+    template_version = publish_version!(template_version, true)
+
+    template_version
+  end
+
+  def self.publish_version!(template_version, skip_date_check = false)
     return template_version if template_version.status == "published" || template_version.status == "deprecated"
 
-    if template_version.version_date > Date.current
-      raise StandardError.new("Version cannot be published before it's scheduled date")
+    skip_date_check = skip_date_check && (ENV["ENABLE_TEMPLATE_FORCE_PUBLISH"] == "true")
+
+    if template_version.version_date > Date.current && (!skip_date_check)
+      raise TemplateVersionPublishError.new("Version cannot be published before it's scheduled date")
     end
 
     ActiveRecord::Base.transaction do
@@ -64,7 +95,7 @@ class TemplateVersioningService
 
       deprecate_versions_before_template(template_version)
 
-      raise StandardError.new(template_version.errors.full_messages.join(", ")) if !template_version.save
+      raise TemplateVersionPublishError.new(template_version.errors.full_messages.join(", ")) if !template_version.save
 
       previous_version = previous_version(template_version)
 
@@ -104,7 +135,7 @@ class TemplateVersioningService
       .template_versions
       .where("version_date <=?", template_version.version_date)
       .where.not(id: template_version.id)
-      .order(version_date: :desc)
+      .order(version_date: :desc, created_at: :desc)
       .first
   end
 
@@ -191,7 +222,7 @@ class TemplateVersioningService
     end
 
     if !copied_jurisdiction_template_version_customization.save
-      raise StandardError.new(
+      raise TemplateVersionPublishError.new(
               "Old jurisdiction customizations could not be copied to new template version for jurisdiction_id:#{jurisdiction_template_version_customization.jurisdiction_id}",
             )
     end
@@ -223,7 +254,7 @@ class TemplateVersioningService
   end
 
   def self.is_valid_schedule_version_date?(requirement_template, version_date)
-    last_version = requirement_template.template_versions.order(version_date: :desc).first
+    last_version = requirement_template.template_versions.order(version_date: :desc, created_at: :desc).first
 
     version_date > Date.current && (last_version.blank? || version_date > last_version.version_date)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -205,6 +205,9 @@ en:
       schedule_success:
         title: ""
         message: "Permit has been scheduled to published."
+      force_publish_now_success:
+        title: ""
+        message: "Permit has been published."
       create_error:
         title: Error
         message: "%{error_message}"
@@ -219,6 +222,9 @@ en:
         message: "%{error_message}"
       schedule_error:
         title: Error
+        message: "%{error_message}"
+      force_publish_now_error:
+        title: Error force publishing template
         message: "%{error_message}"
       delete_error:
         title: Error

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
     resources :requirement_templates, only: %i[show create destroy update] do
       post "search", on: :collection, to: "requirement_templates#index"
       post "schedule", to: "requirement_templates#schedule", on: :member
+      post "force_publish_now", to: "requirement_templates#force_publish_now", on: :member
       patch "restore", on: :member
     end
 

--- a/spec/services/template_versioning_service_spec.rb
+++ b/spec/services/template_versioning_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe TemplateVersioningService, type: :service do
         version_date = Date.yesterday
 
         expect { TemplateVersioningService.schedule!(requirement_template, version_date) }.to raise_error(
-          StandardError,
+          TemplateVersionScheduleError,
           "Version date must be in the future and after latest scheduled version date",
         )
       end
@@ -43,7 +43,7 @@ RSpec.describe TemplateVersioningService, type: :service do
         template_version = TemplateVersioningService.schedule!(requirement_template, version_date)
 
         expect { TemplateVersioningService.schedule!(requirement_template, Date.tomorrow) }.to raise_error(
-          StandardError,
+          TemplateVersionScheduleError,
           "Version date must be in the future and after latest scheduled version date",
         )
       end
@@ -53,7 +53,7 @@ RSpec.describe TemplateVersioningService, type: :service do
         template_version = TemplateVersioningService.schedule!(requirement_template, version_date)
 
         expect { TemplateVersioningService.schedule!(requirement_template, Date.tomorrow) }.to raise_error(
-          StandardError,
+          TemplateVersionScheduleError,
           "Version date must be in the future and after latest scheduled version date",
         )
       end
@@ -101,7 +101,7 @@ RSpec.describe TemplateVersioningService, type: :service do
         template_version = TemplateVersioningService.schedule!(requirement_template, Date.tomorrow)
 
         expect { TemplateVersioningService.publish_version!(template_version) }.to raise_error(
-          StandardError,
+          TemplateVersionPublishError,
           "Version cannot be published before it's scheduled date",
         )
       end


### PR DESCRIPTION
## Description
[bphh-907] Add ability to force publish template version, turned on by an env flag
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ x] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-907
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Start with fresh seed
- Ensure env variables are set ` ENABLE_TEMPLATE_FORCE_PUBLISH="true"
 VITE_ENABLE_TEMPLATE_FORCE_PUBLISH="true"`
- Log in as super admin
- Navigate to permits template catalogue
- Edit any template in draft mode
- Make some changes then click publish
- Once modal is up, click force publish
- The current template state should be published immediately