### PR TITLE
Remove warning on configuration management screen

### DIFF
--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/index.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/index.tsx
@@ -23,7 +23,6 @@ export const ConfigurationManagementScreen = observer(function ConfigurationMana
             <Heading mb={0} fontSize="3xl">
               {t(`${i18nPrefix}.title`)}
             </Heading>
-            <Text fontSize="md">{t(`${i18nPrefix}.editPermission`)}</Text>
 
             <SectionBox>
               <Flex align="flex-end">

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -924,7 +924,6 @@ const options = {
             adminDescription:
               "Manage site-wide settings and messages along with providing administrative control to Super Admins.",
             jurisdictionLocalityTypeLabel: "Locality type of local jurisdiction",
-            editPermission: "Only Review Managers are able to edit.",
             jurisdictionNameLabel: "Name of local jurisdiction",
             jurisdictionLocationLabel: "Location",
             jurisdictionAbout: {


### PR DESCRIPTION
## Description

Remove warning on configuration management screen. The warning is not relevant since RMs cannot edit this

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

[BPHH-1399](https://hous-bssb.atlassian.net/browse/BPHH-1399)

## Steps to QA

warning does not appear on RM configuration management screen

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
