### PR TITLE
[bphh-860] Fix query to get elective counts and reasons used by juris…

### DIFF
--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -88,38 +88,6 @@ class Requirement < ApplicationRecord
     false
   end
 
-  def count_of_jurisdictions_using
-    JurisdictionTemplateVersionCustomization
-      .joins(:template_version)
-      .where(template_versions: { status: "published" })
-      .where(
-        "customizations -> 'requirement_block_changes' -> :requirement_id -> 'enabled_elective_field_ids' @> :id",
-        requirement_id: id.to_s,
-        id: "[\"#{id}\"]",
-      )
-      .count
-  end
-
-  def count_by_reason(reason)
-    return 0 unless JurisdictionTemplateVersionCustomization::ACCEPTED_ENABLED_ELECTIVE_FIELD_REASONS.include?(reason)
-    JurisdictionTemplateVersionCustomization
-      .joins(:template_version)
-      .where(template_versions: { status: "published" })
-      .where(
-        "customizations -> 'requirement_block_changes' -> :requirement_id -> 'enabled_elective_field_ids' @> :id",
-        requirement_id: id.to_s,
-        id: "[\"#{id}\"]",
-      )
-      .select do |jtvc|
-        jtvc
-          .customizations
-          .dig("requirement_block_changes", id.to_s, "enabled_elective_field_reasons")
-          &.values
-          &.include?(reason)
-      end
-      .count
-  end
-
   def self.extract_requirement_id_from_submission_key(key)
     key.split("|").second
   end

--- a/app/models/template_version.rb
+++ b/app/models/template_version.rb
@@ -16,17 +16,23 @@ class TemplateVersion < ApplicationRecord
   end
 
   def lookup_props
-    #form_json starts at root template
+    # form_json starts at root template
     flatten_requirements_from_form_hash(form_json)
   end
 
   def form_json_requirements
-    requirement_ids = []
-    requirement_blocks_json.each_pair do |_block_id, block_json|
-      block_json["requirements"].each { |requirement| requirement_ids.push(requirement["id"]) }
+    json_requirements = []
+    requirement_blocks_json.each_pair do |block_id, block_json|
+      block_json["requirements"].each do |requirement|
+        dup_requirement = requirement.dup
+
+        dup_requirement["requirement_block_id"] = block_id
+
+        json_requirements.push(dup_requirement)
+      end
     end
 
-    Requirement.find(requirement_ids)
+    json_requirements
   end
 
   private
@@ -34,6 +40,7 @@ class TemplateVersion < ApplicationRecord
   def reindex_requirement_template_if_published
     reindex_requirement_template if published?
   end
+
   def reindex_requirement_template
     requirement_template.reindex
   end

--- a/app/services/template_export_service.rb
+++ b/app/services/template_export_service.rb
@@ -9,15 +9,40 @@ class TemplateExportService
   def summary_csv
     CSV.generate(headers: true) do |csv|
       csv << I18n.t("export.requirement_summary_csv_headers").split(",")
-      requirements = template_version.form_json_requirements
-      requirements.each do |req|
+      json_requirements = template_version.form_json_requirements
+      json_requirements.each do |req|
         jurisdictions_count = Jurisdiction.count
 
-        label = req.label
-        count_of_jurisdictions_using = req.elective ? req.count_of_jurisdictions_using : jurisdictions_count
-        reason_bylaw_count = req.count_by_reason("bylaw")
-        reason_policy_count = req.count_by_reason("policy")
-        reason_zoning_count = req.count_by_reason("zoning")
+        label = req["label"]
+        count_of_jurisdictions_using =
+          (
+            if req["elective"]
+              JurisdictionTemplateVersionCustomization.count_of_jurisdictions_using_requirement(
+                req["requirement_block_id"],
+                req["id"],
+              )
+            else
+              jurisdictions_count
+            end
+          )
+        reason_bylaw_count =
+          JurisdictionTemplateVersionCustomization.requirement_count_by_reason(
+            req["requirement_block_id"],
+            req["id"],
+            "bylaw",
+          )
+        reason_policy_count =
+          JurisdictionTemplateVersionCustomization.requirement_count_by_reason(
+            req["requirement_block_id"],
+            req["id"],
+            "policy",
+          )
+        reason_zoning_count =
+          JurisdictionTemplateVersionCustomization.requirement_count_by_reason(
+            req["requirement_block_id"],
+            req["id"],
+            "zoning",
+          )
 
         csv << [label, count_of_jurisdictions_using, reason_bylaw_count, reason_policy_count, reason_zoning_count]
       end

--- a/spec/models/jurisdiction_template_version_customization_spec.rb
+++ b/spec/models/jurisdiction_template_version_customization_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe JurisdictionTemplateVersionCustomization, type: :model do
   let(:jurisdiction) { create(:sub_district) }
   let(:published_template_version) { create(:template_version, status: "published") }
   let(:scheduled_template_version) { create(:template_version, status: "scheduled") }
-  describe "#count_of_jurisdictions_using" do
+  describe "#count_of_jurisdictions_using_requirement" do
     context "when no customizations reference the requirement" do
       it "returns 0 for published templates" do
         create(
@@ -13,7 +13,12 @@ RSpec.describe JurisdictionTemplateVersionCustomization, type: :model do
           jurisdiction: jurisdiction,
           template_version: published_template_version,
         )
-        expect(requirement.count_of_jurisdictions_using).to eq(0)
+        expect(
+          JurisdictionTemplateVersionCustomization.count_of_jurisdictions_using_requirement(
+            requirement.requirement_block_id,
+            requirement.id,
+          ),
+        ).to eq(0)
       end
 
       it "returns 0 for scheduled templates" do
@@ -22,7 +27,12 @@ RSpec.describe JurisdictionTemplateVersionCustomization, type: :model do
           jurisdiction: jurisdiction,
           template_version: scheduled_template_version,
         )
-        expect(requirement.count_of_jurisdictions_using).to eq(0)
+        expect(
+          JurisdictionTemplateVersionCustomization.count_of_jurisdictions_using_requirement(
+            requirement.requirement_block_id,
+            requirement.id,
+          ),
+        ).to eq(0)
       end
     end
 
@@ -32,7 +42,7 @@ RSpec.describe JurisdictionTemplateVersionCustomization, type: :model do
           :jurisdiction_template_version_customization,
           customizations: {
             "requirement_block_changes" => {
-              requirement.id.to_s => {
+              requirement.requirement_block_id.to_s => {
                 "enabled_elective_field_ids" => [requirement.id.to_s],
               },
             },
@@ -45,7 +55,7 @@ RSpec.describe JurisdictionTemplateVersionCustomization, type: :model do
           :jurisdiction_template_version_customization,
           customizations: {
             "requirement_block_changes" => {
-              requirement.id.to_s => {
+              requirement.requirement_block_id.to_s => {
                 "enabled_elective_field_ids" => [requirement.id.to_s],
               },
             },
@@ -56,7 +66,12 @@ RSpec.describe JurisdictionTemplateVersionCustomization, type: :model do
       end
 
       it "counts only customizations linked to published templates" do
-        expect(requirement.count_of_jurisdictions_using).to eq(1)
+        expect(
+          JurisdictionTemplateVersionCustomization.count_of_jurisdictions_using_requirement(
+            requirement.requirement_block_id,
+            requirement.id,
+          ),
+        ).to eq(1)
       end
     end
   end
@@ -167,7 +182,7 @@ RSpec.describe JurisdictionTemplateVersionCustomization, type: :model do
           :jurisdiction_template_version_customization,
           customizations: {
             "requirement_block_changes" => {
-              requirement.id.to_s => {
+              requirement.requirement_block_id.to_s => {
                 "enabled_elective_field_ids" => [requirement.id.to_s],
                 "enabled_elective_field_reasons" => {
                   requirement.id.to_s => "bylaw",
@@ -185,7 +200,7 @@ RSpec.describe JurisdictionTemplateVersionCustomization, type: :model do
           :jurisdiction_template_version_customization,
           customizations: {
             "requirement_block_changes" => {
-              requirement.id.to_s => {
+              requirement.requirement_block_id.to_s => {
                 "enabled_elective_field_ids" => [requirement.id.to_s],
                 "enabled_elective_field_reasons" => {
                   requirement.id.to_s => "policy",
@@ -199,9 +214,27 @@ RSpec.describe JurisdictionTemplateVersionCustomization, type: :model do
       end
 
       it "counts only occurrences with the specified reason and published template version" do
-        expect(requirement.count_by_reason("bylaw")).to eq(1)
-        expect(requirement.count_by_reason("policy")).to eq(0) # Because template version is unpublished
-        expect(requirement.count_by_reason("zoning")).to eq(0)
+        expect(
+          JurisdictionTemplateVersionCustomization.requirement_count_by_reason(
+            requirement.requirement_block_id,
+            requirement.id,
+            "bylaw",
+          ),
+        ).to eq(1)
+        expect(
+          JurisdictionTemplateVersionCustomization.requirement_count_by_reason(
+            requirement.requirement_block_id,
+            requirement.id,
+            "policy",
+          ),
+        ).to eq(0) # Because template version is unpublished
+        expect(
+          JurisdictionTemplateVersionCustomization.requirement_count_by_reason(
+            requirement.requirement_block_id,
+            requirement.id,
+            "zoning",
+          ),
+        ).to eq(0)
       end
     end
   end


### PR DESCRIPTION
## Description
- Fixes query used to retrieve counts for:
   - Number of jurisdictions using a elective
   - Number of elective requirements used for a given reason
-  Refactors csv generation logic to use `requirement_block_json snapshot from the `template_version` for getting `requirements` instead of relying `requirement` model as the `requirement` DB record might be deleted 

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ x] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-860
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->
