### PR TITLE
Fix error when omniauth fails due to invalid CSRF

### DIFF
--- a/app/controllers/api/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/omniauth_callbacks_controller.rb
@@ -14,17 +14,19 @@ class Api::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in(resource_name, @user, store: false)
       redirect_to root_path
     else
-      redirect_to login_path frontend_flash_message(
-                               result.error_key,
-                               "error",
-                               message_opts: {
-                                 error_message: @user&.errors&.full_messages&.join(","),
-                               },
-                             )
+      redirect_to login_path(
+                    frontend_flash_message(
+                      result.error_key,
+                      "error",
+                      message_opts: {
+                        error_message: @user&.errors&.full_messages&.join(","),
+                      },
+                    ),
+                  )
     end
   end
 
   def failure
-    redirect_to login_path, frontend_flash_message("omniauth.failure", "error")
+    redirect_to login_path(frontend_flash_message("omniauth.failure", "error"))
   end
 end

--- a/app/frontend/components/domains/authentication/login-screen.tsx
+++ b/app/frontend/components/domains/authentication/login-screen.tsx
@@ -33,8 +33,8 @@ export const LoginScreen = ({ isAdmin }: ILoginScreenProps) => {
           {!isAdmin && <Text fontSize="md">{t("auth.prompt")}</Text>}
         </VStack>
         <form action="/api/auth/keycloak" method="post">
-          {/* @ts-ignore */}
           <input type="hidden" name="kc_idp_hint" value={isAdmin ? "idir" : "bceidboth"} />
+          {/* @ts-ignore */}
           <input type="hidden" name="authenticity_token" value={document.querySelector("[name=csrf-token]").content} />
           <Button variant="primary" w="full" type="submit">
             {isAdmin ? t("auth.idir_login") : t("auth.bceid_login")}


### PR DESCRIPTION
## Description

Fix error when omniauth fails due to invalid CSRF

If the user tries to login on a stale page with an old CSRF token, the omniauth call fails. This was causing a 500 rather than failing gracefully due to a comma in the `redirect_to` call. This resulted in the `frontend_flash_message` getting passed as a second param to redirect_to`, rather than getting passed to `login_path` as intended.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

[BPHH-1446](https://hous-bssb.atlassian.net/browse/BPHH-1446)

## Steps to QA

1. Navigate to BCeID Login page and manually update the CSRF token in the hidden input on the login form.
2. Login should fail with a generic error.
3. Subsequent login should succeed since the page reloaded with a new, valid CSRF token.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
