### PR TITLE
Feature/bphh 1291/permit application external api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ VITE_ENABLE_TEMPLATE_FORCE_PUBLISH="true"
 REDIS_URL="redis://localhost:6379/0"
 ANYCABLE_DEV_REDIS_URL="redis://localhost:6379/1"
 
+# Rate Limiting
+RATE_LIMIT_DEV_REDIS_URL="redis://localhost:6379/2"
+RATE_LIMIT_REDIS_DB=2
+
 ########################################################################
 # Production Only (HA related or security settings)
 ########################################################################

--- a/Gemfile
+++ b/Gemfile
@@ -108,3 +108,5 @@ group :development do
 end
 
 gem "faraday-multipart", "~> 1.0"
+
+gem "rack-attack", "~> 6.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,8 @@ GEM
     raabro (1.4.0)
     racc (1.7.3)
     rack (3.0.10)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-protection (3.0.6)
       rack
     rack-proxy (0.7.7)
@@ -556,6 +558,7 @@ DEPENDENCIES
   puma (>= 6.4.2)
   pundit (~> 2.3.1)
   rack (>= 3.0.9.1)
+  rack-attack (~> 6.7)
   rails (~> 7.1.3.1)
   rdoc (>= 6.6.3.1)
   redis (~> 5.0.8)

--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -28,7 +28,11 @@ class PermitApplicationBlueprint < Blueprinter::Base
 
   view :extended do
     include_view :base
-    fields :form_json, :submission_data, :formatted_compliance_data, :front_end_form_update, :form_customizations
+    fields :form_json,
+           :submission_data,
+           :formatted_compliance_data,
+           :front_end_form_update,
+           :form_customizations
 
     field :is_fully_loaded do |pa, options|
       true
@@ -43,5 +47,31 @@ class PermitApplicationBlueprint < Blueprinter::Base
   view :compliance_update do
     identifier :id
     fields :formatted_compliance_data, :front_end_form_update
+  end
+
+  view :external_api do
+    identifier :id
+    fields :nickname,
+           :status,
+           :number,
+           :full_address,
+           :pid,
+           :pin,
+           :zipfile_size,
+           :zipfile_name,
+           :zipfile_url,
+           :reference_number,
+           :submitted_at
+
+    field :submission_data do |pa, _options|
+      pa.formatted_submission_data_for_external_use
+    end
+
+    field :permit_classifications do |pa, _options|
+      pa.formatted_permit_classifications
+    end
+
+    association :permit_type, blueprint: PermitClassificationBlueprint
+    association :activity, blueprint: PermitClassificationBlueprint
   end
 end

--- a/app/blueprints/requirement_blueprint.rb
+++ b/app/blueprints/requirement_blueprint.rb
@@ -8,7 +8,6 @@ class RequirementBlueprint < Blueprinter::Base
          :input_options,
          :hint,
          :required,
-         :requirement_code,
          :related_content,
          :required_for_in_person_hint,
          :required_for_multiple_owners,

--- a/app/blueprints/requirement_blueprint.rb
+++ b/app/blueprints/requirement_blueprint.rb
@@ -8,6 +8,7 @@ class RequirementBlueprint < Blueprinter::Base
          :input_options,
          :hint,
          :required,
+         :requirement_code,
          :related_content,
          :required_for_in_person_hint,
          :required_for_multiple_owners,

--- a/app/controllers/external_api/application_controller.rb
+++ b/app/controllers/external_api/application_controller.rb
@@ -16,6 +16,10 @@ class ExternalApi::ApplicationController < ActionController::API
 
   protected
 
+  def apply_search_authorization(results, policy_action = action_name)
+    results.select { |result| policy([:external_api, result]).send("#{policy_action}?".to_sym) }
+  end
+
   def store_currents
     Current.external_api_key = current_external_api_key
   end

--- a/app/controllers/external_api/concerns/search/permit_applications.rb
+++ b/app/controllers/external_api/concerns/search/permit_applications.rb
@@ -1,0 +1,63 @@
+module ExternalApi::Concerns::Search::PermitApplications
+  extend ActiveSupport::Concern
+
+  def perform_permit_application_search
+    # This search should always be scoped to a jurisdiction via the api key.
+    # The following condition should never be true, but is an added reduncy
+    # for security purposes.
+    if current_external_api_key.blank? || current_external_api_key.jurisdiction_id.blank?
+      raise Pundit::NotAuthorizedError
+    end
+
+    search_conditions = {
+      order: permit_application_order,
+      match: :word_start,
+      where: permit_application_where_clause,
+      page: permit_application_search_params[:page],
+      per_page:
+        (
+          if permit_application_search_params[:page]
+            (permit_application_search_params[:per_page] || Kaminari.config.default_per_page)
+          else
+            nil
+          end
+        ),
+    }
+
+    @permit_application_search = PermitApplication.search(permit_application_query, **search_conditions)
+  end
+
+  private
+
+  def permit_application_search_params
+    params.permit(
+      :page,
+      :per_page,
+      constraints: [:permit_classifications, submitted_at: %i[gt lt gte lte]],
+      sort: %i[field direction],
+    )
+  end
+
+  def permit_application_query
+    # We do not support querying for permit applications for external apis
+    "*"
+  end
+
+  def permit_application_order
+    if (sort = permit_application_search_params[:sort])
+      { sort[:field] => { order: sort[:direction], unmapped_type: "long" } }
+    else
+      { submitted_at: { order: :desc, unmapped_type: "long" } }
+    end
+  end
+
+  def permit_application_where_clause
+    constraints = permit_application_search_params[:constraints]
+
+    where = { status: %i[submitted], jurisdiction_id: current_external_api_key.jurisdiction_id }
+
+    where.merge!(constraints.to_h.deep_symbolize_keys) if constraints.present?
+
+    where
+  end
+end

--- a/app/controllers/external_api/permit_applications_controller.rb
+++ b/app/controllers/external_api/permit_applications_controller.rb
@@ -1,0 +1,37 @@
+class ExternalApi::PermitApplicationsController < ExternalApi::ApplicationController
+  include ExternalApi::Concerns::Search::PermitApplications
+
+  before_action :set_permit_application, only: :show
+
+  def index
+    perform_permit_application_search
+    authorized_results = apply_search_authorization(@permit_application_search.results)
+    render_success authorized_results,
+                   nil,
+                   {
+                     meta: {
+                       total_pages: @permit_application_search.total_pages,
+                       total_count: @permit_application_search.total_count,
+                       current_page: @permit_application_search.current_page,
+                     },
+                     blueprint: PermitApplicationBlueprint,
+                     blueprint_opts: {
+                       view: :external_api,
+                     },
+                   }
+  end
+
+  def show
+    authorize [:external_api, @permit_application]
+
+    render_success @permit_application,
+                   nil,
+                   { blueprint: PermitApplicationBlueprint, blueprint_opts: { view: :external_api } }
+  end
+
+  private
+
+  def set_permit_application
+    @permit_application = PermitApplication.find(params[:id])
+  end
+end

--- a/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
+++ b/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
@@ -64,7 +64,7 @@ export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModal
   const [token, setToken] = useState("")
 
   const onClose = () => {
-    navigate(`/jurisdictions/${currentJurisdiction?.id}/external-api-keys`)
+    navigate(`/jurisdictions/${currentJurisdiction?.id}/api-settings`)
   }
 
   useEffect(() => {
@@ -87,7 +87,7 @@ export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModal
     if (updatedExternalApiKey) {
       externalApiKey
         ? onClose()
-        : navigate(`/jurisdictions/${currentJurisdiction?.id}/external-api-keys/${updatedExternalApiKey.id}/manage`)
+        : navigate(`/jurisdictions/${currentJurisdiction?.id}/api-settings/${updatedExternalApiKey.id}/manage`)
     }
   })
 

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/index.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/index.tsx
@@ -91,7 +91,7 @@ export const ConfigurationManagementScreen = observer(function ConfigurationMana
                   description={t(`${i18nPrefix}.externalApiKeys.description`)}
                   linkText={t("ui.edit")}
                   icon={<Users size={24} />}
-                  href={`/jurisdictions/${currentJurisdiction.slug}/external-api-keys`}
+                  href={`/jurisdictions/${currentJurisdiction.slug}/api-settings`}
                   h="full"
                 />
               </GridItem>

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -255,7 +255,7 @@ const AppRoutes = observer(() => {
     <>
       <Route path="/jurisdictions/:jurisdictionId/users" element={<JurisdictionUserIndexScreen />} />
       <Route path="/jurisdictions/:jurisdictionId/users/invite" element={<InviteScreen />} />
-      <Route path="/jurisdictions/:jurisdictionId/external-api-keys" element={<ExternalApiKeysIndexScreen />}>
+      <Route path="/jurisdictions/:jurisdictionId/api-settings" element={<ExternalApiKeysIndexScreen />}>
         <Route path="create" element={<ExternalApiKeyModalSubRoute />} />
         <Route path=":externalApiKeyId/manage" element={<ExternalApiKeyModalSubRoute />} />
       </Route>

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -201,8 +201,8 @@ const NavBarMenu = observer(({}: INavBarMenuProps) => {
       />
       <NavMenuItem label={t("site.breadcrumb.users")} to={`/jurisdictions/${currentUser?.jurisdiction?.slug}/users`} />
       <NavMenuItem
-        label={t("site.breadcrumb.externalApiKeys")}
-        to={`/jurisdictions/${currentUser?.jurisdiction?.slug}/external-api-keys`}
+        label={t("site.breadcrumb.apiSettings")}
+        to={`/jurisdictions/${currentUser?.jurisdiction?.slug}/api-settings`}
       />
       <MenuDivider />
     </MenuGroup>

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/sections-display.tsx
@@ -69,6 +69,7 @@ const SectionDisplay = observer(
       control,
     })
 
+    const watchedSections = watch(`requirementTemplateSectionsAttributes`)
     const watchedSectionBlocks = watch(
       `requirementTemplateSectionsAttributes.${sectionIndex}.templateSectionBlocksAttributes`
     )
@@ -80,6 +81,14 @@ const SectionDisplay = observer(
       setEditableSectionName(watchedSectionName)
     }, [watchedSectionName])
 
+    // only one instance of any requirement block can be used on a template
+    const disabledUseForBlockIds = new Set(
+      watchedSections
+        .map((sections) =>
+          (sections?.templateSectionBlocksAttributes ?? []).map((sectionBlock) => sectionBlock.requirementBlockId)
+        )
+        .flat()
+    )
     return (
       <Box
         ref={(el) => setSectionRef(el, section.id)}
@@ -151,7 +160,8 @@ const SectionDisplay = observer(
             onUse={(requirementBlock, closeDrawer) => {
               appendSectionBlock({ id: uuidv4(), requirementBlockId: requirementBlock.id })
             }}
-            disableUseForBlockIds={new Set(watchedSectionBlocks.map((sectionBlock) => sectionBlock.requirementBlockId))}
+            disableUseForBlockIds={disabledUseForBlockIds}
+            disabledReason={t("requirementTemplate.edit.duplicateRequirementBlockDisabledReason")}
           />
         </Stack>
       </Box>

--- a/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
@@ -5,6 +5,7 @@ import {
   DrawerCloseButton,
   DrawerContent,
   DrawerOverlay,
+  Tooltip,
   useDisclosure,
 } from "@chakra-ui/react"
 import { Plus } from "@phosphor-icons/react"
@@ -19,6 +20,7 @@ interface IProps {
   renderTriggerButton?: (props: ButtonProps & { ref: Ref<HTMLElement> }) => JSX.Element
   onUse?: (requirementBlock: IRequirementBlock, closeDrawer?: () => void) => void
   disableUseForBlockIds?: Set<string>
+  disabledReason?: string
 }
 
 export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDrawer({
@@ -26,6 +28,7 @@ export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDr
   renderTriggerButton,
   onUse,
   disableUseForBlockIds,
+  disabledReason,
 }: IProps) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -52,16 +55,26 @@ export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDr
             h={"calc(100% - 120px)"}
             flex={1}
             p={8}
-            renderActionButton={({ requirementBlock }) => (
-              <Button
-                size={"sm"}
-                variant={"primary"}
-                onClick={() => onUse(requirementBlock, onClose)}
-                isDisabled={disableUseForBlockIds.has(requirementBlock.id)}
-              >
-                {t("ui.use")}
-              </Button>
-            )}
+            renderActionButton={({ requirementBlock }) => {
+              const isDisabled = disableUseForBlockIds.has(requirementBlock.id)
+              const shouldShowDisabledReason = isDisabled && disabledReason
+
+              const buttonProps = {
+                size: "sm",
+                variant: "primary",
+                onClick: () => onUse(requirementBlock, onClose),
+                isDisabled,
+                children: t("ui.use"),
+              }
+
+              return shouldShowDisabledReason ? (
+                <Tooltip label={disabledReason}>
+                  <Button {...buttonProps} />
+                </Tooltip>
+              ) : (
+                <Button {...buttonProps} />
+              )
+            }}
           />
         </DrawerContent>
       </Drawer>

--- a/app/frontend/components/shared/jurisdiction/manage-jurisdiction-menu.tsx
+++ b/app/frontend/components/shared/jurisdiction/manage-jurisdiction-menu.tsx
@@ -31,7 +31,7 @@ export const ManageJurisdictionMenu = observer(function ManageJurisdictionMenu<T
           <ManageMenuItem icon={<Users size={16} />} to={`${jurisdiction.slug}/users`}>
             {t("jurisdiction.index.users")}
           </ManageMenuItem>
-          <ManageMenuItem icon={<Key size={16} />} to={`${jurisdiction.slug}/external-api-keys`}>
+          <ManageMenuItem icon={<Key size={16} />} to={`${jurisdiction.slug}/api-settings`}>
             {t("jurisdiction.index.externalApiKeys")}
           </ManageMenuItem>
         </MenuList>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -249,7 +249,7 @@ const options = {
             createButton: "Create new jurisdiction",
             tableHeading: "Local governments",
             users: "Users",
-            externalApiKeys: "External API keys",
+            externalApiKeys: "API settings",
             about: "About",
           },
           fields: {
@@ -947,8 +947,8 @@ const options = {
               },
             },
             externalApiKeys: {
-              title: "Manage external API keys",
-              description: "Manage external API keys for the Building Permit Hub.",
+              title: "API settings",
+              description: "Manage API keys for the Building Permit Hub.",
             },
           },
           superAdminTitle: "Admin home",
@@ -1165,11 +1165,10 @@ const options = {
             enabled: "Enabled",
             disabled: "Disabled",
             table: {
-              heading: "External API keys",
+              heading: "API keys",
             },
             disabledWarningTitle:
-              "External API keys for this jurisdiction have not been enabled. To enable them, please contact" +
-              " us at",
+              "API keys for this jurisdiction have not been enabled. To enable them, please contact" + " us at",
             disabledTooltipLabel: "User is not authorized to make this change",
             disableConfirmationModal: {
               title: "Are you sure you want to disable API keys for this jurisdiction?",
@@ -1177,8 +1176,8 @@ const options = {
             },
           },
           modal: {
-            createTitle: "Create external API key",
-            manageTitle: "Manage external API key",
+            createTitle: "Create API key",
+            manageTitle: "Manage API key",
             removeConfirmationModal: {
               title: "Are you sure you want to revoke this API key?",
               body: "Any applications using this token will be unable to access the API.",
@@ -1288,7 +1287,7 @@ const options = {
             confirmed: "E-mail confirmed",
             welcome: "Welcome",
             sitewideMessage: "Site-Wide Message",
-            externalApiKeys: "External API keys",
+            apiSettings: "API settings",
             create: "Create",
           },
           questionSupport: "Question support",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1065,6 +1065,7 @@ const options = {
               title: "There are {{count}} fields with errors on the page",
               instructions: "Please fix the following before submitting:",
             },
+            duplicateRequirementBlockDisabledReason: "This requirement block is already in the template",
           },
           fields: {
             status: "Status",

--- a/app/models/template_section_block.rb
+++ b/app/models/template_section_block.rb
@@ -10,7 +10,7 @@ class TemplateSectionBlock < ApplicationRecord
   private
 
   def validate_block_uniqueness_on_template
-    return unless duplicate_requirement_block_on_template_exits?
+    return unless duplicate_requirement_block_on_template_exists?
 
     errors.add(
       :requirement_block,
@@ -22,7 +22,7 @@ class TemplateSectionBlock < ApplicationRecord
     )
   end
 
-  def duplicate_requirement_block_on_template_exits?
+  def duplicate_requirement_block_on_template_exists?
     requirement_template
       .requirement_template_sections
       .joins(:template_section_blocks)

--- a/app/models/template_section_block.rb
+++ b/app/models/template_section_block.rb
@@ -1,8 +1,34 @@
 class TemplateSectionBlock < ApplicationRecord
   belongs_to :requirement_template_section
   belongs_to :requirement_block
+  has_one :requirement_template, through: :requirement_template_section
 
   acts_as_list scope: :requirement_template_section, top_of_list: 0
 
-  validates_uniqueness_of :requirement_block, scope: :requirement_template_section
+  validate :validate_block_uniqueness_on_template
+
+  private
+
+  def validate_block_uniqueness_on_template
+    return unless duplicate_requirement_block_on_template_exits?
+
+    errors.add(
+      :requirement_block,
+      message:
+        I18n.t(
+          "model_validation.template_section_block.requirement_block_on_template_exits",
+          requirement_block_name: requirement_block.name,
+        ),
+    )
+  end
+
+  def duplicate_requirement_block_on_template_exits?
+    requirement_template
+      .requirement_template_sections
+      .joins(:template_section_blocks)
+      .where(template_section_blocks: { requirement_block: requirement_block })
+      .where.not(template_section_blocks: { id: id })
+      .limit(1)
+      .exists?
+  end
 end

--- a/app/policies/external_api/permit_application_policy.rb
+++ b/app/policies/external_api/permit_application_policy.rb
@@ -1,0 +1,15 @@
+class ExternalApi::PermitApplicationPolicy < ExternalApi::ApplicationPolicy
+  def index?
+    external_api_key.jurisdiction == record.jurisdiction && record.submitted?
+  end
+
+  def show?
+    index?
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.where(submitter: user)
+    end
+  end
+end

--- a/app/services/external_permit_application_service.rb
+++ b/app/services/external_permit_application_service.rb
@@ -1,0 +1,124 @@
+class ExternalPermitApplicationService
+  attr_accessor :permit_application
+
+  def initialize(permit_application)
+    self.permit_application = permit_application
+  end
+
+  def formatted_submission_data_for_external_use
+    unless self.permit_application.submission_data.present? && self.permit_application.submission_data["data"].present?
+      return {}
+    end
+
+    cloned_submission_data = self.permit_application.submission_data["data"].deep_dup
+
+    cloned_submission_data.each do |section_key, section_value|
+      contact_submissions_to_merge = {}
+
+      section_value.each do |submitted_field_key, submitted_value|
+        unless !submitted_field_key.ends_with?("multi_contact") &&
+                 (
+                   submitted_field_key.include?("general_contact") ||
+                     submitted_field_key.include?("professional_contact")
+                 )
+          next
+        end
+
+        # create a new key and value pair, to collect non multi_contact contact field values
+        # into a single array of contact objects, similar to multi_contact contacts.
+        # This will enable us to have a consistent data structure for all contact submissions, making
+        # it easier to format the data
+        split_submitted_field_key = submitted_field_key.split("|")
+
+        contact_property_key = split_submitted_field_key.pop
+
+        formatted_requirement_key = split_submitted_field_key.join("|")
+
+        contact_submissions_to_merge[formatted_requirement_key] = [{}] unless contact_submissions_to_merge[
+          formatted_requirement_key
+        ].present?
+
+        contact_submissions_to_merge[formatted_requirement_key].first[contact_property_key] = submitted_value
+
+        cloned_submission_data[section_key].delete(submitted_field_key)
+      end
+
+      cloned_submission_data[section_key].merge!(contact_submissions_to_merge)
+    end
+
+    formatted_submission_data = {}
+
+    # first level key is the section_key, which we can ignore
+    # second level is the actual submitted values
+    cloned_submission_data.each do |section_key, section_value|
+      section_value.each do |submitted_field_key, submitted_value|
+        # key is in the format "formSubmissionDataRSTsection6736da0b-860e-43e6-9823-86c7d6562f1e|RBc2683830-8fe1-4979
+        # -bd54-d6c993f3148c|building_project_value"
+        # The requirement_block_id is in the format |RB{id}|, so the id in the example is c2683830-8fe1-4979-bd54-d6c993f3148c
+        submitted_field_key_split = submitted_field_key.split("|RB")
+
+        next unless submitted_field_key_split.length > 1
+
+        requirement_block_id = submitted_field_key_split.last.split("|").first
+
+        requirement_block = get_requirement_block_json(requirement_block_id)
+
+        next unless requirement_block.present?
+
+        if !formatted_submission_data.key?(requirement_block["sku"])
+          formatted_submission_data[requirement_block["sku"]] = {
+            id: requirement_block["id"],
+            requirement_block_code: requirement_block["sku"],
+            name: requirement_block["name"],
+            description: requirement_block["description"],
+            requirements: [],
+          }
+        end
+
+        requirement =
+          requirement_block["requirements"].find do |req|
+            req.dig("form_json", "key").ends_with?(submitted_field_key.split("|RB").last)
+          end
+
+        next unless requirement.present?
+
+        formatted_value =
+          if submitted_field_key.to_s.ends_with?("multi_contact")
+            submitted_value.map do |contact_value|
+              formatted_contact_value = {}
+
+              contact_value.each do |contact_field_key, contact_field_value|
+                contact_field_key_split = contact_field_key.split("|")
+
+                next unless contact_field_key_split.length > 1
+
+                formatted_key = contact_field_key_split.last
+
+                formatted_contact_value[formatted_key] = contact_field_value
+              end
+
+              formatted_contact_value
+            end
+          else
+            submitted_value
+          end
+
+        formatted_submission_data[requirement_block["sku"]][:requirements] << {
+          id: requirement["id"],
+          name: requirement["label"],
+          requirement_code: requirement["requirement_code"],
+          type: requirement["input_type"],
+          value: formatted_value,
+        }
+      end
+    end
+
+    formatted_submission_data
+  end
+
+  def get_requirement_block_json(requirement_block_id)
+    self.permit_application.template_version.requirement_blocks_json[requirement_block_id]
+  end
+
+  private
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,53 @@
+class Rack::Attack
+  # cache.store = ActiveSupport::Cache::RedisStore.new # Configure cache store (replace if necessary)
+
+  redis_options =
+    if Rails.env.production? && ENV["SKIP_DEPENDENCY_INITIALIZERS"].blank? # skip this during precompilation in the docker build stage
+      {
+        url: "redis://#{ENV["REDIS_SENTINEL_MASTER_SET_NAME"]}/#{ENV["RATE_LIMIT_REDIS_DB"]&.to_i || 2}",
+        sentinels:
+          Resolv
+            .getaddresses(ENV["REDIS_SENTINEL_HEADLESS"])
+            .map { |address| { host: address, port: (ENV["REDIS_SENTINEL_PORT"]&.to_i || 26_379) } },
+      }
+    else
+      { url: ENV["RATE_LIMIT_DEV_REDIS_URL"] }
+    end
+
+  self.cache.store = ActiveSupport::Cache::RedisCacheStore.new(**redis_options)
+
+  # Define a Rack-Attack throttle for IP address
+  throttle("external_api/ip", limit: 300, period: 5.minutes) do |req|
+    # Limit applies if route starts with "/external_api"
+    req.ip if req.path.start_with?("/external_api")
+  end
+
+  # Define a Rack-Attack throttle for API token
+  throttle("external_api/token", limit: 100, period: 1.minutes) do |req|
+    # Extract bearer token from authorization header
+    if req.path.start_with?("/external_api")
+      token = req.env["HTTP_AUTHORIZATION"]&.split(" ")&.try(:[], 1)
+      # Apply throttle only if token is present
+      token.present? ? token : nil
+    end
+  end
+
+  self.throttled_responder =
+    lambda do |_request|
+      [
+        429,
+        { "Content-Type" => "application/json" },
+        [
+          {
+            data: {
+            },
+            meta: {
+              message: "Rate limit exceeded. Try again later.",
+              title: "Rate limit exceeded",
+              type: "error",
+            },
+          }.to_json,
+        ],
+      ]
+    end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,5 +383,7 @@ en:
     performance_type:
       error: "%{field_name} performance type must be one of %{accepted_values}"
   model_validation:
+    template_section_block:
+      requirement_block_on_template_exits: ": \"%{requirement_block_name}\" already exists on this template"
     jurisdiction_template_version_customization:
       enabled_elective_field_reason_incorrect: "Reason required when enabling a field and must be one of {accepted_reasons}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,12 @@ Rails.application.routes.draw do
     end
   end
 
+  scope module: :external_api, path: :external_api do
+    resources :permit_applications, only: %i[show] do
+      post "search", on: :collection, to: "permit_applications#index"
+    end
+  end
+
   root to: "home#index"
 
   get "/reset-password" => "home#index", :as => :reset_password

--- a/spec/concerns/validate_url_attributes_spec.rb
+++ b/spec/concerns/validate_url_attributes_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe ValidateUrlAttributes, type: :model do
   end
 
   # Rollback migration after running the tests
-  after(:all) { ActiveRecord::Migration.drop_table(:dummy_models) }
+  after(:all) do
+    ActiveRecord::Migration.drop_table(:dummy_models) if ActiveRecord::Base.connection.table_exists?(:dummy_models)
+  end
 
   describe "URL validation" do
     let(:dummy_model) { DummyModel.new }

--- a/spec/models/requirement_block_spec.rb
+++ b/spec/models/requirement_block_spec.rb
@@ -51,10 +51,30 @@ RSpec.describe RequirementBlock, type: :model do
   describe "validations" do
     let!(:existing_block) { create(:requirement_block, sku: "existing_value") }
 
-    it "validates uniqueness of sku" do
-      new_block = build(:requirement_block, sku: existing_block.sku)
-      expect(new_block).not_to be_valid
-      expect(new_block.errors[:sku]).to include("has already been taken")
+    context "sku" do
+      it "validates uniqueness of sku" do
+        new_block = build(:requirement_block, sku: existing_block.sku)
+        expect(new_block).not_to be_valid
+        expect(new_block.errors[:sku]).to include("has already been taken")
+      end
+
+      it "auto generates human readable sku when not supplied" do
+        new_block = build(:requirement_block, name: "Test Name")
+
+        expect(new_block).to be_valid
+        expect(new_block.sku).to eq("test_name")
+      end
+
+      it "auto generates unique human readable sku when not supplied" do
+        new_block = create(:requirement_block, name: "Test Name")
+        new_block_with_name_clash = build(:requirement_block, name: "Test Name ") # has an extra space
+
+        expect(new_block).to be_valid
+        expect(new_block.sku).to eq("test_name")
+
+        expect(new_block_with_name_clash).to be_valid
+        expect(new_block_with_name_clash.sku).to start_with("test_name_")
+      end
     end
 
     it "validates presence of sku" do


### PR DESCRIPTION
## Description
- Add's unique constraint to `requirement_block` scoped to the `requirement_template`
- Adds a formatted Data Transfer Object (DTO), for the submitted permit application data. This is going to to be used to push our app data to external third party integrators
- Create new end points for permit applications, which external integrators can use to retrieve permit application data
  - includes `POST /external_api/permit_applications/search` endpoint, which is filterable by `submitted_at` and `permit_classifications`, to retrieve a collection of records 
  - includes `GET /external_api/permit_applications/{permit_application_id}`, to retrieve a single record
- Refactors `requirement_block sku` auto generation logic, to make the `sku` more human readable based on the `label` instead of just using a `UUID`, which is harder to read 
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
- https://hous-bssb.atlassian.net/browse/BPHH-1287
- https://hous-bssb.atlassian.net/browse/BPHH-1289
- https://hous-bssb.atlassian.net/browse/BPHH-1291
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
### Pre-requisites:
- Ensure you have the following env variables:  
```
ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=""
ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=""
ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=""
```
- Log in as super admin
- Navigate to Jurisdictions -> Search for "North Vancouver" -> Click "Manage" -> Click "API Settings"
- Wait to navigate to "API Settings" page
- Enable the API keys if disabled
- Click "Create new API key", enter necessary details and click "Create"
- Wait to navigate to manage route. The token should be available now
- Copy/Take note of this token
- Log in as a submitter then complete and submit one or more permit applications for the North Vancouver jurisdiction

### API QA steps
- Will need to test via Postman
- Use the noted token from the [pre-requisites](#prerequisites) and authorize using Bearer Token type
![Screenshot 2024-05-02 at 10 55 10 AM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/dbedf973-23c8-49e1-8e7b-26f0698a3a5c)
- Postman variables:
![Screenshot 2024-05-02 at 10 58 26 AM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/857425f8-4bab-4aaf-bf23-fa2e96fd7efa)
- Routes to Test:
  - `POST /external_api/permit_applications/search`. (Can use the commented out filter params in the picture below)
![Screenshot 2024-05-02 at 11 02 05 AM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/549aa243-a223-4336-8f91-56bc1a24e948)
   - `GET /external_api/permit_applications/:id`.
   ![Screenshot 2024-05-02 at 11 03 14 AM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/fca252d6-78f7-4298-9af0-4ce9a25d99bd)

<!--
Please provide some steps for the reviewer to test your change. If you have written tests, you can mention that here instead.
Provide any relevant screenshots here.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->
