### PR TITLE
[bphh-1401] Fix bug with req block modal state not resetting after create

### DIFF
--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
@@ -11,8 +11,6 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react"
-import { resetForm } from "@formio/react"
-import { autorun } from "mobx"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
 import React, { useEffect } from "react"
@@ -146,14 +144,11 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
     onClose()
   }
 
-  useEffect(
-    autorun(() => {
-      if (isOpen) {
-        resetForm(getDefaultValues())
-      }
-    }),
-    [isOpen]
-  )
+  useEffect(() => {
+    if (isOpen) {
+      reset(getDefaultValues())
+    }
+  }, [isOpen, requirementBlock])
 
   return (
     <>


### PR DESCRIPTION
## Description
[bphh-1401] Fix bug with req block modal state not resetting after create
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1401
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- log in as super admin
- navigate to requirements library
- create a new requirement block with the modal
- after initial creation is successful, open the create modal again
- the modal state should have reset
