### PR TITLE
Fix error handling when accepting invitation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,9 +125,12 @@ en:
       registration_error:
         title: Account could not be created.
         message: "%{error_message}"
-      accept_invite_error:
+      invalid_invitation_error:
         title: Error
-        message: We are sorry the invite link you have clicked on has expired. Please reach out to the person who sent you the invite for further assistance.
+        message: We are sorry the invite link you have clicked on is not valid. Please reach out to the person who sent you the invite for further assistance.
+      accept_invite_error:
+        title: Error accepting invite
+        message: "%{error_message}"
       create_invite_error:
         title: Error
         message: "Something went wrong inviting users"


### PR DESCRIPTION
## Description

Show the user a meaningful message if they enter invalid data in the form (e.g. username is already in use)

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Fixes [BPHH-1205](https://hous-bssb.atlassian.net/browse/BPHH-1205)

## Steps to QA

1. As a super admin or review manager, invite a reviewer
2. Accept the invitation with a username that already exists in the system.
3. The user should see a specific error message indicating the username is already in use.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
