### PR TITLE
[bphh-1442] Fix  api key jurisdiction toggle FE and authorisation bug

### DIFF
--- a/app/blueprints/jurisdiction_blueprint.rb
+++ b/app/blueprints/jurisdiction_blueprint.rb
@@ -29,6 +29,6 @@ class JurisdictionBlueprint < Blueprinter::Base
   end
 
   view :minimal do
-    fields :qualified_name
+    fields :qualified_name, :external_api_enabled
   end
 end

--- a/app/controllers/api/jurisdictions_controller.rb
+++ b/app/controllers/api/jurisdictions_controller.rb
@@ -60,7 +60,7 @@ class Api::JurisdictionsController < Api::ApplicationController
                          "jurisdiction.external_api_disabled_success"
                        end
                      ),
-                     { blueprint: JurisdictionBlueprint }
+                     { blueprint: JurisdictionBlueprint, blueprint_opts: { view: :minimal } }
     else
       render_error "jurisdiction.update_external_api_enabled_error",
                    message_opts: {

--- a/app/frontend/components/domains/external-api-key/grid-header.tsx
+++ b/app/frontend/components/domains/external-api-key/grid-header.tsx
@@ -73,7 +73,8 @@ const ExternalApiEnabledSwitchWithConfirmation = observer(() => {
   const { currentUser } = userStore
   const { t } = useTranslation()
 
-  const isDisabled = currentUser.isReviewManager
+  const isDisabled =
+    (currentUser.isReviewManager || currentUser.isRegionalReviewManager) && !currentJurisdiction.externalApiEnabled
   const shouldUseDisableConfirmationModal =
     !isDisabled && currentJurisdiction.externalApiEnabled && currentJurisdiction.externalApiKeysMap.size > 0
 

--- a/app/frontend/components/domains/external-api-key/index.tsx
+++ b/app/frontend/components/domains/external-api-key/index.tsx
@@ -64,7 +64,7 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
             {t("externalApiKey.index.createExternalApiKey")}
           </RouterLinkButton>
         </Flex>
-        {!externalApiEnabled && currentUser.isReviewManager && (
+        {!externalApiEnabled && (currentUser.isReviewManager || currentUser.isRegionalReviewManager) && (
           <CalloutBanner
             type={"warning"}
             title={

--- a/app/policies/jurisdiction_policy.rb
+++ b/app/policies/jurisdiction_policy.rb
@@ -24,7 +24,9 @@ class JurisdictionPolicy < ApplicationPolicy
   end
 
   def update_external_api_enabled?
-    user.super_admin?
+    return true if user.super_admin?
+
+    (user.review_manager? || user.regional_review_manager?) && record.external_api_enabled?
   end
 
   def search_users?


### PR DESCRIPTION
## Description
[bphh-1442] Fixes bug with front-end state not updating when using api key toggle. Also fixes authorization policy for this action to allow review mangers to disable api key for the jurisdiction.

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1442
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Bug 1 (Front-end state update issue)
  - Log in as super admin
  - Navigate to jurisdictions table
  - Select any Jurisdiction -> manage -> api settings option
  - This should navigate to api settings page
  - Toggle enable/disable. This should update front-end state

https://github.com/bcgov/HOUS-permit-portal/assets/32022335/bdd9df10-36cc-40b2-a22d-0f8850e5023f

- Bug 2 (Updates authorization to allow review/ regional managers to disable api but not enable)
- Follow  Bug1 steps and enable api for a jurisdiction
- Login and review manager or regional review manager
- Navigate to configuration management -> api settings
- Clicking Disable -> Should be allowed
- Clicking Enable  -> should be blocked


https://github.com/bcgov/HOUS-permit-portal/assets/32022335/20cd19f0-0c98-40cb-838d-8406e54fa538




