### PR TITLE
Expire invitation token after 72 hours

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -170,7 +170,7 @@ Devise.setup do |config|
   # The period the generated invitation token is valid.
   # After this period, the invited resource won't be able to accept the invitation.
   # When invite_for is 0 (the default), the invitation won't expire.
-  # config.invite_for = 2.weeks
+  config.invite_for = 72.hours
 
   # Number of invitations users can send.
   # - If invitation_limit is nil, there is no limit for invitations, users can


### PR DESCRIPTION
## Description

Expires invitation tokens after 72 hours as per https://hous-bssb.atlassian.net/browse/BPHH-1463

Locally this was tested by setting invitation expiry to 30 seconds. When an expired token tries to get redeemed, the user will get this screen:

<img width="1168" alt="Screenshot 2024-05-22 at 9 02 02 AM" src="https://github.com/bcgov/HOUS-permit-portal/assets/451563/1b94e67d-516c-46b1-9226-9ec475fc5abd">
