### PR TITLE
Feature/bphh 1340/external api file

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -59,6 +59,10 @@ class PermitApplicationBlueprint < Blueprinter::Base
       pa.formatted_permit_classifications
     end
 
+    field :raw_h2k_files do |pa, _options|
+      pa.formatted_raw_h2k_files_for_external_use
+    end
+
     association :submitter, blueprint: UserBlueprint, view: :external_api
     association :permit_type, blueprint: PermitClassificationBlueprint
     association :activity, blueprint: PermitClassificationBlueprint

--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -59,6 +59,7 @@ class PermitApplicationBlueprint < Blueprinter::Base
       pa.formatted_permit_classifications
     end
 
+    association :submitter, blueprint: UserBlueprint, view: :external_api
     association :permit_type, blueprint: PermitClassificationBlueprint
     association :activity, blueprint: PermitClassificationBlueprint
   end

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -20,6 +20,10 @@ class UserBlueprint < Blueprinter::Base
            :last_sign_in_at
   end
 
+  view :external_api do
+    fields :email
+  end
+
   view :current_user do
     include_view :base
     field :eula_accepted do |user, _options|

--- a/app/jobs/pdf_generation_job.rb
+++ b/app/jobs/pdf_generation_job.rb
@@ -61,8 +61,8 @@ class PdfGenerationJob
 
         # Check for errors or handle output based on the exit status
         if exit_status.success?
-          pdfs = [{ fname: application_filename, key: :permit_application_pdf }]
-          pdfs << { fname: step_code_filename, key: :step_code_checklist_pdf } if checklist
+          pdfs = [{ fname: application_filename, key: PermitApplication::PERMIT_APP_PDF_DATA_KEY }]
+          pdfs << { fname: step_code_filename, key: PermitApplication::CHECKLIST_PDF_DATA_KEY } if checklist
           pdfs.each do |pdf|
             path = "#{generation_directory_path}/#{pdf[:fname]}"
             file = File.open(path)

--- a/app/models/concerns/form_supporting_documents.rb
+++ b/app/models/concerns/form_supporting_documents.rb
@@ -8,19 +8,21 @@ module FormSupportingDocuments
              ->(permit_application) { where(id: permit_application.supporting_doc_ids_from_submission_data) },
              class_name: "SupportingDocument"
 
-    STEP_CODE_DOCUMENT_DATA_KEYS = %i[permit_application_pdf step_code_checklist_pdf]
+    CHECKLIST_PDF_DATA_KEY = :step_code_checklist_pdf
+    PERMIT_APP_PDF_DATA_KEY = :permit_application_pdf
+    STATIC_DOCUMENT_DATA_KEYS = [PERMIT_APP_PDF_DATA_KEY, CHECKLIST_PDF_DATA_KEY].freeze
 
     has_many :inactive_supporting_documents,
              ->(permit_application) do
                where
                  .not(id: permit_application.supporting_doc_ids_from_submission_data)
-                 .where.not(data_key: STEP_CODE_DOCUMENT_DATA_KEYS)
+                 .where.not(data_key: STATIC_DOCUMENT_DATA_KEYS)
              end,
              class_name: "SupportingDocument"
     has_many :completed_supporting_documents,
              ->(permit_application) do
                where(id: permit_application.supporting_doc_ids_from_submission_data).or(
-                 where(data_key: STEP_CODE_DOCUMENT_DATA_KEYS),
+                 where(data_key: STATIC_DOCUMENT_DATA_KEYS),
                )
              end,
              class_name: "SupportingDocument"

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -160,6 +160,10 @@ class PermitApplication < ApplicationRecord
     ExternalPermitApplicationService.new(self).formatted_submission_data_for_external_use
   end
 
+  def formatted_raw_h2k_files_for_external_use
+    ExternalPermitApplicationService.new(self).get_raw_h2k_files
+  end
+
   def send_submitted_webhook
     return unless submitted?
 

--- a/app/models/step_code_data_entry.rb
+++ b/app/models/step_code_data_entry.rb
@@ -10,4 +10,28 @@ class StepCodeDataEntry < ApplicationRecord
   def set_stage
     self.stage = :proposed
   end
+
+  def h2k_file_id
+    h2k_file_data.dig("id")
+  end
+
+  def h2k_file_size
+    h2k_file_data.dig("metadata", "size")
+  end
+
+  def h2k_file_name
+    h2k_file_data.dig("metadata", "filename")
+  end
+
+  def h2k_file_type
+    h2k_file_data.dig("metadata", "mime_type")
+  end
+
+  def h2k_file_url
+    h2k_file&.url(
+      public: false,
+      expires_in: 3600,
+      response_content_disposition: "attachment; filename=\"#{file.original_filename}\"",
+    )
+  end
 end

--- a/app/models/step_code_data_entry.rb
+++ b/app/models/step_code_data_entry.rb
@@ -31,7 +31,7 @@ class StepCodeDataEntry < ApplicationRecord
     h2k_file&.url(
       public: false,
       expires_in: 3600,
-      response_content_disposition: "attachment; filename=\"#{file.original_filename}\"",
+      response_content_disposition: "attachment; filename=\"#{h2k_file.original_filename}\"",
     )
   end
 end

--- a/app/models/supporting_document.rb
+++ b/app/models/supporting_document.rb
@@ -72,6 +72,10 @@ class SupportingDocument < ApplicationRecord
     file_data.dig("metadata", "filename")
   end
 
+  def file_type
+    file_data.dig("metadata", "mime_type")
+  end
+
   def file_url
     file&.url(
       public: false,

--- a/app/services/external_permit_application_service.rb
+++ b/app/services/external_permit_application_service.rb
@@ -106,6 +106,27 @@ class ExternalPermitApplicationService
     self.permit_application.template_version.requirement_blocks_json[requirement_block_id]
   end
 
+  def get_raw_h2k_files
+    return nil unless permit_application.step_code.present? && !permit_application.step_code.data_entries.empty?
+
+    permit_application
+      .step_code
+      .data_entries
+      .map do |data_entry|
+        url = data_entry.h2k_file_url
+        next unless url.present?
+
+        {
+          id: data_entry.h2k_file_id,
+          name: data_entry.h2k_file_name,
+          type: data_entry.h2k_file_type,
+          size: data_entry.h2k_file_size,
+          url: data_entry.h2k_file_url,
+        }
+      end
+      .compact
+  end
+
   private
 
   # single_contact submissions are not formatted in the same way as multi_contact submissions.

--- a/app/services/external_permit_application_service.rb
+++ b/app/services/external_permit_application_service.rb
@@ -238,34 +238,29 @@ class ExternalPermitApplicationService
   def form_remaining_energy_step_code_submission_data
     return nil unless permit_application.present?
 
-    step_code_documents =
-      permit_application.supporting_documents.where(data_key: PermitApplication::STEP_CODE_DOCUMENT_DATA_KEYS)
+    checklist_document =
+      permit_application.supporting_documents.find_by(data_key: PermitApplication::CHECKLIST_PDF_DATA_KEY)
 
-    return nil if step_code_documents.empty?
+    return nil unless checklist_document.present?
+
+    url = checklist_document.file_url
+
+    return nil unless url.present?
 
     # These is originally not part of the requirement model, but to keep a unified structure, we will format it as such.
-    file_values =
-      step_code_documents
-        .map do |step_code_document|
-          url = step_code_document.file_url
-
-          next unless url.present?
-
-          {
-            id: step_code_document.id,
-            name: step_code_document.file_name,
-            type: step_code_document.file_type,
-            size: step_code_document.file_size,
-            url: step_code_document.file_url,
-          }
-        end
-        .compact
-
-    return nil if file_values.empty?
+    file_values = [
+      {
+        id: checklist_document.id,
+        name: checklist_document.file_name,
+        type: checklist_document.file_type,
+        size: checklist_document.file_size,
+        url: checklist_document.file_url,
+      },
+    ]
 
     {
-      id: "energy_step_code",
-      requirement_block_code: "energy_step_code_compliance",
+      id: "energy_step_code_tool",
+      requirement_block_code: "energy_step_code_tool",
       name: "Energy step code",
       description: "",
       requirement: [

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -169,6 +169,9 @@ in this document.
               activity: {
                 "$ref" => "#/components/schemas/PermitClassification",
               },
+              submitter: {
+                "$ref" => "#/components/schemas/Submitter",
+              },
               submission_data: {
                 "$ref" => "#/components/schemas/SubmissionData",
               },
@@ -327,6 +330,20 @@ in this document.
                   format: "url",
                   description: "The signed URL to download the file.",
                 },
+              },
+            },
+          },
+          Submitter: {
+            type: :object,
+            description: "The submitter of the permit application.",
+            properties: {
+              id: {
+                type: :string,
+                description: "The ID of the submitter.",
+              },
+              email: {
+                type: :string,
+                description: "The email of the submitter.",
               },
             },
           },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -9,9 +9,9 @@ RSpec.configure do |config|
   config.openapi_root = Rails.root.join("swagger").to_s
 
   servers = [
-    { url: "https:/buildingpermit.gov.bc.ca", description: "Production server" },
+    { url: "/external_api/v1", description: "Current environment server" },
     {
-      url: "{serverUrl}",
+      url: "{serverUrl}/external_api/v1",
       description: "Server url",
       variables: {
         serverUrl: {
@@ -63,7 +63,7 @@ may necessitate further contact with the building permit hub team.
 The base path for all API endpoints is `/external_api/v1`.
 
 ### Server information for testing:
-For testing purposes, please use the server located at {serverUrl}. The computed URL for API interactions is https://buildingpermit.gov.bc.ca.
+By default the requests from the documentation will be sent to the current environment servers. For testing purposes, you can specify a different server using the {serverUrl} variable. 
 During your integration testing phase, you have the flexibility to use custom URLs by configuring the serverUrl variable. This allows you to
 tailor the API environment to better suit your development needs. Ensure that your custom URLs are configured correctly to avoid any connectivity or data access issues.
 
@@ -110,7 +110,6 @@ in this document.
       },
       paths: {
       },
-      basePath: "/external_api/v1",
       servers: servers,
       tags: [
         { name: "Permit applications", description: "Submitted permit applications (scoped to API key jurisdiction)" },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -67,6 +67,11 @@ For testing purposes, please use the server located at {serverUrl}. The computed
 During your integration testing phase, you have the flexibility to use custom URLs by configuring the serverUrl variable. This allows you to
 tailor the API environment to better suit your development needs. Ensure that your custom URLs are configured correctly to avoid any connectivity or data access issues.
 
+### Special considerations:
+For security purposes, any API response that includes a file URL will have a signed URL. These files will be available for download for a limited time (1 hour).
+We recommend downloading the file immediately upon receiving the URL to avoid any issues. If necessary, you can always call the API again to retrieve a 
+new file URL.
+
 ### Visual aids and examples:
 For a better understanding of how our APIs work, including webhook setups and request handling, please refer to the code examples included later
 in this document.
@@ -217,6 +222,7 @@ in this document.
                           { type: :boolean },
                           { "$ref" => "#/components/schemas/ContactSubmissionValue" },
                           { "$ref" => "#/components/schemas/MultiOptionSubmissionValue" },
+                          { "$ref" => "#/components/schemas/FileSubmissionValue" },
                         ],
                       },
                     },
@@ -248,12 +254,17 @@ in this document.
           },
           MultiOptionSubmissionValue: {
             type: :object,
+            description:
+              "The submission value for requirement input types, which are limited to a set of options. e.g. an option from a select drop down, or checkboxes",
             additionalProperties: {
               type: :boolean,
+              description:
+                "The key is the option value, and the value is a boolean indicating if the option was selected.",
             },
           },
           ContactSubmissionValue: {
             type: :array,
+            description: "The contact submission value. It is an array of contact objects",
             items: {
               type: :object,
               properties: {
@@ -284,6 +295,37 @@ in this document.
                 organization: {
                   type: :string,
                   description: "The organization of the contact.",
+                },
+              },
+            },
+          },
+          FileSubmissionValue: {
+            description:
+              "The file submission value. It is an array of file objects. Note: the urls are signed and will expire after 1 hour .",
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                id: {
+                  type: :string,
+                  description: "The ID of the file.",
+                },
+                name: {
+                  type: :string,
+                  description: "The name of the file.",
+                },
+                size: {
+                  type: :integer,
+                  description: "The size of the file in bytes.",
+                },
+                type: {
+                  type: :string,
+                  description: "The type of the file. e.g. image/png, application/pdf, etc.",
+                },
+                url: {
+                  type: :string,
+                  format: "url",
+                  description: "The signed URL to download the file.",
                 },
               },
             },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -175,6 +175,9 @@ in this document.
               submission_data: {
                 "$ref" => "#/components/schemas/SubmissionData",
               },
+              raw_h2k_files: {
+                "$ref" => "#/components/schemas/FileSubmissionValue",
+              },
             },
           },
           SubmissionData: {

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -176,7 +176,13 @@ in this document.
                 "$ref" => "#/components/schemas/SubmissionData",
               },
               raw_h2k_files: {
-                "$ref" => "#/components/schemas/FileSubmissionValue",
+                description:
+                  "The raw h2k files uploaded by the submitter. Note: the urls are signed and will expire after 1 hour.",
+                type: :array,
+                items: {
+                  "$ref" => "#/components/schemas/File",
+                },
+                nullable: true,
               },
             },
           },
@@ -310,29 +316,32 @@ in this document.
               "The file submission value. It is an array of file objects. Note: the urls are signed and will expire after 1 hour .",
             type: :array,
             items: {
-              type: :object,
-              properties: {
-                id: {
-                  type: :string,
-                  description: "The ID of the file.",
-                },
-                name: {
-                  type: :string,
-                  description: "The name of the file.",
-                },
-                size: {
-                  type: :integer,
-                  description: "The size of the file in bytes.",
-                },
-                type: {
-                  type: :string,
-                  description: "The type of the file. e.g. image/png, application/pdf, etc.",
-                },
-                url: {
-                  type: :string,
-                  format: "url",
-                  description: "The signed URL to download the file.",
-                },
+              "$ref" => "#/components/schemas/File",
+            },
+          },
+          File: {
+            type: :object,
+            properties: {
+              id: {
+                type: :string,
+                description: "The ID of the file.",
+              },
+              name: {
+                type: :string,
+                description: "The name of the file.",
+              },
+              size: {
+                type: :integer,
+                description: "The size of the file in bytes.",
+              },
+              type: {
+                type: :string,
+                description: "The type of the file. e.g. image/png, application/pdf, etc.",
+              },
+              url: {
+                type: :string,
+                format: "url",
+                description: "The signed URL to download the file.",
               },
             },
           },

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -244,6 +244,8 @@ components:
           "$ref": "#/components/schemas/Submitter"
         submission_data:
           "$ref": "#/components/schemas/SubmissionData"
+        raw_h2k_files:
+          "$ref": "#/components/schemas/FileSubmissionValue"
     SubmissionData:
       type: object
       description: 'The submitted permit application data. Note: the keys are the

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -245,7 +245,12 @@ components:
         submission_data:
           "$ref": "#/components/schemas/SubmissionData"
         raw_h2k_files:
-          "$ref": "#/components/schemas/FileSubmissionValue"
+          description: 'The raw h2k files uploaded by the submitter. Note: the urls
+            are signed and will expire after 1 hour.'
+          type: array
+          items:
+            "$ref": "#/components/schemas/File"
+          nullable: true
     SubmissionData:
       type: object
       description: 'The submitted permit application data. Note: the keys are the
@@ -370,24 +375,26 @@ components:
         the urls are signed and will expire after 1 hour .'
       type: array
       items:
-        type: object
-        properties:
-          id:
-            type: string
-            description: The ID of the file.
-          name:
-            type: string
-            description: The name of the file.
-          size:
-            type: integer
-            description: The size of the file in bytes.
-          type:
-            type: string
-            description: The type of the file. e.g. image/png, application/pdf, etc.
-          url:
-            type: string
-            format: url
-            description: The signed URL to download the file.
+        "$ref": "#/components/schemas/File"
+    File:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The ID of the file.
+        name:
+          type: string
+          description: The name of the file.
+        size:
+          type: integer
+          description: The size of the file in bytes.
+        type:
+          type: string
+          description: The type of the file. e.g. image/png, application/pdf, etc.
+        url:
+          type: string
+          format: url
+          description: The signed URL to download the file.
     Submitter:
       type: object
       description: The submitter of the permit application.

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -240,6 +240,8 @@ components:
           "$ref": "#/components/schemas/PermitClassification"
         activity:
           "$ref": "#/components/schemas/PermitClassification"
+        submitter:
+          "$ref": "#/components/schemas/Submitter"
         submission_data:
           "$ref": "#/components/schemas/SubmissionData"
     SubmissionData:
@@ -384,6 +386,16 @@ components:
             type: string
             format: url
             description: The signed URL to download the file.
+    Submitter:
+      type: object
+      description: The submitter of the permit application.
+      properties:
+        id:
+          type: string
+          description: The ID of the submitter.
+        email:
+          type: string
+          description: The email of the submitter.
     ResponseError:
       type: object
       properties:

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -23,12 +23,13 @@ info:
     If this occurs, we recommend spacing out your requests. Continued exceeding of
     rate limits\nmay necessitate further contact with the building permit hub team.\n\n###
     Api base path:\nThe base path for all API endpoints is `/external_api/v1`.\n\n###
-    Server information for testing:\nFor testing purposes, please use the server located
-    at {serverUrl}. The computed URL for API interactions is https://buildingpermit.gov.bc.ca.\nDuring
-    your integration testing phase, you have the flexibility to use custom URLs by
-    configuring the serverUrl variable. This allows you to\ntailor the API environment
-    to better suit your development needs. Ensure that your custom URLs are configured
-    correctly to avoid any connectivity or data access issues.\n\n### Special considerations:\nFor
+    Server information for testing:\nBy default the requests from the documentation
+    will be sent to the current environment servers. For testing purposes, you can
+    specify a different server using the {serverUrl} variable. \nDuring your integration
+    testing phase, you have the flexibility to use custom URLs by configuring the
+    serverUrl variable. This allows you to\ntailor the API environment to better suit
+    your development needs. Ensure that your custom URLs are configured correctly
+    to avoid any connectivity or data access issues.\n\n### Special considerations:\nFor
     security purposes, any API response that includes a file URL will have a signed
     URL. These files will be available for download for a limited time (1 hour).\nWe
     recommend downloading the file immediately upon receiving the URL to avoid any
@@ -185,11 +186,10 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ResponseError"
-basePath: "/external_api/v1"
 servers:
-- url: https:/buildingpermit.gov.bc.ca
-  description: Production server
-- url: "{serverUrl}"
+- url: "/external_api/v1"
+  description: Current environment server
+- url: "{serverUrl}/external_api/v1"
   description: Server url
   variables:
     serverUrl:

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -28,10 +28,14 @@ info:
     your integration testing phase, you have the flexibility to use custom URLs by
     configuring the serverUrl variable. This allows you to\ntailor the API environment
     to better suit your development needs. Ensure that your custom URLs are configured
-    correctly to avoid any connectivity or data access issues.\n\n### Visual aids
-    and examples:\nFor a better understanding of how our APIs work, including webhook
-    setups and request handling, please refer to the code examples included later\nin
-    this document.\n"
+    correctly to avoid any connectivity or data access issues.\n\n### Special considerations:\nFor
+    security purposes, any API response that includes a file URL will have a signed
+    URL. These files will be available for download for a limited time (1 hour).\nWe
+    recommend downloading the file immediately upon receiving the URL to avoid any
+    issues. If necessary, you can always call the API again to retrieve a \nnew file
+    URL.\n\n### Visual aids and examples:\nFor a better understanding of how our APIs
+    work, including webhook setups and request handling, please refer to the code
+    examples included later\nin this document.\n"
 webhooks:
   permit_submitted:
     tags:
@@ -297,6 +301,7 @@ components:
                   - type: boolean
                   - "$ref": "#/components/schemas/ContactSubmissionValue"
                   - "$ref": "#/components/schemas/MultiOptionSubmissionValue"
+                  - "$ref": "#/components/schemas/FileSubmissionValue"
               required:
               - id
               - name
@@ -323,10 +328,15 @@ components:
           description: The code of the permit classification.
     MultiOptionSubmissionValue:
       type: object
+      description: The submission value for requirement input types, which are limited
+        to a set of options. e.g. an option from a select drop down, or checkboxes
       additionalProperties:
         type: boolean
+        description: The key is the option value, and the value is a boolean indicating
+          if the option was selected.
     ContactSubmissionValue:
       type: array
+      description: The contact submission value. It is an array of contact objects
       items:
         type: object
         properties:
@@ -351,6 +361,29 @@ components:
           organization:
             type: string
             description: The organization of the contact.
+    FileSubmissionValue:
+      description: 'The file submission value. It is an array of file objects. Note:
+        the urls are signed and will expire after 1 hour .'
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+            description: The ID of the file.
+          name:
+            type: string
+            description: The name of the file.
+          size:
+            type: integer
+            description: The size of the file in bytes.
+          type:
+            type: string
+            description: The type of the file. e.g. image/png, application/pdf, etc.
+          url:
+            type: string
+            format: url
+            description: The signed URL to download the file.
     ResponseError:
       type: object
       properties:


### PR DESCRIPTION
## Description
- Adds the ability for the external API to handle files.
- Adds energy step code files
- Also adds submitter info in the api
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [X ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1340
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
### Pre rquisite
- Generate an API key for jurisdiction of choice
- Ensure there is a template with files and energy step code published
- As a submitted create and submit a permit application with the above template in the jurisdiction of the api

### QA
- visit `/integrations/api_docs`, route to access the swagger documentation for the external api 
- enter api token for authorizing
- call the search end point
- in the returned data, you should be able to see file requirements and energy step code files
![Screenshot 2024-05-31 at 4 16 39 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/11808c10-df71-48cd-9112-26fa9b2bf94e)
![Screenshot 2024-05-31 at 4 18 31 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/d028421b-9b18-497e-9f8a-1f7822f36122)
![Screenshot 2024-05-31 at 4 18 56 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/65bddeb4-f6cb-471d-b9a9-53b88f5a65d4)

