### PR TITLE
Feature/bphh 1236/external api admin screens

### DIFF
--- a/app/blueprints/external_api_key_blueprint.rb
+++ b/app/blueprints/external_api_key_blueprint.rb
@@ -2,7 +2,7 @@
 
 class ExternalApiKeyBlueprint < Blueprinter::Base
   identifier :id
-  fields :name, :expired_at, :webhook_url, :revoked_at, :updated_at, :created_at
+  fields :name, :connecting_application, :expired_at, :webhook_url, :revoked_at, :updated_at, :created_at
 
   view :with_token do
     field :token

--- a/app/blueprints/jurisdiction_blueprint.rb
+++ b/app/blueprints/jurisdiction_blueprint.rb
@@ -19,8 +19,10 @@ class JurisdictionBlueprint < Blueprinter::Base
          :zero_carbon_step_required,
          :regional_district_name,
          :created_at,
-         :updated_at
+         :updated_at,
+         :external_api_enabled
 
   association :contacts, blueprint: ContactBlueprint
-  association :permit_type_submission_contacts, blueprint: PermitTypeSubmissionContactBlueprint
+  association :permit_type_submission_contacts,
+              blueprint: PermitTypeSubmissionContactBlueprint
 end

--- a/app/controllers/api/external_api_keys_controller.rb
+++ b/app/controllers/api/external_api_keys_controller.rb
@@ -93,6 +93,12 @@ class Api::ExternalApiKeysController < Api::ApplicationController
   end
 
   def external_api_key_params
-    params.require(:external_api_key).permit(:name, :expired_at, :jurisdiction_id, :webhook_url)
+    params.require(:external_api_key).permit(
+      :name,
+      :expired_at,
+      :connecting_application,
+      :jurisdiction_id,
+      :webhook_url,
+    )
   end
 end

--- a/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
+++ b/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
@@ -5,9 +5,11 @@ import {
   Grid,
   GridItem,
   HStack,
+  IconButton,
   Input,
   InputGroup,
   InputLeftElement,
+  Link,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -16,7 +18,7 @@ import {
   ModalHeader,
   ModalOverlay,
 } from "@chakra-ui/react"
-import { Key, Prohibit } from "@phosphor-icons/react"
+import { Info, Key, Prohibit } from "@phosphor-icons/react"
 import { addYears } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useState } from "react"
@@ -159,6 +161,19 @@ export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModal
                 <UrlFormControl
                   label={t("externalApiKey.fieldLabels.webhookUrl")}
                   fieldName={"webhookUrl"}
+                  LabelInfo={() => (
+                    <IconButton
+                      as={Link}
+                      // TODO: Placeholder generic help link for now. Replace with actual link when available
+                      href={`https://www2.gov.bc.ca/gov/content?id=A5A88A4CE1D54D95AB23D57858EF11EE`}
+                      target={"_blank"}
+                      mb={1}
+                      minW={6}
+                      variant={"tertiary"}
+                      aria-label={"Webhook Url info link"}
+                      icon={<Info />}
+                    />
+                  )}
                   inputProps={{ placeholder: t("externalApiKey.fieldPlaceholders.webhookUrl") }}
                   validate
                 />

--- a/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
+++ b/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
@@ -17,6 +17,7 @@ import {
   ModalOverlay,
 } from "@chakra-ui/react"
 import { Key } from "@phosphor-icons/react"
+import { addYears } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useState } from "react"
 import { FormProvider, useForm } from "react-hook-form"
@@ -37,7 +38,8 @@ interface IExternalApiKeyForm extends IExternalApiKeyParams {
 const formFormDefaultValues = (externalApiKey?: IExternalApiKey): IExternalApiKeyForm => {
   return {
     name: externalApiKey?.name || "",
-    expiredAt: externalApiKey?.expiredAt,
+    connectingApplication: externalApiKey?.connectingApplication || "",
+    expiredAt: externalApiKey?.expiredAt ?? addYears(new Date(), 1),
     webhookUrl: externalApiKey?.webhookUrl,
     revokedAt: externalApiKey?.revokedAt,
   }
@@ -99,13 +101,18 @@ export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModal
                 <TextFormControl label={t("externalApiKey.fieldLabels.name")} fieldName={"name"} required />
               </GridItem>
               <GridItem>
-                <UrlFormControl label={t("externalApiKey.fieldLabels.webhookUrl")} fieldName={"webhookUrl"} validate />
+                <TextFormControl
+                  label={t("externalApiKey.fieldLabels.connectingApplication")}
+                  fieldName={"connectingApplication"}
+                  required
+                />
               </GridItem>
+
               <GridItem>
                 <DatePickerFormControl
-                  inputProps={{ isClearable: true }}
                   label={t("externalApiKey.fieldLabels.expiredAt")}
                   fieldName={"expiredAt"}
+                  required
                 />
               </GridItem>
               <GridItem>
@@ -115,6 +122,9 @@ export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModal
                   inputProps={{ readOnly: true }}
                   isReadOnly
                 />
+              </GridItem>
+              <GridItem colSpan={2}>
+                <UrlFormControl label={t("externalApiKey.fieldLabels.webhookUrl")} fieldName={"webhookUrl"} validate />
               </GridItem>
               <GridItem colSpan={2}>
                 <FormControl isReadOnly>

--- a/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
+++ b/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
@@ -39,7 +39,7 @@ const formFormDefaultValues = (externalApiKey?: IExternalApiKey): IExternalApiKe
   return {
     name: externalApiKey?.name || "",
     connectingApplication: externalApiKey?.connectingApplication || "",
-    expiredAt: externalApiKey?.expiredAt ?? addYears(new Date(), 1),
+    expiredAt: externalApiKey?.expiredAt ?? addYears(new Date(), 2),
     webhookUrl: externalApiKey?.webhookUrl,
     revokedAt: externalApiKey?.revokedAt,
   }
@@ -124,7 +124,12 @@ export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModal
                 />
               </GridItem>
               <GridItem colSpan={2}>
-                <UrlFormControl label={t("externalApiKey.fieldLabels.webhookUrl")} fieldName={"webhookUrl"} validate />
+                <UrlFormControl
+                  label={t("externalApiKey.fieldLabels.webhookUrl")}
+                  fieldName={"webhookUrl"}
+                  inputProps={{ placeholder: t("externalApiKey.fieldPlaceholders.webhookUrl") }}
+                  validate
+                />
               </GridItem>
               <GridItem colSpan={2}>
                 <FormControl isReadOnly>

--- a/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
+++ b/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
@@ -16,7 +16,7 @@ import {
   ModalHeader,
   ModalOverlay,
 } from "@chakra-ui/react"
-import { Key } from "@phosphor-icons/react"
+import { Key, Prohibit } from "@phosphor-icons/react"
 import { addYears } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useState } from "react"
@@ -28,6 +28,7 @@ import { useMst } from "../../../setup/root"
 import { IExternalApiKeyParams } from "../../../types/api-request"
 import { CopyableValue } from "../../shared/base/copyable-value"
 import { DatePickerFormControl, TextFormControl, UrlFormControl } from "../../shared/form/input-form-control"
+import { RemoveConfirmationModal } from "../../shared/remove-confirmation-modal"
 
 interface IProps {}
 
@@ -84,16 +85,47 @@ export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModal
     if (updatedExternalApiKey) {
       externalApiKey
         ? onClose()
-        : navigate(`/jurisdictions/${currentJurisdiction?.id}/external-api-keys/${updatedExternalApiKey.id}/edit`)
+        : navigate(`/jurisdictions/${currentJurisdiction?.id}/external-api-keys/${updatedExternalApiKey.id}/manage`)
     }
   })
+
+  const onRevoke = async () => {
+    if (!externalApiKey) {
+      return
+    }
+
+    const updatedExternalApiKey = await currentJurisdiction.revokeExternalApiKey(externalApiKey.id)
+
+    updatedExternalApiKey && onClose()
+  }
+
+  const sharedRevokeButtonProps = {
+    color: "error",
+    borderColor: "error",
+  }
+  const revokeButtonProps = {
+    variant: "primaryInverse",
+    leftIcon: <Prohibit />,
+    isDisabled: externalApiKey && externalApiKey.isRevoked,
+    ...sharedRevokeButtonProps,
+    _hover: {
+      ...sharedRevokeButtonProps,
+    },
+    _active: {
+      ...sharedRevokeButtonProps,
+    },
+
+    _focus: {
+      ...sharedRevokeButtonProps,
+    },
+  }
 
   return (
     <Modal isOpen onClose={onClose}>
       <ModalOverlay />
       <FormProvider {...formMethods}>
         <ModalContent as={"form"} maxW={"container.md"} onSubmit={onSubmit}>
-          <ModalHeader>{t(`externalApiKey.modal.${externalApiKey ? "editTitle" : "createTitle"}`)}</ModalHeader>
+          <ModalHeader>{t(`externalApiKey.modal.${externalApiKey ? "manageTitle" : "createTitle"}`)}</ModalHeader>
           <ModalCloseButton />
           <ModalBody>
             <Grid templateColumns={"1fr 1fr"} gap={6}>
@@ -169,7 +201,16 @@ export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModal
             </Grid>
           </ModalBody>
 
-          <ModalFooter>
+          <ModalFooter justifyContent={externalApiKey ? "space-between" : undefined}>
+            {externalApiKey && (
+              <RemoveConfirmationModal
+                title={t("externalApiKey.modal.removeConfirmationModal.title")}
+                body={t("externalApiKey.modal.removeConfirmationModal.body")}
+                triggerButtonProps={revokeButtonProps}
+                triggerText={t("ui.revoke")}
+                onRemove={onRevoke}
+              />
+            )}
             <HStack>
               <Button
                 variant={"primary"}
@@ -177,7 +218,7 @@ export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModal
                 isDisabled={isSubmitting || !isValid}
                 isLoading={isSubmitting}
               >
-                {t("ui.onlySave")}
+                {externalApiKey ? t("ui.onlySave") : t("ui.create")}
               </Button>
               <Button variant={"secondary"} onClick={onClose} isDisabled={isSubmitting}>
                 {t("ui.cancel")}

--- a/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
+++ b/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
@@ -1,0 +1,176 @@
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Grid,
+  GridItem,
+  HStack,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from "@chakra-ui/react"
+import { Key } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React, { useEffect, useState } from "react"
+import { FormProvider, useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import { useNavigate, useParams } from "react-router-dom"
+import { IExternalApiKey } from "../../../models/external-api-key"
+import { useMst } from "../../../setup/root"
+import { IExternalApiKeyParams } from "../../../types/api-request"
+import { CopyableValue } from "../../shared/base/copyable-value"
+import { DatePickerFormControl, TextFormControl, UrlFormControl } from "../../shared/form/input-form-control"
+
+interface IProps {}
+
+interface IExternalApiKeyForm extends IExternalApiKeyParams {
+  revokedAt?: Date
+}
+
+const formFormDefaultValues = (externalApiKey?: IExternalApiKey): IExternalApiKeyForm => {
+  return {
+    name: externalApiKey?.name || "",
+    expiredAt: externalApiKey?.expiredAt,
+    webhookUrl: externalApiKey?.webhookUrl,
+    revokedAt: externalApiKey?.revokedAt,
+  }
+}
+
+export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModalSubRoute({}: IProps) {
+  const { t } = useTranslation()
+  const { externalApiKeyId } = useParams()
+  const navigate = useNavigate()
+  const { jurisdictionStore } = useMst()
+  const { currentJurisdiction } = jurisdictionStore
+  const externalApiKey = currentJurisdiction?.getExternalApiKey(externalApiKeyId)
+  const formMethods = useForm<IExternalApiKeyForm>({
+    defaultValues: formFormDefaultValues(externalApiKey),
+  })
+  const { handleSubmit, reset, formState } = formMethods
+  const { isSubmitting, isValid } = formState
+  const [showToken, setShowToken] = useState(false)
+  const [token, setToken] = useState("")
+
+  const onClose = () => {
+    navigate(`/jurisdictions/${currentJurisdiction?.id}/external-api-keys`)
+  }
+
+  useEffect(() => {
+    reset(formFormDefaultValues(externalApiKey))
+
+    if (currentJurisdiction && externalApiKey) {
+      ;(async () => {
+        const apiKey = await currentJurisdiction.fetchExternalApiKey(externalApiKeyId)
+
+        apiKey?.token && setToken(apiKey.token)
+      })()
+    }
+  }, [currentJurisdiction, externalApiKey])
+
+  const onSubmit = handleSubmit(async (data) => {
+    const updatedExternalApiKey = externalApiKey
+      ? await currentJurisdiction.updateExternalApiKey(externalApiKey.id, data)
+      : await currentJurisdiction.createExternalApiKey(data)
+
+    if (updatedExternalApiKey) {
+      externalApiKey
+        ? onClose()
+        : navigate(`/jurisdictions/${currentJurisdiction?.id}/external-api-keys/${updatedExternalApiKey.id}/edit`)
+    }
+  })
+
+  return (
+    <Modal isOpen onClose={onClose}>
+      <ModalOverlay />
+      <FormProvider {...formMethods}>
+        <ModalContent as={"form"} maxW={"container.md"} onSubmit={onSubmit}>
+          <ModalHeader>{t(`externalApiKey.modal.${externalApiKey ? "editTitle" : "createTitle"}`)}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Grid templateColumns={"1fr 1fr"} gap={6}>
+              <GridItem>
+                <TextFormControl label={t("externalApiKey.fieldLabels.name")} fieldName={"name"} required />
+              </GridItem>
+              <GridItem>
+                <UrlFormControl label={t("externalApiKey.fieldLabels.webhookUrl")} fieldName={"webhookUrl"} validate />
+              </GridItem>
+              <GridItem>
+                <DatePickerFormControl
+                  inputProps={{ isClearable: true }}
+                  label={t("externalApiKey.fieldLabels.expiredAt")}
+                  fieldName={"expiredAt"}
+                />
+              </GridItem>
+              <GridItem>
+                <DatePickerFormControl
+                  label={t("externalApiKey.fieldLabels.revokedAt")}
+                  fieldName={"revokedAt"}
+                  inputProps={{ readOnly: true }}
+                  isReadOnly
+                />
+              </GridItem>
+              <GridItem colSpan={2}>
+                <FormControl isReadOnly>
+                  <FormLabel>{t("externalApiKey.fieldLabels.token")}</FormLabel>
+                  <CopyableValue
+                    CustomDisplay={({ value }) => (
+                      <>
+                        <InputGroup>
+                          <InputLeftElement>
+                            <Key />
+                          </InputLeftElement>
+                          <Input
+                            overflow={"auto "}
+                            type={showToken ? "text" : "password"}
+                            bg={"greys.grey04"}
+                            value={value}
+                          />
+                        </InputGroup>
+                        <Button
+                          px={4}
+                          size={"sm"}
+                          fontSize={"sm"}
+                          variant="link"
+                          onClick={() => setShowToken((pastState) => !pastState)}
+                          isDisabled={!externalApiKey}
+                        >
+                          {showToken ? t("ui.hide") : t("ui.show")}
+                        </Button>
+                      </>
+                    )}
+                    value={token ?? ""}
+                    label={t("externalApiKey.fieldLabels.token")}
+                    iconButtonProps={{ isDisabled: !externalApiKey }}
+                  />
+                </FormControl>
+              </GridItem>
+            </Grid>
+          </ModalBody>
+
+          <ModalFooter>
+            <HStack>
+              <Button
+                variant={"primary"}
+                type={"submit"}
+                isDisabled={isSubmitting || !isValid}
+                isLoading={isSubmitting}
+              >
+                {t("ui.onlySave")}
+              </Button>
+              <Button variant={"secondary"} onClick={onClose} isDisabled={isSubmitting}>
+                {t("ui.cancel")}
+              </Button>
+            </HStack>
+          </ModalFooter>
+        </ModalContent>
+      </FormProvider>
+    </Modal>
+  )
+})

--- a/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
+++ b/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
@@ -48,7 +48,7 @@ const formFormDefaultValues = (externalApiKey?: IExternalApiKey): IExternalApiKe
   }
 }
 
-export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModalSubRoute({}: IProps) {
+export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModalSubRoute() {
   const { t } = useTranslation()
   const { externalApiKeyId } = useParams()
   const navigate = useNavigate()

--- a/app/frontend/components/domains/external-api-key/external-api-key-status-tag.tsx
+++ b/app/frontend/components/domains/external-api-key/external-api-key-status-tag.tsx
@@ -1,0 +1,46 @@
+import { HStack, Tag, Text } from "@chakra-ui/react"
+import { Key, Prohibit } from "@phosphor-icons/react"
+import React, { ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+import { ExternalApiKeyStatus } from "../../../types/enums"
+
+interface IExternalApiKeyStatusTagProps {
+  status: ExternalApiKeyStatus
+}
+
+const statusColors: { [key in ExternalApiKeyStatus]: string } = {
+  [ExternalApiKeyStatus.active]: "semantic.successLight",
+  [ExternalApiKeyStatus.notActive]: "semantic.errorLight",
+}
+
+const statusBorderColors: { [key in ExternalApiKeyStatus]: string } = {
+  [ExternalApiKeyStatus.active]: "semantic.success",
+  [ExternalApiKeyStatus.notActive]: "semantic.error",
+}
+
+const statusIcons: { [key in ExternalApiKeyStatus]: ReactNode } = {
+  [ExternalApiKeyStatus.active]: <Key />,
+  [ExternalApiKeyStatus.notActive]: <Prohibit style={{ color: "var(--chakra-colors-semantic-error)" }} />,
+}
+
+export const ExternalApiKeyStatusTag = ({ status }: IExternalApiKeyStatusTagProps) => {
+  const color = statusColors[status]
+  const borderColor = statusBorderColors[status]
+  const { t } = useTranslation()
+  return (
+    <Tag
+      p={1}
+      pr={2}
+      borderRadius="sm"
+      border="1px solid"
+      borderColor={borderColor}
+      backgroundColor={color}
+      textTransform="capitalize"
+    >
+      <HStack>
+        {statusIcons[status]}
+        <Text>{t(`externalApiKey.status.${status}`)}</Text>
+      </HStack>
+    </Tag>
+  )
+}

--- a/app/frontend/components/domains/external-api-key/grid-header.tsx
+++ b/app/frontend/components/domains/external-api-key/grid-header.tsx
@@ -8,6 +8,7 @@ export const GridHeaders = observer(function GridHeaders() {
   const { t } = useTranslation()
   const columnHeaders: string[] = [
     t("externalApiKey.fieldLabels.name"),
+    t("externalApiKey.fieldLabels.connectingApplication"),
     t("externalApiKey.fieldLabels.status"),
     t("externalApiKey.fieldLabels.createdAt"),
     t("externalApiKey.fieldLabels.expiredAt"),
@@ -19,7 +20,7 @@ export const GridHeaders = observer(function GridHeaders() {
       <Box display={"contents"} role={"row"}>
         <GridItem
           as={Flex}
-          gridColumn={"span 6"}
+          gridColumn={"span 7"}
           p={6}
           bg={"greys.grey10"}
           justifyContent={"space-between"}
@@ -33,7 +34,8 @@ export const GridHeaders = observer(function GridHeaders() {
           <GridHeader key={heading} role={"columnheader"}>
             <Flex
               w={"full"}
-              justifyContent={"space-between"}
+              h={"full"}
+              alignItems={"center"}
               borderY={"none"}
               borderX={"none"}
               borderRight={"1px solid"}

--- a/app/frontend/components/domains/external-api-key/grid-header.tsx
+++ b/app/frontend/components/domains/external-api-key/grid-header.tsx
@@ -1,0 +1,51 @@
+import { Box, Flex, GridItem, Text } from "@chakra-ui/react"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { GridHeader } from "../../shared/grid/grid-header"
+
+export const GridHeaders = observer(function GridHeaders() {
+  const { t } = useTranslation()
+  const columnHeaders: string[] = [
+    t("externalApiKey.index.table.columnHeaders.name"),
+    t("externalApiKey.index.table.columnHeaders.status"),
+    t("externalApiKey.index.table.columnHeaders.createdAt"),
+    t("externalApiKey.index.table.columnHeaders.expiredAt"),
+    t("externalApiKey.index.table.columnHeaders.revokedAt"),
+  ]
+
+  return (
+    <Box display={"contents"} role={"rowgroup"}>
+      <Box display={"contents"} role={"row"}>
+        <GridItem
+          as={Flex}
+          gridColumn={"span 6"}
+          p={6}
+          bg={"greys.grey10"}
+          justifyContent={"space-between"}
+          align="center"
+        >
+          <Text role={"heading"}>{t("externalApiKey.index.table.heading")}</Text>
+        </GridItem>
+      </Box>
+      <Box display={"contents"} role={"row"}>
+        {columnHeaders.map((heading) => (
+          <GridHeader key={heading} role={"columnheader"}>
+            <Flex
+              w={"full"}
+              justifyContent={"space-between"}
+              borderY={"none"}
+              borderX={"none"}
+              borderRight={"1px solid"}
+              borderColor={"border.light"}
+              px={4}
+            >
+              {heading}
+            </Flex>
+          </GridHeader>
+        ))}
+        <GridHeader role={"columnheader"} />
+      </Box>
+    </Box>
+  )
+})

--- a/app/frontend/components/domains/external-api-key/grid-header.tsx
+++ b/app/frontend/components/domains/external-api-key/grid-header.tsx
@@ -7,11 +7,11 @@ import { GridHeader } from "../../shared/grid/grid-header"
 export const GridHeaders = observer(function GridHeaders() {
   const { t } = useTranslation()
   const columnHeaders: string[] = [
-    t("externalApiKey.index.table.columnHeaders.name"),
-    t("externalApiKey.index.table.columnHeaders.status"),
-    t("externalApiKey.index.table.columnHeaders.createdAt"),
-    t("externalApiKey.index.table.columnHeaders.expiredAt"),
-    t("externalApiKey.index.table.columnHeaders.revokedAt"),
+    t("externalApiKey.fieldLabels.name"),
+    t("externalApiKey.fieldLabels.status"),
+    t("externalApiKey.fieldLabels.createdAt"),
+    t("externalApiKey.fieldLabels.expiredAt"),
+    t("externalApiKey.fieldLabels.revokedAt"),
   ]
 
   return (

--- a/app/frontend/components/domains/external-api-key/index.tsx
+++ b/app/frontend/components/domains/external-api-key/index.tsx
@@ -77,7 +77,7 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
                   </SearchGridItem>
 
                   <SearchGridItem justifyContent={"center"}>
-                    <RouterLinkButton variant={"link"} to={`${externalApiKey.id}/edit`}>
+                    <RouterLinkButton variant={"link"} to={`${externalApiKey.id}/manage`}>
                       {t("ui.manage")}
                     </RouterLinkButton>
                   </SearchGridItem>

--- a/app/frontend/components/domains/external-api-key/index.tsx
+++ b/app/frontend/components/domains/external-api-key/index.tsx
@@ -1,0 +1,92 @@
+import { Box, Container, Flex, Heading, HStack, StackProps, VStack } from "@chakra-ui/react"
+import { format } from "date-fns"
+import { observer } from "mobx-react-lite"
+import React, { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { datefnsTableDateFormat } from "../../../constants"
+import { useJurisdiction } from "../../../hooks/resources/use-jurisdiction"
+import { ErrorScreen } from "../../shared/base/error-screen"
+import { LoadingScreen } from "../../shared/base/loading-screen"
+import { SharedSpinner } from "../../shared/base/shared-spinner"
+import { SearchGrid } from "../../shared/grid/search-grid"
+import { SearchGridItem } from "../../shared/grid/search-grid-item"
+import { RouterLinkButton } from "../../shared/navigation/router-link-button"
+import { ExternalApiKeyStatusTag } from "./external-api-key-status-tag"
+import { GridHeaders } from "./grid-header"
+
+interface IProps extends Partial<StackProps> {}
+
+export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndexScreen({ ...containerProps }: IProps) {
+  const { currentJurisdiction, error } = useJurisdiction()
+  const [isFetching, setIsFetching] = useState(false)
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    if (currentJurisdiction) {
+      ;(async () => {
+        setIsFetching(true)
+
+        await currentJurisdiction.fetchExternalApiKeys()
+
+        setIsFetching(false)
+      })()
+    }
+  }, [currentJurisdiction])
+
+  if (error) return <ErrorScreen error={error} />
+  if (!currentJurisdiction) return <LoadingScreen />
+
+  const externalApiKeys = currentJurisdiction.externalApiKeys
+
+  return (
+    <Container maxW="container.lg" p={8} as={"main"} h={"full"} w={"full"} {...containerProps}>
+      <VStack alignItems={"flex-start"} spacing={5} w={"full"} h={"full"}>
+        <Flex justifyContent={"space-between"} w={"full"} alignItems={"flex-end"}>
+          <Box>
+            <Heading as="h1">{currentJurisdiction?.qualifiedName}</Heading>
+          </Box>
+          <RouterLinkButton alignSelf="flex-end" to={"invite"}>
+            {t("externalApiKey.index.createExternalApiKey")}
+          </RouterLinkButton>
+        </Flex>
+        <SearchGrid templateColumns="1fr max(200px) repeat(3, 1fr) 85px" pos={"relative"}>
+          <GridHeaders />
+
+          {isFetching ? (
+            <Flex py={50} gridColumn={"span 6"}>
+              <SharedSpinner />
+            </Flex>
+          ) : (
+            externalApiKeys.map((externalApiKey) => {
+              return (
+                <Box key={externalApiKey.id} role={"row"} display={"contents"}>
+                  <SearchGridItem fontWeight={700} minW="250px">
+                    {externalApiKey.name}
+                  </SearchGridItem>
+                  <SearchGridItem maxW="200px">
+                    <HStack flexWrap={"wrap"} maxW={"full"} alignSelf={"middle"}>
+                      <ExternalApiKeyStatusTag status={externalApiKey.status} />
+                    </HStack>
+                  </SearchGridItem>
+                  <SearchGridItem>{format(externalApiKey.createdAt, datefnsTableDateFormat)}</SearchGridItem>
+                  <SearchGridItem>
+                    {externalApiKey.expiredAt && format(externalApiKey.expiredAt, datefnsTableDateFormat)}
+                  </SearchGridItem>
+                  <SearchGridItem>
+                    {externalApiKey.revokedAt && format(externalApiKey.revokedAt, datefnsTableDateFormat)}
+                  </SearchGridItem>
+
+                  <SearchGridItem justifyContent={"center"}>
+                    <RouterLinkButton to={`/external-api-keys/${externalApiKey.id}/edit`} variant={"link"}>
+                      {t("ui.manage")}
+                    </RouterLinkButton>
+                  </SearchGridItem>
+                </Box>
+              )
+            })
+          )}
+        </SearchGrid>
+      </VStack>
+    </Container>
+  )
+})

--- a/app/frontend/components/domains/external-api-key/index.tsx
+++ b/app/frontend/components/domains/external-api-key/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Flex, Heading, HStack, StackProps, VStack } from "@chakra-ui/react"
+import { Box, Container, Flex, Heading, StackProps, VStack } from "@chakra-ui/react"
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useState } from "react"
@@ -41,6 +41,7 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
 
   return (
     <Container maxW="container.lg" p={8} as={"main"} h={"full"} w={"full"} {...containerProps}>
+      {/*This outlet will render the create/edit modal*/}
       <Outlet />
       <VStack alignItems={"flex-start"} spacing={5} w={"full"} h={"full"}>
         <Flex justifyContent={"space-between"} w={"full"} alignItems={"flex-end"}>
@@ -51,7 +52,7 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
             {t("externalApiKey.index.createExternalApiKey")}
           </RouterLinkButton>
         </Flex>
-        <SearchGrid templateColumns="1fr max(200px) repeat(3, 1fr) 85px" pos={"relative"}>
+        <SearchGrid templateColumns="repeat(6, 1fr) 85px" pos={"relative"}>
           <GridHeaders />
 
           {isFetching ? (
@@ -62,13 +63,10 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
             externalApiKeys.map((externalApiKey) => {
               return (
                 <Box key={externalApiKey.id} role={"row"} display={"contents"}>
-                  <SearchGridItem fontWeight={700} minW="250px">
-                    {externalApiKey.name}
-                  </SearchGridItem>
-                  <SearchGridItem maxW="200px">
-                    <HStack flexWrap={"wrap"} maxW={"full"} alignSelf={"middle"}>
-                      <ExternalApiKeyStatusTag status={externalApiKey.status} />
-                    </HStack>
+                  <SearchGridItem fontWeight={700}>{externalApiKey.name}</SearchGridItem>
+                  <SearchGridItem>{externalApiKey.connectingApplication}</SearchGridItem>
+                  <SearchGridItem>
+                    <ExternalApiKeyStatusTag status={externalApiKey.status} />
                   </SearchGridItem>
                   <SearchGridItem>{format(externalApiKey.createdAt, datefnsTableDateFormat)}</SearchGridItem>
                   <SearchGridItem>

--- a/app/frontend/components/domains/external-api-key/index.tsx
+++ b/app/frontend/components/domains/external-api-key/index.tsx
@@ -3,6 +3,7 @@ import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { Outlet } from "react-router-dom"
 import { datefnsTableDateFormat } from "../../../constants"
 import { useJurisdiction } from "../../../hooks/resources/use-jurisdiction"
 import { ErrorScreen } from "../../shared/base/error-screen"
@@ -40,12 +41,13 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
 
   return (
     <Container maxW="container.lg" p={8} as={"main"} h={"full"} w={"full"} {...containerProps}>
+      <Outlet />
       <VStack alignItems={"flex-start"} spacing={5} w={"full"} h={"full"}>
         <Flex justifyContent={"space-between"} w={"full"} alignItems={"flex-end"}>
           <Box>
             <Heading as="h1">{currentJurisdiction?.qualifiedName}</Heading>
           </Box>
-          <RouterLinkButton alignSelf="flex-end" to={"invite"}>
+          <RouterLinkButton alignSelf={"flex-end"} variant={"primary"} to={"create"}>
             {t("externalApiKey.index.createExternalApiKey")}
           </RouterLinkButton>
         </Flex>
@@ -77,7 +79,7 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
                   </SearchGridItem>
 
                   <SearchGridItem justifyContent={"center"}>
-                    <RouterLinkButton to={`/external-api-keys/${externalApiKey.id}/edit`} variant={"link"}>
+                    <RouterLinkButton variant={"link"} to={`${externalApiKey.id}/edit`}>
                       {t("ui.manage")}
                     </RouterLinkButton>
                   </SearchGridItem>

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/index.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/index.tsx
@@ -1,5 +1,5 @@
 import { Container, Flex, FormControl, FormLabel, Grid, GridItem, Heading, Input, Text, VStack } from "@chakra-ui/react"
-import { FileText, Info, Tray } from "@phosphor-icons/react"
+import { FileText, Info, Tray, Users } from "@phosphor-icons/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
 import React, { Suspense } from "react"
@@ -82,6 +82,16 @@ export const ConfigurationManagementScreen = observer(function ConfigurationMana
                   linkText={t("ui.edit")}
                   icon={<Info size="24px" color="--var(chakra-colors-text-primary)" />}
                   href={`/jurisdictions/${currentJurisdiction.slug}`}
+                  h="full"
+                />
+              </GridItem>
+              <GridItem>
+                <HomeScreenBox
+                  title={t(`${i18nPrefix}.externalApiKeys.title`)}
+                  description={t(`${i18nPrefix}.externalApiKeys.description`)}
+                  linkText={t("ui.edit")}
+                  icon={<Users size={24} />}
+                  href={`/jurisdictions/${currentJurisdiction.slug}/external-api-keys`}
                   h="full"
                 />
               </GridItem>

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -14,6 +14,11 @@ import { NavBar } from "./nav-bar"
 const ExternalApiKeysIndexScreen = lazy(() =>
   import("../external-api-key").then((module) => ({ default: module.ExternalApiKeysIndexScreen }))
 )
+const ExternalApiKeyModalSubRoute = lazy(() =>
+  import("../external-api-key/external-api-key-modal-sub-route").then((module) => ({
+    default: module.ExternalApiKeyModalSubRoute,
+  }))
+)
 
 const NotFoundScreen = lazy(() =>
   import("../../shared/base/not-found-screen").then((module) => ({ default: module.NotFoundScreen }))
@@ -250,7 +255,10 @@ const AppRoutes = observer(() => {
     <>
       <Route path="/jurisdictions/:jurisdictionId/users" element={<JurisdictionUserIndexScreen />} />
       <Route path="/jurisdictions/:jurisdictionId/users/invite" element={<InviteScreen />} />
-      <Route path="/jurisdictions/:jurisdictionId/external-api-keys" element={<ExternalApiKeysIndexScreen />} />
+      <Route path="/jurisdictions/:jurisdictionId/external-api-keys" element={<ExternalApiKeysIndexScreen />}>
+        <Route path="create" element={<ExternalApiKeyModalSubRoute />} />
+        <Route path=":externalApiKeyId/edit" element={<ExternalApiKeyModalSubRoute />} />
+      </Route>
     </>
   )
 

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -257,7 +257,7 @@ const AppRoutes = observer(() => {
       <Route path="/jurisdictions/:jurisdictionId/users/invite" element={<InviteScreen />} />
       <Route path="/jurisdictions/:jurisdictionId/external-api-keys" element={<ExternalApiKeysIndexScreen />}>
         <Route path="create" element={<ExternalApiKeyModalSubRoute />} />
-        <Route path=":externalApiKeyId/edit" element={<ExternalApiKeyModalSubRoute />} />
+        <Route path=":externalApiKeyId/manage" element={<ExternalApiKeyModalSubRoute />} />
       </Route>
     </>
   )

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -11,6 +11,10 @@ import { EULAModal } from "../../shared/eula-modal"
 import { AdminInviteScreen } from "../users/admin-invite-screen"
 import { NavBar } from "./nav-bar"
 
+const ExternalApiKeysIndexScreen = lazy(() =>
+  import("../external-api-key").then((module) => ({ default: module.ExternalApiKeysIndexScreen }))
+)
+
 const NotFoundScreen = lazy(() =>
   import("../../shared/base/not-found-screen").then((module) => ({ default: module.NotFoundScreen }))
 )
@@ -246,6 +250,7 @@ const AppRoutes = observer(() => {
     <>
       <Route path="/jurisdictions/:jurisdictionId/users" element={<JurisdictionUserIndexScreen />} />
       <Route path="/jurisdictions/:jurisdictionId/users/invite" element={<InviteScreen />} />
+      <Route path="/jurisdictions/:jurisdictionId/external-api-keys" element={<ExternalApiKeysIndexScreen />} />
     </>
   )
 

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -200,6 +200,10 @@ const NavBarMenu = observer(({}: INavBarMenuProps) => {
         to={`/jurisdictions/${currentUser?.jurisdiction?.slug}/configuration-management`}
       />
       <NavMenuItem label={t("site.breadcrumb.users")} to={`/jurisdictions/${currentUser?.jurisdiction?.slug}/users`} />
+      <NavMenuItem
+        label={t("site.breadcrumb.externalApiKeys")}
+        to={`/jurisdictions/${currentUser?.jurisdiction?.slug}/external-api-keys`}
+      />
       <MenuDivider />
     </MenuGroup>
   )

--- a/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
@@ -2,6 +2,7 @@ import { Box, ButtonProps, Flex, HStack, ListItem, StackProps, Tag, UnorderedLis
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React from "react"
+import { datefnsTableDateFormat } from "../../../constants"
 import { useSearch } from "../../../hooks/use-search"
 import { ISearch } from "../../../lib/create-search-model"
 import { IRequirementBlock } from "../../../models/requirement-block"
@@ -79,7 +80,7 @@ export const RequirementBlocksTable = observer(function RequirementBlocksTable({
                   </UnorderedList>
                 </SearchGridItem>
                 <SearchGridItem maxW="150px" fontSize={"sm"}>
-                  {format(requirementBlock.updatedAt, "yyyy-MM-dd")}
+                  {format(requirementBlock.updatedAt, datefnsTableDateFormat)}
                 </SearchGridItem>
                 <SearchGridItem maxW="200px">
                   <HStack flexWrap={"wrap"} maxW={"full"} alignSelf={"middle"}>

--- a/app/frontend/components/shared/base/callout-banner.tsx
+++ b/app/frontend/components/shared/base/callout-banner.tsx
@@ -4,14 +4,17 @@ import React from "react"
 
 interface IProps {
   type: "warning" | "error" | "success" | "info"
-  title: string
-  body?: string
+  title: string | JSX.Element
+  body?: string | JSX.Element
 }
 
 const iconProps = {
   size: 16,
+  flexShrink: 0,
   style: {
     marginTop: "var(--chakra-space-1)",
+    minWidth: "16px",
+    minH: "16px",
   },
 }
 

--- a/app/frontend/components/shared/base/copyable-value.tsx
+++ b/app/frontend/components/shared/base/copyable-value.tsx
@@ -1,4 +1,4 @@
-import { HStack, IconButton, StackProps, Text } from "@chakra-ui/react"
+import { HStack, IconButton, IconButtonProps, StackProps, Text } from "@chakra-ui/react"
 import { Copy } from "@phosphor-icons/react"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -7,10 +7,18 @@ import { EFlashMessageStatus } from "../../../types/enums"
 
 interface ICopyableNumberProps extends StackProps {
   value: string
-  label: string
+  label?: string
+  CustomDisplay?: ({ value }: { value: string; label?: string }) => JSX.Element
+  iconButtonProps?: Partial<IconButtonProps>
 }
 
-export const CopyableValue = ({ value, label, ...containerProps }: ICopyableNumberProps) => {
+export const CopyableValue = ({
+  value,
+  label,
+  CustomDisplay,
+  iconButtonProps,
+  ...containerProps
+}: ICopyableNumberProps) => {
   const { t } = useTranslation()
   const { uiStore } = useMst()
 
@@ -25,12 +33,16 @@ export const CopyableValue = ({ value, label, ...containerProps }: ICopyableNumb
 
   return (
     <HStack gap={1} {...containerProps}>
-      <Text mt={1}>
-        {label}:{" "}
-        <Text as="span" fontWeight={700}>
-          {value}
+      {CustomDisplay ? (
+        <CustomDisplay value={value} label={label} />
+      ) : (
+        <Text mt={1}>
+          {label}:{" "}
+          <Text as="span" fontWeight={700}>
+            {value}
+          </Text>
         </Text>
-      </Text>
+      )}
       <IconButton
         aria-label={"copy value"}
         icon={<Copy />}
@@ -38,6 +50,7 @@ export const CopyableValue = ({ value, label, ...containerProps }: ICopyableNumb
         variant="ghost"
         color="theme.yellow"
         size="sm"
+        {...iconButtonProps}
       />
     </HStack>
   )

--- a/app/frontend/components/shared/date-picker.tsx
+++ b/app/frontend/components/shared/date-picker.tsx
@@ -1,24 +1,26 @@
 import { Box, BoxProps, Button, Text } from "@chakra-ui/react"
 import { CalendarBlank, CaretDown } from "@phosphor-icons/react"
+import * as R from "ramda"
 import React, { forwardRef } from "react"
 import ReactDatePicker, { ReactDatePickerProps } from "react-datepicker"
 import "react-datepicker/dist/react-datepicker.css"
 import { useTranslation } from "react-i18next"
 import { datefnsAppDateFormat } from "../../constants"
 
-interface IProps extends ReactDatePickerProps {
+export interface IDatePickerProps extends ReactDatePickerProps {
   containerProps?: Partial<BoxProps>
 }
 
 const CustomInput = forwardRef<
   HTMLButtonElement,
   {
-    placeHolderText?: string
     value?: string | null
+    readOnly?: boolean
     onClick?: () => void
   }
->(({ value, onClick, ...rest }, ref) => {
+>(({ value, onClick, readOnly, ...rest }, ref) => {
   const { t } = useTranslation()
+
   return (
     <Button
       w={"full"}
@@ -27,12 +29,21 @@ const CustomInput = forwardRef<
       px={3}
       py={"0.375rem"}
       _disabled={{
-        bg: "greys.grey10",
+        bg: "greys.grey04",
+        color: "text.secondary",
+        opacity: 1,
+        _hover: {
+          borderColor: "greys.grey01",
+          cursor: "not-allowed",
+        },
+        _focus: {
+          borderColor: "focus",
+        },
       }}
       border={"1px solid"}
-      borderColor="border.light"
+      borderColor="border.input"
       bg={"white"}
-      _hover={{ borderColor: "border.base" }}
+      _hover={{ borderColor: "border.input" }}
       sx={{
         "&:focus": { borderColor: "focus" },
       }}
@@ -40,27 +51,42 @@ const CustomInput = forwardRef<
       rightIcon={<CaretDown color={"var(--chakra-colors-text-secondary)"} size={20} />}
       color={value ? "text.primary" : "greys.grey01"}
       aria-label={"Select date"}
+      role={"date-picker"}
       onClick={onClick}
       ref={ref}
+      isDisabled={readOnly}
       {...rest}
     >
       <Text as={"span"} textAlign={"start"} flex={1}>
-        {value || t("ui.select")}
+        {value || (!readOnly && t("ui.select"))}
       </Text>
     </Button>
   )
 })
 
-export function DatePicker({ containerProps, ...datePickerProps }: IProps) {
+export function DatePicker({ containerProps, ...datePickerProps }: IDatePickerProps) {
+  const sxStyles = containerProps?.sx || {}
   return (
     <Box
       w={"200px"}
-      sx={{
-        ".react-datepicker__input-container": {
-          w: "200px",
-        },
-      }}
       {...containerProps}
+      sx={R.mergeDeepRight(
+        {
+          ".react-datepicker__input-container": {
+            w: "200px",
+          },
+          ".react-datepicker__close-icon": {
+            "::after": {
+              color: "var(--chakra-colors-text-secondary)",
+              background: "none",
+              content: `"\\2715"`,
+              fontSize: "var(--chakra-fontSizes-sm)",
+            },
+            left: "130px",
+          },
+        },
+        sxStyles
+      )}
     >
       <ReactDatePicker
         customInput={<CustomInput />}

--- a/app/frontend/components/shared/form/input-form-control.tsx
+++ b/app/frontend/components/shared/form/input-form-control.tsx
@@ -9,17 +9,19 @@ import {
   Input,
   InputGroup,
   InputLeftElement,
+  InputProps,
   InputRightElement,
 } from "@chakra-ui/react"
 import { AsteriskSimple, Phone } from "@phosphor-icons/react"
 import { t } from "i18next"
 import * as R from "ramda"
 import React from "react"
-import { useFormContext } from "react-hook-form"
+import { useController, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
+import { DatePicker, IDatePickerProps } from "../date-picker"
 import { fieldArrayCompatibleErrorMessage } from "./form-helpers"
 
-interface IInputFormControlProps extends FormControlProps {
+interface IInputFormControlProps<TInputProps = Partial<InputProps>> extends FormControlProps {
   label?: string
   fieldName?: string
   required?: boolean
@@ -28,7 +30,7 @@ interface IInputFormControlProps extends FormControlProps {
   hint?: string[]
   leftElement?: JSX.Element
   rightElement?: JSX.Element
-  inputProps?: any
+  inputProps?: TInputProps
   key?: string
 }
 
@@ -45,6 +47,19 @@ export const TextFormControl = (props: IInputFormControlProps) => {
         },
         props
       ) as IInputFormControlProps)}
+    />
+  )
+}
+
+export const UrlFormControl = (props: IInputFormControlProps) => {
+  return (
+    <InputFormControl
+      {...R.mergeDeepRight(
+        {
+          inputProps: { type: "url" },
+        },
+        props
+      )}
     />
   )
 }
@@ -68,6 +83,70 @@ export const PhoneFormControl = (props: IInputFormControlProps) => {
 
 export const FileFormControl = (props: IInputFormControlProps) => {
   return <InputFormControl {...(R.mergeDeepRight({ inputProps: { type: "file" } }, props) as IInputFormControlProps)} />
+}
+
+export const DatePickerFormControl = ({
+  label,
+  fieldName,
+  required,
+  validate,
+  hint,
+  leftElement,
+  rightElement,
+  inputProps = {},
+  key = fieldName,
+  ...rest
+}: IInputFormControlProps<Partial<IDatePickerProps>>) => {
+  const { control, formState } = useFormContext()
+  const { errors } = formState
+  const { t } = useTranslation()
+  const errorMessage = (fieldName && fieldArrayCompatibleErrorMessage(fieldName, errors)) || null
+  const { field } = useController({
+    name: fieldName,
+    control,
+    rules: {
+      required: required && t("ui.isRequired", { field: label }),
+      validate,
+    },
+  })
+  const { value, onChange } = field
+
+  const id = `${fieldName}-form-control-label`
+  return (
+    <FormControl isInvalid={!!errorMessage} {...rest}>
+      {label && (
+        <HStack gap={0}>
+          <FormLabel id={id}>{label} </FormLabel>
+          {required && (
+            <Box color="semantic.error" ml={-2} mb={2}>
+              <AsteriskSimple />
+            </Box>
+          )}
+        </HStack>
+      )}
+
+      <InputGroup w="full" display="flex" flexDirection="column" zIndex={1}>
+        <DatePicker
+          selected={value}
+          onChange={onChange}
+          containerProps={{
+            zIndex: "dropdown",
+            w: "full",
+            sx: {
+              ".react-datepicker-wrapper": { w: "full" },
+              ".react-datepicker__input-container": { w: "full" },
+            },
+          }}
+          ariaLabelledBy={id}
+          {...inputProps}
+        />
+        {errorMessage && <FormErrorMessage>{errorMessage}</FormErrorMessage>}
+        {hint && <FormHelperText color="border.base">{hint}</FormHelperText>}
+        {leftElement && <InputLeftElement pointerEvents="none">{leftElement}</InputLeftElement>}
+        {rightElement && <InputRightElement pointerEvents="none">{rightElement}</InputRightElement>}
+      </InputGroup>
+    </FormControl>
+  )
 }
 
 const InputFormControl = ({

--- a/app/frontend/components/shared/form/input-form-control.tsx
+++ b/app/frontend/components/shared/form/input-form-control.tsx
@@ -32,6 +32,7 @@ interface IInputFormControlProps<TInputProps = Partial<InputProps>> extends Form
   rightElement?: JSX.Element
   inputProps?: TInputProps
   key?: string
+  LabelInfo?: () => JSX.Element
 }
 
 export const TextFormControl = (props: IInputFormControlProps) => {
@@ -159,6 +160,7 @@ const InputFormControl = ({
   rightElement,
   inputProps = {},
   key = fieldName,
+  LabelInfo,
   ...rest
 }: IInputFormControlProps) => {
   const { register, formState } = useFormContext()
@@ -179,6 +181,7 @@ const InputFormControl = ({
               <AsteriskSimple />
             </Box>
           )}
+          {LabelInfo && <LabelInfo />}
         </HStack>
       )}
 

--- a/app/frontend/components/shared/jurisdiction/manage-jurisdiction-menu.tsx
+++ b/app/frontend/components/shared/jurisdiction/manage-jurisdiction-menu.tsx
@@ -1,5 +1,5 @@
 import { Button, Menu, MenuButton, MenuList } from "@chakra-ui/react"
-import { Info, Users } from "@phosphor-icons/react"
+import { Info, Key, Users } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -30,6 +30,9 @@ export const ManageJurisdictionMenu = observer(function ManageJurisdictionMenu<T
           </ManageMenuItem>
           <ManageMenuItem icon={<Users size={16} />} to={`${jurisdiction.slug}/users`}>
             {t("jurisdiction.index.users")}
+          </ManageMenuItem>
+          <ManageMenuItem icon={<Key size={16} />} to={`${jurisdiction.slug}/external-api-keys`}>
+            {t("jurisdiction.index.externalApiKeys")}
           </ManageMenuItem>
         </MenuList>
       </Menu>

--- a/app/frontend/components/shared/remove-confirmation-modal.tsx
+++ b/app/frontend/components/shared/remove-confirmation-modal.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from "react-i18next"
 
 interface IProps {
   triggerButtonProps?: Partial<ButtonProps>
+  triggerText?: string
   renderTriggerButton?: (props: ButtonProps) => JSX.Element
   title?: string
   body?: string
@@ -27,6 +28,7 @@ interface IProps {
 export const RemoveConfirmationModal = observer(function RemoveConfirmationModal({
   triggerButtonProps,
   renderTriggerButton,
+  triggerText,
   title,
   body,
   onRemove,
@@ -39,7 +41,7 @@ export const RemoveConfirmationModal = observer(function RemoveConfirmationModal
         renderTriggerButton({ onClick: onOpen })
       ) : (
         <Button leftIcon={<X />} variant={"ghost"} color={"error"} onClick={onOpen} {...triggerButtonProps}>
-          {t("ui.remove")}
+          {triggerText ?? t("ui.remove")}
         </Button>
       )}
       <Modal isOpen={isOpen} onClose={onClose}>
@@ -56,7 +58,7 @@ export const RemoveConfirmationModal = observer(function RemoveConfirmationModal
           <ModalFooter justifyContent={"flex-start"}>
             <ButtonGroup spacing={4}>
               <Button variant={"primary"} onClick={() => onRemove(onClose)}>
-                {t("ui.remove")}
+                {triggerText ?? t("ui.remove")}
               </Button>
               <Button variant={"secondary"} onClick={onClose}>
                 {t("ui.neverMind")}

--- a/app/frontend/constants.ts
+++ b/app/frontend/constants.ts
@@ -54,6 +54,7 @@ export const unitGroups: { [key: string]: ENumberUnit[] } = {
 }
 
 export const datefnsAppDateFormat = "yyyy/MM/dd"
+export const datefnsTableDateFormat = "yyyy-MM-dd"
 
 export const vancouverTimeZone = "America/Vancouver" // Vancouver time zone
 

--- a/app/frontend/hooks/resources/use-jurisdiction.ts
+++ b/app/frontend/hooks/resources/use-jurisdiction.ts
@@ -19,14 +19,12 @@ export const useJurisdiction = () => {
     ;(async () => {
       try {
         if (isUUID(jurisdictionId)) {
-          setCurrentJurisdiction(jurisdictionId)
-          await fetchJurisdiction(jurisdictionId)
-          setCurrentJurisdiction(jurisdictionId)
+          const jurisdiction = await fetchJurisdiction(jurisdictionId)
+          jurisdiction && setCurrentJurisdiction(jurisdictionId)
         } else {
           //assume slug
-          setCurrentJurisdictionBySlug(jurisdictionId)
-          await fetchJurisdiction(jurisdictionId)
-          setCurrentJurisdictionBySlug(jurisdictionId)
+          const jurisdiction = await fetchJurisdiction(jurisdictionId)
+          jurisdiction && setCurrentJurisdictionBySlug(jurisdictionId)
         }
       } catch (e) {
         console.error(e.message)

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1141,14 +1141,20 @@ const options = {
             createExternalApiKey: "Create new API key",
             table: {
               heading: "External API keys",
-              columnHeaders: {
-                name: "Name",
-                revokedAt: "Revoked at",
-                expiredAt: "Expired at",
-                createdAt: "Created at",
-                status: "Status",
-              },
             },
+          },
+          modal: {
+            createTitle: "Create external API key",
+            editTitle: "Edit external API key",
+          },
+          fieldLabels: {
+            name: "Name",
+            revokedAt: "Revoked at",
+            webhookUrl: "Webhook URL",
+            expiredAt: "Expired at",
+            createdAt: "Created at",
+            token: "Token",
+            status: "Status",
           },
           status: {
             active: "Active",
@@ -1242,6 +1248,7 @@ const options = {
             welcome: "Welcome",
             sitewideMessage: "Site-Wide Message",
             externalApiKeys: "External API keys",
+            create: "Create",
           },
           questionSupport: "Question support",
         },

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -113,6 +113,7 @@ const options = {
           browseList: "Browse list of jurisdictions",
         },
         ui: {
+          disable: "Disable",
           revoke: "Revoke",
           create: "Create",
           tip: "Tip",
@@ -1141,8 +1142,18 @@ const options = {
         externalApiKey: {
           index: {
             createExternalApiKey: "Create new API key",
+            enabled: "Enabled",
+            disabled: "Disabled",
             table: {
               heading: "External API keys",
+            },
+            disabledWarningTitle:
+              "External API keys for this jurisdiction have not been enabled. To enable them, please contact" +
+              " us at",
+            disabledTooltipLabel: "User is not authorized to make this change",
+            disableConfirmationModal: {
+              title: "Are you sure you want to disable API keys for this jurisdiction?",
+              body: "All active API keys will be disabled",
             },
           },
           modal: {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1149,9 +1149,10 @@ const options = {
           },
           fieldLabels: {
             name: "Name",
+            connectingApplication: "Application connecting to",
             revokedAt: "Revoked at",
             webhookUrl: "Webhook URL",
-            expiredAt: "Expired at",
+            expiredAt: "Expires on",
             createdAt: "Created at",
             token: "Token",
             status: "Status",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1157,6 +1157,9 @@ const options = {
             token: "Token",
             status: "Status",
           },
+          fieldPlaceholders: {
+            webhookUrl: "https://example.com/webhook",
+          },
           status: {
             active: "Active",
             notActive: "Not-Active",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -241,6 +241,7 @@ const options = {
             createButton: "Create new jurisdiction",
             tableHeading: "Local governments",
             users: "Users",
+            externalApiKeys: "External API keys",
             about: "About",
           },
           fields: {
@@ -923,6 +924,10 @@ const options = {
                 },
               },
             },
+            externalApiKeys: {
+              title: "Manage external API keys",
+              description: "Manage external API keys for the Building Permit Hub.",
+            },
           },
           superAdminTitle: "Admin home",
           submissionsInboxTitle: "Submissions inbox",
@@ -1131,6 +1136,25 @@ const options = {
             settings: "Site-wide message settings",
           },
         },
+        externalApiKey: {
+          index: {
+            createExternalApiKey: "Create new API key",
+            table: {
+              heading: "External API keys",
+              columnHeaders: {
+                name: "Name",
+                revokedAt: "Revoked at",
+                expiredAt: "Expired at",
+                createdAt: "Created at",
+                status: "Status",
+              },
+            },
+          },
+          status: {
+            active: "Active",
+            notActive: "Not-Active",
+          },
+        },
         site: {
           title: "Building Permit Hub",
           titleLong: "Building Permit Hub",
@@ -1217,6 +1241,7 @@ const options = {
             confirmed: "E-mail confirmed",
             welcome: "Welcome",
             sitewideMessage: "Site-Wide Message",
+            externalApiKeys: "External API keys",
           },
           questionSupport: "Question support",
         },

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -113,6 +113,8 @@ const options = {
           browseList: "Browse list of jurisdictions",
         },
         ui: {
+          revoke: "Revoke",
+          create: "Create",
           tip: "Tip",
           manage: "Manage",
           preview: "Preview",
@@ -1145,7 +1147,11 @@ const options = {
           },
           modal: {
             createTitle: "Create external API key",
-            editTitle: "Edit external API key",
+            manageTitle: "Manage external API key",
+            removeConfirmationModal: {
+              title: "Are you sure you want to revoke this API key?",
+              body: "Any applications using this token will be unable to access the API.",
+            },
           },
           fieldLabels: {
             name: "Name",

--- a/app/frontend/models/external-api-key.ts
+++ b/app/frontend/models/external-api-key.ts
@@ -1,0 +1,29 @@
+import { isFuture } from "date-fns"
+import { Instance, types } from "mobx-state-tree"
+import { ExternalApiKeyStatus } from "../types/enums"
+
+export const ExternalApiKeyModel = types
+  .model("ExternalApiKeyModel")
+  .props({
+    id: types.identifier,
+    name: types.string,
+    expiredAt: types.maybeNull(types.Date),
+    revokedAt: types.maybeNull(types.Date),
+    createdAt: types.Date,
+  })
+  .views((self) => ({
+    get isExpired() {
+      return self.expiredAt !== null && isFuture(self.expiredAt)
+    },
+    get isRevoked() {
+      // any revokedAt date is considered revoked, time is for logging purposes
+      return self.revokedAt !== null
+    },
+  }))
+  .views((self) => ({
+    get status() {
+      return self.isRevoked || self.isExpired ? ExternalApiKeyStatus.notActive : ExternalApiKeyStatus.active
+    },
+  }))
+
+export interface IExternalApiKey extends Instance<typeof ExternalApiKeyModel> {}

--- a/app/frontend/models/external-api-key.ts
+++ b/app/frontend/models/external-api-key.ts
@@ -7,13 +7,14 @@ export const ExternalApiKeyModel = types
   .props({
     id: types.identifier,
     name: types.string,
+    webhookUrl: types.maybeNull(types.string),
     expiredAt: types.maybeNull(types.Date),
     revokedAt: types.maybeNull(types.Date),
     createdAt: types.Date,
   })
   .views((self) => ({
     get isExpired() {
-      return self.expiredAt !== null && isFuture(self.expiredAt)
+      return self.expiredAt !== null && !isFuture(self.expiredAt)
     },
     get isRevoked() {
       // any revokedAt date is considered revoked, time is for logging purposes

--- a/app/frontend/models/external-api-key.ts
+++ b/app/frontend/models/external-api-key.ts
@@ -1,5 +1,5 @@
 import { isFuture } from "date-fns"
-import { Instance, types } from "mobx-state-tree"
+import { getParent, Instance, types } from "mobx-state-tree"
 import { ExternalApiKeyStatus } from "../types/enums"
 
 export const ExternalApiKeyModel = types
@@ -21,10 +21,21 @@ export const ExternalApiKeyModel = types
       // any revokedAt date is considered revoked, time is for logging purposes
       return self.revokedAt !== null
     },
+    get jurisdiction() {
+      return getParent(self, 2)
+    },
   }))
   .views((self) => ({
     get status() {
-      return self.isRevoked || self.isExpired ? ExternalApiKeyStatus.notActive : ExternalApiKeyStatus.active
+      return !(
+        self.jurisdiction as {
+          externalApiEnabled: boolean
+        }
+      )?.externalApiEnabled ||
+        self.isRevoked ||
+        self.isExpired
+        ? ExternalApiKeyStatus.notActive
+        : ExternalApiKeyStatus.active
     },
   }))
 

--- a/app/frontend/models/external-api-key.ts
+++ b/app/frontend/models/external-api-key.ts
@@ -7,8 +7,9 @@ export const ExternalApiKeyModel = types
   .props({
     id: types.identifier,
     name: types.string,
+    connectingApplication: types.string,
     webhookUrl: types.maybeNull(types.string),
-    expiredAt: types.maybeNull(types.Date),
+    expiredAt: types.Date,
     revokedAt: types.maybeNull(types.Date),
     createdAt: types.Date,
   })

--- a/app/frontend/models/jurisdiction.ts
+++ b/app/frontend/models/jurisdiction.ts
@@ -37,6 +37,7 @@ export const JurisdictionModel = types
     mapZoom: types.maybeNull(types.number),
     energyStepRequired: types.maybeNull(types.number),
     zeroCarbonStepRequired: types.maybeNull(types.number),
+    externalApiEnabled: types.optional(types.boolean, false),
   })
   .extend(withEnvironment())
   .extend(withRootStore())
@@ -142,6 +143,18 @@ export const JurisdictionModel = types
         return self.getExternalApiKey(data.id)
       }
 
+      return response.ok
+    }),
+  }))
+  .actions((self) => ({
+    toggleExternalApiEnabled: flow(function* () {
+      const response = yield* toGenerator(
+        self.environment.api.updateJurisdictionExternalApiEnabled(self.id, !self.externalApiEnabled)
+      )
+
+      if (response.ok) {
+        self.externalApiEnabled = !!response.data?.data?.externalApiEnabled
+      }
       return response.ok
     }),
   }))

--- a/app/frontend/models/jurisdiction.ts
+++ b/app/frontend/models/jurisdiction.ts
@@ -131,6 +131,19 @@ export const JurisdictionModel = types
 
       return response.ok
     }),
+    revokeExternalApiKey: flow(function* (externalApiKeyId: string) {
+      const response = yield* toGenerator(self.environment.api.revokeExternalApiKey(externalApiKeyId))
+
+      if (response.ok) {
+        const data = response.data.data
+
+        self.mergeUpdate(data, "externalApiKeysMap")
+
+        return self.getExternalApiKey(data.id)
+      }
+
+      return response.ok
+    }),
   }))
 
 export interface IJurisdiction extends Instance<typeof JurisdictionModel> {}

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -3,6 +3,7 @@ import { TCreatePermitApplicationFormData } from "../../components/domains/permi
 import { TCreateRequirementTemplateFormData } from "../../components/domains/requirement-template/new-requirement-template-screen"
 import { IJurisdictionTemplateVersionCustomizationForm } from "../../components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen"
 import { TCreateContactFormData } from "../../components/shared/contact/create-contact-modal"
+import { IExternalApiKey } from "../../models/external-api-key"
 import { IJurisdiction } from "../../models/jurisdiction"
 import { IJurisdictionTemplateVersionCustomization } from "../../models/jurisdiction-template-version-customization"
 import { IPermitApplication } from "../../models/permit-application"
@@ -343,6 +344,10 @@ export class Api {
 
   async fetchSiteConfiguration() {
     return this.client.get<ApiResponse<ISiteConfiguration>>(`/site_configuration`, {})
+  }
+
+  async fetchExternalApiKeys(jurisdictionId: string) {
+    return this.client.get<ApiResponse<IExternalApiKey[]>>(`/external_api_keys/`, { jurisdictionId })
   }
 
   async updateSiteConfiguration(siteConfiguration) {

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -367,6 +367,10 @@ export class Api {
     return this.client.patch<ApiResponse<IExternalApiKey>>(`/external_api_keys/${externalApiKeyId}`, { externalApiKey })
   }
 
+  async revokeExternalApiKey(externalApiKeyId: string) {
+    return this.client.post<ApiResponse<IExternalApiKey>>(`/external_api_keys/${externalApiKeyId}/revoke`)
+  }
+
   async updateSiteConfiguration(siteConfiguration) {
     return this.client.put<ApiResponse<ISiteConfiguration>>(`/site_configuration`, { siteConfiguration })
   }

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -13,7 +13,12 @@ import { IStepCode } from "../../models/step-code"
 import { IStepCodeChecklist } from "../../models/step-code-checklist"
 import { ITemplateVersion } from "../../models/template-version"
 import { IUser } from "../../models/user"
-import { IRequirementBlockParams, IRequirementTemplateUpdateParams, ITagSearchParams } from "../../types/api-request"
+import {
+  IExternalApiKeyParams,
+  IRequirementBlockParams,
+  IRequirementTemplateUpdateParams,
+  ITagSearchParams,
+} from "../../types/api-request"
 import {
   IAcceptInvitationResponse,
   IApiResponse,
@@ -348,6 +353,18 @@ export class Api {
 
   async fetchExternalApiKeys(jurisdictionId: string) {
     return this.client.get<ApiResponse<IExternalApiKey[]>>(`/external_api_keys/`, { jurisdictionId })
+  }
+
+  async fetchExternalApiKey(externalApiKeyId: string) {
+    return this.client.get<ApiResponse<IExternalApiKey>>(`/external_api_keys/${externalApiKeyId}`)
+  }
+
+  async createExternalApiKey(externalApiKey: IExternalApiKeyParams) {
+    return this.client.post<ApiResponse<IExternalApiKey>>(`/external_api_keys/`, { externalApiKey })
+  }
+
+  async updateExternalApiKey(externalApiKeyId: string, externalApiKey: IExternalApiKeyParams) {
+    return this.client.patch<ApiResponse<IExternalApiKey>>(`/external_api_keys/${externalApiKeyId}`, { externalApiKey })
   }
 
   async updateSiteConfiguration(siteConfiguration) {

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -165,6 +165,12 @@ export class Api {
     return this.client.patch<ApiResponse<IJurisdiction>>(`/jurisdictions/${id}`, { jurisdiction: params })
   }
 
+  async updateJurisdictionExternalApiEnabled(id: string, externalApiEnabled: boolean) {
+    return this.client.patch<ApiResponse<IJurisdiction>>(`/jurisdictions/${id}/update_external_api_enabled`, {
+      externalApiEnabled: externalApiEnabled,
+    })
+  }
+
   async fetchRequirementBlocks(params?: TSearchParams<ERequirementLibrarySortFields>) {
     return this.client.post<IRequirementBlockResponse>("/requirement_blocks/search", params)
   }

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -53,6 +53,7 @@ export interface ITagSearchParams {
 
 export interface IExternalApiKeyParams {
   name?: string
+  connectingApplication?: string
   webhookUrl?: string
   expiredAt?: Date
   jurisdictionId?: string

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -50,3 +50,10 @@ export interface ITagSearchParams {
   query?: string
   taggableTypes?: Array<ETagType>
 }
+
+export interface IExternalApiKeyParams {
+  name?: string
+  webhookUrl?: string
+  expiredAt?: Date
+  jurisdictionId?: string
+}

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -32,6 +32,11 @@ export enum ETemplateVersionStatus {
   draft = "draft",
 }
 
+export enum ExternalApiKeyStatus {
+  active = "active",
+  notActive = "notActive",
+}
+
 export enum EUserRoles {
   submitter = "submitter",
   reviewManager = "review_manager",

--- a/app/models/external_api_key.rb
+++ b/app/models/external_api_key.rb
@@ -19,6 +19,8 @@ NULL",
 
   validates :token, uniqueness: true
   validates :name, presence: true, uniqueness: { scope: :jurisdiction_id }
+  validates :connecting_application, presence: true
+  validates :expired_at, presence: true
 
   before_create :generate_token
 

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -18,6 +18,7 @@ class Jurisdiction < ApplicationRecord
   has_many :template_versions, through: :jurisdiction_template_version_customizations
   has_many :requirement_templates, through: :template_versions
   has_many :permit_type_submission_contacts
+  has_many :external_api_keys, dependent: :destroy
 
   validates :name, uniqueness: { scope: :locality_type, case_sensitive: false }
   validates :locality_type, presence: true

--- a/app/policies/external_api_key_policy.rb
+++ b/app/policies/external_api_key_policy.rb
@@ -29,7 +29,7 @@ class ExternalApiKeyPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return [] unless user.super_admin? || user.review_manager?
+      raise Pundit::NotAuthorizedError unless user.super_admin? || user.review_manager?
 
       user.super_admin? ? ExternalApiKey.all : ExternalApiKey.where(jurisdiction_id: user.jurisdiction_id)
     end

--- a/app/policies/jurisdiction_policy.rb
+++ b/app/policies/jurisdiction_policy.rb
@@ -23,6 +23,10 @@ class JurisdictionPolicy < ApplicationPolicy
     user.super_admin? || (user.staff? && user.jurisdiction_id == record.id)
   end
 
+  def update_external_api_enabled?
+    user.super_admin?
+  end
+
   def search_users?
     update?
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -283,6 +283,15 @@ en:
       update_success:
         title: ""
         message: "Jurisdiction successfully updated!"
+      external_api_enabled_success:
+        title: ""
+        message: "Jurisdiction external api successfully enabled!"
+      update_external_api_enabled_error:
+        title: Error
+        message: "%{error_message}"
+      external_api_disabled_success:
+        title: ""
+        message: "Jurisdiction external api successfully disabled!"
     permit_application:
       create_error:
         title: Error

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,10 +223,13 @@ en:
         message: "New external api key created successfully!"
       update_success:
         title: Success
-        message: "New external api key updated successfully!"
+        message: "External api key updated successfully!"
+      delete_success:
+        title: Success
+        message: "External api key deleted successfully!"
       revoke_success:
         title: Success
-        message: "New external api key revoked successfully!"
+        message: "External api key revoked successfully!"
     requirement_template:
       create_success:
         title: ""

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
       post "search", on: :collection, to: "jurisdictions#index"
       post "users/search", on: :member, to: "jurisdictions#search_users"
       post "permit_applications/search", on: :member, to: "jurisdictions#search_permit_applications"
+      patch "update_external_api_enabled", on: :member, to: "jurisdictions#update_external_api_enabled"
       get "locality_type_options", on: :collection
       get "jurisdiction_options", on: :collection
     end

--- a/db/migrate/20240425172912_add_connecting_application_to_external_api_key.rb
+++ b/db/migrate/20240425172912_add_connecting_application_to_external_api_key.rb
@@ -1,0 +1,5 @@
+class AddConnectingApplicationToExternalApiKey < ActiveRecord::Migration[7.1]
+  def change
+    add_column :external_api_keys, :connecting_application, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_23_203202) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_25_172912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_23_203202) do
     t.uuid "jurisdiction_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "connecting_application", null: false
     t.index ["jurisdiction_id"],
             name: "index_external_api_keys_on_jurisdiction_id"
     t.index ["token"], name: "index_external_api_keys_on_token", unique: true

--- a/spec/factories/external_api_key.rb
+++ b/spec/factories/external_api_key.rb
@@ -2,7 +2,8 @@ FactoryBot.define do
   factory :external_api_key do
     association :jurisdiction, factory: :sub_district, external_api_enabled: true
     name { Faker::Lorem.words(number: 2).join(" ") }
-    expired_at { nil }
+    connecting_application { Faker::Lorem.words(number: 2).join(" ") }
+    expired_at { Time.now + 1.day }
     revoked_at { nil }
   end
 end

--- a/spec/models/external_api_key_spec.rb
+++ b/spec/models/external_api_key_spec.rb
@@ -96,6 +96,28 @@ RSpec.describe ExternalApiKey, type: :model do
       end
     end
 
+    context "expired_at" do
+      it "enforces expired_at is required" do
+        valid_external_api_key = build(:external_api_key) # factory defaults to Time.now + 1.day
+        invalid_external_api_key = build(:external_api_key, expired_at: nil)
+
+        expect(invalid_external_api_key.valid?).to eq(false)
+        expect(invalid_external_api_key.errors[:expired_at]).to include("can't be blank")
+        expect(valid_external_api_key.valid?).to eq(true)
+      end
+    end
+
+    context "connecting_application" do
+      it "enforces connecting_application is required" do
+        valid_external_api_key = build(:external_api_key) # factory defaults connecting_application using Faker
+        invalid_external_api_key = build(:external_api_key, connecting_application: nil)
+
+        expect(invalid_external_api_key.valid?).to eq(false)
+        expect(invalid_external_api_key.errors[:connecting_application]).to include("can't be blank")
+        expect(valid_external_api_key.valid?).to eq(true)
+      end
+    end
+
     context "webhook_url" do
       it "enforces webhook_url is a valid url when set to a non blank value" do
         valid_external_api_key = build(:external_api_key, webhook_url: "https://www.example.com") # with valid url
@@ -144,12 +166,6 @@ RSpec.describe ExternalApiKey, type: :model do
 
       it "returns false if expired_at is in the future" do
         external_api_key = create(:external_api_key, expired_at: Time.now + 1.day)
-
-        expect(external_api_key.expired?).to eq(false)
-      end
-
-      it "returns false if expired_at is nil" do
-        external_api_key = create(:external_api_key, expired_at: nil)
 
         expect(external_api_key.expired?).to eq(false)
       end


### PR DESCRIPTION
## Description
Feature/bphh 1236/external api admin screens
- Adds external api key index screen with a table of api keys for jurisdictions. Viewable as super admin and admin
- Adds ability to enable or disable api keys for a whole jurisdiction as a super admin
- Add's ability to create, update, expire and revoke api key's as super admin and review manager is api keys are enabled for the jurisdiction
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
- https://hous-bssb.atlassian.net/browse/BPHH-1236
- https://hous-bssb.atlassian.net/browse/BPHH-1237
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- First enable api keys for a jurisdiction as a Super admin
    - Navigate to jurisdictions page
    -  Select any jurisdiction and click manage -> External Api keys
    - Should navigate to index screen
    - Enable api key's using the switch top right of screen
   
![Screenshot 2024-04-25 at 5 12 25 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/c5027128-f361-4495-a794-8c2ea865ce66)
- To perform CRUD operations for external api key when api keys are enabled for the jurisdiction:
    - Navigate to external api key index page 
        - As a super admin - Navigate to Jurisdictions -> Click Manage -> External API keys
        - As a review manager - Navigate to Configuration Management -> Click edit on "Manage Configuration Management"
    - To Create click "Create new API key " button which should open up a modal
        - Add required details then click "Create"
        - On success should navigate to Manage modal
     - To Manage/Edit External API key, click "Manage" on any of the table keys
         - Should open up the Manage modal
         - Should be able to change everything except token, and revoked at
         - Should be able to revoke if already not revoked.  Should show a confirmation modal
         - And save
 
![Screenshot 2024-04-25 at 5 22 20 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/f16359cf-27f3-4f4a-9028-67e4384b4540)

![Screenshot 2024-04-25 at 5 22 26 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/83fc00a2-b9b1-4ef2-9690-240a2762f617)

https://github.com/bcgov/HOUS-permit-portal/assets/32022335/a7480500-b3ae-4390-a26d-f8e3a4d19c40

- to disable api keys for a jurisdiction as a Super admin
    - Navigate to jurisdictions page
    - Select any jurisdiction and click manage -> External Api keys
    - Should navigate to index screen
    - Disable api key's using the switch top right of screen
    - The Create and Manage buttons should become disabled
    - Should be the same for review manager once disabled, but should also show a warning banner
 
![Screenshot 2024-04-25 at 5 12 00 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/94ede139-99f6-4b7d-b33e-27451af7654e)

https://github.com/bcgov/HOUS-permit-portal/assets/32022335/af43b674-aaac-4cbb-9ad2-926ebcd9767a


