### PR TITLE
Feature/bphh 1392/unschedule template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,3 +111,4 @@ end
 gem "faraday-multipart", "~> 1.0"
 
 gem "rack-attack", "~> 6.7"
+gem "data_migrate", "~> 9.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,9 @@ GEM
     connection_pool (2.4.1)
     content_disposition (1.0.0)
     crass (1.0.6)
+    data_migrate (9.4.0)
+      activerecord (>= 6.1)
+      railties (>= 6.1)
     date (3.3.4)
     debug (1.9.0)
       irb (~> 1.10)
@@ -564,6 +567,7 @@ DEPENDENCIES
   blueprinter (~> 1.0.2)
   bootsnap
   bullet (~> 7.1.6)
+  data_migrate (~> 9.4)
   debug
   devise (= 4.9.3)
   devise-jwt (= 0.8.1)

--- a/app/blueprints/template_version_blueprint.rb
+++ b/app/blueprints/template_version_blueprint.rb
@@ -1,6 +1,6 @@
 class TemplateVersionBlueprint < Blueprinter::Base
   identifier :id
-  fields :status, :version_date, :created_at, :updated_at, :version_date, :label
+  fields :status, :deprecation_reason, :version_date, :created_at, :updated_at, :version_date, :label
 
   field :version_date do |template_version|
     # Parse version date in BC time

--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -120,7 +120,7 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     authorize @template_version, policy_class: RequirementTemplatePolicy
 
     begin
-      template_version = TemplateVersioningService.unschedule!(@template_version)
+      template_version = TemplateVersioningService.unschedule!(@template_version, current_user)
     rescue StandardError => e
       render_error "requirement_template.template_unschedule_error", message_opts: { error_message: e.message }
     end

--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -2,6 +2,7 @@ class Api::RequirementTemplatesController < Api::ApplicationController
   include Api::Concerns::Search::RequirementTemplates
 
   before_action :set_requirement_template, only: %i[show destroy restore update schedule force_publish_now]
+  before_action :set_template_version, only: %i[unschedule_template_version]
   skip_after_action :verify_policy_scoped, only: [:index]
 
   def index
@@ -115,6 +116,20 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     end
   end
 
+  def unschedule_template_version
+    authorize @template_version, policy_class: RequirementTemplatePolicy
+
+    begin
+      template_version = TemplateVersioningService.unschedule!(@template_version)
+    rescue StandardError => e
+      render_error "requirement_template.template_unschedule_error", message_opts: { error_message: e.message }
+    end
+
+    render_success @template_version,
+                   "requirement_template.template_unschedule_success",
+                   { blueprint: TemplateVersionBlueprint }
+  end
+
   def destroy
     authorize @requirement_template
     if @requirement_template.discard
@@ -137,6 +152,10 @@ class Api::RequirementTemplatesController < Api::ApplicationController
 
   def set_requirement_template
     @requirement_template = RequirementTemplate.find(params[:id])
+  end
+
+  def set_template_version
+    @template_version = TemplateVersion.find(params[:id])
   end
 
   def requirement_template_params

--- a/app/errors/template_version_unschedule_error.rb
+++ b/app/errors/template_version_unschedule_error.rb
@@ -1,0 +1,2 @@
+class TemplateVersionUnscheduleError < StandardError
+end

--- a/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
+++ b/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
@@ -30,6 +30,7 @@ import { IRequirementTemplate } from "../../../models/requirement-template"
 import { ITemplateVersion } from "../../../models/template-version"
 import { ETemplateVersionStatus } from "../../../types/enums"
 import { RouterLink } from "../../shared/navigation/router-link"
+import { RemoveConfirmationModal } from "../../shared/remove-confirmation-modal"
 import { TemplateStatusTag } from "../../shared/requirement-template/template-status-tag"
 import { VersionTag } from "../../shared/version-tag"
 
@@ -174,7 +175,6 @@ const VersionCard = observer(function VersionCard({
   ...containerProps
 }: TVersionCardProps) {
   const { t } = useTranslation()
-  const [isPending, setIsPending] = React.useState(false)
 
   const renderTemplateButton = () => {
     if (status === ETemplateVersionStatus.published || status === ETemplateVersionStatus.deprecated) {
@@ -195,31 +195,19 @@ const VersionCard = observer(function VersionCard({
           <Button as={RouterLink} to={viewRoute} variant={"primary"} size="sm">
             {t("ui.preview")}
           </Button>
-          <Button
-            variant={"secondary"}
-            size="sm"
-            onClick={
-              onUnschedule
-                ? async () => {
-                    try {
-                      setIsPending(true)
-                      const isSuccess = await onUnschedule()
-
-                      // only update the state if the unschedule was unsuccessful.
-                      // this is because on successfull unschedule, this component would be
-                      // unmounted and removed
-                      !isSuccess && setIsPending(false)
-                    } catch (e) {
-                      setIsPending(false)
-                    }
-                  }
-                : undefined
-            }
-            isDisabled={isPending}
-            isLoading={isPending}
-          >
-            {t("translation:requirementTemplate.versionSidebar.unscheduleButton")}
-          </Button>
+          <RemoveConfirmationModal
+            title={t("requirementTemplate.versionSidebar.unscheduleWarning.title")}
+            body={t("requirementTemplate.versionSidebar.unscheduleWarning.body")}
+            renderTriggerButton={(props) => {
+              return (
+                <Button variant={"secondary"} size="sm" {...props}>
+                  {t("translation:requirementTemplate.versionSidebar.unscheduleButton")}
+                </Button>
+              )
+            }}
+            onRemove={onUnschedule}
+            triggerText={t("translation:requirementTemplate.versionSidebar.unscheduleButton")}
+          />
         </ButtonGroup>
       )
     }

--- a/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
+++ b/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
@@ -147,6 +147,7 @@ const VersionsList = observer(function VersionsList({
           borderBottomRadius={index === templateVersions.length - 1 ? "sm" : undefined}
           borderRadius={"none"}
           onUnschedule={() => onUnschedule(templateVersion.id)}
+          deprecationReasonLabel={templateVersion.deprecationReasonLabel}
         />
       ))}
     </Box>
@@ -154,8 +155,13 @@ const VersionsList = observer(function VersionsList({
 })
 
 type TVersionCardProps = Partial<FlexProps> & { viewRoute: string; onUnschedule?: () => Promise<boolean> } & (
-    | { status: Exclude<ETemplateVersionStatus, ETemplateVersionStatus.draft>; versionDate: Date; updatedAt?: never }
-    | { status: ETemplateVersionStatus.draft; versionDate?: never; updatedAt: Date }
+    | {
+        status: Exclude<ETemplateVersionStatus, ETemplateVersionStatus.draft>
+        versionDate: Date
+        updatedAt?: never
+        deprecationReasonLabel?: string
+      }
+    | { status: ETemplateVersionStatus.draft; versionDate?: never; updatedAt: Date; deprecationReasonLabel?: never }
   )
 
 const VersionCard = observer(function VersionCard({
@@ -164,6 +170,7 @@ const VersionCard = observer(function VersionCard({
   status,
   versionDate,
   updatedAt,
+  deprecationReasonLabel,
   ...containerProps
 }: TVersionCardProps) {
   const { t } = useTranslation()
@@ -231,6 +238,7 @@ const VersionCard = observer(function VersionCard({
         <TemplateStatusTag
           status={status}
           scheduledFor={status === ETemplateVersionStatus.scheduled && versionDate ? versionDate : undefined}
+          subText={status === ETemplateVersionStatus.deprecated ? deprecationReasonLabel : undefined}
         />
         {status === ETemplateVersionStatus.draft ? (
           <Text>

--- a/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
+++ b/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
@@ -93,7 +93,7 @@ export const TemplateVersionsSidebar = observer(function TemplateVersionsSidebar
 
               <VersionsList
                 type={ETemplateVersionStatus.deprecated}
-                templateVersions={requirementTemplate.deprecatedTemplateVersions}
+                templateVersions={requirementTemplate.lastThreeDeprecatedTemplateVersions}
               />
               {requirementTemplate.publishedTemplateVersion && (
                 <Menu>

--- a/app/frontend/components/shared/remove-confirmation-modal.tsx
+++ b/app/frontend/components/shared/remove-confirmation-modal.tsx
@@ -35,6 +35,7 @@ export const RemoveConfirmationModal = observer(function RemoveConfirmationModal
 }: IProps) {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { t } = useTranslation()
+
   return (
     <>
       {renderTriggerButton ? (

--- a/app/frontend/components/shared/requirement-template/template-status-tag.tsx
+++ b/app/frontend/components/shared/requirement-template/template-status-tag.tsx
@@ -10,6 +10,7 @@ import { ETemplateVersionStatus } from "../../../types/enums"
 interface ITemplateStatusTagProps {
   status: ETemplateVersionStatus
   scheduledFor?: Date
+  subText?: string
 }
 
 const statusColors: { [key in ETemplateVersionStatus]: string } = {
@@ -33,7 +34,7 @@ const statusIcons: { [key in ETemplateVersionStatus]: ReactNode } = {
   [ETemplateVersionStatus.deprecated]: <TrashSimple />,
 }
 
-export const TemplateStatusTag = ({ status, scheduledFor }: ITemplateStatusTagProps) => {
+export const TemplateStatusTag = ({ status, scheduledFor, subText }: ITemplateStatusTagProps) => {
   const color = statusColors[status]
   const borderColor = statusBorderColors[status]
   const { t } = useTranslation()
@@ -56,6 +57,11 @@ export const TemplateStatusTag = ({ status, scheduledFor }: ITemplateStatusTagPr
       {scheduledFor && (
         <Text fontSize="sm" fontWeight="bold">
           {format(utcToZonedTime(scheduledFor, vancouverTimeZone), "yyyy-MM-dd")}
+        </Text>
+      )}
+      {subText && (
+        <Text fontSize="sm" fontWeight="bold">
+          {subText}
         </Text>
       )}
     </Flex>

--- a/app/frontend/components/shared/requirement-template/template-status-tag.tsx
+++ b/app/frontend/components/shared/requirement-template/template-status-tag.tsx
@@ -1,5 +1,5 @@
 import { Flex, HStack, Tag, Text } from "@chakra-ui/react"
-import { CheckSquareOffset, Clock, Pencil } from "@phosphor-icons/react"
+import { CheckSquareOffset, Clock, Pencil, TrashSimple } from "@phosphor-icons/react"
 import { format } from "date-fns"
 import { utcToZonedTime } from "date-fns-tz"
 import React, { ReactNode } from "react"
@@ -30,7 +30,7 @@ const statusIcons: { [key in ETemplateVersionStatus]: ReactNode } = {
   [ETemplateVersionStatus.published]: <CheckSquareOffset />,
   [ETemplateVersionStatus.scheduled]: <Clock />,
   [ETemplateVersionStatus.draft]: <Pencil />,
-  [ETemplateVersionStatus.deprecated]: <></>,
+  [ETemplateVersionStatus.deprecated]: <TrashSimple />,
 }
 
 export const TemplateStatusTag = ({ status, scheduledFor }: ITemplateStatusTagProps) => {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1205,7 +1205,7 @@ const options = {
               published: "Published",
               draft: "Drafts",
               scheduled: "Scheduled",
-              deprecated: "Deprecated",
+              deprecated: "Deprecated (last 3)",
             },
             deprecationReasonLabels: {
               unscheduled: "reason: unscheduled",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1207,6 +1207,10 @@ const options = {
               scheduled: "Scheduled",
               deprecated: "Deprecated (last 3)",
             },
+            unscheduleWarning: {
+              title: "Are you sure you want to unschedule this template?",
+              body: "This action cannot be undone.",
+            },
             deprecationReasonLabels: {
               unscheduled: "reason: unscheduled",
               new_publish: "reason: new publish",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1178,6 +1178,7 @@ const options = {
             draft: "Draft",
             deprecated: "Deprecated",
           },
+
           index: {
             tableHeading: "Templates",
             title: "Permit templates catalogue",
@@ -1205,6 +1206,10 @@ const options = {
               draft: "Drafts",
               scheduled: "Scheduled",
               deprecated: "Deprecated",
+            },
+            deprecationReasonLabels: {
+              unscheduled: "reason: unscheduled",
+              new_publish: "reason: new publish",
             },
             lastUpdated: "Last updated",
           },

--- a/app/frontend/models/requirement-template.ts
+++ b/app/frontend/models/requirement-template.ts
@@ -1,6 +1,6 @@
 import { addDays, isAfter, isSameDay, max, startOfDay } from "date-fns"
 import { utcToZonedTime } from "date-fns-tz"
-import { Instance, flow, types } from "mobx-state-tree"
+import { Instance, flow, toGenerator, types } from "mobx-state-tree"
 import { vancouverTimeZone } from "../constants"
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
@@ -12,10 +12,23 @@ import { TemplateVersionModel } from "./template-version"
 function preProcessor(snapshot) {
   const processedSnapShot = {
     ...snapshot,
-    scheduledTemplateVersions: snapshot.templateVersions
-      ?.filter((version) => version.status === ETemplateVersionStatus.scheduled)
-      .map((version) => version.id),
     publishedTemplateVersion: snapshot.publishedTemplateVersion?.id,
+  }
+
+  if (Array.isArray(snapshot.templateVersions)) {
+    const statusToTemplateVersions =
+      snapshot.templateVersions.reduce((acc, version) => {
+        if (!acc[version.status]) {
+          acc[version.status] = []
+        }
+
+        acc[version.status].push(version.id)
+
+        return acc
+      }, {}) ?? {}
+
+    processedSnapShot.scheduledTemplateVersions = statusToTemplateVersions[ETemplateVersionStatus.scheduled]
+    processedSnapShot.deprecatedTemplateVersions = statusToTemplateVersions[ETemplateVersionStatus.deprecated]
   }
 
   if (snapshot.requirementTemplateSections) {
@@ -40,6 +53,7 @@ export const RequirementTemplateModel = types.snapshotProcessor(
       jurisdictionsSize: types.optional(types.number, 0),
       publishedTemplateVersion: types.maybeNull(types.safeReference(TemplateVersionModel)),
       scheduledTemplateVersions: types.array(types.safeReference(TemplateVersionModel)),
+      deprecatedTemplateVersions: types.array(types.safeReference(TemplateVersionModel)),
       permitType: types.frozen<IPermitType>(),
       activity: types.frozen<IActivity>(),
       formJson: types.frozen<IRequirementTemplateFormJson>(),
@@ -87,8 +101,40 @@ export const RequirementTemplateModel = types.snapshotProcessor(
       getRequirementSectionById(id: string) {
         return self.requirementTemplateSectionMap.get(id)
       },
+      getScheduledTemplateVersionById(id: string) {
+        return self.scheduledTemplateVersions.find((version) => version.id === id)
+      },
     }))
     .actions((self) => ({
+      addDeprecatedTemplateVersionReference(templateVersionId: string) {
+        self.deprecatedTemplateVersions.unshift(templateVersionId)
+      },
+      removeScheduledTemplateVersion(templateVersionId: string) {
+        const templateVersion = self.getScheduledTemplateVersionById(templateVersionId)
+
+        if (!templateVersion) {
+          return
+        }
+        self.scheduledTemplateVersions.remove(templateVersion)
+      },
+    }))
+    .actions((self) => ({
+      unscheduleTemplateVersion: flow(function* (templateVersionId: string) {
+        const templateVersion = self.getScheduledTemplateVersionById(templateVersionId)
+
+        if (!templateVersion) {
+          return false
+        }
+
+        const updateSuccessful = yield* toGenerator(templateVersion.unschedule())
+
+        if (updateSuccessful) {
+          self.addDeprecatedTemplateVersionReference(templateVersionId)
+          self.removeScheduledTemplateVersion(templateVersionId)
+        }
+
+        return updateSuccessful
+      }),
       destroy: flow(function* () {
         const response = yield self.environment.api.destroyRequirementTemplate(self.id)
         return response.ok

--- a/app/frontend/models/requirement-template.ts
+++ b/app/frontend/models/requirement-template.ts
@@ -104,10 +104,14 @@ export const RequirementTemplateModel = types.snapshotProcessor(
       getScheduledTemplateVersionById(id: string) {
         return self.scheduledTemplateVersions.find((version) => version.id === id)
       },
+      get lastThreeDeprecatedTemplateVersions() {
+        return self.deprecatedTemplateVersions.slice(0, 3)
+      },
     }))
     .actions((self) => ({
       addDeprecatedTemplateVersionReference(templateVersionId: string) {
         self.deprecatedTemplateVersions.unshift(templateVersionId)
+        self.deprecatedTemplateVersions.sort((a, b) => b.versionDate.getTime() - a.versionDate.getTime())
       },
       removeScheduledTemplateVersion(templateVersionId: string) {
         const templateVersion = self.getScheduledTemplateVersionById(templateVersionId)

--- a/app/frontend/models/template-version.ts
+++ b/app/frontend/models/template-version.ts
@@ -4,7 +4,7 @@ import { Instance, toGenerator, types } from "mobx-state-tree"
 import { IJurisdictionTemplateVersionCustomizationForm } from "../components/domains/requirement-template/screens/jurisdiction-edit-digital-permit-screen"
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
-import { EExportFormat, ETemplateVersionStatus } from "../types/enums"
+import { EDeprecationReason, EExportFormat, ETemplateVersionStatus } from "../types/enums"
 import { IDenormalizedTemplate } from "../types/types"
 import { startBlobDownload } from "../utils/utility-functions"
 import { JurisdictionTemplateVersionCustomizationModel } from "./jurisdiction-template-version-customization"
@@ -14,6 +14,7 @@ export const TemplateVersionModel = types
   .props({
     id: types.identifier,
     status: types.enumeration(Object.values(ETemplateVersionStatus)),
+    deprecationReason: types.maybeNull(types.enumeration(Object.values(EDeprecationReason))),
     versionDate: types.Date,
     label: types.string,
     updatedAt: types.Date,
@@ -38,6 +39,15 @@ export const TemplateVersionModel = types
     getJurisdictionTemplateVersionCustomization(jurisdictionId: string) {
       return self.templateVersionCustomizationsByJurisdiction.get(jurisdictionId)
     },
+    get deprecationReasonLabel() {
+      if (!self.deprecationReason) {
+        return ""
+      }
+
+      return t(
+        `requirementTemplate.versionSidebar.deprecationReasonLabels.${self.deprecationReason as EDeprecationReason}`
+      )
+    },
   }))
   .actions((self) => ({
     setJurisdictionTemplateVersionCustomization(
@@ -48,6 +58,9 @@ export const TemplateVersionModel = types
     },
     setStatus(status: ETemplateVersionStatus) {
       self.status = status
+    },
+    setDeprecationReason(reason: EDeprecationReason | null) {
+      self.deprecationReason = reason
     },
   }))
   .actions((self) => ({
@@ -145,6 +158,7 @@ export const TemplateVersionModel = types
 
       if (response.ok) {
         self.setStatus(response.data.data.status)
+        self.setDeprecationReason(response.data.data.deprecationReason)
       }
 
       return response.ok

--- a/app/frontend/models/template-version.ts
+++ b/app/frontend/models/template-version.ts
@@ -46,6 +46,9 @@ export const TemplateVersionModel = types
     ) {
       self.templateVersionCustomizationsByJurisdiction.set(jurisdictionId, customization)
     },
+    setStatus(status: ETemplateVersionStatus) {
+      self.status = status
+    },
   }))
   .actions((self) => ({
     fetchJurisdictionTemplateVersionCustomization: flow(function* (jurisdictionId: string) {
@@ -133,6 +136,18 @@ export const TemplateVersionModel = types
         }
         throw error
       }
+    }),
+    unschedule: flow(function* () {
+      if (!self.isScheduled) {
+        return false
+      }
+      const response = yield* toGenerator(self.environment.api.unscheduleTemplateVersion(self.id))
+
+      if (response.ok) {
+        self.setStatus(response.data.data.status)
+      }
+
+      return response.ok
     }),
   }))
 

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -334,6 +334,12 @@ export class Api {
     )
   }
 
+  async unscheduleTemplateVersion(templateId: string) {
+    return this.client.post<ApiResponse<ITemplateVersion>>(
+      `requirement_templates/template_versions/${templateId}/unschedule`
+    )
+  }
+
   async fetchStepCodes() {
     return this.client.get<ApiResponse<IStepCode[]>>("/step_codes")
   }

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -332,3 +332,8 @@ export enum EAutoComplianceType {
   internalValueExtractor = "internal_value_extractor",
   externalOptionsMapper = "external_options_mapper",
 }
+
+export enum EDeprecationReason {
+  newPublish = "new_publish",
+  unscheduled = "unscheduled",
+}

--- a/app/policies/requirement_template_policy.rb
+++ b/app/policies/requirement_template_policy.rb
@@ -31,6 +31,10 @@ class RequirementTemplatePolicy < ApplicationPolicy
     create?
   end
 
+  def unschedule_template_version?
+    create? && record.scheduled?
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -54,6 +54,18 @@ class TemplateVersioningService
     template_version
   end
 
+  def self.unschedule!(template_version)
+    return template_version unless template_version.status == "scheduled"
+
+    template_version.status = "deprecated"
+
+    unless template_version.save
+      raise TemplateVersionUnscheduleError.new(template_version.errors.full_messages.join(", "))
+    end
+
+    template_version
+  end
+
   def self.force_publish_now!(requirement_template)
     unless ENV["ENABLE_TEMPLATE_FORCE_PUBLISH"] == "true"
       raise TemplateVersionForcePublishNowError.new("Force publish is not enabled")

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -273,9 +273,14 @@ class TemplateVersioningService
   end
 
   def self.is_valid_schedule_version_date?(requirement_template, version_date)
-    last_version = requirement_template.template_versions.order(version_date: :desc, created_at: :desc).first
+    last_scheduled_version =
+      requirement_template
+        .template_versions
+        .where(status: TemplateVersion.statuses[:scheduled])
+        .order(version_date: :desc, created_at: :desc)
+        .first
 
-    version_date > Date.current && (last_version.blank? || version_date > last_version.version_date)
+    version_date > Date.current && (last_scheduled_version.blank? || version_date > last_scheduled_version.version_date)
   end
 
   def self.diff_of_current_changes_and_last_version

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,6 +284,12 @@ en:
       schedule_error:
         title: Error
         message: "%{error_message}"
+      template_unschedule_error:
+        title: Error unscheduling template
+        message: "%{error_message}"
+      template_unschedule_success:
+        title: ""
+        message: "Template unscheduled successfully"
       force_publish_now_error:
         title: Error force publishing template
         message: "%{error_message}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
       post "schedule", to: "requirement_templates#schedule", on: :member
       post "force_publish_now", to: "requirement_templates#force_publish_now", on: :member
       patch "restore", on: :member
+      post "template_versions/:id/unschedule", on: :collection, to: "requirement_templates#unschedule_template_version"
     end
 
     resources :template_versions, only: %i[index show]

--- a/db/data/20240521222127_add_deprecated_reason_to_template_version.rb
+++ b/db/data/20240521222127_add_deprecated_reason_to_template_version.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDeprecatedReasonToTemplateVersion < ActiveRecord::Migration[7.1]
+  def up
+    TemplateVersion.where(status: "deprecated", deprecation_reason: nil).update_all(deprecation_reason: "new_publish")
+  end
+
+  def down
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,0 +1,1 @@
+DataMigrate::Data.define(version: 20_240_521_222_127)

--- a/db/migrate/20240521213238_add_deprecation_reason_to_template_version.rb
+++ b/db/migrate/20240521213238_add_deprecation_reason_to_template_version.rb
@@ -1,0 +1,7 @@
+class AddDeprecationReasonToTemplateVersion < ActiveRecord::Migration[7.1]
+  def change
+    add_column :template_versions, :deprecation_reason, :integer, null: true
+
+    add_reference :template_versions, :deprecated_by, null: true, foreign_key: { to_table: :users }, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_16_230948) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_21_213238) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -62,6 +62,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_16_230948) do
     t.uuid "contactable_id"
     t.index %w[contactable_type contactable_id],
             name: "index_contacts_on_contactable"
+  end
+
+  create_table "data_migrations",
+               primary_key: "version",
+               id: :string,
+               force: :cascade do |t|
   end
 
   create_table "end_user_license_agreements",
@@ -573,6 +579,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_16_230948) do
     t.uuid "requirement_template_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "deprecation_reason"
+    t.uuid "deprecated_by_id"
+    t.index ["deprecated_by_id"],
+            name: "index_template_versions_on_deprecated_by_id"
     t.index ["requirement_template_id"],
             name: "index_template_versions_on_requirement_template_id"
   end
@@ -711,6 +721,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_16_230948) do
   add_foreign_key "template_section_blocks", "requirement_blocks"
   add_foreign_key "template_section_blocks", "requirement_template_sections"
   add_foreign_key "template_versions", "requirement_templates"
+  add_foreign_key "template_versions", "users", column: "deprecated_by_id"
   add_foreign_key "user_license_agreements",
                   "end_user_license_agreements",
                   column: "agreement_id"

--- a/spec/services/template_versioning_service_spec.rb
+++ b/spec/services/template_versioning_service_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe TemplateVersioningService, type: :service do
         end
       end
 
-      it "sets all earlier versions to be deprecated" do
+      it "sets all earlier versions to be deprecated and adds correct depreciation reason" do
         template_version_1 = nil
         template_version_2 = nil
         Timecop.freeze(Date.current - 3) do
@@ -141,6 +141,7 @@ RSpec.describe TemplateVersioningService, type: :service do
             template_version.reload
 
             expect(template_version.status).to eq("deprecated")
+            expect(template_version.deprecation_reason).to eq("new_publish")
           end
 
           expect(template_version_4.status).to eq("scheduled")
@@ -209,7 +210,7 @@ RSpec.describe TemplateVersioningService, type: :service do
   end
 
   context "publish_versions_publishable_now!" do
-    it "publishes latest version publishable now and deprecates all older versions" do
+    it "publishes latest version publishable now and deprecates all older versions with correct reason" do
       expected_published_versions = []
       expected_deprecated_versions = []
       expected_scheduled_versions = []
@@ -241,6 +242,7 @@ RSpec.describe TemplateVersioningService, type: :service do
         expected_deprecated_version.reload
 
         expect(expected_deprecated_version.status).to eq("deprecated")
+        expect(expected_deprecated_version.deprecation_reason).to eq("new_publish")
       end
 
       expected_scheduled_versions.each do |expected_scheduled_version|


### PR DESCRIPTION
## Description
- Adds the ability to unschedule a template
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1392
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- pre req: bundle install and reset db and data  or run `rails db:migrate:with_data`
- log in as super admin
- navigate to permits catalogue and enter any template in draft mode
- schedule a version to be publish
- go back to the permits catalogue and open the side bar for the scheduled template
- click unschedule
- the template should now be deprecated
<img width="1749" alt="Screenshot 2024-05-22 at 11 20 47 AM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/4140193f-e02c-4e4b-b1bf-203cf71e46b2">
