### PR TITLE
Persist path on login redirect

### DIFF
--- a/app/frontend/components/domains/navigation/protected-route.tsx
+++ b/app/frontend/components/domains/navigation/protected-route.tsx
@@ -1,0 +1,22 @@
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { Navigate, Outlet, useLocation } from "react-router-dom"
+import { useMst } from "../../../setup/root"
+
+interface IProps {
+  isAllowed: boolean
+  redirectPath?: string
+  children?: JSX.Element
+}
+export const ProtectedRoute = observer(({ isAllowed, redirectPath = "/login", children }: IProps) => {
+  const location = useLocation()
+  const { sessionStore } = useMst()
+  const { setAfterLoginPath } = sessionStore
+
+  if (!isAllowed) {
+    setAfterLoginPath(location.pathname)
+    return <Navigate to={redirectPath || "/login"} replace />
+  }
+
+  return children ? children : <Outlet />
+})

--- a/app/frontend/stores/session-store.ts
+++ b/app/frontend/stores/session-store.ts
@@ -9,6 +9,7 @@ export const SessionStoreModel = types
     tokenExpired: types.optional(types.boolean, false),
     isValidating: types.optional(types.boolean, true),
     isLoggingOut: types.optional(types.boolean, false),
+    afterLoginPath: types.maybeNull(types.string),
   })
   .extend(withEnvironment())
   .extend(withRootStore())
@@ -20,6 +21,9 @@ export const SessionStoreModel = types
       self.rootStore.userStore.unsetCurrentUser()
       self.rootStore.disconnectUserChannel()
     }),
+    setAfterLoginPath(path: string | null) {
+      self.afterLoginPath = path
+    },
   }))
   .actions((self) => ({
     handleLogin(response, opts = { redirectToRoot: false }) {


### PR DESCRIPTION
## Description

If a logged out user tries to access a protected route, persist the pathname in local storage so we can navigate the user back to the original route after they login.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

[BPHH-869](https://hous-bssb.atlassian.net/browse/BPHH-869)

## Steps to QA

Try to access a protected route as a logged out user (e.g. a specific permit application). You should be redirected to the login screen. After logging in, IF the logged in user is authorized to view the initial route, they should be redirected to the route. If they are NOT authorized (e.g. the application is for a different user), they should go to the not found screen after login.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
