### PR TITLE
Add support for skipping keycloak login page

### DIFF
--- a/app/frontend/components/domains/authentication/login-screen.tsx
+++ b/app/frontend/components/domains/authentication/login-screen.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, HStack, Heading, Text, VStack } from "@chakra-ui/react"
+import { AbsoluteCenter, Box, Button, Divider, Flex, HStack, Heading, Text, VStack } from "@chakra-ui/react"
 import React from "react"
 import { FormProvider, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
@@ -38,8 +38,9 @@ export const LoginScreen = ({}: ILoginScreenProps) => {
     <CenterContainer>
       <Flex direction="column" gap={6} w="full" p={10} border="solid 1px" borderColor="border.light" bg="greys.white">
         <Heading as="h1">{t("auth.login")}</Heading>
-        {/* Disabling BCeID login pending IDIM approval */}
-        {/* <form action="/api/auth/keycloak" method="post">
+        <form action="/api/auth/keycloak" method="post">
+          {/* @ts-ignore */}
+          <input type="hidden" name="kc_idp_hint" value="bceidboth" />
           <input type="hidden" name="authenticity_token" value={document.querySelector("[name=csrf-token]").content} />
           <Button variant="primary" w="full" type="submit">
             {t("auth.bceid_login")}
@@ -50,7 +51,7 @@ export const LoginScreen = ({}: ILoginScreenProps) => {
           <AbsoluteCenter bg="white" px="4" textTransform="uppercase" fontSize="sm" fontWeight="medium">
             {t("auth.or")}
           </AbsoluteCenter>
-        </Box> */}
+        </Box>
         <FormProvider {...formMethods}>
           <form onSubmit={handleSubmit(onSubmit)}>
             <VStack spacing={4} align="start">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -35,6 +35,7 @@ Devise.setup do |config|
                     site: ENV["KEYCLOAK_AUTH_URL"],
                     realm: "standard",
                   },
+                  authorize_options: [:kc_idp_hint],
                   name: :keycloak,
                   strategy_class: OmniAuth::Strategies::KeycloakOpenId
 


### PR DESCRIPTION
## Description

Add support for skipping keycloak login page. This will facilitate having separate login pages for different user types (e.g. submitter/reviewers use BCeID, admins use IDIR).

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Implements [BPHH-1264](https://hous-bssb.atlassian.net/browse/BPHH-1264)

## Steps to QA

1. Navigate to login page
2. Click 'Login with BCeID'
3. User should get redirected to BCeID login screen directly instead of seeing the screen where they are given the option to choose between BCeID, IDIR, or GitHub.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
