### PR TITLE
[bphh-1200] Implement rate limiting for external_api/* routes based on ip and token using it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ VITE_ENABLE_TEMPLATE_FORCE_PUBLISH="true"
 REDIS_URL="redis://localhost:6379/0"
 ANYCABLE_DEV_REDIS_URL="redis://localhost:6379/1"
 
+# Rate Limiting
+RATE_LIMIT_DEV_REDIS_URL="redis://localhost:6379/2"
+RATE_LIMIT_REDIS_DB=2
+
 ########################################################################
 # Production Only (HA related or security settings)
 ########################################################################

--- a/Gemfile
+++ b/Gemfile
@@ -108,3 +108,5 @@ group :development do
 end
 
 gem "faraday-multipart", "~> 1.0"
+
+gem "rack-attack", "~> 6.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,8 @@ GEM
     raabro (1.4.0)
     racc (1.7.3)
     rack (3.0.10)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-protection (3.0.6)
       rack
     rack-proxy (0.7.7)
@@ -556,6 +558,7 @@ DEPENDENCIES
   puma (>= 6.4.2)
   pundit (~> 2.3.1)
   rack (>= 3.0.9.1)
+  rack-attack (~> 6.7)
   rails (~> 7.1.3.1)
   rdoc (>= 6.6.3.1)
   redis (~> 5.0.8)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,53 @@
+class Rack::Attack
+  # cache.store = ActiveSupport::Cache::RedisStore.new # Configure cache store (replace if necessary)
+
+  redis_options =
+    if Rails.env.production? && ENV["SKIP_DEPENDENCY_INITIALIZERS"].blank? # skip this during precompilation in the docker build stage
+      {
+        url: "redis://#{ENV["REDIS_SENTINEL_MASTER_SET_NAME"]}/#{ENV["RATE_LIMIT_REDIS_DB"]&.to_i || 2}",
+        sentinels:
+          Resolv
+            .getaddresses(ENV["REDIS_SENTINEL_HEADLESS"])
+            .map { |address| { host: address, port: (ENV["REDIS_SENTINEL_PORT"]&.to_i || 26_379) } },
+      }
+    else
+      { url: ENV["RATE_LIMIT_DEV_REDIS_URL"] }
+    end
+
+  self.cache.store = ActiveSupport::Cache::RedisCacheStore.new(**redis_options)
+
+  # Define a Rack-Attack throttle for IP address
+  throttle("external_api/ip", limit: 300, period: 5.minutes) do |req|
+    # Limit applies if route starts with "/external_api"
+    req.ip if req.path.start_with?("/external_api")
+  end
+
+  # Define a Rack-Attack throttle for API token
+  throttle("external_api/token", limit: 100, period: 1.minutes) do |req|
+    # Extract bearer token from authorization header
+    if req.path.start_with?("/external_api")
+      token = req.env["HTTP_AUTHORIZATION"]&.split(" ")&.try(:[], 1)
+      # Apply throttle only if token is present
+      token.present? ? token : nil
+    end
+  end
+
+  self.throttled_responder =
+    lambda do |_request|
+      [
+        429,
+        { "Content-Type" => "application/json" },
+        [
+          {
+            data: {
+            },
+            meta: {
+              message: "Rate limit exceeded. Try again later.",
+              title: "Rate limit exceeded",
+              type: "error",
+            },
+          }.to_json,
+        ],
+      ]
+    end
+end


### PR DESCRIPTION
## Description
[bphh-1200] Adds rack-attack gem and implements rate limiting for external_api/* route based on ip and bearer token

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1200
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
### Pre-requisites:
- Ensure you have the following env variables:  
```
ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=""
ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=""
ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=""
RATE_LIMIT_DEV_REDIS_URL="redis://localhost:6379/2"
```
- Log in as super admin
- Navigate to Jurisdictions -> Search for "North Vancouver" -> Click "Manage" -> Click "API Settings"
- Wait to navigate to "API Settings" page
- Enable the API keys if disabled
- Click "Create new API key", enter necessary details and click "Create"
- Wait to navigate to manage route. The token should be available now
- Copy/Take note of this token
- Log in as a submitter then complete and submit one or more permit applications for the North Vancouver jurisdiction
- Edit `config/initializers/rack_attack.rb` and change `limit` to `3` and period to `1.minutes`, to make testing easier, **Note: will need a server restart**
![Screenshot 2024-05-02 at 11 09 11 AM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/d77b4be5-7453-4aa2-aa93-67112f89ec87)


### API QA steps
- Will need to test via Postman
- Use the noted token from the [pre-requisites](#prerequisites) and authorize using Bearer Token type
![Screenshot 2024-05-02 at 10 55 10 AM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/dbedf973-23c8-49e1-8e7b-26f0698a3a5c)
- Postman variables:
![Screenshot 2024-05-02 at 10 58 26 AM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/857425f8-4bab-4aaf-bf23-fa2e96fd7efa)
- Routes available:
  - `POST /external_api/permit_applications/search`. (Can use the commented out filter params in the picture below)
   - `GET /external_api/permit_applications/:id`.
- Make 3 consecutive request to any of the above routes. Should receive a `429 Too Many Requests` Status
- This should happen if using the same token or IP
![Screenshot 2024-05-02 at 11 12 29 AM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/40c9499c-da98-4e0d-bc23-ecb8e60bdd8a)
![Screenshot 2024-05-02 at 11 12 59 AM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/ed39b976-9e19-4e45-8f71-681458c02449)
