### PR TITLE
add backend search data for if a jurisdiciton is set up and show on landing

### DIFF
--- a/app/blueprints/jurisdiction_blueprint.rb
+++ b/app/blueprints/jurisdiction_blueprint.rb
@@ -22,7 +22,8 @@ class JurisdictionBlueprint < Blueprinter::Base
            :regional_district_name,
            :created_at,
            :updated_at,
-           :external_api_enabled
+           :external_api_enabled,
+           :submission_inbox_set_up
 
     association :contacts, blueprint: ContactBlueprint
     association :permit_type_submission_contacts, blueprint: PermitTypeSubmissionContactBlueprint

--- a/app/controllers/api/concerns/search/jurisdictions.rb
+++ b/app/controllers/api/concerns/search/jurisdictions.rb
@@ -2,27 +2,32 @@ module Api::Concerns::Search::Jurisdictions
   extend ActiveSupport::Concern
 
   def perform_search
-    @search =
-      Jurisdiction.search(
-        jurisdiction_query,
-        order: jurisdiction_order,
-        match: :word_start,
-        page: jurisdiction_search_params[:page],
-        per_page:
-          (
-            if jurisdiction_search_params[:page]
-              (jurisdiction_search_params[:per_page] || Kaminari.config.default_per_page)
-            else
-              nil
-            end
-          ),
-      )
+    search_params = {
+      order: jurisdiction_order,
+      match: :word_start,
+      page: jurisdiction_search_params[:page],
+      per_page:
+        (
+          if jurisdiction_search_params[:page]
+            (jurisdiction_search_params[:per_page] || Kaminari.config.default_per_page)
+          else
+            nil
+          end
+        ),
+    }
+
+    # Conditionally add the `where` clause
+    unless jurisdiction_search_params[:submission_inbox_set_up].nil?
+      search_params[:where] = { submission_inbox_set_up: jurisdiction_search_params[:submission_inbox_set_up] }
+    end
+
+    @search = Jurisdiction.search(jurisdiction_query, **search_params)
   end
 
   private
 
   def jurisdiction_search_params
-    params.permit(:query, :page, :per_page, sort: %i[field direction])
+    params.permit(:query, :page, :per_page, :submission_inbox_set_up, sort: %i[field direction])
   end
 
   def jurisdiction_query

--- a/app/frontend/components/domains/jurisdictions/index.tsx
+++ b/app/frontend/components/domains/jurisdictions/index.tsx
@@ -1,4 +1,5 @@
 import { Box, Container, Flex, Heading, Text, VStack } from "@chakra-ui/react"
+import { CheckCircle } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -44,9 +45,9 @@ export const JurisdictionIndexScreen = observer(function JurisdictionIndex() {
           </RouterLinkButton>
         </Flex>
 
-        <SearchGrid templateColumns="3fr repeat(3, 1fr) 1fr">
+        <SearchGrid templateColumns="3fr repeat(5, 1fr)">
           <GridHeaders
-            span={5}
+            span={6}
             includeActionColumn
             columns={Object.values(EJurisdictionSortFields).filter(
               (field) => field !== EJurisdictionSortFields.regionalDistrict
@@ -54,7 +55,7 @@ export const JurisdictionIndexScreen = observer(function JurisdictionIndex() {
           />
 
           {isSearching ? (
-            <Flex py={50} gridColumn={"span 5"}>
+            <Flex py={50} gridColumn={"span 6"}>
               <SharedSpinner />
             </Flex>
           ) : (
@@ -65,6 +66,14 @@ export const JurisdictionIndexScreen = observer(function JurisdictionIndex() {
                   <SearchGridItem>{j.reviewManagersSize}</SearchGridItem>
                   <SearchGridItem>{j.reviewersSize}</SearchGridItem>
                   <SearchGridItem>{j.permitApplicationsSize}</SearchGridItem>
+                  <SearchGridItem>
+                    {j.submissionInboxSetUp && (
+                      <Flex gap={1}>
+                        <CheckCircle color="var(--chakra-colors-semantic-success)" size={18} />
+                        {t("ui.yes")}
+                      </Flex>
+                    )}
+                  </SearchGridItem>
                   <SearchGridItem>
                     <Flex justify="center" w="full" gap={3}>
                       <RouterLink to={`${j.slug}/users/invite`}>{t("user.invite")}</RouterLink>

--- a/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
@@ -22,8 +22,10 @@ import { useTranslation } from "react-i18next"
 import { useJurisdiction } from "../../../hooks/resources/use-jurisdiction"
 import { IJurisdiction } from "../../../models/jurisdiction"
 import { useMst } from "../../../setup/root"
+import { EFlashMessageStatus } from "../../../types/enums"
 import { IContact, TLatLngTuple } from "../../../types/types"
 import { BlueTitleBar } from "../../shared/base/blue-title-bar"
+import { CustomMessageBox } from "../../shared/base/custom-message-box"
 import { ErrorScreen } from "../../shared/base/error-screen"
 import { LoadingScreen } from "../../shared/base/loading-screen"
 import { EditorWithPreview } from "../../shared/editor/custom-extensions/editor-with-preview"
@@ -96,6 +98,11 @@ export const JurisdictionScreen = observer(() => {
         <JurisdictionMap mapPosition={mapPositionWatch} mapZoom={mapZoomWatch} />
       </Show>
       <Container maxW="container.lg" py={{ base: 6, md: 16 }} px={8}>
+        {!currentJurisdiction.submissionInboxSetUp && (
+          <Box my={8}>
+            <CustomMessageBox status={EFlashMessageStatus.warning} description={t("jurisdiction.notEnabled")} />
+          </Box>
+        )}
         <FormProvider {...formMethods}>
           <form onSubmit={handleSubmit(onSubmit)}>
             <Flex direction="column" gap={16}>

--- a/app/frontend/components/domains/jurisdictions/limited-jurisdiction-index-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/limited-jurisdiction-index-screen.tsx
@@ -1,4 +1,5 @@
 import { Box, Container, Flex, Heading, Text, VStack } from "@chakra-ui/react"
+import { CheckCircle } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -39,10 +40,14 @@ export const LimitedJurisdictionIndexScreen = observer(function JurisdictionInde
           </Box>
         </Flex>
 
-        <SearchGrid templateColumns="3fr 3fr">
+        <SearchGrid templateColumns="4fr 4fr 2fr">
           <GridHeaders
-            span={2}
-            columns={[EJurisdictionSortFields.reverseQualifiedName, EJurisdictionSortFields.regionalDistrict]}
+            span={3}
+            columns={[
+              EJurisdictionSortFields.reverseQualifiedName,
+              EJurisdictionSortFields.regionalDistrict,
+              EJurisdictionSortFields.submissionInboxSetUp,
+            ]}
           />
 
           {isSearching ? (
@@ -57,6 +62,13 @@ export const LimitedJurisdictionIndexScreen = observer(function JurisdictionInde
                     <RouterLink to={`/jurisdictions/${j.slug}`}>{j.reverseQualifiedName}</RouterLink>
                   </SearchGridItem>
                   <SearchGridItem>{j.regionalDistrictName}</SearchGridItem>
+                  <SearchGridItem>
+                    {j.submissionInboxSetUp && (
+                      <Flex gap={1}>
+                        <CheckCircle color="var(--chakra-colors-semantic-success)" size={18} /> {t("ui.yes")}
+                      </Flex>
+                    )}
+                  </SearchGridItem>
                 </Box>
               )
             })

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/jurisdiction-submisson-inbox-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/jurisdiction-submisson-inbox-screen.tsx
@@ -41,7 +41,7 @@ export const JurisdictionSubmissionInboxScreen = observer(function JurisdictionS
   return (
     <Container maxW="container.lg" p={8} as={"main"}>
       <VStack align={"start"} spacing={5} w={"full"} h={"full"}>
-        {!currentJurisdiction.isSubmissionContactSetupComplete && (
+        {!currentJurisdiction.submissionInboxSetUp && (
           <CalloutBanner type={"error"} title={t("permitApplication.submissionInbox.contactInviteWarning")} />
         )}
         <Flex justify={"space-between"} w={"full"}>

--- a/app/frontend/components/domains/landing/index.tsx
+++ b/app/frontend/components/domains/landing/index.tsx
@@ -408,7 +408,7 @@ const AvailableJurisdictionsMessageBox: React.FC = observer(() => {
   const { tableJurisdictions, searchEnabledJurisdictions, totalPages } = jurisdictionStore
 
   useEffect(() => {
-    searchEnabledJurisdictions()
+    searchEnabledJurisdictions(12)
   }, [])
 
   return (

--- a/app/frontend/components/domains/landing/index.tsx
+++ b/app/frontend/components/domains/landing/index.tsx
@@ -24,7 +24,6 @@ import * as R from "ramda"
 import React, { ReactNode, useEffect, useRef, useState } from "react"
 import { Controller, FormProvider, useForm } from "react-hook-form"
 import { Trans, useTranslation } from "react-i18next"
-import { enabledJurisdictions } from "../../../constants"
 import { IJurisdiction } from "../../../models/jurisdiction"
 import { useMst } from "../../../setup/root"
 import { YellowLineSmall } from "../../shared/base/decorative/yellow-line-small"
@@ -402,8 +401,15 @@ const BareBox: React.FC<IBareBoxProps> = ({ n, children }) => {
   )
 }
 
-const AvailableJurisdictionsMessageBox: React.FC = () => {
+const AvailableJurisdictionsMessageBox: React.FC = observer(() => {
   const { t } = useTranslation()
+  const { jurisdictionStore } = useMst()
+
+  const { tableJurisdictions, searchEnabledJurisdictions, totalPages } = jurisdictionStore
+
+  useEffect(() => {
+    searchEnabledJurisdictions()
+  }, [])
 
   return (
     <Flex
@@ -422,21 +428,26 @@ const AvailableJurisdictionsMessageBox: React.FC = () => {
         <Flex direction="column" gap={2}>
           <Text fontWeight="bold">
             {t("landing.enabledCommunitiesDescription")}{" "}
-            {enabledJurisdictions.map((obj) => (
-              <Text as="span" fontWeight="normal">
-                {" "}
-                <RouterLink color="black" to={obj.href}>
-                  {obj.label}
+            {tableJurisdictions.map((jurisdiction) => (
+              <Text as="span" fontWeight="normal" key={jurisdiction.id} mr={2}>
+                <RouterLink color="black" to={`/jurisdictions/${jurisdiction.slug}`}>
+                  {jurisdiction.qualifiedName}
                 </RouterLink>
               </Text>
             ))}
-            <Text as="span" fontWeight="normal">
-              {" "}
-              {t("landing.moreComingSoon")}
-            </Text>
+            <br />
+            {totalPages > 1 ? (
+              <Text as="span" fontWeight="bold">
+                {t("landing.andMore")}
+              </Text>
+            ) : (
+              <Text as="span" fontWeight="normal">
+                {t("landing.moreComingSoon")}
+              </Text>
+            )}
           </Text>
         </Flex>
       </Flex>
     </Flex>
   )
-}
+})

--- a/app/frontend/components/domains/permit-application/checklist-sidebar.tsx
+++ b/app/frontend/components/domains/permit-application/checklist-sidebar.tsx
@@ -65,9 +65,9 @@ export const ChecklistSideBar = observer(({ permitApplication, completedBlocks }
                           <Flex align="center">
                             <Box w={5} mr={2}>
                               {completedBlocks[block.key] ? (
-                                <CheckCircle color="#2E8540" size={18} />
+                                <CheckCircle color="var(--chakra-colors-semantic-success)" size={18} />
                               ) : (
-                                <CircleDashed color="#A19F9D" size={18} />
+                                <CircleDashed color="var(--chakra-colors-greys-grey01)" size={18} />
                               )}{" "}
                             </Box>
                             <Text>{block.title}</Text>

--- a/app/frontend/components/domains/users/accept-invitation-screen.tsx
+++ b/app/frontend/components/domains/users/accept-invitation-screen.tsx
@@ -6,6 +6,7 @@ import { Trans } from "react-i18next"
 import { useSearchParams } from "react-router-dom"
 import { IUser } from "../../../models/user"
 import { useMst } from "../../../setup/root"
+import { EUserRoles } from "../../../types/enums"
 import { LoadingScreen } from "../../shared/base/loading-screen"
 import { BusinessBCeIDInfo } from "../../shared/bceid/business"
 import { CenterContainer } from "../../shared/containers/center-container"
@@ -65,7 +66,7 @@ function Content({ invitedUser }: Readonly<IProps>) {
                 {jurisdiction.qualifiedName}
               </Heading>
               <Text>{t("user.invitedAs")}</Text>
-              <Text fontWeight="bold">{t(`user.roles.${role}`)}</Text>
+              <Text fontWeight="bold">{t(`user.roles.${role as EUserRoles}`)}</Text>
             </VStack>
           </>
         ) : (
@@ -87,7 +88,11 @@ function Content({ invitedUser }: Readonly<IProps>) {
         </Heading>
         <form action={`/api/auth/keycloak`} method="post">
           <input type="hidden" name="kc_idp_hint" value={isSuperAdmin ? "idir" : "bceidboth"} />
-          <input type="hidden" name="authenticity_token" value={document.querySelector("[name=csrf-token]").content} />
+          <input
+            type="hidden"
+            name="authenticity_token"
+            value={(document.querySelector("[name=csrf-token]") as HTMLMetaElement).content}
+          />
           <Button variant="primary" w="full" type="submit">
             {isSuperAdmin ? t("auth.idir_login") : t("auth.bceid_login")}
           </Button>

--- a/app/frontend/constants.ts
+++ b/app/frontend/constants.ts
@@ -176,11 +176,3 @@ export const VALUE_EXTRACTION_AUTO_COMPLIANCE_TYPES = [
 ]
 
 export const OPTIONS_MAPPER_AUTO_COMPLIANCE_TYPES = [EAutoComplianceType.externalOptionsMapper]
-
-export const enabledJurisdictions = [
-  {
-    // Translations not necessary for place names
-    label: "City of North Vancouver",
-    href: "/jurisdictions/corporation-of-the-city-of-north-vancouver",
-  },
-]

--- a/app/frontend/hooks/resources/use-jurisdiction.ts
+++ b/app/frontend/hooks/resources/use-jurisdiction.ts
@@ -38,13 +38,13 @@ export const useJurisdiction = () => {
   // check if this is a jurisdiction specific route
   // if it is and if the user's jurisdiction changes, navigate to the same route for the new jurisdiction
   useEffect(() => {
-    if (currentUser.isRegionalReviewManager && currentUser.jurisdiction.id != jurisdictionId) {
+    if (currentUser?.isRegionalReviewManager && currentUser?.jurisdiction?.id != jurisdictionId) {
       const originalPath = findMatchingPathTemplate(pathname)
       if (!originalPath) return
       const path = generatePath(originalPath, { jurisdictionId: currentUser.jurisdiction.slug })
       navigate(path, { replace: true })
     }
-  }, [currentUser.jurisdiction])
+  }, [currentUser?.jurisdiction])
 
   useEffect(() => {
     ;(async () => {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -74,7 +74,7 @@ const options = {
           bestPractices: "Standardized requirements across participating jurisdictions",
           easyToFollow: "Easy to follow instructions to help you submit a building permit application",
           accessMyPermits: "Access my building permits",
-          accessExplanation: "Use your BCeID account to log or register for the Building Permit Hub.",
+          accessExplanation: "Use your BCeID account to log in or register for the Building Permit Hub.",
           whoForTitle: "Who is this for?",
           whoFor: [
             "I want to build housing",
@@ -123,6 +123,7 @@ const options = {
           adminPanel: "admin panel",
           enabledCommunitiesDescription: "Communities you can submit Building Permit applications in:",
           moreComingSoon: "(more coming soon)",
+          andMore: "...and more",
           additionalContent: {
             left: "See helpful tips from your local jurisdictions to streamline your digital building permit applications",
             mid: "Preview the New construction checklist for 1 - 4 Dwelling Units",
@@ -304,6 +305,7 @@ const options = {
             templatesUsed: "Templates used",
             mapPosition: "Map position",
             regionalDistrictName: "Regional district",
+            submissionInboxSetUp: "Accepting submissions",
           },
           submissionEmailConfirmed: {
             heading: "Email confirmed!",
@@ -312,6 +314,7 @@ const options = {
           lat: "Latitude",
           lng: "Longitude",
           title: "Local housing permits",
+          notEnabled: "Permit application submissions are temporarily unavailable for this jurisdiction.",
           checklist: "Checklist",
           lookOut: "Things to look out for",
           startApplication: "Start a permit application",

--- a/app/frontend/models/jurisdiction.ts
+++ b/app/frontend/models/jurisdiction.ts
@@ -38,6 +38,7 @@ export const JurisdictionModel = types
     energyStepRequired: types.maybeNull(types.number),
     zeroCarbonStepRequired: types.maybeNull(types.number),
     externalApiEnabled: types.optional(types.boolean, false),
+    submissionInboxSetUp: types.boolean,
   })
   .extend(withEnvironment())
   .extend(withRootStore())
@@ -56,18 +57,6 @@ export const JurisdictionModel = types
     },
     getPermitTypeSubmissionContact(id: string): IPermitTypeSubmissionContact {
       return self.permitTypeSubmissionContacts.find((c) => c.id == id)
-    },
-    get isSubmissionContactSetupComplete() {
-      const permitTypes = self.rootStore.permitClassificationStore.permitTypes
-
-      const hasValidContactForAllPermitTypes = permitTypes.every((permitType) => {
-        //   checks if there is at least one confirmed email for each permit type
-        return self.permitTypeSubmissionContacts.some(
-          (c) => c.permitTypeId == permitType.id && c.email && c.confirmedAt
-        )
-      })
-
-      return hasValidContactForAllPermitTypes
     },
     getExternalApiKey(externalApiKeyId: string) {
       return self.externalApiKeysMap.get(externalApiKeyId)

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -37,7 +37,13 @@ import {
   ERequirementTemplateSortFields,
   EUserSortFields,
 } from "../../types/enums"
-import { IContact, ISiteConfiguration, ITemplateVersionDiff, TSearchParams } from "../../types/types"
+import {
+  IContact,
+  IJurisdictionSearchFilters,
+  ISiteConfiguration,
+  ITemplateVersionDiff,
+  TSearchParams,
+} from "../../types/types"
 import { camelizeResponse, decamelizeRequest } from "../../utils"
 
 export class Api {
@@ -92,7 +98,7 @@ export class Api {
     return this.client.get<ApiResponse<IUser>>(`/invitations/${token}`)
   }
 
-  async searchJurisdictions(params?: TSearchParams<EJurisdictionSortFields>) {
+  async searchJurisdictions(params?: TSearchParams<EJurisdictionSortFields, IJurisdictionSearchFilters>) {
     return this.client.post<IJurisdictionResponse>("/jurisdictions/search", params)
   }
 

--- a/app/frontend/stores/jurisdiction-store.ts
+++ b/app/frontend/stores/jurisdiction-store.ts
@@ -122,8 +122,8 @@ export const JurisdictionStoreModel = types
     },
   }))
   .actions((self) => ({
-    searchEnabledJurisdictions: flow(function* () {
-      return self.searchJurisdictions({ reset: true, page: 1, countPerPage: 12 }, true)
+    searchEnabledJurisdictions: flow(function* (countPerPage: number = 10) {
+      return self.searchJurisdictions({ reset: true, page: 1, countPerPage }, true)
     }),
   }))
 

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -64,6 +64,7 @@ export enum EJurisdictionSortFields {
   reviewersSize = "reviewers_size",
   permitApplicationsSize = "permit_applications_size",
   regionalDistrict = "regional_district_name",
+  submissionInboxSetUp = "submission_inbox_set_up",
 }
 
 export enum EUserSortFields {

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -66,14 +66,14 @@ export interface IOption<TValue = string> {
 
 export type TDebouncedFunction<T extends (...args: any[]) => any> = (...args: Parameters<T>) => void
 
-export type TSearchParams<IModelSortFields> = {
+export type TSearchParams<IModelSortFields, IModelFilterFields = {}> = {
   sort?: ISort<IModelSortFields>
   query?: string
   page?: number
   perPage?: number
   showArchived?: boolean
   statusFilter?: string
-}
+} & IModelFilterFields
 
 export type TComputedCompliance = {
   module: EAutoComplianceModule
@@ -364,6 +364,9 @@ export interface IJurisdictionFilters {
   name?: string
   type?: EJurisdictionTypes
   userId?: string
+}
+export interface IJurisdictionSearchFilters {
+  submissionInboxSetUp?: boolean
 }
 
 export interface ITemplateVersionDiff {

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -129,11 +129,11 @@ class Jurisdiction < ApplicationRecord
   end
 
   def submission_inbox_set_up
-    PermitType.all.all? do |permit_type|
-      self.permit_type_submission_contacts.any? do |contact|
-        contact.permit_type_id == permit_type.id && contact.email.present? && contact.confirmed_at.present?
-      end
-    end
+    # preload all of the permit_types and contacts for efficiency
+    permit_types = PermitType.all.to_a
+    contacts = permit_type_submission_contacts.where.not(email: nil).where.not(confirmed_at: nil).to_a
+
+    permit_types.all? { |permit_type| contacts.any? { |contact| contact.permit_type_id == permit_type.id } }
   end
 
   def self.class_for_locality_type(locality_type)

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -92,6 +92,7 @@ class Jurisdiction < ApplicationRecord
       reviewers_size: reviewers_size,
       permit_applications_size: permit_applications_size,
       user_ids: users.pluck(:id),
+      submission_inbox_set_up: submission_inbox_set_up,
     }
   end
 
@@ -125,6 +126,14 @@ class Jurisdiction < ApplicationRecord
 
   def unviewed_permit_applications
     permit_applications.unviewed
+  end
+
+  def submission_inbox_set_up
+    PermitType.all.all? do |permit_type|
+      self.permit_type_submission_contacts.any? do |contact|
+        contact.permit_type_id == permit_type.id && contact.email.present? && contact.confirmed_at.present?
+      end
+    end
   end
 
   def self.class_for_locality_type(locality_type)

--- a/app/models/permit_type_submission_contact.rb
+++ b/app/models/permit_type_submission_contact.rb
@@ -5,6 +5,8 @@ class PermitTypeSubmissionContact < ApplicationRecord
   before_create :generate_confirmation_token
   before_update :reset_confirmation, if: :email_changed?
   after_commit :send_confirmation_instructions, on: %i[create update]
+  after_commit :reindex_jurisdiction, on: %i[create update]
+  after_destroy :reindex_jurisdiction
 
   validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }
 
@@ -35,5 +37,9 @@ class PermitTypeSubmissionContact < ApplicationRecord
 
   def reset_confirmation
     self.confirmed_at = nil
+  end
+
+  def reindex_jurisdiction
+    jurisdiction.reindex
   end
 end

--- a/app/services/wrappers/geocoder.rb
+++ b/app/services/wrappers/geocoder.rb
@@ -26,7 +26,6 @@ class Wrappers::Geocoder < Wrappers::Base
 
     site_params[:addressString] = address_string if address_string.present?
     site_params[:parcelPoint] = coordinates.join(",") if coordinates.present?
-
     r = get("/addresses.json", site_params)
     return(
       r["features"]

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_21_213238) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_29_205744) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
## Description

determining if an inbox is set up for a jurisdiction is now determined on the backend and indexed in search data.
Add this search data to the jurisdiction tables and show up to 10 of the enabled jurisdictions on the landing.

@Skye Smith wants us to say “not accepting submissions” until ALL inboxes are set up (this means that the message will not be accurate for some permit types)

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1496

## Steps to QA

see card


