### PR TITLE
Feature/bphh 1364/Automated Compliance and Energy Step Code related guard clauses

### DIFF
--- a/app/controllers/api/requirement_blocks_controller.rb
+++ b/app/controllers/api/requirement_blocks_controller.rb
@@ -91,7 +91,14 @@ class Api::RequirementBlocksController < Api::ApplicationController
         :required_for_multiple_owners,
         :elective,
         :_destroy,
-        input_options: [:number_unit, :can_add_multiple_contacts, value_options: [%i[value label]], conditional: {}],
+        input_options: [
+          :number_unit,
+          :can_add_multiple_contacts,
+          :energy_step_code,
+          value_options: [%i[value label]],
+          conditional: {
+          },
+        ],
       ],
     )
   end

--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -1,8 +1,7 @@
 class Api::RequirementTemplatesController < Api::ApplicationController
   include Api::Concerns::Search::RequirementTemplates
 
-  before_action :set_requirement_template,
-                only: %i[show destroy restore update schedule force_publish_now]
+  before_action :set_requirement_template, only: %i[show destroy restore update schedule force_publish_now]
   skip_after_action :verify_policy_scoped, only: [:index]
 
   def index
@@ -14,9 +13,9 @@ class Api::RequirementTemplatesController < Api::ApplicationController
                      meta: {
                        total_pages: @search.total_pages,
                        total_count: @search.total_count,
-                       current_page: @search.current_page
+                       current_page: @search.current_page,
                      },
-                     blueprint: RequirementTemplateBlueprint
+                     blueprint: RequirementTemplateBlueprint,
                    }
   end
 
@@ -25,17 +24,11 @@ class Api::RequirementTemplatesController < Api::ApplicationController
 
     render_success @requirement_template,
                    nil,
-                   {
-                     blueprint: RequirementTemplateBlueprint,
-                     blueprint_opts: {
-                       view: :extended
-                     }
-                   }
+                   { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
   end
 
   def create
-    @requirement_template =
-      RequirementTemplate.build(requirement_template_params)
+    @requirement_template = RequirementTemplate.build(requirement_template_params)
     authorize @requirement_template
 
     if @requirement_template.save
@@ -45,8 +38,7 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     else
       render_error "requirement_template.create_error",
                    message_opts: {
-                     error_message:
-                       @requirement_template.errors.full_messages.join(", ")
+                     error_message: @requirement_template.errors.full_messages.join(", "),
                    }
     end
   end
@@ -57,17 +49,11 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     if @requirement_template.update(requirement_template_params)
       render_success @requirement_template,
                      "requirement_template.update_success",
-                     {
-                       blueprint: RequirementTemplateBlueprint,
-                       blueprint_opts: {
-                         view: :extended
-                       }
-                     }
+                     { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
     else
       render_error "requirement_template.update_error",
                    message_opts: {
-                     error_message:
-                       @requirement_template.errors.full_messages.join(", ")
+                     error_message: @requirement_template.errors.full_messages.join(", "),
                    }
     end
   end
@@ -79,23 +65,16 @@ class Api::RequirementTemplatesController < Api::ApplicationController
       unless @requirement_template.update(requirement_template_params)
         render_error "requirement_template.schedule_error",
                      message_opts: {
-                       error_message:
-                         @requirement_template.errors.full_messages.join(", ")
+                       error_message: @requirement_template.errors.full_messages.join(", "),
                      }
       end
 
       begin
         scheduled_template_version =
-          TemplateVersioningService.schedule!(
-            @requirement_template,
-            Date.parse(schedule_params)
-          )
+          TemplateVersioningService.schedule!(@requirement_template, Date.parse(schedule_params))
       rescue StandardError => e
         # If there is an error in TemplateVersioningService.schedule!, rollback the transaction
-        render_error "requirement_template.schedule_error",
-                     message_opts: {
-                       error_message: e.message
-                     }
+        render_error "requirement_template.schedule_error", message_opts: { error_message: e.message }
         raise ActiveRecord::Rollback
       end
 
@@ -104,12 +83,7 @@ class Api::RequirementTemplatesController < Api::ApplicationController
 
       render_success @requirement_template,
                      "requirement_template.schedule_success",
-                     {
-                       blueprint: RequirementTemplateBlueprint,
-                       blueprint_opts: {
-                         view: :extended
-                       }
-                     }
+                     { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
     end
   end
 
@@ -120,20 +94,15 @@ class Api::RequirementTemplatesController < Api::ApplicationController
       unless @requirement_template.update(requirement_template_params)
         render_error "requirement_template.force_publish_now_error",
                      message_opts: {
-                       error_message:
-                         @requirement_template.errors.full_messages.join(", ")
+                       error_message: @requirement_template.errors.full_messages.join(", "),
                      }
       end
 
       begin
-        published_template_version =
-          TemplateVersioningService.force_publish_now!(@requirement_template)
+        published_template_version = TemplateVersioningService.force_publish_now!(@requirement_template)
       rescue StandardError => e
         # If there is an error in TemplateVersioningService.schedule!, rollback the transaction
-        render_error "requirement_template.force_publish_now_error",
-                     message_opts: {
-                       error_message: e.message
-                     }
+        render_error "requirement_template.force_publish_now_error", message_opts: { error_message: e.message }
         raise ActiveRecord::Rollback
       end
 
@@ -142,22 +111,14 @@ class Api::RequirementTemplatesController < Api::ApplicationController
 
       render_success @requirement_template,
                      "requirement_template.force_publish_now_success",
-                     {
-                       blueprint: RequirementTemplateBlueprint,
-                       blueprint_opts: {
-                         view: :extended
-                       }
-                     }
+                     { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
     end
   end
 
   def destroy
     authorize @requirement_template
     if @requirement_template.discard
-      render_success(
-        @requirement_template,
-        "requirement_template.destroy_success"
-      )
+      render_success(@requirement_template, "requirement_template.destroy_success")
     else
       render_error "requirement_template.destroy_error"
     end
@@ -166,10 +127,7 @@ class Api::RequirementTemplatesController < Api::ApplicationController
   def restore
     authorize @requirement_template
     if @requirement_template.update(discarded_at: nil)
-      render_success(
-        @requirement_template,
-        "requirement_template.restore_success"
-      )
+      render_success(@requirement_template, "requirement_template.restore_success")
     else
       render_error "requirement_template.restore_error", {}
     end
@@ -182,23 +140,28 @@ class Api::RequirementTemplatesController < Api::ApplicationController
   end
 
   def requirement_template_params
-    params.require(:requirement_template).permit(
-      :description,
-      :activity_id,
-      :permit_type_id,
-      requirement_template_sections_attributes: [
-        :id,
-        :name,
-        :position,
-        :_destroy,
-        template_section_blocks_attributes: %i[
-          id
-          requirement_block_id
-          position
-          _destroy
-        ]
-      ]
-    )
+    permitted_params =
+      params.require(:requirement_template).permit(
+        :description,
+        :activity_id,
+        :permit_type_id,
+        requirement_template_sections_attributes: [
+          :id,
+          :name,
+          :position,
+          :_destroy,
+          template_section_blocks_attributes: %i[id requirement_block_id position _destroy],
+        ],
+      )
+
+    # This is a workaround needed to validate step code related errors
+    if permitted_params[:requirement_template_sections_attributes].present?
+      permitted_params[:requirement_template_sections_attributes_copy] = permitted_params[
+        :requirement_template_sections_attributes
+      ].deep_dup
+    end
+
+    permitted_params
   end
 
   def schedule_params

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/controls-header.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/controls-header.tsx
@@ -15,6 +15,7 @@ interface IProps {
   onSaveDraft: () => void
   onAddSection: () => void
   requirementTemplate: IRequirementTemplate
+  hasStepCodeDependencyError?: boolean
 }
 
 export const ControlsHeader = observer(function ControlsHeader({
@@ -23,6 +24,7 @@ export const ControlsHeader = observer(function ControlsHeader({
   onSaveDraft,
   onAddSection,
   onForcePublishNow,
+  hasStepCodeDependencyError,
 }: IProps) {
   const navigate = useNavigate()
   const { t } = useTranslation()
@@ -32,7 +34,7 @@ export const ControlsHeader = observer(function ControlsHeader({
   const onClose = () => {
     window.history.state && window.history.state.idx > 0 ? navigate(-1) : navigate(`/requirement-templates`)
   }
-  const isSubmitDisabled = !!requirementTemplate.discardedAt || isSubmitting || !isValid
+  const isSubmitDisabled = hasStepCodeDependencyError || !!requirementTemplate.discardedAt || isSubmitting || !isValid
 
   return (
     <HStack

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
@@ -154,6 +154,7 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
     (section) => section.templateSectionBlocksAttributes
   )
 
+  const stepCodeRelatedWarningBannerErrors = getStepCodeRelatedWarningBannerErrors()
   return (
     <Box as="main" id="admin-edit-permit-template">
       <FormProvider {...formMethods}>
@@ -188,6 +189,7 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
               onForcePublishNow={onForcePublishNow}
               onAddSection={onAddSection}
               requirementTemplate={requirementTemplate}
+              hasStepCodeDependencyError={stepCodeRelatedWarningBannerErrors.length > 0}
             />
             <FloatingHelpDrawer top="100px" />
             {hasNoSections ? (
@@ -205,7 +207,7 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
             ) : (
               <>
                 <Box w="full" px={6}>
-                  {getStepCodeRelatedWarningBannerErrors().map((error) => (
+                  {stepCodeRelatedWarningBannerErrors.map((error) => (
                     <CalloutBanner key={error.title} type={error.type} title={error.title} />
                   ))}
                 </Box>

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
@@ -155,6 +155,8 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
   )
 
   const stepCodeRelatedWarningBannerErrors = getStepCodeRelatedWarningBannerErrors()
+
+  const hasStepCodeDependencyError = !!stepCodeRelatedWarningBannerErrors.find((error) => error.type === "error")
   return (
     <Box as="main" id="admin-edit-permit-template">
       <FormProvider {...formMethods}>
@@ -189,7 +191,7 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
               onForcePublishNow={onForcePublishNow}
               onAddSection={onAddSection}
               requirementTemplate={requirementTemplate}
-              hasStepCodeDependencyError={stepCodeRelatedWarningBannerErrors.length > 0}
+              hasStepCodeDependencyError={hasStepCodeDependencyError}
             />
             <FloatingHelpDrawer top="100px" />
             {hasNoSections ? (
@@ -244,36 +246,44 @@ export const EditRequirementTemplateScreen = observer(function EditRequirementTe
     const hasAnyStepCodePackageFileBlock = stepCodePackageFileBlocks.length > 0
     const hasDuplicateStepCodePackageFileBlock = stepCodePackageFileBlocks.length > 1
 
-    const errors: Array<{ title: string; type: "warning" }> = []
+    const errors: Array<{ title: string; type: "warning" | "error" }> = []
 
     if (!hasAnyEnergyStepCodeBlocks && !hasAnyStepCodePackageFileBlock) {
       return errors
     }
 
-    if (!hasAnyStepCodePackageFileBlock) {
-      errors.push({
-        title: t("requirementTemplate.edit.stepCodeWarnings.stepCodePackageRequired"),
-        type: "warning",
-      })
-    }
-    if (!hasAnyEnergyStepCodeBlocks) {
-      errors.push({
-        title: t("requirementTemplate.edit.stepCodeWarnings.energyStepCodeRequired"),
-        type: "warning",
-      })
+    if (hasAnyEnergyStepCodeBlocks) {
+      if (!hasAnyStepCodePackageFileBlock) {
+        errors.push({
+          title: t("requirementTemplate.edit.stepCodeErrors.stepCodePackageRequired"),
+          type: "error",
+        })
+      }
+
+      if (hasDuplicateStepCodePackageFileBlock) {
+        errors.push({
+          title: t("requirementTemplate.edit.stepCodeErrors.duplicateStepCodePackage"),
+          type: "error",
+        })
+      }
+    } else if (hasAnyStepCodePackageFileBlock) {
+      if (hasDuplicateStepCodePackageFileBlock) {
+        errors.push({
+          title: t("requirementTemplate.edit.stepCodeWarnings.duplicateStepCodePackage"),
+          type: "warning",
+        })
+      } else {
+        errors.push({
+          title: t("requirementTemplate.edit.stepCodeWarnings.energyStepCodeRecommended"),
+          type: "warning",
+        })
+      }
     }
 
     if (hasDuplicateEnergyStepCodeBlocks) {
       errors.push({
-        title: t("requirementTemplate.edit.stepCodeWarnings.duplicateEnergyStepCode"),
-        type: "warning",
-      })
-    }
-
-    if (hasDuplicateStepCodePackageFileBlock) {
-      errors.push({
-        title: t("requirementTemplate.edit.stepCodeWarnings.duplicateStepCodePackage"),
-        type: "warning",
+        title: t("requirementTemplate.edit.stepCodeErrors.duplicateEnergyStepCode"),
+        type: "error",
       })
     }
 

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/sections-display.tsx
@@ -44,7 +44,7 @@ export const SectionsDisplay = observer(function SectionsDisplay(props: IProps) 
           key={section.id}
           section={section}
           sectionIndex={index}
-          disableUseForBlockIds={usedRequirementBlockIds}
+          disabledUseForBlockIds={usedRequirementBlockIds}
           {...props}
         />
       ))}
@@ -58,13 +58,13 @@ const SectionDisplay = observer(
     sectionIndex,
     isCollapsedAll,
     setSectionRef,
-    disableUseForBlockIds = [],
+    disabledUseForBlockIds = [],
   }: {
     section: IRequirementTemplateSectionAttributes
     sectionIndex: number
     isCollapsedAll?: boolean
     setSectionRef: (el: HTMLElement, id: string) => void
-    disableUseForBlockIds?: string[]
+    disabledUseForBlockIds?: string[]
   }) => {
     const { requirementBlockStore } = useMst()
     const { control, watch, register, setValue } = useFormContext<IRequirementTemplateForm>()
@@ -163,7 +163,7 @@ const SectionDisplay = observer(
             onUse={(requirementBlock, closeDrawer) => {
               appendSectionBlock({ id: uuidv4(), requirementBlockId: requirementBlock.id })
             }}
-            disableUseForBlockIds={new Set(disableUseForBlockIds)}
+            disabledUseForBlockIds={new Set(disabledUseForBlockIds)}
           />
         </Stack>
       </Box>

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/sections-display.tsx
@@ -22,6 +22,9 @@ interface IProps {
 export const SectionsDisplay = observer(function SectionsDisplay(props: IProps) {
   const { watch } = useFormContext<IRequirementTemplateForm>()
   const watchedSections = watch("requirementTemplateSectionsAttributes")
+  const usedRequirementBlockIds = watchedSections.flatMap((section) =>
+    section.templateSectionBlocksAttributes.map((sectionBlock) => sectionBlock.requirementBlockId)
+  )
 
   return (
     <Stack
@@ -37,7 +40,13 @@ export const SectionsDisplay = observer(function SectionsDisplay(props: IProps) 
       maxWidth="container.lg"
     >
       {watchedSections.map((section, index) => (
-        <SectionDisplay key={section.id} section={section} sectionIndex={index} {...props} />
+        <SectionDisplay
+          key={section.id}
+          section={section}
+          sectionIndex={index}
+          disableUseForBlockIds={usedRequirementBlockIds}
+          {...props}
+        />
       ))}
     </Stack>
   )
@@ -49,11 +58,13 @@ const SectionDisplay = observer(
     sectionIndex,
     isCollapsedAll,
     setSectionRef,
+    disableUseForBlockIds = [],
   }: {
     section: IRequirementTemplateSectionAttributes
     sectionIndex: number
     isCollapsedAll?: boolean
     setSectionRef: (el: HTMLElement, id: string) => void
+    disableUseForBlockIds?: string[]
   }) => {
     const { requirementBlockStore } = useMst()
     const { control, watch, register, setValue } = useFormContext<IRequirementTemplateForm>()
@@ -74,6 +85,7 @@ const SectionDisplay = observer(
     )
 
     const watchedSectionName = watch(`requirementTemplateSectionsAttributes.${sectionIndex}.name`)
+
     const [editableSectionName, setEditableSectionName] = React.useState<string>(watchedSectionName ?? "")
 
     useEffect(() => {
@@ -151,7 +163,7 @@ const SectionDisplay = observer(
             onUse={(requirementBlock, closeDrawer) => {
               appendSectionBlock({ id: uuidv4(), requirementBlockId: requirementBlock.id })
             }}
-            disableUseForBlockIds={new Set(watchedSectionBlocks.map((sectionBlock) => sectionBlock.requirementBlockId))}
+            disableUseForBlockIds={new Set(disableUseForBlockIds)}
           />
         </Stack>
       </Box>

--- a/app/frontend/components/domains/requirements-library/fields-setup-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/fields-setup-drawer.tsx
@@ -24,6 +24,7 @@ interface IProps {
   defaultButtonProps?: Partial<ButtonProps>
   renderTriggerButton?: (props: ButtonProps & { ref: Ref<HTMLElement> }) => JSX.Element
   onUse?: (requirementType: ERequirementType, closeDrawer?: () => void) => void
+  disabledRequirementTypes?: ERequirementType[]
 }
 
 // TODO: remove when backend for these types is implemented
@@ -33,10 +34,12 @@ export const FieldsSetupDrawer = observer(function FieldsSetupMenu({
   defaultButtonProps,
   renderTriggerButton,
   onUse,
+  disabledRequirementTypes = [],
 }: IProps) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const btnRef = useRef<HTMLButtonElement>()
+  const disabledTypes = [...DISABLED_TYPES, ...disabledRequirementTypes]
 
   return (
     <>
@@ -98,7 +101,7 @@ export const FieldsSetupDrawer = observer(function FieldsSetupMenu({
                     <Button
                       variant={"primary"}
                       rightIcon={<CaretRight />}
-                      isDisabled={DISABLED_TYPES.includes(requirementType)}
+                      isDisabled={disabledTypes.includes(requirementType)}
                       onClick={() => onUse?.(requirementType, onClose)}
                     >
                       {t("requirementsLibrary.fieldsDrawer.useButton")}

--- a/app/frontend/components/domains/requirements-library/fields-setup-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/fields-setup-drawer.tsx
@@ -110,7 +110,7 @@ export const FieldsSetupDrawer = observer(function FieldsSetupMenu({
             <Flex flexDir={"column"} w={"full"}>
               {requirementTypeOptions
                 .filter(({ requirementType }) => hasRequirementFieldDisplayComponent(requirementType))
-                .map(({ requirementType, isStepCodePackageFileRequirement }) => (
+                .map(({ requirementType, isStepCodePackageFileRequirement = false }) => (
                   <HStack
                     key={requirementType}
                     alignItems={"flex-end"}

--- a/app/frontend/components/domains/requirements-library/fields-setup-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/fields-setup-drawer.tsx
@@ -23,24 +23,52 @@ import { RequirementFieldDisplay, hasRequirementFieldDisplayComponent } from "./
 interface IProps {
   defaultButtonProps?: Partial<ButtonProps>
   renderTriggerButton?: (props: ButtonProps & { ref: Ref<HTMLElement> }) => JSX.Element
-  onUse?: (requirementType: ERequirementType, closeDrawer?: () => void) => void
-  disabledRequirementTypes?: ERequirementType[]
+  onUse?: (
+    requirementType: ERequirementType,
+    closeDrawer?: () => void,
+    isStepCodePackageFileRequirement?: boolean
+  ) => void
+  disabledRequirementTypeOptions?: Array<{
+    requirementType: ERequirementType
+    isStepCodePackageFileRequirement?: boolean
+  }>
 }
 
 // TODO: remove when backend for these types is implemented
-const DISABLED_TYPES = [ERequirementType.address]
+const DISABLED_TYPE_OPTIONS = [{ requirementType: ERequirementType.address }]
 
 export const FieldsSetupDrawer = observer(function FieldsSetupMenu({
   defaultButtonProps,
   renderTriggerButton,
   onUse,
-  disabledRequirementTypes = [],
+  disabledRequirementTypeOptions = [],
 }: IProps) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const btnRef = useRef<HTMLButtonElement>()
-  const disabledTypes = [...DISABLED_TYPES, ...disabledRequirementTypes]
+  const disabledTypeOptions: Array<{
+    requirementType: ERequirementType
+    isStepCodePackageFileRequirement?: boolean
+  }> = [...DISABLED_TYPE_OPTIONS, ...disabledRequirementTypeOptions]
 
+  const requirementTypeOptions = Object.values(ERequirementType).reduce<
+    {
+      requirementType: ERequirementType
+      isStepCodePackageFileRequirement?: boolean
+    }[]
+  >((acc, type) => {
+    let options = {
+      requirementType: type,
+    }
+    acc.push(options)
+
+    // add pseudo type for step code package file
+    if (type === ERequirementType.energyStepCode) {
+      acc.push({ requirementType: ERequirementType.file, isStepCodePackageFileRequirement: true })
+    }
+
+    return acc
+  }, [])
   return (
     <>
       {renderTriggerButton?.({ onClick: onOpen, ref: btnRef }) ?? (
@@ -80,9 +108,9 @@ export const FieldsSetupDrawer = observer(function FieldsSetupMenu({
               </RouterLinkButton>
             </Flex>
             <Flex flexDir={"column"} w={"full"}>
-              {Object.values(ERequirementType)
-                .filter((requirementType) => hasRequirementFieldDisplayComponent(requirementType))
-                .map((requirementType) => (
+              {requirementTypeOptions
+                .filter(({ requirementType }) => hasRequirementFieldDisplayComponent(requirementType))
+                .map(({ requirementType, isStepCodePackageFileRequirement }) => (
                   <HStack
                     key={requirementType}
                     alignItems={"flex-end"}
@@ -97,12 +125,21 @@ export const FieldsSetupDrawer = observer(function FieldsSetupMenu({
                       "&:last-of-type": { border: "none" },
                     }}
                   >
-                    <RequirementFieldDisplay requirementType={requirementType} />
+                    <RequirementFieldDisplay
+                      requirementType={requirementType}
+                      matchesStepCodePackageRequirementCode={isStepCodePackageFileRequirement}
+                    />
                     <Button
                       variant={"primary"}
                       rightIcon={<CaretRight />}
-                      isDisabled={disabledTypes.includes(requirementType)}
-                      onClick={() => onUse?.(requirementType, onClose)}
+                      isDisabled={
+                        !!disabledTypeOptions.find(
+                          (typeOption) =>
+                            typeOption.requirementType === requirementType &&
+                            (typeOption?.isStepCodePackageFileRequirement ?? false) === isStepCodePackageFileRequirement
+                        )
+                      }
+                      onClick={() => onUse?.(requirementType, onClose, isStepCodePackageFileRequirement)}
                     >
                       {t("requirementsLibrary.fieldsDrawer.useButton")}
                     </Button>

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/generic-field-display.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/generic-field-display.tsx
@@ -23,6 +23,7 @@ const helperTextStyles = {
 }
 
 export const GenericFieldDisplay = observer(function GroupedFieldDisplay({
+  matchesStepCodePackageRequirementCode,
   inputDisplay,
   label,
   labelProps,
@@ -44,7 +45,7 @@ export const GenericFieldDisplay = observer(function GroupedFieldDisplay({
         {label ??
           (showAddLabelIndicator
             ? `${t("requirementsLibrary.modals.addLabel")} *`
-            : getRequirementTypeLabel(requirementType))}
+            : getRequirementTypeLabel(requirementType, matchesStepCodePackageRequirementCode))}
       </FormLabel>
       {inputDisplay}
       {!isQuillEmpty(helperText) && (

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
@@ -25,6 +25,7 @@ import { GenericContactDisplay } from "./generic-contact-display"
 import { GenericFieldDisplay } from "./generic-field-display"
 
 export type TRequirementFieldDisplayProps = {
+  matchesStepCodePackageRequirementCode?: boolean
   labelProps?: Partial<FormLabelProps | HeadingProps>
   label?: string
   options?: string[]

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-group.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-group.tsx
@@ -2,6 +2,7 @@ import { Stack, StackProps } from "@chakra-ui/react"
 import React from "react"
 import { FieldValues } from "react-hook-form"
 import { EEnergyStepCodeDependencyRequirementCode } from "../../../../types/enums"
+import { isStepCodePackageFileRequirementCode } from "../../../../utils/utility-functions"
 import { EditableHelperText, TEditableHelperTextProps } from "./editable-helper-text"
 import { EditableLabel, TEditableLabelProps } from "./editable-label"
 import { IsElectiveCheckbox, TIsElectiveCheckboxProps } from "./is-elective-checkbox"
@@ -27,9 +28,11 @@ export function EditableGroup<TFieldValues>({
   requirementCode,
   ...containerProps
 }: TEditableGroupProps<TFieldValues>) {
-  const isEditLimited = Object.values(EEnergyStepCodeDependencyRequirementCode).includes(
-    requirementCode as EEnergyStepCodeDependencyRequirementCode
-  )
+  const isEditLimited =
+    isStepCodePackageFileRequirementCode(requirementCode) ||
+    Object.values(EEnergyStepCodeDependencyRequirementCode).includes(
+      requirementCode as EEnergyStepCodeDependencyRequirementCode
+    )
   return (
     <Stack spacing={4} {...containerProps}>
       <EditableLabel {...editableLabelProps} />

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-group.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-group.tsx
@@ -1,6 +1,7 @@
 import { Stack, StackProps } from "@chakra-ui/react"
 import React from "react"
 import { FieldValues } from "react-hook-form"
+import { EEnergyStepCodeDependencyRequirementCode } from "../../../../types/enums"
 import { EditableHelperText, TEditableHelperTextProps } from "./editable-helper-text"
 import { EditableLabel, TEditableLabelProps } from "./editable-label"
 import { IsElectiveCheckbox, TIsElectiveCheckboxProps } from "./is-elective-checkbox"
@@ -13,6 +14,7 @@ export type TEditableGroupProps<TFieldValues extends FieldValues> = {
   isElectiveCheckboxProps: TIsElectiveCheckboxProps<TFieldValues>
   editableInput?: JSX.Element
   multiOptionEditableInput?: JSX.Element
+  requirementCode: string
 } & Partial<StackProps>
 
 export function EditableGroup<TFieldValues>({
@@ -22,8 +24,12 @@ export function EditableGroup<TFieldValues>({
   multiOptionEditableInput,
   isOptionalCheckboxProps,
   isElectiveCheckboxProps,
+  requirementCode,
   ...containerProps
 }: TEditableGroupProps<TFieldValues>) {
+  const isEditLimited = Object.values(EEnergyStepCodeDependencyRequirementCode).includes(
+    requirementCode as EEnergyStepCodeDependencyRequirementCode
+  )
   return (
     <Stack spacing={4} {...containerProps}>
       <EditableLabel {...editableLabelProps} />
@@ -35,8 +41,8 @@ export function EditableGroup<TFieldValues>({
           <EditableHelperText {...editableHelperTextProps} />
         </Stack>
       )}
-      <IsOptionalCheckbox {...isOptionalCheckboxProps} />
-      <IsElectiveCheckbox mt={"0.625rem"} {...isElectiveCheckboxProps} />
+      <IsOptionalCheckbox isDisabled={isEditLimited} {...isOptionalCheckboxProps} />
+      <IsElectiveCheckbox isDisabled={isEditLimited} mt={"0.625rem"} {...isElectiveCheckboxProps} />
     </Stack>
   )
 }

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/index.tsx
@@ -16,7 +16,12 @@ import React from "react"
 import { Controller, FieldValues, useFieldArray } from "react-hook-form"
 import { UseFieldArrayProps } from "react-hook-form/dist/types"
 import { useTranslation } from "react-i18next"
-import { ENumberUnit, ERequirementContactFieldItemType, ERequirementType } from "../../../../types/enums"
+import {
+  EEnergyStepCodeDependencyRequirementCode,
+  ENumberUnit,
+  ERequirementContactFieldItemType,
+  ERequirementType,
+} from "../../../../types/enums"
 import { IOption } from "../../../../types/types"
 import { isContactRequirement, isMultiOptionRequirement } from "../../../../utils/utility-functions"
 import { UnitSelect } from "../../../shared/select/selectors/unit-select"
@@ -239,7 +244,7 @@ const requirementsComponentMap = {
 
     const { useFieldArrayProps, onOptionValueChange, getOptionValue } = multiOptionProps
 
-    const { fields, append, remove } = useFieldArray<TFieldValues>(useFieldArrayProps)
+    const { fields, append, remove } = useFieldArray<TFieldValues>({ ...useFieldArrayProps })
 
     return (
       <EditableGroup
@@ -292,10 +297,12 @@ const requirementsComponentMap = {
       import.meta.env.DEV && console.error("multiOptionProps is required for select requirement edit")
       return null
     }
-
     const { useFieldArrayProps, onOptionValueChange, getOptionValue } = multiOptionProps
 
     const { fields, append, remove } = useFieldArray<TFieldValues>(useFieldArrayProps)
+
+    const isEnergyStepCodeDependency =
+      editableGroupProps.requirementCode === EEnergyStepCodeDependencyRequirementCode.energyStepCodeMethod
 
     return (
       <EditableGroup
@@ -309,18 +316,25 @@ const requirementsComponentMap = {
                   value={getOptionValue(idx).label}
                   onChange={(e) => onOptionValueChange(idx, e.target.value)}
                   w={"150px"}
+                  isDisabled={isEnergyStepCodeDependency}
                 />
                 <IconButton
                   aria-label={"remove option"}
                   variant={"unstyled"}
                   icon={<X />}
                   onClick={() => remove(idx)}
+                  isDisabled={isEnergyStepCodeDependency}
                 />
               </HStack>
             ))}
 
-            {/*  @ts-ignore*/}
-            <Button variant={"link"} textDecoration={"underline"} onClick={() => append({ value: "", label: "" })}>
+            <Button
+              variant={"link"}
+              textDecoration={"underline"}
+              //  @ts-ignore
+              onClick={() => append({ value: "", label: "" })}
+              isDisabled={isEnergyStepCodeDependency}
+            >
               {t("requirementsLibrary.modals.addOptionButton")}
             </Button>
           </>

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/is-elective-checkbox.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/is-elective-checkbox.tsx
@@ -9,15 +9,14 @@ export type TIsElectiveCheckboxProps<TFieldValues extends FieldValues> = IContro
 
 export function IsElectiveCheckbox<TFieldValues extends FieldValues>({
   controlProps,
-  isDisabled,
   ...checkboxProps
 }: TIsElectiveCheckboxProps<TFieldValues>) {
   const {
     field: { value, ...restField },
-  } = useController({ ...controlProps, disabled: isDisabled })
+  } = useController(controlProps)
   const { t } = useTranslation()
   return (
-    <Checkbox {...checkboxProps} isDisabled={isDisabled} isChecked={value} {...restField}>
+    <Checkbox {...checkboxProps} isChecked={value} {...restField}>
       {t("requirementsLibrary.modals.isAnElectiveField")}
     </Checkbox>
   )

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/is-elective-checkbox.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/is-elective-checkbox.tsx
@@ -9,14 +9,15 @@ export type TIsElectiveCheckboxProps<TFieldValues extends FieldValues> = IContro
 
 export function IsElectiveCheckbox<TFieldValues extends FieldValues>({
   controlProps,
+  isDisabled,
   ...checkboxProps
 }: TIsElectiveCheckboxProps<TFieldValues>) {
   const {
     field: { value, ...restField },
-  } = useController(controlProps)
+  } = useController({ ...controlProps, disabled: isDisabled })
   const { t } = useTranslation()
   return (
-    <Checkbox {...checkboxProps} isChecked={value} {...restField}>
+    <Checkbox {...checkboxProps} isDisabled={isDisabled} isChecked={value} {...restField}>
       {t("requirementsLibrary.modals.isAnElectiveField")}
     </Checkbox>
   )

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/is-optional-checkbox.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/is-optional-checkbox.tsx
@@ -9,12 +9,11 @@ export type TIsOptionalCheckboxProps<TFieldValues extends FieldValues> = IContro
 
 export function IsOptionalCheckbox<TFieldValues extends FieldValues>({
   controlProps,
-  isDisabled,
   ...checkboxProps
 }: TIsOptionalCheckboxProps<TFieldValues>) {
   const {
     field: { value, onChange, ...restField },
-  } = useController({ ...controlProps, disabled: isDisabled })
+  } = useController(controlProps)
   const { t } = useTranslation()
 
   return (
@@ -22,7 +21,6 @@ export function IsOptionalCheckbox<TFieldValues extends FieldValues>({
     //   optional, and by default it should be required
     <Checkbox
       {...checkboxProps}
-      isDisabled={isDisabled}
       isChecked={value === undefined ? value : !value}
       onChange={(e) => {
         onChange(!e.target.checked)

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/is-optional-checkbox.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/is-optional-checkbox.tsx
@@ -9,11 +9,12 @@ export type TIsOptionalCheckboxProps<TFieldValues extends FieldValues> = IContro
 
 export function IsOptionalCheckbox<TFieldValues extends FieldValues>({
   controlProps,
+  isDisabled,
   ...checkboxProps
 }: TIsOptionalCheckboxProps<TFieldValues>) {
   const {
     field: { value, onChange, ...restField },
-  } = useController(controlProps)
+  } = useController({ ...controlProps, disabled: isDisabled })
   const { t } = useTranslation()
 
   return (
@@ -21,6 +22,7 @@ export function IsOptionalCheckbox<TFieldValues extends FieldValues>({
     //   optional, and by default it should be required
     <Checkbox
       {...checkboxProps}
+      isDisabled={isDisabled}
       isChecked={value === undefined ? value : !value}
       onChange={(e) => {
         onChange(!e.target.checked)

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
@@ -16,14 +16,21 @@ import React, { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { ConditionalSetupModal } from "./conditional-setup-modal"
 
-interface IProps {
+export interface IRequirementOptionsMenu {
   menuButtonProps?: Partial<ButtonProps>
   onRemove?: () => void
   emitOpenState?: (isOpen: boolean) => void
   index: number
+  disabledOptions?: Array<"remove" | "conditional">
 }
 
-export const OptionsMenu = observer(function UnitSelect({ menuButtonProps, onRemove, emitOpenState, index }: IProps) {
+export const OptionsMenu = observer(function OptionsMenu({
+  disabledOptions = [],
+  menuButtonProps,
+  onRemove,
+  emitOpenState,
+  index,
+}: IRequirementOptionsMenu) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
 
@@ -57,10 +64,15 @@ export const OptionsMenu = observer(function UnitSelect({ menuButtonProps, onRem
             <Text as={"span"}>{t("requirementsLibrary.modals.optionsMenu.dataValidation")}</Text>
           </HStack>
         </MenuItem>
-        <ConditionalSetupModal index={index} />
+        <ConditionalSetupModal
+          index={index}
+          triggerButtonProps={{
+            isDisabled: disabledOptions.includes("remove"),
+          }}
+        />
 
         <MenuDivider />
-        <MenuItem color={"semantic.error"} onClick={onRemove}>
+        <MenuItem color={"semantic.error"} onClick={onRemove} isDisabled={disabledOptions.includes("remove")}>
           <HStack spacing={2} fontSize={"sm"}>
             <X />
             <Text as={"span"}>{t("requirementsLibrary.modals.optionsMenu.remove")}</Text>

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
@@ -67,7 +67,7 @@ export const OptionsMenu = observer(function OptionsMenu({
         <ConditionalSetupModal
           index={index}
           triggerButtonProps={{
-            isDisabled: disabledOptions.includes("remove"),
+            isDisabled: disabledOptions.includes("conditional"),
           }}
         />
 

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
@@ -6,19 +6,21 @@ import { ERequirementType } from "../../../../types/enums"
 import { ElectiveTag } from "../../../shared/elective-tag"
 import { HasConditionalTag } from "../../../shared/has-conditional-tag"
 import { RequirementTypeTag } from "../../../shared/requirement-type-tag"
-import { OptionsMenu } from "../requirement-field-edit/options-menu"
+import { IRequirementOptionsMenu, OptionsMenu } from "../requirement-field-edit/options-menu"
 
 interface IProps {
   isRequirementInEditMode: boolean
   toggleRequirementToEdit: () => void
   requirementType: ERequirementType
-  onRemove: () => void
+  onRemove: IRequirementOptionsMenu["onRemove"]
+  disabledMenuOptions?: IRequirementOptionsMenu["disabledOptions"]
   elective?: boolean
   conditional?: IFormConditional
   index: number
 }
 
 export function FieldControlsHeader({
+  disabledMenuOptions,
   isRequirementInEditMode,
   toggleRequirementToEdit,
   elective,
@@ -37,6 +39,7 @@ export function FieldControlsHeader({
             size: "sm",
           }}
           onRemove={onRemove}
+          disabledOptions={disabledMenuOptions}
           index={index}
         />
       )}

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 import { IFormConditional } from "../../../../types/api-request"
 import { ERequirementType } from "../../../../types/enums"
+import { isStepCodePackageFileRequirementCode } from "../../../../utils/utility-functions"
 import { ElectiveTag } from "../../../shared/elective-tag"
 import { HasConditionalTag } from "../../../shared/has-conditional-tag"
 import { RequirementTypeTag } from "../../../shared/requirement-type-tag"
@@ -12,6 +13,7 @@ interface IProps {
   isRequirementInEditMode: boolean
   toggleRequirementToEdit: () => void
   requirementType: ERequirementType
+  requirementCode: string
   onRemove: IRequirementOptionsMenu["onRemove"]
   disabledMenuOptions?: IRequirementOptionsMenu["disabledOptions"]
   elective?: boolean
@@ -28,6 +30,7 @@ export function FieldControlsHeader({
   requirementType,
   onRemove,
   index,
+  requirementCode,
 }: IProps) {
   const { t } = useTranslation()
 
@@ -51,7 +54,12 @@ export function FieldControlsHeader({
           <HasConditionalTag display={isRequirementInEditMode ? "none" : "flex"} />
         )}
         {!isRequirementInEditMode && (
-          <RequirementTypeTag type={requirementType} className={"requirement-edit-controls"} display={"none"} />
+          <RequirementTypeTag
+            type={requirementType}
+            matchesStepCodePackageRequirementCode={isStepCodePackageFileRequirementCode(requirementCode)}
+            className={"requirement-edit-controls"}
+            display={"none"}
+          />
         )}
         <Button
           variant={"primary"}

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
@@ -33,16 +33,18 @@ export function FieldControlsHeader({
 
   return (
     <HStack pos={"absolute"} right={0} top={0} spacing={4}>
-      {isRequirementInEditMode && (
-        <OptionsMenu
-          menuButtonProps={{
-            size: "sm",
-          }}
-          onRemove={onRemove}
-          disabledOptions={disabledMenuOptions}
-          index={index}
-        />
-      )}
+      {/*right now there is only two menu options,so if both are disabled we just hide the options menu*/}
+      {isRequirementInEditMode &&
+        !(disabledMenuOptions.includes("remove") && disabledMenuOptions.includes("conditional")) && (
+          <OptionsMenu
+            menuButtonProps={{
+              size: "sm",
+            }}
+            onRemove={onRemove}
+            disabledOptions={disabledMenuOptions}
+            index={index}
+          />
+        )}
       <HStack className={"requirement-edit-controls-container"}>
         {elective && !isRequirementInEditMode && <ElectiveTag display={isRequirementInEditMode ? "none" : "flex"} />}
         {conditional && !isRequirementInEditMode && (

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -40,6 +40,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
     name: "displayName",
     rules: { required: true },
   })
+  const watchedRequirements = watch("requirementsAttributes")
 
   const [requirementIdsToEdit, setRequirementIdsToEdit] = useState<Record<string, boolean>>({})
 
@@ -80,6 +81,36 @@ export const FieldsSetup = observer(function FieldsSetup() {
 
   function isRequirementInEditMode(id: string) {
     return !!requirementIdsToEdit[id]
+  }
+
+  const onRemoveRequirement = (index: number) => {
+    const requirement = watchedRequirements[index]
+
+    if (!requirement) {
+      return
+    }
+
+    const isEnergyStepCodeRequirement = requirement.inputType === ERequirementType.energyStepCode
+
+    if (!isEnergyStepCodeRequirement) {
+      remove(index)
+
+      return
+    }
+
+    const stepCodeDependencyIndexes = watchedRequirements.reduce((acc, req, idx) => {
+      const isEnergyStepCodeDependency = Object.values(EEnergyStepCodeDependencyRequirementCode).includes(
+        req.requirementCode as EEnergyStepCodeDependencyRequirementCode
+      )
+
+      if (isEnergyStepCodeDependency) {
+        acc.push(idx)
+      }
+
+      return acc
+    }, [])
+
+    remove(stepCodeDependencyIndexes)
   }
 
   return (
@@ -145,7 +176,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
               const disabledMenuOptions: ("remove" | "conditional")[] =
                 watchedRequirementCode !== EEnergyStepCodeDependencyRequirementCode.energyStepCodeToolPart9 &&
                 Object.values(EEnergyStepCodeDependencyRequirementCode).includes(
-                  watchedRequirementCode as (typeof EEnergyStepCodeDependencyRequirementCode)[keyof typeof EEnergyStepCodeDependencyRequirementCode]
+                  watchedRequirementCode as EEnergyStepCodeDependencyRequirementCode
                 )
                   ? ["remove", "conditional"]
                   : []
@@ -290,7 +321,7 @@ export const FieldsSetup = observer(function FieldsSetup() {
                   <FieldControlsHeader
                     isRequirementInEditMode={isRequirementInEditMode(field.id)}
                     toggleRequirementToEdit={() => toggleRequirementToEdit(field.id)}
-                    onRemove={() => remove(index)}
+                    onRemove={() => onRemoveRequirement(index)}
                     elective={watchedElective}
                     conditional={watchedConditional}
                     requirementType={requirementType}

--- a/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
@@ -18,14 +18,14 @@ interface IProps {
   defaultButtonProps?: Partial<ButtonProps>
   renderTriggerButton?: (props: ButtonProps & { ref: Ref<HTMLElement> }) => JSX.Element
   onUse?: (requirementBlock: IRequirementBlock, closeDrawer?: () => void) => void
-  disableUseForBlockIds?: Set<string>
+  disabledUseForBlockIds?: Set<string>
 }
 
 export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDrawer({
   defaultButtonProps,
   renderTriggerButton,
   onUse,
-  disableUseForBlockIds,
+  disabledUseForBlockIds,
 }: IProps) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -57,7 +57,7 @@ export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDr
                 size={"sm"}
                 variant={"primary"}
                 onClick={() => onUse(requirementBlock, onClose)}
-                isDisabled={disableUseForBlockIds.has(requirementBlock.id)}
+                isDisabled={disabledUseForBlockIds.has(requirementBlock.id)}
               >
                 {t("ui.use")}
               </Button>

--- a/app/frontend/components/shared/base/callout-banner.tsx
+++ b/app/frontend/components/shared/base/callout-banner.tsx
@@ -1,8 +1,8 @@
-import { HStack, Stack, Text } from "@chakra-ui/react"
+import { HStack, Stack, StackProps, Text } from "@chakra-ui/react"
 import { CheckCircle, Info, Warning, WarningCircle } from "@phosphor-icons/react"
 import React from "react"
 
-interface IProps {
+interface IProps extends Partial<StackProps> {
   type: "warning" | "error" | "success" | "info"
   title: string
   body?: string
@@ -46,7 +46,7 @@ function getTypeSpecificProps(type: IProps["type"]) {
   }
 }
 
-export function CalloutBanner({ type, title, body }: IProps) {
+export function CalloutBanner({ type, title, body, ...rest }: IProps) {
   const typeSpecificProps = getTypeSpecificProps(type)
   return (
     <HStack
@@ -59,6 +59,7 @@ export function CalloutBanner({ type, title, body }: IProps) {
       borderColor={typeSpecificProps.mainColor}
       bg={typeSpecificProps.backgroundColor}
       borderRadius={"lg"}
+      {...rest}
     >
       {typeSpecificProps.icon}
       {title && body ? (

--- a/app/frontend/components/shared/requirement-type-tag.tsx
+++ b/app/frontend/components/shared/requirement-type-tag.tsx
@@ -3,10 +3,17 @@ import React from "react"
 import { getRequirementTypeLabel } from "../../constants"
 import { ERequirementType } from "../../types/enums"
 
-export function RequirementTypeTag({ type, ...tagProps }: { type: ERequirementType } & Partial<TagProps>) {
+export function RequirementTypeTag({
+  type,
+  matchesStepCodePackageRequirementCode,
+  ...tagProps
+}: {
+  type: ERequirementType
+  matchesStepCodePackageRequirementCode: boolean
+} & Partial<TagProps>) {
   return (
     <Tag bg={"greys.grey03"} color={"text.secondary"} fontWeight={700} fontSize={"xs"} {...tagProps}>
-      {getRequirementTypeLabel(type)}
+      {getRequirementTypeLabel(type, matchesStepCodePackageRequirementCode)}
     </Tag>
   )
 }

--- a/app/frontend/constants.ts
+++ b/app/frontend/constants.ts
@@ -59,14 +59,21 @@ export const datefnsAppDateFormat = "yyyy/MM/dd"
 
 export const vancouverTimeZone = "America/Vancouver" // Vancouver time zone
 
-export function getRequirementTypeLabel(requirementType: ERequirementType) {
-  let derivedTranslationKey: keyof typeof ERequirementType
+export function getRequirementTypeLabel(
+  requirementType: ERequirementType,
+  matchesStepCodePackageRequirementCode?: boolean
+) {
+  let derivedTranslationKey: keyof typeof ERequirementType | "stepCodePackageFile"
 
-  Object.entries(ERequirementType).forEach(([key, value]: [keyof typeof ERequirementType, ERequirementType]) => {
-    if (value === requirementType) {
-      derivedTranslationKey = key
-    }
-  })
+  if (requirementType === ERequirementType.file && matchesStepCodePackageRequirementCode) {
+    derivedTranslationKey = "stepCodePackageFile"
+  } else {
+    Object.entries(ERequirementType).forEach(([key, value]: [keyof typeof ERequirementType, ERequirementType]) => {
+      if (value === requirementType) {
+        derivedTranslationKey = key
+      }
+    })
+  }
 
   return t(`requirementsLibrary.requirementTypeLabels.${derivedTranslationKey}`)
 }
@@ -158,3 +165,5 @@ export function getEnergyStepCodeRequirementRequiredSchema(
 
   return requirementCodeToSchema[energyRequirementCode]
 }
+
+export const STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE = "architectural_drawing_file" as const

--- a/app/frontend/constants.ts
+++ b/app/frontend/constants.ts
@@ -1,6 +1,8 @@
 import { t } from "i18next"
+import { IRequirementAttributes } from "./types/api-request"
 import {
   EEnabledElectiveFieldReason,
+  EEnergyStepCodeDependencyRequirementCode,
   EGovFeedbackResponseNoReason,
   ENumberUnit,
   ERequirementContactFieldItemType,
@@ -89,4 +91,70 @@ export function getEnabledElectiveReasonOptions(): IOption<EEnabledElectiveField
       value: reason,
     }
   })
+}
+
+export function getEnergyStepCodeRequirementRequiredSchema(
+  energyRequirementCode: EEnergyStepCodeDependencyRequirementCode
+) {
+  const requirementCodeToSchema: Record<EEnergyStepCodeDependencyRequirementCode, IRequirementAttributes> = {
+    [EEnergyStepCodeDependencyRequirementCode.energyStepCodeMethod]: {
+      requirementCode: EEnergyStepCodeDependencyRequirementCode.energyStepCodeMethod,
+      inputType: ERequirementType.select,
+      label: t("requirementsLibrary.modals.stepCodeDependencies.energyStepCodeMethod.label"),
+      inputOptions: {
+        valueOptions: [
+          {
+            label: t("requirementsLibrary.modals.stepCodeDependencies.energyStepCodeMethod.tool"),
+            value: "tool",
+          },
+          {
+            label: t("requirementsLibrary.modals.stepCodeDependencies.energyStepCodeMethod.file"),
+            value: "file",
+          },
+        ],
+      },
+    },
+    [EEnergyStepCodeDependencyRequirementCode.energyStepCodeToolPart9]: {
+      requirementCode: EEnergyStepCodeDependencyRequirementCode.energyStepCodeToolPart9,
+      inputType: ERequirementType.energyStepCode,
+      label: t("requirementsLibrary.modals.stepCodeDependencies.energyStepCodeToolPart9.label"),
+      inputOptions: {
+        conditional: {
+          // @ts-ignore
+          eq: "tool",
+          show: true,
+          when: EEnergyStepCodeDependencyRequirementCode.energyStepCodeMethod,
+        },
+        energyStepCode: "part_9",
+      },
+    },
+    [EEnergyStepCodeDependencyRequirementCode.energyStepCodeReportFile]: {
+      requirementCode: EEnergyStepCodeDependencyRequirementCode.energyStepCodeReportFile,
+      label: t("requirementsLibrary.modals.stepCodeDependencies.energyStepCodeReportFile.label"),
+      inputType: ERequirementType.file,
+      inputOptions: {
+        conditional: {
+          // @ts-ignore
+          eq: "file",
+          show: true,
+          when: EEnergyStepCodeDependencyRequirementCode.energyStepCodeMethod,
+        },
+      },
+    },
+    [EEnergyStepCodeDependencyRequirementCode.energyStepCodeH2000File]: {
+      requirementCode: EEnergyStepCodeDependencyRequirementCode.energyStepCodeH2000File,
+      label: t("requirementsLibrary.modals.stepCodeDependencies.energyStepCodeH2000File.label"),
+      inputType: ERequirementType.file,
+      inputOptions: {
+        conditional: {
+          // @ts-ignore
+          eq: "file",
+          show: true,
+          when: EEnergyStepCodeDependencyRequirementCode.energyStepCodeMethod,
+        },
+      },
+    },
+  }
+
+  return requirementCodeToSchema[energyRequirementCode]
 }

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -522,6 +522,7 @@ const options = {
             phone: "Phone",
             email: "E-mail",
             energyStepCode: "Energy Step Code",
+            stepCodePackageFile: "Design package file for energy step code",
           },
           contactFieldItemLabels: {
             firstName: "First name",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1097,6 +1097,16 @@ const options = {
               body: "Any requirements inside this section will also be removed along with it.",
             },
             emptyTemplateSectionText: "Start by clicking the Add Section button",
+            stepCodeWarnings: {
+              stepCodePackageRequired:
+                "Warning: Energy step code is required to have the Design package energy step code file.",
+              energyStepCodeRequired:
+                "Warning: Design package energy step code file is present in the template, but there is no Energy step code requirement.",
+              duplicateEnergyStepCode:
+                "Warning: Multiple energy step code requirements found. Please ensure there is only one Energy Step code requirement in the template.",
+              duplicateStepCodePackage:
+                "Warning: Multiple design package energy step code files found. Please ensure there is only one design package energy step code file.",
+            },
             goToTop: "Go to top",
             collapseAll: "Collapse all",
             scheduleModalTitle: "Publish permit?",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -472,6 +472,10 @@ const options = {
             },
             addOptionButton: "Add another option",
             editWarning: "Any changes made here will be reflected in all templates that use this requirement block.",
+            stepCodeMethodDefault: {
+              tool: "Utilizing the digital step code tool",
+              file: "By file upload",
+            },
           },
           fields: {
             name: "Name",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -472,9 +472,22 @@ const options = {
             },
             addOptionButton: "Add another option",
             editWarning: "Any changes made here will be reflected in all templates that use this requirement block.",
-            stepCodeMethodDefault: {
-              tool: "Utilizing the digital step code tool",
-              file: "By file upload",
+            stepCodeDependencies: {
+              energyStepCodeMethod: {
+                tool: "Utilizing the digital step code tool",
+                file: "By file upload",
+                label: "Which method do you want to do use for the energy step code",
+              },
+              energyStepCodeToolPart9: {
+                label:
+                  "Please use this tool to do your fill in your step code details and it will populate onto the application.",
+              },
+              energyStepCodeReportFile: {
+                label: "BC Energy Step Code Compliance Report",
+              },
+              energyStepCodeH2000File: {
+                label: "Pre construction Hot2000 model details, Hot2000 report",
+              },
             },
           },
           fields: {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1098,14 +1098,19 @@ const options = {
             },
             emptyTemplateSectionText: "Start by clicking the Add Section button",
             stepCodeWarnings: {
-              stepCodePackageRequired:
-                "Warning: Energy step code is required to have the Design package energy step code file.",
-              energyStepCodeRequired:
-                "Warning: Design package energy step code file is present in the template, but there is no Energy step code requirement.",
-              duplicateEnergyStepCode:
-                "Warning: Multiple energy step code requirements found. Please ensure there is only one Energy Step code requirement in the template.",
+              energyStepCodeRecommended:
+                'Warning:"Design package energy step code file" is present in the template, but there is no "Energy step code" requirement.',
+
               duplicateStepCodePackage:
-                "Warning: Multiple design package energy step code files found. Please ensure there is only one design package energy step code file.",
+                'Warning: Multiple "Design package energy step code files" found. Please ensure there is only one "Design package energy step code file".',
+            },
+            stepCodeErrors: {
+              duplicateEnergyStepCode:
+                'Warning: Multiple "Energy step code" requirements found. Please ensure there is only one "Energy step code" in the template.',
+              stepCodePackageRequired:
+                'Warning: "Energy step code" is required to have the "Design package energy step code file".',
+              duplicateStepCodePackage:
+                'Multiple "Design package energy step code files" found. Please ensure there is only one "Design package energy step code file" when there is an "Energy step code" requirement',
             },
             goToTop: "Go to top",
             collapseAll: "Collapse all",

--- a/app/frontend/models/requirement-block.ts
+++ b/app/frontend/models/requirement-block.ts
@@ -52,6 +52,7 @@ export const RequirementBlockModel = types
               operand,
               then,
             },
+            energyStepCode: requirement.inputOptions?.energyStepCode,
           },
         }
       })

--- a/app/frontend/models/requirement-block.ts
+++ b/app/frontend/models/requirement-block.ts
@@ -2,6 +2,7 @@ import { applySnapshot, flow, Instance, toGenerator, types } from "mobx-state-tr
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
 import { IRequirementAttributes, IRequirementBlockParams } from "../types/api-request"
+import { EEnergyStepCodeDependencyRequirementCode } from "../types/enums"
 import { RequirementModel } from "./requirement"
 
 export const RequirementBlockModel = types
@@ -42,16 +43,23 @@ export const RequirementBlockModel = types
         const when = conditional.when
         const operand = conditional.eq
         const then = possibleThens.find((t) => Object.keys(conditional).includes(t))
+        const isEnergyStepCodeDependency = Object.values(EEnergyStepCodeDependencyRequirementCode).includes(
+          requirement.requirementCode as EEnergyStepCodeDependencyRequirementCode
+        )
 
+        // energy step code dependency conditionals is not possible to edit from the front-end and has default values
+        // which follows a slightly different structure so we make sure not to remove them or alter them
         return {
           ...requirement,
           inputOptions: {
             ...requirement.inputOptions,
-            conditional: {
-              when,
-              operand,
-              then,
-            },
+            conditional: isEnergyStepCodeDependency
+              ? conditional
+              : {
+                  when,
+                  operand,
+                  then,
+                },
             energyStepCode: requirement.inputOptions?.energyStepCode,
           },
         }
@@ -59,6 +67,9 @@ export const RequirementBlockModel = types
     },
     getRequirementOptions() {
       return self.requirements.map((requirement) => ({ label: requirement.label, value: requirement }))
+    },
+    getRequirementByRequirementCode(requirementCode: string) {
+      return self.requirements.find((requirement) => requirement.requirementCode === requirementCode)
     },
   }))
   .actions((self) => ({

--- a/app/frontend/models/requirement-block.ts
+++ b/app/frontend/models/requirement-block.ts
@@ -1,8 +1,9 @@
 import { applySnapshot, flow, Instance, toGenerator, types } from "mobx-state-tree"
+import { STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE } from "../constants"
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
 import { IRequirementAttributes, IRequirementBlockParams } from "../types/api-request"
-import { EEnergyStepCodeDependencyRequirementCode } from "../types/enums"
+import { EEnergyStepCodeDependencyRequirementCode, ERequirementType } from "../types/enums"
 import { RequirementModel } from "./requirement"
 
 export const RequirementBlockModel = types
@@ -21,6 +22,12 @@ export const RequirementBlockModel = types
   .extend(withEnvironment())
   .extend(withRootStore())
   .views((self) => ({
+    get blocksWithEnergyStepCode() {
+      return self.requirements?.some((r) => r.inputType === ERequirementType.energyStepCode)
+    },
+    get blocksWithStepCodePackageFile() {
+      return self.requirements?.some((r) => r.requirementCode === STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE)
+    },
     hasRequirement(id: string) {
       return self.requirements.findIndex((requirement) => requirement.id === id) !== -1
     },

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -6,6 +6,7 @@ export interface IFormConditional {
   operand: string
   then: string
 }
+
 export interface IRequirementAttributes {
   id?: string
   label?: string
@@ -19,6 +20,7 @@ export interface IRequirementAttributes {
     numberUnit?: ENumberUnit
     canAddMultipleContacts?: boolean
     conditional?: IFormConditional
+    energyStepCode?: string
   }
 }
 

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -286,3 +286,10 @@ export enum EEnabledElectiveFieldReason {
 export enum ECustomEvents {
   handlePermitApplicationUpdate = "handlePermitApplicationUpdate",
 }
+
+export enum EEnergyStepCodeDependencyRequirementCode {
+  energyStepCodeMethod = "energy_step_code_method",
+  energyStepCodeToolPart9 = "energy_step_code_tool_part_9",
+  energyStepCodeReportFile = "energy_step_code_report_file",
+  energyStepCodeH2000File = "energy_step_code_h2000_file",
+}

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -74,6 +74,7 @@ export interface IRequirementOptions {
   numberUnit?: ENumberUnit
   canAddMultipleContacts?: boolean
   conditional?: TConditional
+  energyStepCode?: string
   dataValidation?: Object
 }
 

--- a/app/frontend/utils/utility-functions.ts
+++ b/app/frontend/utils/utility-functions.ts
@@ -1,6 +1,6 @@
 import { format } from "date-fns"
 import { utcToZonedTime } from "date-fns-tz"
-import { vancouverTimeZone } from "../constants"
+import { STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE, vancouverTimeZone } from "../constants"
 import { ERequirementType } from "../types/enums"
 import { TDebouncedFunction } from "../types/types"
 
@@ -121,4 +121,8 @@ export function renameKeys(keysMap, obj) {
     }),
     {}
   )
+}
+
+export function isStepCodePackageFileRequirementCode(requirementCode: string) {
+  return requirementCode === STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE
 }

--- a/app/models/concerns/step_code_field_extraction.rb
+++ b/app/models/concerns/step_code_field_extraction.rb
@@ -1,11 +1,11 @@
 module StepCodeFieldExtraction
   extend ActiveSupport::Concern
 
-  #ASSUMPTIONS:
-  #plan related fields come from extracted data from digital seal validation
-  #if there is no extraction put the details there
-  #if there is no override on the configuration for which requirement_code to look for, make an assumption
-  #we decided to just use the full address instead of the postal code since it should include it
+  # ASSUMPTIONS:
+  # plan related fields come from extracted data from digital seal validation
+  # if there is no extraction put the details there
+  # if there is no override on the configuration for which requirement_code to look for, make an assumption
+  # we decided to just use the full address instead of the postal code since it should include it
 
   # def step_code_builder
   #   #we have no logic for this yet, but eventually we should tell this from contacts
@@ -13,35 +13,35 @@ module StepCodeFieldExtraction
 
   def step_code_plan_author
     return if step_code_plan_document.blank?
-    #assumed to be the last signature placed on the file
+    # assumed to be the last signature placed on the file
     step_code_plan_document.last_signer[:name]
   end
 
   def step_code_plan_version
     return if step_code_plan_document.blank?
-    #assumed to be the file name
+    # assumed to be the file name
     step_code_plan_document.file_data.dig("metadata", "filename")
   end
 
   def step_code_plan_date
     return if step_code_plan_document.blank?
-    #assumed to be the date the last signature placed onteh file was
+    # assumed to be the date the last signature placed onteh file was
     step_code_plan_document.last_signer[:date]
   end
 
   # protected
 
   def step_code_plan_field
-    #can be overridden by config settings requirement_energy_step_code["plan_file_field"]
-    requirements_lookups.keys.find { |k| k.ends_with?("|architectural_drawing_file") }
+    # can be overridden by config settings requirement_energy_step_code["plan_file_field"]
+    requirements_lookups.keys.find { |k| k.ends_with?("|#{Requirement::STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE}") }
   end
 
-  def step_code_plan_document #looks for the first instance that matches the plan field
+  def step_code_plan_document # looks for the first instance that matches the plan field
     @doc ||= active_supporting_documents.find_by(data_key: step_code_plan_field)
   end
 
   def requirement_energy_step_code_key_value
-    #energy stepcode is a unique field, look at the published form_json to find item with lookup_type: "energy_step_code"
+    # energy stepcode is a unique field, look at the published form_json to find item with lookup_type: "energy_step_code"
     requirements_lookups.find { |k, v| v["requirementInputType"] == "energy_step_code" }
   end
 end

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -182,11 +182,6 @@ class Requirement < ApplicationRecord
     uuid_regex.match?(self.requirement_code)
   end
 
-  def using_dummied_energy_requirement_code
-    uuid_regex = /^energy-dummy-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-    uuid_regex.match?(self.requirement_code)
-  end
-
   # requirement codes should not be auto generated during seeding.  Use uuid if not provided
   def set_requirement_code
     using_dummy = self.using_dummied_requirement_code

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -46,6 +46,11 @@ class Requirement < ApplicationRecord
               scope: :requirement_block_id,
               message: "should be unique within the same requirement block",
             }
+  validates :requirement_code,
+            uniqueness: {
+              scope: :requirement_block_id,
+              message: "should be unique within the same requirement block",
+            }
   validate :validate_energy_step_code_requirement_code
   validate :validate_energy_step_code_related_requirements_schema
 

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -145,10 +145,14 @@ class Requirement < ApplicationRecord
     false
   end
 
+  def step_code_package_file?
+    requirement_code == STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE
+  end
+
   private
 
   def validate_step_code_package_file
-    return unless requirement_code == STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE
+    return unless step_code_package_file?
 
     matches_package_file_required_schema =
       attributes.slice("input_type", "required", "elective") !=
@@ -160,7 +164,7 @@ class Requirement < ApplicationRecord
   end
 
   def set_digital_seal_validator_to_step_code_package_file
-    return unless requirement_code == STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE
+    return unless step_code_package_file?
 
     required_computed_compliance = {
       "module" => "DigitalSealValidator",

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -21,7 +21,7 @@ class RequirementBlock < ApplicationRecord
   validate :validate_step_code_dependencies
   validate :validate_requirements_conditional
 
-  before_validation :set_sku
+  before_validation :set_sku, on: :create
 
   acts_as_taggable_on :associations
 
@@ -126,8 +126,25 @@ class RequirementBlock < ApplicationRecord
     configurations
   end
 
-  # sku should be auto generated. Use uuid if not provided
+  # sku should be auto generated, readable and unique.
   def set_sku
-    self.sku ||= SecureRandom.uuid
+    return unless sku.blank?
+
+    parameterized_name = name.parameterize(separator: "_")
+
+    self.sku = parameterized_name
+
+    retry_count = 0
+
+    # Ensure uniqueness by appending a number/id if necessary, but shouldn't
+    # be needed apart from some edge cases as name is unique.
+    # If we have to retry more than 3 times, use a UUID to ensure uniqueness.
+    # With UUIDs it shouldn't be needed, but have a max retry count
+    # to be safe. This is to prevent infinite loops in case of a bug.
+    while RequirementBlock.exists?(sku: self.sku) && retry_count < 5
+      self.sku = "#{parameterized_name}_#{retry_count > 3 ? SecureRandom.uuid : SecureRandom.hex(3)}"
+
+      retry_count += 1
+    end
   end
 end

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -19,6 +19,7 @@ class RequirementBlock < ApplicationRecord
   validates :name, uniqueness: true, presence: true
   validates :display_name, presence: true
   validate :validate_step_code_dependencies
+  validate :validate_requirements_conditional
 
   before_validation :set_sku
 
@@ -78,6 +79,24 @@ class RequirementBlock < ApplicationRecord
   end
 
   private
+
+  def validate_requirements_conditional
+    requirements.each do |requirement|
+      conditional = requirement.input_options["conditional"]
+
+      next unless conditional.present?
+
+      if [conditional["when"], conditional["eq"], conditional["show"]].any?(&:blank?)
+        errors.add(:input_options, "conditional must have when, eq, and show")
+        break
+      end
+
+      if requirements.find { |r| r.requirement_code == conditional["when"] }.blank?
+        errors.add(:input_options, "conditional 'when' field must be a requirement code in the same requirement block")
+        break
+      end
+    end
+  end
 
   def validate_step_code_dependencies
     has_energy_step_code = requirements.any? { |req| req.input_type_energy_step_code? }

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -153,7 +153,7 @@ class RequirementTemplate < ApplicationRecord
   def energy_step_code_requirements_from_nest_attributes_copy
     requirement_block_ids = requirement_block_ids_from_nested_attributes_copy
 
-    return unless requirement_block_ids.length.positive?
+    return [] unless requirement_block_ids.length.positive?
 
     Requirement.where(
       requirement_block_id: requirement_block_ids,
@@ -164,7 +164,7 @@ class RequirementTemplate < ApplicationRecord
   def step_code_package_file_requirements_from_nest_attributes_copy
     requirement_block_ids = requirement_block_ids_from_nested_attributes_copy
 
-    return unless requirement_block_ids.length.positive?
+    return [] unless requirement_block_ids.length.positive?
 
     Requirement.where(
       requirement_block_id: requirement_block_ids,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,11 +43,13 @@ en:
           attributes:
             requirements:
               incorrect_energy_step_code_dependencies: "missing or duplicate energy step code dependencies"
+              duplicate_step_code_package_file: "must have only one design package file for energy step code per requirement block"
         requirement:
           incorrect_energy_requirement_schema: "Incorrect schema for %{requirement_code}"
           attributes:
             requirement_code:
               incorrect_energy_requirement_code: "must be %{correct_requirement_code} for energy step code requirements, but received %{incorrect_requirement_code}"
+              incorrect_step_code_package_file_attributes: "must have input type file, required true, and elective false for design package file for energy step code"
         supporting_document:
           attributes:
             file:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,13 @@ en:
             jurisdiction:
               no_contact: "not available."
             pid_or_pin: "must have a pid or pin."
+        requirement_template:
+          step_code_package_required: "Energy Step code is required to have the Design package energy step code file"
+          energy_step_code_required: "Design package energy step code file is present in the template, but there is no Energy Step code requirement"
+          duplicate_energy_step_code:
+            "Multiple Energy Step code requirements found. Please ensure there is only one Energy Step code requirement in the template"
+          duplicate_step_code_package:
+            "Multiple Design package energy step code files found. Please ensure there is only one Design package energy step code file"
         requirement_block:
           attributes:
             requirements:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,12 +40,11 @@ en:
               no_contact: "not available."
             pid_or_pin: "must have a pid or pin."
         requirement_template:
-          step_code_package_required: "Energy Step code is required to have the Design package energy step code file"
-          energy_step_code_required: "Design package energy step code file is present in the template, but there is no Energy Step code requirement"
+          step_code_package_required: '"Energy step code" is required to have the Design package energy step code file'
           duplicate_energy_step_code:
-            "Multiple Energy Step code requirements found. Please ensure there is only one Energy Step code requirement in the template"
+            'Multiple "Energy step code" requirements found. Please ensure there is only one "Energy step code" requirement in the template'
           duplicate_step_code_package:
-            "Multiple Design package energy step code files found. Please ensure there is only one Design package energy step code file"
+            'Multiple "Design package energy step code files" found. Please ensure there is only one "Design package energy step code file" when there is an "Energy step code" requirement'
         requirement_block:
           attributes:
             requirements:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,15 @@ en:
             jurisdiction:
               no_contact: "not available."
             pid_or_pin: "must have a pid or pin."
+        requirement_block:
+          attributes:
+            requirements:
+              incorrect_energy_step_code_dependencies: "missing or duplicate energy step code dependencies"
+        requirement:
+          incorrect_energy_requirement_schema: "Incorrect schema for %{requirement_code}"
+          attributes:
+            requirement_code:
+              incorrect_energy_requirement_code: "must be %{correct_requirement_code} for energy step code requirements, but received %{incorrect_requirement_code}"
         supporting_document:
           attributes:
             file:

--- a/spec/factories/requirement_blocks.rb
+++ b/spec/factories/requirement_blocks.rb
@@ -20,5 +20,71 @@ FactoryBot.define do
         requirement_block.reload
       end
     end
+
+    factory :valid_energy_step_code_requirement_block do
+      after(:create) do |requirement_block, _evaluator|
+        requirement_block.requirements_attributes = [
+          {
+            "requirement_code" => "energy_step_code_method",
+            "label" => "Which method do you want to do use for the energy step code:",
+            "input_type" => "select",
+            "input_options" => {
+              "value_options" => [
+                { "label" => "Utilizing the digital step code tool", "value" => "tool" },
+                { "label" => "By file upload", "value" => "file" },
+              ],
+            },
+            "hint" => "(if not using the tool, we will allow you to upload by file)",
+            "required" => true,
+          },
+          {
+            "requirement_code" => "energy_step_code_tool_part_9",
+            "label" =>
+              "Please use this tool to do your fill in your step code details and it will populate onto the application.",
+            "input_type" => "energy_step_code",
+            "input_options" => {
+              "conditional" => {
+                "eq" => "tool",
+                "show" => true,
+                "when" => "energy_step_code_method",
+              },
+              "energy_step_code" => "part_9",
+            },
+            "required" => true,
+          },
+          {
+            "requirement_code" => "energy_step_code_report_file",
+            "label" => "BC Energy Step Code Compliance Report",
+            "input_type" => "file",
+            "input_options" => {
+              "conditional" => {
+                "eq" => "file",
+                "show" => true,
+                "when" => "energy_step_code_method",
+              },
+            },
+            "required" => true,
+          },
+          {
+            "requirement_code" => "energy_step_code_h2000_file",
+            "label" => "Pre construction Hot2000 model details, Hot2000 report",
+            "input_type" => "file",
+            "input_options" => {
+              "conditional" => {
+                "eq" => "file",
+                "show" => true,
+                "when" => "energy_step_code_method",
+              },
+            },
+            "required" => true,
+          },
+        ]
+
+        requirement_block.save
+
+        # You may need to reload the record here, depending on your application
+        requirement_block.reload
+      end
+    end
   end
 end

--- a/spec/factories/requirements.rb
+++ b/spec/factories/requirements.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :requirement do
-    label { Faker::Lorem.words(number: 4).join(" ") }
+    label { Faker::Lorem.unique.words(number: 4).join(" ") }
     input_type { 0 }
     input_options { {} }
     hint { nil }
@@ -10,5 +10,45 @@ FactoryBot.define do
     required_for_multiple_owners { false }
 
     association :requirement_block
+
+    factory :energy_step_code_tool_part_9_requirement do
+      requirement_code { "energy_step_code_tool_part_9" }
+      input_type { "energy_step_code" }
+      input_options do
+        {
+          "conditional" => {
+            "eq" => "tool",
+            "show" => true,
+            "when" => "energy_step_code_method",
+          },
+          "energy_step_code" => "part_9",
+        }
+      end
+    end
+
+    factory :energy_step_code_method_requirement do
+      requirement_code { "energy_step_code_method" }
+      input_type { "select" }
+      input_options do
+        {
+          "value_options" => [
+            { "label" => "Utilizing the digital step code tool", "value" => "tool" },
+            { "label" => "By file upload", "value" => "file" },
+          ],
+        }
+      end
+    end
+
+    factory :energy_step_code_report_file_requirement do
+      requirement_code { "energy_step_code_report_file" }
+      input_type { "file" }
+      input_options { { "conditional" => { "eq" => "file", "show" => true, "when" => "energy_step_code_method" } } }
+    end
+
+    factory :energy_step_code_h2000_file_requirement do
+      requirement_code { "energy_step_code_h2000_file" }
+      input_type { "file" }
+      input_options { { "conditional" => { "eq" => "file", "show" => true, "when" => "energy_step_code_method" } } }
+    end
   end
 end

--- a/spec/models/requirement_block_spec.rb
+++ b/spec/models/requirement_block_spec.rb
@@ -61,5 +61,249 @@ RSpec.describe RequirementBlock, type: :model do
       new_block = create(:requirement_block, sku: nil)
       expect(new_block.sku).to be_present
     end
+
+    context "when the block has an energy step code requirement" do
+      it "validate it has exactly one of each required requirement dependencies with expected requirement_codes" do
+        valid_block = create(:valid_energy_step_code_requirement_block)
+        invalid_blocks = [
+          build(
+            :requirement_block,
+            requirements_attributes: [
+              {
+                "requirement_code" => "energy_step_code_tool_part_9",
+                "label" =>
+                  "Please use this tool to do your fill in your step code details and it will populate onto the application.",
+                "input_type" => "energy_step_code",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "tool",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                  "energy_step_code" => "part_9",
+                },
+                "required" => true,
+              },
+            ],
+          ),
+          build(
+            :requirement_block,
+            requirements_attributes: [
+              {
+                "requirement_code" => "energy_step_code_tool_part_9",
+                "label" =>
+                  "Please use this tool to do your fill in your step code details and it will populate onto the application.",
+                "input_type" => "energy_step_code",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "tool",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                  "energy_step_code" => "part_9",
+                },
+                "required" => true,
+              },
+              {
+                "requirement_code" => "energy_step_code_tool_part_9",
+                "label" =>
+                  "Please use this tool to do your fill in your step code details and it will populate onto the application.",
+                "input_type" => "energy_step_code",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "tool",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                  "energy_step_code" => "part_9",
+                },
+                "required" => true,
+              },
+            ],
+          ),
+          build(
+            :requirement_block,
+            requirements_attributes: [
+              {
+                "requirement_code" => "energy_step_code_tool_part_9",
+                "label" =>
+                  "Please use this tool to do your fill in your step code details and it will populate onto the application.",
+                "input_type" => "energy_step_code",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "tool",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                  "energy_step_code" => "part_9",
+                },
+                "required" => true,
+              },
+              {
+                "requirement_code" => "energy_step_code_tool_part_9",
+                "label" =>
+                  "Please use this tool to do your fill in your step code details and it will populate onto the application.",
+                "input_type" => "energy_step_code",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "tool",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                  "energy_step_code" => "part_9",
+                },
+                "required" => true,
+              },
+              {
+                "requirement_code" => "energy_step_code_report_file",
+                "label" => "BC Energy Step Code Compliance Report",
+                "input_type" => "file",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "file",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                },
+                "required" => true,
+              },
+            ],
+          ),
+          build(
+            :requirement_block,
+            requirements_attributes: [
+              {
+                "requirement_code" => "energy_step_code_tool_part_9",
+                "label" =>
+                  "Please use this tool to do your fill in your step code details and it will populate onto the application.",
+                "input_type" => "energy_step_code",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "tool",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                  "energy_step_code" => "part_9",
+                },
+                "required" => true,
+              },
+              {
+                "requirement_code" => "energy_step_code_tool_part_9",
+                "label" =>
+                  "Please use this tool to do your fill in your step code details and it will populate onto the application.",
+                "input_type" => "energy_step_code",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "tool",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                  "energy_step_code" => "part_9",
+                },
+                "required" => true,
+              },
+              {
+                "requirement_code" => "energy_step_code_h2000_file",
+                "label" => "Pre construction Hot2000 model details, Hot2000 report",
+                "input_type" => "file",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "file",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                },
+                "required" => true,
+              },
+            ],
+          ),
+          # has duplicate
+          build(
+            :requirement_block,
+            requirements_attributes: [
+              {
+                "requirement_code" => "energy_step_code_method",
+                "label" => "Which method do you want to do use for the energy step code:",
+                "input_type" => "select",
+                "input_options" => {
+                  "value_options" => [
+                    { "label" => "Utilizing the digital step code tool", "value" => "tool" },
+                    { "label" => "By file upload", "value" => "file" },
+                  ],
+                },
+                "hint" => "(if not using the tool, we will allow you to upload by file)",
+                "required" => true,
+              },
+              {
+                "requirement_code" => "energy_step_code_tool_part_9",
+                "label" =>
+                  "Please use this tool to do your fill in your step code details and it will populate onto the application.",
+                "input_type" => "energy_step_code",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "tool",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                  "energy_step_code" => "part_9",
+                },
+                "required" => true,
+              },
+              {
+                "requirement_code" => "energy_step_code_report_file",
+                "label" => "BC Energy Step Code Compliance Report",
+                "input_type" => "file",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "file",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                },
+                "required" => true,
+              },
+              {
+                "requirement_code" => "energy_step_code_h2000_file",
+                "label" => "Pre construction Hot2000 model details, Hot2000 report",
+                "input_type" => "file",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "file",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                },
+                "required" => true,
+              },
+              {
+                "requirement_code" => "energy_step_code_h2000_file",
+                "label" => "Pre construction Hot2000 model details, Hot2000 report",
+                "input_type" => "file",
+                "input_options" => {
+                  "conditional" => {
+                    "eq" => "file",
+                    "show" => true,
+                    "when" => "energy_step_code_method",
+                  },
+                },
+                "required" => true,
+              },
+            ],
+          ),
+        ]
+
+        expect(valid_block).to be_valid
+
+        invalid_blocks.each do |invalid_block|
+          expect(invalid_block).not_to be_valid
+
+          expect(invalid_block.errors[:requirements]).to include(
+            I18n.t(
+              "activerecord.errors.models.requirement_block.attributes.requirements.incorrect_energy_step_code_dependencies",
+            ),
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -74,6 +74,166 @@ RSpec.describe Requirement, type: :model do
           expect(valid_requirement).to be_valid
         end
       end
+
+      context "energy step code related requirements" do
+        it "ensures the requirement_code for an energy_step_code input_type is 'energy_step_code_tool_part_9'" do
+          valid_requirement = build(:energy_step_code_tool_part_9_requirement)
+          invalid_requirement =
+            build(:requirement, input_type: "energy_step_code", requirement_code: "energy_step_code_tool_part_8")
+
+          allow(valid_requirement).to receive(:validate_conditional)
+          allow(invalid_requirement).to receive(:validate_conditional)
+
+          expect(valid_requirement).to be_valid
+          expect(invalid_requirement).to_not be_valid
+          expect(invalid_requirement.errors[:requirement_code]).to include(
+            I18n.t(
+              "activerecord.errors.models.requirement.attributes.requirement_code.incorrect_energy_requirement_code",
+              correct_requirement_code: Requirement::ENERGY_STEP_CODE_REQUIREMENT_CODE,
+              incorrect_requirement_code: "energy_step_code_tool_part_8",
+            ),
+          )
+        end
+
+        it "ensures energy_step_code_tool_part_9 has correct required schema" do
+          valid_requirement = build(:energy_step_code_tool_part_9_requirement)
+          invalid_requirements = [
+            build(:requirement, input_type: "energy_step_code", requirement_code: "energy_step_code_tool_part_9"),
+            build(
+              :requirement,
+              input_type: "energy_step_code",
+              requirement_code: "energy_step_code_tool_part_9",
+              input_options: {
+                "conditional" => {
+                  "eq" => "tool",
+                  "show" => true,
+                  "when" => "energy_step_code_method_wrong",
+                },
+                "energy_step_code" => "part_9",
+              },
+            ),
+            build(
+              :requirement,
+              input_type: "energy_step_code",
+              requirement_code: "energy_step_code_tool_part_9",
+              input_options: {
+                "conditional" => {
+                  "eq" => "tool",
+                  "show" => true,
+                  "when" => "energy_step_code_method",
+                },
+              },
+            ),
+          ]
+
+          allow(valid_requirement).to receive(:validate_conditional)
+          invalid_requirements.each { |requirement| allow(requirement).to receive(:validate_conditional) }
+
+          expect(valid_requirement).to be_valid
+          invalid_requirements.each do |requirement|
+            expect(requirement).to_not be_valid
+            expect(requirement.errors[:base]).to include(
+              I18n.t(
+                "activerecord.errors.models.requirement.incorrect_energy_requirement_schema",
+                requirement_code: requirement.requirement_code,
+              ),
+            )
+          end
+        end
+      end
+
+      it "ensures energy_step_code_method has correct required schema" do
+        valid_requirement = build(:energy_step_code_method_requirement)
+        invalid_requirements = [
+          build(:requirement, requirement_code: "energy_step_code_tool_part_9"),
+          build(:requirement, input_type: "select", requirement_code: "energy_step_code_tool_part_9"),
+          build(
+            :requirement,
+            input_type: "select",
+            requirement_code: "energy_step_code_tool_part_9",
+            input_options: {
+              "value_options" => [{ "label" => "Utilizing the digital step code tool", "value" => "tool" }],
+            },
+          ),
+        ]
+
+        allow(valid_requirement).to receive(:validate_conditional)
+        invalid_requirements.each { |requirement| allow(requirement).to receive(:validate_conditional) }
+
+        expect(valid_requirement).to be_valid
+        invalid_requirements.each do |requirement|
+          expect(requirement).to_not be_valid
+          expect(requirement.errors[:base]).to include(
+            I18n.t(
+              "activerecord.errors.models.requirement.incorrect_energy_requirement_schema",
+              requirement_code: requirement.requirement_code,
+            ),
+          )
+        end
+      end
+
+      it "ensures energy_step_code_report_file has correct required schema" do
+        valid_requirement = build(:energy_step_code_report_file_requirement)
+        invalid_requirements = [
+          build(:requirement, requirement_code: "energy_step_code_report_file"),
+          build(:requirement, input_type: "file", requirement_code: "energy_step_code_report_file"),
+          build(
+            :requirement,
+            input_type: "file",
+            requirement_code: "energy_step_code_report_file",
+            input_options: {
+              "value_options" => [{ "label" => "Utilizing the digital step code tool", "value" => "tool" }],
+            },
+          ),
+        ]
+
+        allow(valid_requirement).to receive(:validate_conditional)
+        invalid_requirements.each { |requirement| allow(requirement).to receive(:validate_conditional) }
+
+        expect(valid_requirement).to be_valid
+        invalid_requirements.each do |requirement|
+          expect(requirement).to_not be_valid
+          expect(requirement.errors[:base]).to include(
+            I18n.t(
+              "activerecord.errors.models.requirement.incorrect_energy_requirement_schema",
+              requirement_code: requirement.requirement_code,
+            ),
+          )
+        end
+      end
+
+      it "ensures energy_step_code_h2000_file has correct required schema" do
+        valid_requirement = build(:energy_step_code_h2000_file_requirement)
+        invalid_requirements = [
+          build(:requirement, requirement_code: "energy_step_code_h2000_file"),
+          build(:requirement, input_type: "file", requirement_code: "energy_step_code_h2000_file"),
+          build(
+            :requirement,
+            input_type: "file",
+            requirement_code: "energy_step_code_h2000_file",
+            input_options: {
+              "conditional" => {
+                "eq" => "file",
+                "show" => true,
+              },
+            },
+          ),
+        ]
+
+        allow(valid_requirement).to receive(:validate_conditional)
+        invalid_requirements.each { |requirement| allow(requirement).to receive(:validate_conditional) }
+
+        expect(valid_requirement).to be_valid
+        invalid_requirements.each do |requirement|
+          expect(requirement).to_not be_valid
+          expect(requirement.errors[:base]).to include(
+            I18n.t(
+              "activerecord.errors.models.requirement.incorrect_energy_requirement_schema",
+              requirement_code: requirement.requirement_code,
+            ),
+          )
+        end
+      end
     end
 
     context "positions of requirements" do
@@ -212,7 +372,7 @@ types" do
         requirement = create(:requirement, label: "Number Requirement", input_type: "number")
         form_json = requirement.to_form_json.reject { |key| key == :id }
         expected_form_json = {
-          key: "#{requirement.requirement_block.key}|numberRequirement",
+          key: "#{requirement.requirement_block.key}|number_requirement",
           type: "number",
           delimiter: true,
           input: true,
@@ -233,7 +393,7 @@ types" do
         requirement = create(:requirement, label: "Checkbox Requirement", input_type: "checkbox")
         form_json = requirement.to_form_json.reject { |key| key == :id }
         expected_form_json = {
-          key: "#{requirement.requirement_block.key}|checkboxRequirement",
+          key: "#{requirement.requirement_block.key}|checkbox_requirement",
           type: "checkbox",
           input: true,
           label: "Checkbox Requirement",
@@ -250,7 +410,7 @@ types" do
         requirement = create(:requirement, label: "Date  Requirement", input_type: "date")
         form_json = requirement.to_form_json.reject { |key| key == :id }
         expected_form_json = {
-          key: "#{requirement.requirement_block.key}|dateRequirement",
+          key: "#{requirement.requirement_block.key}|date_requirement",
           type: "datetime",
           tableView: false,
           input: true,
@@ -299,7 +459,7 @@ types" do
           )
         form_json = requirement.to_form_json.reject { |key| key == :id }
         expected_form_json = {
-          key: "#{requirement.requirement_block.key}|selectRequirement",
+          key: "#{requirement.requirement_block.key}|select_requirement",
           type: "select",
           input: true,
           label: "select Requirement",
@@ -330,7 +490,7 @@ types" do
         expected_form_json = {
           input: true,
           inputType: "checkbox",
-          key: "#{requirement.requirement_block.key}|multiOptionSelectRequirement",
+          key: "#{requirement.requirement_block.key}|multi_option_select_requirement",
           label: "Multi option select Requirement",
           optionsLabelPosition: "right",
           requirementInputType: "multi_option_select",
@@ -350,7 +510,7 @@ types" do
         requirement = create(:requirement, label: "File Requirement", input_type: "file")
         form_json = requirement.to_form_json.reject { |key| key == :id }
         expected_form_json = {
-          key: "#{requirement.requirement_block.key}|fileRequirement_file",
+          key: "#{requirement.requirement_block.key}|file_requirement_file",
           storage: "s3custom",
           type: "simplefile",
           custom_class: "formio-component-file",

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -81,9 +81,6 @@ RSpec.describe Requirement, type: :model do
           invalid_requirement =
             build(:requirement, input_type: "energy_step_code", requirement_code: "energy_step_code_tool_part_8")
 
-          allow(valid_requirement).to receive(:validate_conditional)
-          allow(invalid_requirement).to receive(:validate_conditional)
-
           expect(valid_requirement).to be_valid
           expect(invalid_requirement).to_not be_valid
           expect(invalid_requirement.errors[:requirement_code]).to include(
@@ -126,9 +123,6 @@ RSpec.describe Requirement, type: :model do
             ),
           ]
 
-          allow(valid_requirement).to receive(:validate_conditional)
-          invalid_requirements.each { |requirement| allow(requirement).to receive(:validate_conditional) }
-
           expect(valid_requirement).to be_valid
           invalid_requirements.each do |requirement|
             expect(requirement).to_not be_valid
@@ -157,9 +151,6 @@ RSpec.describe Requirement, type: :model do
           ),
         ]
 
-        allow(valid_requirement).to receive(:validate_conditional)
-        invalid_requirements.each { |requirement| allow(requirement).to receive(:validate_conditional) }
-
         expect(valid_requirement).to be_valid
         invalid_requirements.each do |requirement|
           expect(requirement).to_not be_valid
@@ -186,9 +177,6 @@ RSpec.describe Requirement, type: :model do
             },
           ),
         ]
-
-        allow(valid_requirement).to receive(:validate_conditional)
-        invalid_requirements.each { |requirement| allow(requirement).to receive(:validate_conditional) }
 
         expect(valid_requirement).to be_valid
         invalid_requirements.each do |requirement|
@@ -219,9 +207,6 @@ RSpec.describe Requirement, type: :model do
             },
           ),
         ]
-
-        allow(valid_requirement).to receive(:validate_conditional)
-        invalid_requirements.each { |requirement| allow(requirement).to receive(:validate_conditional) }
 
         expect(valid_requirement).to be_valid
         invalid_requirements.each do |requirement|


### PR DESCRIPTION
## Description
- Automatically adds energy step code dependencies when energy_step_code requirement is added
- Automatically removes energy step code dependencies when energy_step_code requirement is added
- Adds new step_code_code_package_file type which can be added to a requirement block. This is to make it easier for users to add step_code_file for compliance. Under the hood it is still a file
- Limits edit capability of the above
- Add warning banners when editing requirement_template when
    - Energy step code is there but step code package file is not in the template
    - Step code package file is there but Energy step code requirement is not there
    - There are duplicates of the above two
- Add back-end validations for the above and other related guard clauses 
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1364
