### PR TITLE
Feature/bphh 1190/external api model controllers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,18 @@ MAX_ENERGY_STEP=5
 MIN_ZERO_CARBON_STEP=1
 MAX_ZERO_CARBON_STEP=4
 
+
+# ActiveRecord attribute encryption variables
+
+# the minimum lengths for the keys should be 12 bytes for the
+# primary key (this will be used to derive the AES 32
+# bytes key) and 20 bytes for the salt.
+# You can auto generate this in the console with: bin/rails db:encryption:init
+
+ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=""
+ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=""
+ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=""
+
 ########################################################################
 # Dev Only, we disable compliance checks by default
 ########################################################################

--- a/app/blueprints/external_api_key_blueprint.rb
+++ b/app/blueprints/external_api_key_blueprint.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ExternalApiKeyBlueprint < Blueprinter::Base
+  identifier :id
+  fields :name, :expired_at, :webhook_url, :revoked_at, :updated_at, :created_at
+
+  view :with_token do
+    field :token
+  end
+end

--- a/app/controllers/api/external_api_keys_controller.rb
+++ b/app/controllers/api/external_api_keys_controller.rb
@@ -1,0 +1,85 @@
+class Api::ExternalApiKeysController < Api::ApplicationController
+  before_action :set_external_api_key, except: %i[index create]
+
+  def index
+    @external_api_key = policy_scope(ExternalApiKey)
+
+    render_success @external_api_key, nil, { blueprint: ExternalApiKeyBlueprint }
+  end
+
+  def show
+    authorize @external_api_key
+
+    render_success @external_api_key, nil, { blueprint: ExternalApiKeyBlueprint, blueprint_opts: { view: :with_token } }
+  end
+
+  def create
+    @external_api_key = ExternalApiKey.build(external_api_key_params)
+
+    authorize @external_api_key
+
+    if @external_api_key.save
+      render_success @external_api_key,
+                     "external_api_key.create_success",
+                     { blueprint: ExternalApiKeyBlueprint, blueprint_opts: { view: :with_token } }
+    else
+      render_error "external_api_key.create_error",
+                   message_opts: {
+                     error_message: @external_api_key.errors.full_messages.join(", "),
+                   }
+    end
+  end
+
+  def update
+    authorize @external_api_key
+
+    if @external_api_key.update(external_api_key_params)
+      render_success @external_api_key,
+                     "external_api_key.update_success",
+                     { blueprint: ExternalApiKeyBlueprint, blueprint_opts: { view: :with_token } }
+    else
+      render_error "external_api_key.update_error",
+                   message_opts: {
+                     error_message: @external_api_key.errors.full_messages.join(", "),
+                   }
+    end
+  end
+
+  def destroy
+    authorize @external_api_key
+
+    if @external_api_key.destroy
+      render json: {}, status: :ok
+    else
+      render_error "external_api_key.delete_error",
+                   message_opts: {
+                     error_message: @external_api_key.errors.full_messages.join(", "),
+                   }
+    end
+  end
+
+  def revoke
+    authorize @external_api_key
+
+    if @external_api_key.revoke
+      render_success @external_api_key,
+                     "external_api_key.revoke_success",
+                     { blueprint: ExternalApiKeyBlueprint, blueprint_opts: { view: :with_token } }
+    else
+      render_error "external_api_key.revoke_error",
+                   message_opts: {
+                     error_message: @external_api_key.errors.full_messages.join(", "),
+                   }
+    end
+  end
+
+  private
+
+  def set_external_api_key
+    @external_api_key = ExternalApiKey.find(params[:id])
+  end
+
+  def external_api_key_params
+    params.require(:external_api_key).permit(:name, :expired_at, :jurisdiction_id, :webhook_url)
+  end
+end

--- a/app/controllers/external_api/application_controller.rb
+++ b/app/controllers/external_api/application_controller.rb
@@ -1,0 +1,48 @@
+class ExternalApi::ApplicationController < ActionController::API
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+  include BaseControllerMethods
+  include Pundit::Authorization
+
+  before_action :authenticate_with_token
+  before_action :store_currents
+
+  attr_reader :current_external_api_key
+
+  rescue_from Pundit::NotAuthorizedError, with: :external_api_key_not_authorized
+
+  def pundit_user
+    current_external_api_key
+  end
+
+  protected
+
+  def store_currents
+    Current.external_api_key = current_external_api_key
+  end
+
+  def external_api_key_not_authorized(exception)
+    render_error(
+      "misc.external_api_key_unauthorized_error",
+      { message_opts: { error_message: exception.message }, status: 403 },
+      exception,
+    ) and return
+  end
+
+  def authenticate_with_token
+    authenticate_or_request_with_http_token do |token, options|
+      @current_external_api_key = ExternalApiKey.active.find_by_token(token)
+    end
+  end
+
+  # Override rails default 401 response to return JSON content-type
+  # with request for Bearer token
+  # https://api.rubyonrails.org/classes/ActionController/HttpAuthentication/Token/ControllerMethods.html
+  def request_http_token_authentication(realm = "Extern api", message = nil)
+    headers["WWW-Authenticate"] = %(Bearer realm="#{realm.tr('"', "")}")
+
+    render_error(
+      "misc.external_api_key_forbidden_error",
+      { message_opts: { error_message: message || "Access denied" }, status: 401 },
+    ) and return
+  end
+end

--- a/app/models/concerns/validate_url_attributes.rb
+++ b/app/models/concerns/validate_url_attributes.rb
@@ -1,0 +1,32 @@
+module ValidateUrlAttributes
+  extend ActiveSupport::Concern
+
+  included { validate :validate_url_attributes }
+
+  private
+
+  def validate_url_attributes
+    self.class.url_validatable_attributes.each do |attr_name|
+      value = send(attr_name)
+
+      next if value.blank?
+
+      begin
+        uri = URI.parse(value)
+        errors.add(attr_name, "must be a valid URL") unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+      rescue URI::InvalidURIError
+        errors.add(attr_name, "must be a valid URL")
+      end
+    end
+  end
+
+  class_methods do
+    def url_validatable(*attributes)
+      @url_validatable_attributes = attributes
+    end
+
+    def url_validatable_attributes
+      @url_validatable_attributes || []
+    end
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,4 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :user
+  attribute :external_api_key
   attribute :skip_websocket_broadcasts
 end

--- a/app/models/external_api_key.rb
+++ b/app/models/external_api_key.rb
@@ -1,4 +1,8 @@
 class ExternalApiKey < ApplicationRecord
+  # Token namespace can be useful for secrets scanning tools, e.g. GitHub secret scanning
+  # https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partner-program
+  TOKEN_NAMESPACE = "bphh"
+
   belongs_to :jurisdiction
 
   validates :token, uniqueness: true
@@ -11,6 +15,6 @@ class ExternalApiKey < ApplicationRecord
   private
 
   def generate_token
-    self.token ||= SecureRandom.urlsafe_base64(64)
+    self.token = "#{TOKEN_NAMESPACE}_#{SecureRandom.urlsafe_base64(64)}"
   end
 end

--- a/app/models/external_api_key.rb
+++ b/app/models/external_api_key.rb
@@ -23,6 +23,10 @@ class ExternalApiKey < ApplicationRecord
     revoked_at.present?
   end
 
+  def revoke
+    update(revoked_at: Time.now)
+  end
+
   private
 
   def generate_token

--- a/app/models/external_api_key.rb
+++ b/app/models/external_api_key.rb
@@ -1,16 +1,16 @@
 class ExternalApiKey < ApplicationRecord
   belongs_to :jurisdiction
 
-  validates :api_key, uniqueness: true
+  validates :token, uniqueness: true
   validates :name, presence: true, uniqueness: true
 
-  before_create :generate_api_key
+  before_create :generate_token
 
-  encrypts :api_key, deterministic: true
+  encrypts :token, deterministic: true
 
   private
 
-  def generate_api_key
-    self.api_key ||= SecureRandom.urlsafe_base64(64)
+  def generate_token
+    self.token ||= SecureRandom.urlsafe_base64(64)
   end
 end

--- a/app/models/external_api_key.rb
+++ b/app/models/external_api_key.rb
@@ -1,0 +1,16 @@
+class ExternalApiKey < ApplicationRecord
+  belongs_to :jurisdiction
+
+  validates :api_key, uniqueness: true
+  validates :name, presence: true, uniqueness: true
+
+  before_create :generate_api_key
+
+  encrypts :api_key, deterministic: true
+
+  private
+
+  def generate_api_key
+    self.api_key ||= SecureRandom.urlsafe_base64(64)
+  end
+end

--- a/app/policies/external_api/application_policy.rb
+++ b/app/policies/external_api/application_policy.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class ExternalApi::ApplicationPolicy
+  attr_reader :external_api_key, :record
+
+  def initialize(external_api_key, record)
+    @external_api_key = external_api_key
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_accessor :external_api_key, :scope
+
+    def initialize(external_api_key, scope)
+      @external_api_key = external_api_key
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/external_api_key_policy.rb
+++ b/app/policies/external_api_key_policy.rb
@@ -1,0 +1,33 @@
+class ExternalApiKeyPolicy < ApplicationPolicy
+  def index?
+    user.super_admin? || user.review_manager?
+  end
+
+  def show?
+    user.super_admin? || (user.review_manager? && user.jurisdiction_id == record.jurisdiction_id)
+  end
+
+  def create?
+    show?
+  end
+
+  def update?
+    create?
+  end
+
+  def destroy?
+    create?
+  end
+
+  def revoke?
+    create?
+  end
+
+  class Scope < Scope
+    def resolve
+      return [] unless user.super_admin? || user.review_manager?
+
+      user.super_admin? ? ExternalApiKey.all : ExternalApiKey.where(jurisdiction_id: user.jurisdiction_id)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,19 @@ module HousPermitPortal
 
     # This will force all new tables to use UUIDs for id field
     config.generators { |g| g.orm :active_record, primary_key_type: :uuid }
+
+    # This sets up keys needed for active record attribute encryption
+
+    # the minimum lengths for the keys should be 12 bytes for the
+    # primary key (this will be used to derive the AES 32
+    # bytes key) and 20 bytes for the salt.
+
+    # You can auto generate this in the console with: bin/rails db:encryption:init
+
+    config.active_record.encryption.primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"]
+    config.active_record.encryption.deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
+    config.active_record.encryption.key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
+    # This will enable unique validations on encrypted fields
+    config.active_record.encryption.extend_queries = true
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,6 +202,28 @@ en:
       delete_error:
         title: Error
         message: "Something went wrong deleting the requirement block"
+    external_api_key:
+      create_error:
+        title: Create Error
+        message: "%{error_message}"
+      update_error:
+        title: Update Error
+        message: "%{error_message}"
+      revoke_error:
+        title: Revoke Error
+        message: "%{error_message}"
+      delete_error:
+        title: Delete Error
+        message: "%{error_message}"
+      create_success:
+        title: Success
+        message: "New external api key created successfully!"
+      update_success:
+        title: Success
+        message: "New external api key updated successfully!"
+      revoke_success:
+        title: Success
+        message: "New external api key revoked successfully!"
     requirement_template:
       create_success:
         title: ""

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,6 +302,12 @@ en:
       user_not_authorized_error:
         title: "Unauthorized"
         message: "The user is not authorized to do this action"
+      external_api_key_forbidden_error:
+        title: "Forbidden"
+        message: "The external api key is not authorized to do this action"
+      external_api_key_unauthorized_error:
+        title: "Unauthorized"
+        message: "%{error_message}"
       not_found_error:
         title: "Error"
         message: 404 - The requested resource could not be found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,6 +122,10 @@ Rails.application.routes.draw do
       get :show, on: :collection
       put :update, on: :collection
     end
+
+    resources :external_api_keys do
+      post "revoke", on: :member
+    end
   end
 
   root to: "home#index"

--- a/db/migrate/20240417195959_create_external_api_keys.rb
+++ b/db/migrate/20240417195959_create_external_api_keys.rb
@@ -1,0 +1,15 @@
+class CreateExternalApiKeys < ActiveRecord::Migration[7.1]
+  def change
+    create_table :external_api_keys, id: :uuid do |t|
+      t.string :api_key, null: false, limit: 510
+      t.datetime :expiration_date, null: true
+      t.string :name, null: false
+      t.string :webhook_url, null: true
+      t.references :jurisdiction, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+
+    add_index :external_api_keys, :api_key, unique: true
+  end
+end

--- a/db/migrate/20240417195959_create_external_api_keys.rb
+++ b/db/migrate/20240417195959_create_external_api_keys.rb
@@ -1,7 +1,7 @@
 class CreateExternalApiKeys < ActiveRecord::Migration[7.1]
   def change
     create_table :external_api_keys, id: :uuid do |t|
-      t.string :api_key, null: false, limit: 510
+      t.string :token, null: false, limit: 510
       t.datetime :expiration_date, null: true
       t.string :name, null: false
       t.string :webhook_url, null: true
@@ -10,6 +10,6 @@ class CreateExternalApiKeys < ActiveRecord::Migration[7.1]
       t.timestamps
     end
 
-    add_index :external_api_keys, :api_key, unique: true
+    add_index :external_api_keys, :token, unique: true
   end
 end

--- a/db/migrate/20240417195959_create_external_api_keys.rb
+++ b/db/migrate/20240417195959_create_external_api_keys.rb
@@ -2,7 +2,8 @@ class CreateExternalApiKeys < ActiveRecord::Migration[7.1]
   def change
     create_table :external_api_keys, id: :uuid do |t|
       t.string :token, null: false, limit: 510
-      t.datetime :expiration_date, null: true
+      t.datetime :expired_at, null: true
+      t.datetime :revoked_at, null: true
       t.string :name, null: false
       t.string :webhook_url, null: true
       t.references :jurisdiction, null: false, foreign_key: true, type: :uuid

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,18 +79,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_17_195959) do
                id: :uuid,
                default: -> { "gen_random_uuid()" },
                force: :cascade do |t|
-    t.string "api_key", limit: 510, null: false
+    t.string "token", limit: 510, null: false
     t.datetime "expiration_date"
     t.string "name", null: false
     t.string "webhook_url"
     t.uuid "jurisdiction_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["api_key"],
-            name: "index_external_api_keys_on_api_key",
-            unique: true
     t.index ["jurisdiction_id"],
             name: "index_external_api_keys_on_jurisdiction_id"
+    t.index ["token"], name: "index_external_api_keys_on_token", unique: true
   end
 
   create_table "jurisdiction_template_version_customizations",

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_10_164337) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_17_195959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -73,6 +73,24 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_10_164337) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "variant"
+  end
+
+  create_table "external_api_keys",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
+    t.string "api_key", limit: 510, null: false
+    t.datetime "expiration_date"
+    t.string "name", null: false
+    t.string "webhook_url"
+    t.uuid "jurisdiction_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["api_key"],
+            name: "index_external_api_keys_on_api_key",
+            unique: true
+    t.index ["jurisdiction_id"],
+            name: "index_external_api_keys_on_jurisdiction_id"
   end
 
   create_table "jurisdiction_template_version_customizations",
@@ -604,6 +622,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_10_164337) do
   end
 
   add_foreign_key "allowlisted_jwts", "users", on_delete: :cascade
+  add_foreign_key "external_api_keys", "jurisdictions"
   add_foreign_key "jurisdiction_template_version_customizations",
                   "jurisdictions"
   add_foreign_key "jurisdiction_template_version_customizations",

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -80,7 +80,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_17_195959) do
                default: -> { "gen_random_uuid()" },
                force: :cascade do |t|
     t.string "token", limit: 510, null: false
-    t.datetime "expiration_date"
+    t.datetime "expired_at"
+    t.datetime "revoked_at"
     t.string "name", null: false
     t.string "webhook_url"
     t.uuid "jurisdiction_id", null: false

--- a/spec/concerns/validate_url_attributes_spec.rb
+++ b/spec/concerns/validate_url_attributes_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe ValidateUrlAttributes, type: :model do
+  # Create a dummy model to test the concern
+  class DummyModel < ApplicationRecord
+    include ValidateUrlAttributes
+
+    url_validatable :url, :another_url
+  end
+
+  # Define a migration to create the table for DummyModel
+  class CreateDummyModels < ActiveRecord::Migration[6.0]
+    def change
+      create_table :dummy_models do |t|
+        t.string :url
+        t.string :another_url
+        t.timestamps
+      end
+    end
+  end
+
+  # Run the migration before running the tests
+  before(:all) do
+    CreateDummyModels.new.change
+    ActiveRecord::Migration.maintain_test_schema!
+  end
+
+  # Rollback migration after running the tests
+  after(:all) { ActiveRecord::Migration.drop_table(:dummy_models) }
+
+  describe "URL validation" do
+    let(:dummy_model) { DummyModel.new }
+
+    context "when single URL attribute is valid" do
+      it "is valid" do
+        dummy_model.url = "https://www.example.com"
+        expect(dummy_model).to be_valid
+      end
+    end
+
+    context "when single URL attribute is invalid" do
+      it "is invalid" do
+        dummy_model.url = "not_a_url"
+        expect(dummy_model).not_to be_valid
+        expect(dummy_model.errors[:url]).to include("must be a valid URL")
+      end
+    end
+
+    context "when single URL attribute is blank" do
+      it "is valid" do
+        dummy_model.url = ""
+        expect(dummy_model).to be_valid
+      end
+    end
+
+    context "when single URL attribute is nil" do
+      it "is valid" do
+        dummy_model.url = nil
+        expect(dummy_model).to be_valid
+      end
+    end
+
+    context "when single URL attribute has valid characters but invalid scheme" do
+      it "is invalid" do
+        dummy_model.url = "ftp://www.example.com"
+        expect(dummy_model).not_to be_valid
+        expect(dummy_model.errors[:url]).to include("must be a valid URL")
+      end
+    end
+
+    context "when multiple URL attributes are valid" do
+      it "is valid" do
+        dummy_model.url = "https://www.example.com"
+        dummy_model.another_url = "http://www.example.org"
+        expect(dummy_model).to be_valid
+      end
+    end
+
+    context "when multiple URL attributes contain an invalid URL" do
+      it "is invalid" do
+        dummy_model.url = "https://www.example.com"
+        dummy_model.another_url = "not_a_url"
+        expect(dummy_model).not_to be_valid
+        expect(dummy_model.errors[:another_url]).to include("must be a valid URL")
+      end
+    end
+  end
+end

--- a/spec/controllers/external_api/application_controller_spec.rb
+++ b/spec/controllers/external_api/application_controller_spec.rb
@@ -55,6 +55,22 @@ RSpec.describe MockExternalApiController, type: :controller do
       expect(response).to have_http_status(401)
     end
 
+    it "returns 401 unauthorized with revoked token" do
+      revoked_external_api_key = create(:external_api_key, revoked_at: Time.now)
+
+      request.headers["Authorization"] = "Bearer #{revoked_external_api_key.token}"
+      get :protected_action
+      expect(response).to have_http_status(401)
+    end
+
+    it "returns 401 unauthorized with expired token" do
+      expired_external_api_key = create(:external_api_key, revoked_at: Time.now)
+
+      request.headers["Authorization"] = "Bearer #{expired_external_api_key.token}"
+      get :protected_action
+      expect(response).to have_http_status(401)
+    end
+
     it "returns 200 OK with valid token" do
       external_api_key = create(:external_api_key)
       request.headers["Authorization"] = "Bearer #{external_api_key.token}"

--- a/spec/controllers/external_api/application_controller_spec.rb
+++ b/spec/controllers/external_api/application_controller_spec.rb
@@ -1,0 +1,69 @@
+# spec/controllers/external_api/application_controller_spec.rb
+
+require "rails_helper"
+
+class MockExternalApiController < ExternalApi::ApplicationController
+  def protected_action
+    render json: { message: "mock protected action" }, status: 200
+  end
+
+  def protected_action_with_authorization_pass
+    authorize :mock_external_api_key
+    render json: { message: "mock protected action with authorisation" }, status: 200
+  end
+
+  def protected_action_with_authorization_fail
+    authorize :mock_external_api_key
+    render json: { message: "mock protected action with authorisation" }, status: 200
+  end
+end
+
+class MockExternalApiKeyPolicy < ExternalApi::ApplicationPolicy
+  def protected_action_with_authorization_pass?
+    external_api_key.present?
+  end
+
+  def protected_action_with_authorization_fail?
+    false
+  end
+end
+
+RSpec.describe MockExternalApiController, type: :controller do
+  before(:each) { @controller = MockExternalApiController.new }
+
+  describe "authentication" do
+    it "returns 401 unauthorized without token" do
+      get :protected_action
+      expect(response).to have_http_status(401)
+    end
+
+    it "returns 401 unauthorized with invalid token" do
+      request.headers["Authorization"] = "Bearer invalid_token"
+      get :protected_action
+      expect(response).to have_http_status(401)
+    end
+
+    it "returns 200 OK with valid token" do
+      external_api_key = create(:external_api_key)
+      request.headers["Authorization"] = "Bearer #{external_api_key.token}"
+      get :protected_action
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "authorization" do
+    it "returns 403 forbidden for unauthorized action" do
+      external_api_key = create(:external_api_key)
+      request.headers["Authorization"] = "Bearer #{external_api_key.token}"
+      get :protected_action_with_authorization_fail
+      expect(response).to have_http_status(403)
+    end
+
+    it "returns 200 OK for authorized action" do
+      authorized_external_api_key = create(:external_api_key)
+      request.headers["Authorization"] = "Bearer #{authorized_external_api_key.token}"
+      get :protected_action_with_authorization_pass
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/controllers/external_api/application_controller_spec.rb
+++ b/spec/controllers/external_api/application_controller_spec.rb
@@ -29,7 +29,19 @@ class MockExternalApiKeyPolicy < ExternalApi::ApplicationPolicy
 end
 
 RSpec.describe MockExternalApiController, type: :controller do
+  before do
+    # set up mock routes needed to test external api base controller
+    Rails.application.routes.draw do
+      get "mock_protected_action", to: "mock_external_api#protected_action"
+      get "mock_protected_action_with_authorization_pass",
+          to: "mock_external_api#protected_action_with_authorization_pass"
+      get "mock_protected_action_with_authorization_fail",
+          to: "mock_external_api#protected_action_with_authorization_fail"
+    end
+  end
   before(:each) { @controller = MockExternalApiController.new }
+
+  after { Rails.application.reload_routes! }
 
   describe "authentication" do
     it "returns 401 unauthorized without token" do

--- a/spec/factories/external_api_key.rb
+++ b/spec/factories/external_api_key.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :external_api_key do
+    association :jurisdiction, factory: :sub_district
+    name { Faker::Lorem.words(number: 2).join(" ") }
+    expiration_date { nil }
+  end
+end

--- a/spec/factories/external_api_key.rb
+++ b/spec/factories/external_api_key.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :external_api_key do
     association :jurisdiction, factory: :sub_district
     name { Faker::Lorem.words(number: 2).join(" ") }
-    expiration_date { nil }
+    expired_at { nil }
+    revoked_at { nil }
   end
 end

--- a/spec/models/external_api_key_spec.rb
+++ b/spec/models/external_api_key_spec.rb
@@ -11,6 +11,30 @@ RSpec.describe ExternalApiKey, type: :model do
     expect(external_api_key.encrypted_attribute?(:token)).to be(true)
   end
 
+  describe "scopes" do
+    it "returns non expired and non revoked tokens only for active scope" do
+      active_external_api_keys = [
+        create(:external_api_key),
+        create(:external_api_key),
+        create(:external_api_key, expired_at: Time.now + 1.day),
+        create(:external_api_key, expired_at: Time.now + 10.minute),
+      ]
+      revoked_external_api_keys = [
+        create(:external_api_key, revoked_at: Time.now + 1.day),
+        create(:external_api_key, revoked_at: Time.now - 1.day),
+        create(:external_api_key, revoked_at: Time.now),
+      ] # any non nil revoked_at value should be considered as immediately revoked
+
+      expired_external_api_keys = [
+        create(:external_api_key, revoked_at: Time.now - 1.day),
+        create(:external_api_key, revoked_at: Time.now - 10.minute),
+        create(:external_api_key, revoked_at: Time.now),
+      ]
+
+      expect(ExternalApiKey.active).to match_array(active_external_api_keys)
+    end
+  end
+
   describe "validations" do
     context "name" do
       it "enforces name is required" do

--- a/spec/models/external_api_key_spec.rb
+++ b/spec/models/external_api_key_spec.rb
@@ -73,4 +73,49 @@ RSpec.describe ExternalApiKey, type: :model do
       end
     end
   end
+
+  describe "methods" do
+    context "expired?" do
+      it "returns true if expired_at is in the past" do
+        external_api_key = create(:external_api_key, expired_at: Time.now - 1.day)
+
+        expect(external_api_key.expired?).to eq(true)
+      end
+
+      it "returns true if expired_at is the current time" do
+        external_api_key = create(:external_api_key, expired_at: Time.now)
+
+        expect(external_api_key.expired?).to eq(true)
+      end
+
+      it "returns false if expired_at is in the future" do
+        external_api_key = create(:external_api_key, expired_at: Time.now + 1.day)
+
+        expect(external_api_key.expired?).to eq(false)
+      end
+
+      it "returns false if expired_at is nil" do
+        external_api_key = create(:external_api_key, expired_at: nil)
+
+        expect(external_api_key.expired?).to eq(false)
+      end
+    end
+
+    context "revoked?" do
+      it "returns true if revoked_at is any non nil value" do
+        external_api_key_1 = create(:external_api_key, revoked_at: Time.now - 1.day)
+        external_api_key_2 = create(:external_api_key, revoked_at: Time.now + 1.day) # should still be considered
+        # revoked is timestamp is in the future. The timestamp is just for logging purposes
+
+        expect(external_api_key_1.revoked?).to eq(true)
+        expect(external_api_key_2.revoked?).to eq(true)
+      end
+
+      it "returns false if revoked_at is nil" do
+        external_api_key = create(:external_api_key, revoked_at: nil)
+
+        expect(external_api_key.revoked?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/models/external_api_key_spec.rb
+++ b/spec/models/external_api_key_spec.rb
@@ -28,25 +28,25 @@ RSpec.describe ExternalApiKey, type: :model do
       end
     end
 
-    context "api_key" do
-      it "enforces api_key is auto set when not provided" do
-        api_key = "test_key"
+    context "token" do
+      it "enforces token is auto set when not provided" do
+        token = "test_key"
         external_api_key_without_key_provided = create(:external_api_key)
-        external_api_key_with_key_provided = create(:external_api_key, api_key: api_key)
+        external_api_key_with_key_provided = create(:external_api_key, token: token)
 
-        expect(external_api_key_without_key_provided.api_key).to be_present
-        expect(external_api_key_with_key_provided.api_key).to be_present
-        expect(external_api_key_with_key_provided.api_key).to eq(api_key)
+        expect(external_api_key_without_key_provided.token).to be_present
+        expect(external_api_key_with_key_provided.token).to be_present
+        expect(external_api_key_with_key_provided.token).to eq(token)
       end
 
-      it "enforces api_key is unique" do
-        api_key = "test_key"
-        valid_external_api_key = create(:external_api_key, api_key: api_key)
-        invalid_external_api_key = build(:external_api_key, api_key: api_key)
+      it "enforces token is unique" do
+        token = "test_key"
+        valid_external_api_key = create(:external_api_key, token: token)
+        invalid_external_api_key = build(:external_api_key, token: token)
 
         expect(valid_external_api_key.valid?).to eq(true)
         expect(invalid_external_api_key.valid?).to eq(false)
-        expect(invalid_external_api_key.errors[:api_key]).to include("has already been taken")
+        expect(invalid_external_api_key.errors[:token]).to include("has already been taken")
       end
     end
   end

--- a/spec/models/external_api_key_spec.rb
+++ b/spec/models/external_api_key_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe ExternalApiKey, type: :model do
+  describe "associations" do
+    # Testing direct associations
+    it { should belong_to(:jurisdiction) }
+  end
+
+  describe "validations" do
+    context "name" do
+      it "enforces name is required" do
+        valid_external_api_key = build(:external_api_key)
+        invalid_external_api_key = build(:external_api_key, name: nil)
+
+        expect(invalid_external_api_key.valid?).to eq(false)
+        expect(invalid_external_api_key.errors[:name]).to include("can't be blank")
+        expect(valid_external_api_key.valid?).to eq(true)
+      end
+
+      it "enforces name is unique" do
+        name = "test_name"
+        valid_external_api_key = create(:external_api_key, name: name)
+        invalid_external_api_key = build(:external_api_key, name: name)
+
+        expect(valid_external_api_key.valid?).to eq(true)
+        expect(invalid_external_api_key.valid?).to eq(false)
+        expect(invalid_external_api_key.errors[:name]).to include("has already been taken")
+      end
+    end
+
+    context "api_key" do
+      it "enforces api_key is auto set when not provided" do
+        api_key = "test_key"
+        external_api_key_without_key_provided = create(:external_api_key)
+        external_api_key_with_key_provided = create(:external_api_key, api_key: api_key)
+
+        expect(external_api_key_without_key_provided.api_key).to be_present
+        expect(external_api_key_with_key_provided.api_key).to be_present
+        expect(external_api_key_with_key_provided.api_key).to eq(api_key)
+      end
+
+      it "enforces api_key is unique" do
+        api_key = "test_key"
+        valid_external_api_key = create(:external_api_key, api_key: api_key)
+        invalid_external_api_key = build(:external_api_key, api_key: api_key)
+
+        expect(valid_external_api_key.valid?).to eq(true)
+        expect(invalid_external_api_key.valid?).to eq(false)
+        expect(invalid_external_api_key.errors[:api_key]).to include("has already been taken")
+      end
+    end
+  end
+end

--- a/spec/models/external_api_key_spec.rb
+++ b/spec/models/external_api_key_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe ExternalApiKey, type: :model do
       end
     end
 
+    context "webhook_url" do
+      it "enforces webhook_url is a valid url when set to a non blank value" do
+        valid_external_api_key = build(:external_api_key, webhook_url: "https://www.example.com") # with valid url
+        valid_external_api_key_2 = build(:external_api_key, webhook_url: "") # with blank url
+        valid_external_api_key_3 = build(:external_api_key, webhook_url: nil) # with nil url
+        invalid_external_api_key = build(:external_api_key, webhook_url: "invalid") # with invalid url
+
+        expect(invalid_external_api_key.valid?).to eq(false)
+        expect(invalid_external_api_key.errors[:webhook_url]).to include("must be a valid URL")
+        expect(valid_external_api_key.valid?).to eq(true)
+        expect(valid_external_api_key_2.valid?).to eq(true)
+        expect(valid_external_api_key_3.valid?).to eq(true)
+      end
+    end
+
     context "token" do
       it "enforces token is auto set on create" do
         external_api_key_without_key_provided = create(:external_api_key)

--- a/spec/models/external_api_key_spec.rb
+++ b/spec/models/external_api_key_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe ExternalApiKey, type: :model do
     it { should belong_to(:jurisdiction) }
   end
 
+  it "has an encrypted token property" do
+    external_api_key = create(:external_api_key)
+    expect(external_api_key.encrypted_attribute?(:token)).to be(true)
+  end
+
   describe "validations" do
     context "name" do
       it "enforces name is required" do
@@ -29,24 +34,18 @@ RSpec.describe ExternalApiKey, type: :model do
     end
 
     context "token" do
-      it "enforces token is auto set when not provided" do
-        token = "test_key"
+      it "enforces token is auto set on create" do
         external_api_key_without_key_provided = create(:external_api_key)
-        external_api_key_with_key_provided = create(:external_api_key, token: token)
 
         expect(external_api_key_without_key_provided.token).to be_present
-        expect(external_api_key_with_key_provided.token).to be_present
-        expect(external_api_key_with_key_provided.token).to eq(token)
       end
 
-      it "enforces token is unique" do
+      it "enforces token starts with a fixed name space" do
         token = "test_key"
-        valid_external_api_key = create(:external_api_key, token: token)
-        invalid_external_api_key = build(:external_api_key, token: token)
+        external_api_key = create(:external_api_key, token: token)
 
-        expect(valid_external_api_key.valid?).to eq(true)
-        expect(invalid_external_api_key.valid?).to eq(false)
-        expect(invalid_external_api_key.errors[:token]).to include("has already been taken")
+        expect(external_api_key.valid?).to eq(true)
+        expect(external_api_key.token).to start_with(ExternalApiKey::TOKEN_NAMESPACE)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,13 +18,6 @@
 # in spec/support/ and its subdirectories.
 Dir[File.expand_path(File.join(File.dirname(__FILE__), "support", "**", "*.rb"))].each { |f| require f }
 
-# set up mock routes needed to test external api base controller
-Rails.application.routes.draw do
-  get "mock_protected_action", to: "mock_external_api#protected_action"
-  get "mock_protected_action_with_authorization_pass", to: "mock_external_api#protected_action_with_authorization_pass"
-  get "mock_protected_action_with_authorization_fail", to: "mock_external_api#protected_action_with_authorization_fail"
-end
-
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,13 @@
 # in spec/support/ and its subdirectories.
 Dir[File.expand_path(File.join(File.dirname(__FILE__), "support", "**", "*.rb"))].each { |f| require f }
 
+# set up mock routes needed to test external api base controller
+Rails.application.routes.draw do
+  get "mock_protected_action", to: "mock_external_api#protected_action"
+  get "mock_protected_action_with_authorization_pass", to: "mock_external_api#protected_action_with_authorization_pass"
+  get "mock_protected_action_with_authorization_fail", to: "mock_external_api#protected_action_with_authorization_fail"
+end
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## Description
- Adds External Api models with token encryption
- Adds base controller which future external api namespaced controller can utilise
    - Includes token authentication and authorisation 
- Adds external_api_key_controller for CRUD operations on the external api key model itself. (This for in app super admins and review mangers)
- Adds relevant specs
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Add the .env variables. This can be generated usiong `bin/rails db:encryption:init`
    - ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=""
    - ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=""
    - ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=""
- Run `bundle exec rspec` for external_api namespace base controllers and external_api_key model validations
- To test CRUD operations via external api key controller, can use postman for the following requests. (Logged in as super admin or review manager)

![Screenshot 2024-04-19 at 12 34 18 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/156c7e1f-1cea-44ad-a80a-1f09ba45799f)
![Screenshot 2024-04-19 at 12 34 28 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/e756833f-6c06-4e4b-940b-11c6c397c33c)
![Screenshot 2024-04-19 at 12 34 42 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/672ec5e7-87a3-4664-80b5-0bd4d97fd141)
![Screenshot 2024-04-19 at 12 34 49 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/b20c2d71-cc8d-494d-944c-f4fa40489548)
![Screenshot 2024-04-19 at 12 39 08 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/c65fb9fb-30e0-4d9c-886e-bc69c728212a)
