### PR TITLE
No address permit applications

### DIFF
--- a/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
@@ -85,16 +85,16 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
   const jurisdictionWatch = watch("jurisdiction")
 
   useEffect(() => {
-    if (R.isNil(siteWatch?.value)) return
+    if (R.isNil(siteWatch?.value) && !pidWatch) return
 
-    if (siteWatch.value == "") {
+    if (siteWatch?.value == "") {
       setPinMode(true)
       setValue("jurisdiction", null)
       return
     }
 
     ;(async () => {
-      const jurisdiction = await fetchGeocodedJurisdiction(siteWatch?.value)
+      const jurisdiction = await fetchGeocodedJurisdiction(siteWatch?.value, pidWatch)
       if (jurisdiction && !R.isEmpty(jurisdiction)) {
         setPinMode(false)
         setValue("jurisdiction", jurisdiction)
@@ -103,7 +103,7 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
         setValue("jurisdiction", null)
       }
     })()
-  }, [siteWatch?.value])
+  }, [siteWatch?.value, pidWatch])
 
   return (
     <Flex as="main" direction="column" w="full" bg="greys.white" pb="24">

--- a/app/frontend/components/shared/select/selectors/sites-select.tsx
+++ b/app/frontend/components/shared/select/selectors/sites-select.tsx
@@ -6,7 +6,8 @@ import * as R from "ramda"
 import React, { useCallback, useRef, useState } from "react"
 import { Controller, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import Select, { ControlProps, InputProps, OptionProps, components } from "react-select"
+import { ControlProps, InputProps, OptionProps, components } from "react-select"
+import CreatableSelect from "react-select/creatable"
 import { useMst } from "../../../../setup/root"
 import { IOption } from "../../../../types/types"
 import { AsyncSelect, TAsyncSelectProps } from "../async-select"
@@ -112,18 +113,24 @@ export const SitesSelect = observer(function ({
               }}
               render={({ field: { onChange, value } }) => {
                 return (
-                  <Select
+                  <CreatableSelect
+                    // @ts-ignore
                     options={pidOptions}
                     ref={pidSelectRef}
-                    value={
-                      pidOptions.find((option) => option.value === value) ?? {
-                        label: null,
-                        value: null,
-                      }
-                    }
+                    value={{
+                      label: value,
+                      value: value,
+                    }}
                     onChange={(option) => {
                       onChange(option.value)
                     }}
+                    onCreateOption={(inputValue: string) => {
+                      const newValue = { label: inputValue, value: inputValue }
+                      onChange(newValue.value)
+                    }}
+                    formatCreateLabel={(inputValue: string) => t("permitApplication.usePid", { inputValue })}
+                    isClearable
+                    isSearchable
                   />
                 )
               }}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -277,6 +277,7 @@ const options = {
             contactInfo: "Contact information",
             applicantInfo: "Applicant contact details",
           },
+          usePid: "Use '{{ inputValue }}' as PID",
           indexTitle: "My active permits",
           start: "Start a permit application",
           drafts: "Draft Permits",

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -266,8 +266,8 @@ export class Api {
     return this.client.get<IOptionResponse>(`/geocoder/site_options`, { address, pid })
   }
 
-  async fetchGeocodedJurisdiction(siteId: string) {
-    return this.client.get<IOptionResponse>(`/geocoder/jurisdiction`, { siteId })
+  async fetchGeocodedJurisdiction(siteId: string, pid: string = null) {
+    return this.client.get<IOptionResponse>(`/geocoder/jurisdiction`, { siteId, pid })
   }
 
   async fetchPids(siteId: string) {

--- a/app/frontend/stores/geocoder-store.ts
+++ b/app/frontend/stores/geocoder-store.ts
@@ -31,9 +31,9 @@ export const GeocoderStoreModel = types
       self.fetchingPids = false
       return response.ok
     }),
-    fetchGeocodedJurisdiction: flow(function* (siteId: string) {
+    fetchGeocodedJurisdiction: flow(function* (siteId: string, pid: string = null) {
       self.fetchingJurisdiction = true
-      const response: any = yield self.environment.api.fetchGeocodedJurisdiction(siteId)
+      const response: any = yield self.environment.api.fetchGeocodedJurisdiction(siteId, pid)
       let responseData = response?.data?.data
       self.fetchingJurisdiction = false
       if (response.ok) {


### PR DESCRIPTION
## Description

Allows the user to enter a pid manually, leveraging creatable select.
makes the geocoded jurisdiction endpoint work with either Site ID or PID.

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-661

## Steps to QA

log in as submitter
start a new permit application
enter a pid, hit the "create" option in the dropdown
PIN/manual jurisdiction mode should appear

