### PR TITLE
[bphh-1183] Fix issue with mobx error causing merge update error when trying to update or schedule a template after removing a section with requirement blocks

### DIFF
--- a/app/frontend/models/requirement-template-section.ts
+++ b/app/frontend/models/requirement-template-section.ts
@@ -22,7 +22,7 @@ export const RequirementTemplateSectionModel = types.snapshotProcessor(
       id: types.identifier,
       name: types.maybeNull(types.string),
       templateSectionBlockMap: types.map(TemplateSectionBlockModel),
-      sortedTemplateSectionBlocks: types.array(types.safeReference(TemplateSectionBlockModel)),
+      sortedTemplateSectionBlocks: types.array(types.reference(TemplateSectionBlockModel)),
     })
     .views((self) => ({
       hasTemplateSectionBlock(id: string) {


### PR DESCRIPTION
## Description
[bphh-1183] Fix issue with mobx error causing merge update error when trying to update or schedule a template after removing a section with requirement blocks
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1183
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Log in as super admin
- Go to permit templates catalogue
- Select a requirement template with sections and blocks in it
- Remove a whole section with requirement blocks
- Schedule to publish
- After schedule succeeds, the page should navigate to the scheduled template
## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [ ] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [ ] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->
