### PR TITLE
BPHH-1472 add bceidboth to omniauth provider enum

### DIFF
--- a/db/migrate/20240529205744_remove_bceid_both_users.rb
+++ b/db/migrate/20240529205744_remove_bceid_both_users.rb
@@ -1,0 +1,8 @@
+class RemoveBceidBothUsers < ActiveRecord::Migration[7.1]
+  def up
+    User.where(omniauth_provider: "bceidboth").destroy_all
+  end
+
+  def down
+  end
+end

--- a/lib/tasks/sensitive_seeder.rake
+++ b/lib/tasks/sensitive_seeder.rake
@@ -28,9 +28,9 @@ namespace :db do
         password: Devise.friendly_token[0, 20],
         jurisdiction: j,
         omniauth_uid: row["bceid_uid"],
-        omniauth_provider: "bceidboth",
         omniauth_email: row["bceid_email"],
-        omniauth_username: row["bceid_username"]
+        omniauth_username: row["bceid_username"],
+        omniauth_provider: row["omniauth_provider"]
       ).confirm
     rescue ActiveRecord::RecordInvalid => e
       puts "Skipping invalid user record: #{e.message}"


### PR DESCRIPTION
## Description

Bug was found trying to load super admin user table. When one of the fetched users has a omniauth_provider of "bceidboth" the fetched data cant be loaded, as this is not a known enum value for omniauth_provider.



## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1472

## Steps to QA

log in as super admin
go to configuration management > users
make sure the table loads.