### PR TITLE
[bphh-196] Add permit submitted webhook 

### DIFF
--- a/app/errors/permit_webhook_error.rb
+++ b/app/errors/permit_webhook_error.rb
@@ -1,0 +1,2 @@
+class PermitWebhookError < StandardError
+end

--- a/app/jobs/permit_webhook_job.rb
+++ b/app/jobs/permit_webhook_job.rb
@@ -1,0 +1,12 @@
+class PermitWebhookJob
+  include Sidekiq::Worker
+  sidekiq_options queue: :webhooks, retry: 8 # exponential back-off shouldn't go over 24 hours
+
+  def perform(external_api_key_id, event_type, permit_application_id)
+    external_api_key = ExternalApiKey.find(external_api_key_id)
+
+    service = PermitWebhookService.new(external_api_key)
+
+    service.send_submitted_event(permit_application_id) if event_type == "permit_submitted"
+  end
+end

--- a/app/models/external_api_key.rb
+++ b/app/models/external_api_key.rb
@@ -36,6 +36,10 @@ NULL",
     revoked_at.present?
   end
 
+  def enabled?
+    jurisdiction.external_api_enabled && !expired? && !revoked?
+  end
+
   def revoke
     update(revoked_at: Time.now)
   end

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -135,6 +135,10 @@ class Jurisdiction < ApplicationRecord
     end
   end
 
+  def active_external_api_keys
+    external_api_keys.active
+  end
+
   private
 
   def sanitize_html_fields

--- a/app/services/permit_webhook_service.rb
+++ b/app/services/permit_webhook_service.rb
@@ -1,0 +1,59 @@
+class PermitWebhookService
+  attr_accessor :external_api_key, :client
+
+  def initialize(external_api_key)
+    @external_api_key = external_api_key
+
+    unless external_api_key.webhook_url.present?
+      raise PermitWebhookError.new(
+              "Webhook URL is not present for external API key with ID: #{external_api_key.id}
+and name: #{external_api_key.name}",
+            )
+    end
+
+    unless external_api_key.enabled?
+      raise PermitWebhookError.new(
+              "External API key with ID: #{external_api_key.id} and name: #{external_api_key.name} is not enabled.",
+            )
+    end
+
+    @client =
+      Faraday.new() do |f|
+        f.request :json
+        f.request :url_encoded
+        f.response :raise_error
+        f.adapter Faraday.default_adapter
+      end
+  end
+
+  def send_submitted_event(permit_id)
+    permit_application = PermitApplication.find(permit_id)
+
+    unless permit_application.submitted?
+      raise PermitWebhookError.new("Permit application with ID #{permit_id} is not submitted.")
+    end
+
+    payload = {
+      event: "permit_submitted",
+      payload: {
+        permit_id: permit_id,
+        submitted_at: permit_application.submitted_at,
+      },
+    }
+
+    send_webhook(payload)
+  end
+
+  def send_webhook(payload)
+    begin
+      response = client.post(external_api_key.webhook_url, payload.to_json) # should automatically throw an error if
+      # 4xx or 5xx
+
+      response.success?
+    rescue Faraday::Error => e
+      raise PermitWebhookError.new(
+              "Failed to send permit_submitted webhook to #{external_api_key.webhook_url}: #{e.message}",
+            )
+    end
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -16,7 +16,7 @@ if Rails.env.production? && ENV["SKIP_DEPENDENCY_INITIALIZERS"].blank? # skip th
 
   Sidekiq.configure_server do |config|
     config.redis = redis_cfg
-    config.queues = %w[file_processing default]
+    config.queues = %w[file_processing webhooks default]
     config.concurrency = ENV["SIDEKIQ_CONCURRENCY"].to_i
 
     config.client_middleware { |chain| chain.add SidekiqUniqueJobs::Middleware::Client }


### PR DESCRIPTION
## Description
[bphh-196] Add jobs and services to send permit_submitted webhook event to external_api_key webhook_urls

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-196 
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->
## Steps to QA
## Steps to QA
### Pre-requisites:
- Ensure you have the following env variables:  
```
ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=""
ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=""
ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=""
RATE_LIMIT_DEV_REDIS_URL="redis://localhost:6379/2"
```
- Log in as super admin
- Navigate to Jurisdictions -> Search for "North Vancouver" -> Click "Manage" -> Click "API Settings"
- Wait to navigate to "API Settings" page
- Enable the API keys if disabled
- Click "Create new API key", enter necessary details, and `webhook_url: http://localhost:6000/webhook ` and click "Create"

#### Webhook Consumer Test Server Setup
- open command line and create a `test` directory and cd into it
- run the following commands in the terminal:
```
npm init -y

npm i express

touch index.js
```
- open up `index.js` and paste the following code and save:
```
const express = require("express");

const app = express();
const port = 6000;

// Middleware to parse JSON bodies
app.use(express.json());

// Middleware to parse URL-encoded bodies
app.use(express.urlencoded({ extended: true }));

app.post("/webhook", (req, res) => {
  console.log("Webhook received successfully", req.body);
  return res.send("Webhook received successfully");
});

app.post("/webhook_broken", (req, res) => {
  return res.status(500).send("Webhook failure");
});

app.listen(port, () => {
  console.log(`Server is running on port ${port}`);
});
```
- In the terminal run `node index.js` to run the server

### Webhook QA Steps
- Ensure Sidekiq is running with command `bundle exec sidekiq -q default -q file_processing -q webhooks`
- Log in as a submitter then complete and submit one or more permit applications for the North Vancouver jurisdiction
- This should trigger the webhook. To manually trigger the webhook (only for submitted permits) can use the following in a `rails console`
```
p = PermiApplication.find("id of submitted permit application")
p.send_submitted_webhook
```
- On the console where the test webhook consumer server is running, you should be see "Webhook received successfully" with the payload


