### PR TITLE
[bphh-1208] Add ability to enable or disable external_api_keys for a whole jurisdiction

### DIFF
--- a/app/controllers/api/jurisdictions_controller.rb
+++ b/app/controllers/api/jurisdictions_controller.rb
@@ -140,6 +140,7 @@ class Api::JurisdictionsController < Api::ApplicationController
       :energy_step_required,
       :zero_carbon_step_required,
       :map_zoom,
+      :external_api_enabled,
       map_position: [],
       users_attributes: %i[first_name last_name role email],
       contacts_attributes: %i[id first_name last_name department title phone cell email],

--- a/app/policies/external_api_key_policy.rb
+++ b/app/policies/external_api_key_policy.rb
@@ -4,7 +4,11 @@ class ExternalApiKeyPolicy < ApplicationPolicy
   end
 
   def show?
-    user.super_admin? || (user.review_manager? && user.jurisdiction_id == record.jurisdiction_id)
+    user.super_admin? ||
+      (
+        user.review_manager? && record.jurisdiction.external_api_enabled? &&
+          user.jurisdiction_id == record.jurisdiction_id
+      )
   end
 
   def create?

--- a/db/migrate/20240422165748_add_external_api_enabled_to_jurisdiction.rb
+++ b/db/migrate/20240422165748_add_external_api_enabled_to_jurisdiction.rb
@@ -1,0 +1,5 @@
+class AddExternalApiEnabledToJurisdiction < ActiveRecord::Migration[7.1]
+  def change
+    add_column :jurisdictions, :external_api_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_17_195959) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_22_165748) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -128,6 +128,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_17_195959) do
     t.integer "zero_carbon_step_required", default: 1
     t.string "slug"
     t.integer "map_zoom"
+    t.boolean "external_api_enabled", default: false
     t.index ["prefix"], name: "index_jurisdictions_on_prefix", unique: true
     t.index ["regional_district_id"],
             name: "index_jurisdictions_on_regional_district_id"

--- a/spec/controllers/external_api/application_controller_spec.rb
+++ b/spec/controllers/external_api/application_controller_spec.rb
@@ -71,6 +71,16 @@ RSpec.describe MockExternalApiController, type: :controller do
       expect(response).to have_http_status(401)
     end
 
+    it "returns 401 unauthorized with existing token, if corresponding jurisdiction did not enable api" do
+      expired_external_api_key =
+        create(:external_api_key, jurisdiction: create(:sub_district, external_api_enabled: false))
+
+      request.headers["Authorization"] = "Bearer #{expired_external_api_key.token}"
+
+      get :protected_action
+      expect(response).to have_http_status(401)
+    end
+
     it "returns 200 OK with valid token" do
       external_api_key = create(:external_api_key)
       request.headers["Authorization"] = "Bearer #{external_api_key.token}"

--- a/spec/factories/external_api_key.rb
+++ b/spec/factories/external_api_key.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :external_api_key do
-    association :jurisdiction, factory: :sub_district
+    association :jurisdiction, factory: :sub_district, external_api_enabled: true
     name { Faker::Lorem.words(number: 2).join(" ") }
     expired_at { nil }
     revoked_at { nil }


### PR DESCRIPTION
## Description
[bphh-1208] Add back-end ability to enable or disable external_api_keys for a whole jurisdiction. Update relevant scope, logic, and spec's to handle this.
- The review_managers are not able to perform CRUD operations on an external api if they haven't been enabled for the jurisdiction. The super admins can still access as usual
- The active scope is updated to only return active apis for jurisdictions who has external api's enabled
- The external_api base application controller now reject's api key's if the jurisdiction the key belong's to does not have api 's enabled
- Changes the unique name validation of external_api_key to be scoped by jurisdiction
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1208
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->