### PR TITLE
BPHH-1507 - fix autosave re-render

### DIFF
--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -202,7 +202,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
         color="greys.white"
         position="sticky"
         top="0"
-        zIndex={10}
+        zIndex={12}
         flexDirection={{ base: "column", md: "row" }}
       >
         <HStack gap={4} flex={1}>

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -307,17 +307,7 @@ export const RequirementForm = observer(
           }}
         >
           {permitApplication.isLoading && (
-            <Center
-              position="absolute"
-              top={0}
-              left={0}
-              right={0}
-              zIndex={12}
-              h="100vh"
-              w="full"
-              bg="greys.grey03"
-              opacity={0.5}
-            >
+            <Center position="absolute" top={0} left={0} right={0} zIndex={12} h="100vh" w="full" bg="greys.overlay">
               <SharedSpinner h={24} w={24} />
             </Center>
           )}

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Center,
   Flex,
   Heading,
   Link,
@@ -283,8 +284,6 @@ export const RequirementForm = observer(
       }
     }
 
-    if (permitApplication.isLoading) return <SharedSpinner />
-
     return (
       <>
         <Flex
@@ -307,6 +306,22 @@ export const RequirementForm = observer(
             },
           }}
         >
+          {permitApplication.isLoading && (
+            <Center
+              position="absolute"
+              top={0}
+              left={0}
+              right={0}
+              zIndex={12}
+              h="100vh"
+              w="full"
+              bg="greys.grey03"
+              opacity={0.5}
+            >
+              <SharedSpinner h={24} w={24} />
+            </Center>
+          )}
+
           <ErrorsBox data={errorBoxData} />
           {(!usesPublishedTemplateVersion || permitApplication.showCompareAfter) &&
             (permitApplication.diff ? (

--- a/app/frontend/styles/theme/foundations/colors.ts
+++ b/app/frontend/styles/theme/foundations/colors.ts
@@ -19,6 +19,7 @@ export const colors = {
     },
   },
   greys: {
+    overlay: "rgba(150, 150, 150, 0.35)",
     white: "#FFFFFF",
     grey01: "#A19F9D",
     grey02: "#E1DFDD",


### PR DESCRIPTION
use an overlay loading component on save instead of fully re-rendering form

## Description

the loading spinner on form update was interfereing with some complicated timing and rendering logic with the submitter form. This simply displays a loading overlay instead of re-rendering the entire form, which is more performant, and does not interfere with the re-registering of scroll listeners etc.



bonus: fix a z indexing issue where red asterisks were over the blue bar.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1507

## Steps to QA

see card