### PR TITLE
Allow contact fields to be optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ group :development, :test do
   gem "faker", "~> 3.2.2"
   gem "shoulda-matchers", "~> 5.3.0"
   gem "vcr", "~> 6.2"
-  gem "bullet", '~> 7.1.6'
+  gem "bullet", "~> 7.1.6"
 end
 
 group :test do

--- a/app/controllers/api/jurisdictions_controller.rb
+++ b/app/controllers/api/jurisdictions_controller.rb
@@ -25,7 +25,6 @@ class Api::JurisdictionsController < Api::ApplicationController
 
   def update
     authorize @jurisdiction
-
     if jurisdiction_params[:contacts_attributes]
       # Get current contact ids from the params
       payload_contact_ids = jurisdiction_params[:contacts_attributes].map { |c| c[:id] }

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/submissions-inbox-setup-screen/editable-block.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/submissions-inbox-setup-screen/editable-block.tsx
@@ -147,7 +147,6 @@ export const EditableBlock = observer(function SubmissionsInboxSetupEditableBloc
         )}
       </VStack>
       <Box alignSelf="start">
-        <FormLabel visibility="hidden">PLACEHOLDER</FormLabel>
         {isEditing ? (
           <HStack>
             <Button

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/contact-field-item-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/contact-field-item-display.tsx
@@ -5,21 +5,23 @@ import { RequirementFieldDisplay, TRequirementFieldDisplayProps } from "./index"
 
 interface IContactFieldItemDisplayProps {
   contactFieldItemType: ERequirementContactFieldItemType
+  required?: boolean
 }
 
-export function ContactFieldItemDisplay({ contactFieldItemType }: IContactFieldItemDisplayProps) {
+export function ContactFieldItemDisplay({ contactFieldItemType, required }: IContactFieldItemDisplayProps) {
   const defaultProps: Partial<TRequirementFieldDisplayProps> = {
     label: getRequirementContactFieldItemLabel(contactFieldItemType),
     requirementType: ERequirementType.text,
-    required: true,
   }
-  const required = [
-    ERequirementContactFieldItemType.firstName,
-    ERequirementContactFieldItemType.lastName,
-    ERequirementContactFieldItemType.email,
-    ERequirementContactFieldItemType.phone,
-    ERequirementContactFieldItemType.address,
-  ].includes(contactFieldItemType)
+  const isRequiredItem =
+    required &&
+    [
+      ERequirementContactFieldItemType.firstName,
+      ERequirementContactFieldItemType.lastName,
+      ERequirementContactFieldItemType.email,
+      ERequirementContactFieldItemType.phone,
+      ERequirementContactFieldItemType.address,
+    ].includes(contactFieldItemType)
 
   const propsByType = {
     [ERequirementContactFieldItemType.email]: {
@@ -35,5 +37,5 @@ export function ContactFieldItemDisplay({ contactFieldItemType }: IContactFieldI
       labelProps: { maxW: "full" },
     },
   }
-  return <RequirementFieldDisplay {...defaultProps} {...propsByType[contactFieldItemType]} required={required} />
+  return <RequirementFieldDisplay {...defaultProps} {...propsByType[contactFieldItemType]} required={isRequiredItem} />
 }

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/generic-contact-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/generic-contact-display.tsx
@@ -1,13 +1,14 @@
 import { Box, BoxProps, Button, FormControl, FormLabel, Heading, HeadingProps, Switch } from "@chakra-ui/react"
 import { Plus } from "@phosphor-icons/react"
 import React from "react"
+import { FieldValues } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { getRequirementTypeLabel } from "../../../../constants"
 import { ERequirementContactFieldItemType } from "../../../../types/enums"
 import { ContactFieldItemDisplay } from "./contact-field-item-display"
 import { TRequirementFieldDisplayProps } from "./index"
 
-export type TGenericContactDisplayProps = {
+export type TGenericContactDisplayProps<TFieldValues extends FieldValues> = {
   contactFieldItems: Array<{
     type: ERequirementContactFieldItemType
     containerProps?: BoxProps
@@ -16,7 +17,7 @@ export type TGenericContactDisplayProps = {
   renderHeading?: () => JSX.Element
 } & TRequirementFieldDisplayProps
 
-export function GenericContactDisplay({
+export function GenericContactDisplay<TFieldValues>({
   contactFieldItems,
   label,
   labelProps,
@@ -26,10 +27,11 @@ export function GenericContactDisplay({
   renderHeading,
   addMultipleContactProps,
   showAddPersonButton,
-}: TGenericContactDisplayProps) {
+  required,
+}: TGenericContactDisplayProps<TFieldValues>) {
   const { t } = useTranslation()
   return (
-    <>
+    <Box>
       <Box
         w={"full"}
         as={"section"}
@@ -70,7 +72,7 @@ export function GenericContactDisplay({
               }}
               {...containerProps}
             >
-              <ContactFieldItemDisplay contactFieldItemType={type} />
+              <ContactFieldItemDisplay required={required} contactFieldItemType={type} />
             </Box>
           ))}
         </Box>
@@ -126,6 +128,6 @@ export function GenericContactDisplay({
           {t("requirementsLibrary.addAnotherPerson")}
         </Button>
       )}
-    </>
+    </Box>
   )
 }

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/generic-contact-edit.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/generic-contact-edit.tsx
@@ -1,3 +1,4 @@
+import { Stack } from "@chakra-ui/react"
 import React from "react"
 import { useController } from "react-hook-form"
 import {
@@ -5,35 +6,42 @@ import {
   TGenericContactDisplayProps,
 } from "../requirement-field-display/generic-contact-display"
 import { EditableLabel, TEditableLabelProps } from "./editable-label"
+import { IsOptionalCheckbox, TIsOptionalCheckboxProps } from "./is-optional-checkbox"
 import { IControlProps } from "./types"
 
 export type TGenericContactEditProps<TFieldValues> = {
   editableLabelProps: TEditableLabelProps<TFieldValues>
-} & TGenericContactDisplayProps &
+  isOptionalCheckboxProps: TIsOptionalCheckboxProps<TFieldValues>
+} & TGenericContactDisplayProps<TFieldValues> &
   IControlProps<TFieldValues>
 
 export function GenericContactEdit<TFieldValues>({
   controlProps,
   editableLabelProps,
+  isOptionalCheckboxProps,
   ...contactDisplayProps
 }: TGenericContactEditProps<TFieldValues>) {
   const {
     field: { value, ...restField },
   } = useController(controlProps)
+
   return (
-    <GenericContactDisplay
-      containerProps={{
-        borderBottomRadius: "none",
-      }}
-      renderHeading={() => <EditableLabel {...editableLabelProps} />}
-      addMultipleContactProps={{
-        switchProps: {
-          isChecked: !!value,
-          ...restField,
-        },
-        shouldRender: true,
-      }}
-      {...contactDisplayProps}
-    />
+    <Stack spacing={4}>
+      <GenericContactDisplay
+        containerProps={{
+          borderBottomRadius: "none",
+        }}
+        renderHeading={() => <EditableLabel {...editableLabelProps} />}
+        addMultipleContactProps={{
+          switchProps: {
+            isChecked: !!value,
+            ...restField,
+          },
+          shouldRender: true,
+        }}
+        {...contactDisplayProps}
+      />
+      <IsOptionalCheckbox {...isOptionalCheckboxProps} />
+    </Stack>
   )
 }

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
@@ -340,6 +340,7 @@ const requirementsComponentMap = {
   [ERequirementType.generalContact]: function <TFieldValues>({
     editableLabelProps,
     canAddMultipleContactProps,
+    ...rest
   }: TRequirementEditProps<TFieldValues>) {
     const contactFieldItemTypes: Array<{ type: ERequirementContactFieldItemType; containerProps?: BoxProps }> = [
       { type: ERequirementContactFieldItemType.firstName },
@@ -371,6 +372,7 @@ const requirementsComponentMap = {
         contactFieldItems={contactFieldItemTypes}
         editableLabelProps={editableLabelProps}
         {...canAddMultipleContactProps}
+        {...rest}
       />
     )
   },
@@ -378,6 +380,7 @@ const requirementsComponentMap = {
   [ERequirementType.professionalContact]: function <TFieldValues>({
     editableLabelProps,
     canAddMultipleContactProps,
+    ...rest
   }: TRequirementEditProps<TFieldValues>) {
     if (!canAddMultipleContactProps) {
       import.meta.env.DEV && console.error("multipleContactProps is required for contact requirement edit")
@@ -404,13 +407,13 @@ const requirementsComponentMap = {
       { type: ERequirementContactFieldItemType.professionalNumber },
       { type: ERequirementContactFieldItemType.organization },
     ]
-
     return (
       <GenericContactEdit<TFieldValues>
         requirementType={ERequirementType.professionalContact}
         contactFieldItems={contactFieldItemTypes}
         editableLabelProps={editableLabelProps}
         {...canAddMultipleContactProps}
+        {...rest}
       />
     )
   },
@@ -444,7 +447,6 @@ export const RequirementFieldEdit = observer(function RequirementFieldEdit<TFiel
     return toRemove
   })()
   const formattedProps = R.omit(propsToRemove, rest)
-
   return requirementsComponentMap[requirementType]?.(formattedProps) ?? null
 })
 

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/is-optional-checkbox.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/is-optional-checkbox.tsx
@@ -15,10 +15,10 @@ export function IsOptionalCheckbox<TFieldValues extends FieldValues>({
     field: { value, onChange, ...restField },
   } = useController(controlProps)
   const { t } = useTranslation()
-
   return (
     //   This is checked inverse of the boolean value. This is because the db field is for "required", instead of
     //   optional, and by default it should be required
+
     <Checkbox
       {...checkboxProps}
       isChecked={value === undefined ? value : !value}

--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -242,31 +242,45 @@ class RequirementFormJsonService
   end
 
   def get_general_contact_field_components(parent_key = nil)
+    required = self.requirement.required
     [
       get_columns_form_json(
         "name_columns",
-        [get_contact_field_form_json(:first_name, parent_key), get_contact_field_form_json(:last_name, parent_key)],
+        [
+          get_contact_field_form_json(:first_name, parent_key, required),
+          get_contact_field_form_json(:last_name, parent_key, required),
+        ],
       ),
       get_columns_form_json(
         "reach_columns",
-        [get_contact_field_form_json(:email, parent_key), get_contact_field_form_json(:phone, parent_key)],
+        [
+          get_contact_field_form_json(:email, parent_key, required),
+          get_contact_field_form_json(:phone, parent_key, required),
+        ],
       ),
-      get_contact_field_form_json(:address, parent_key),
+      get_contact_field_form_json(:address, parent_key, required),
       get_columns_form_json("organization_columns", [get_contact_field_form_json(:organization, parent_key, false)]),
     ]
   end
 
   def get_professional_contact_field_components(parent_key = nil)
+    required = self.requirement.required
     [
       get_columns_form_json(
         "name_columns",
-        [get_contact_field_form_json(:first_name, parent_key), get_contact_field_form_json(:last_name, parent_key)],
+        [
+          get_contact_field_form_json(:first_name, parent_key, required),
+          get_contact_field_form_json(:last_name, parent_key, required),
+        ],
       ),
       get_columns_form_json(
         "reach_columns",
-        [get_contact_field_form_json(:email, parent_key), get_contact_field_form_json(:phone, parent_key)],
+        [
+          get_contact_field_form_json(:email, parent_key, required),
+          get_contact_field_form_json(:phone, parent_key, required),
+        ],
       ),
-      get_contact_field_form_json(:address, parent_key),
+      get_contact_field_form_json(:address, parent_key, required),
       get_columns_form_json(
         "business_columns",
         [


### PR DESCRIPTION
## Description

Adds a checkbox to make contacts optional. This will make all of the contact fields optional instead of just the few fields at the end which are always optional. Shows the required fields with red asterisk. Works with professional + multi contact as well.

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-949

## Steps to QA

Log in as super admin
Requirements library
create new
add 4 contact blocks, general and professional, both single and multi

add names and save
Notice the required fields marked with red asterisks
add this to a requirement template and force publish
log in as submitter, create new permit application under the corresponding types
verify required fields.

