### PR TITLE
Feature/bphh 1510/jurisdiction field map api

### DIFF
--- a/app/blueprints/jurisdiction_integration_requirements_mapping_blueprint.rb
+++ b/app/blueprints/jurisdiction_integration_requirements_mapping_blueprint.rb
@@ -1,0 +1,5 @@
+class JurisdictionIntegrationRequirementsMappingBlueprint < Blueprinter::Base
+  identifier :id
+
+  fields :jurisdiction_id, :requirements_mapping
+end

--- a/app/controllers/api/jurisdiction_integration_requirements_mappings_controller.rb
+++ b/app/controllers/api/jurisdiction_integration_requirements_mappings_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class Api::JurisdictionIntegrationRequirementsMappingsController < Api::ApplicationController
+  before_action :set_jurisdiction_integration_requirements_mapping, only: %i[update]
+
+  def update
+    authorize @jurisdiction_integration_requirements_mapping
+
+    if @jurisdiction_integration_requirements_mapping.update_requirements_mapping(
+         jurisdiction_integration_requirements_mapping_params.to_h[:simplified_map],
+       )
+      render_success @jurisdiction_integration_requirements_mapping,
+                     "jurisdiction_integration_requirements_mapping.update_success"
+    else
+      render_error "jurisdiction_integration_requirements_mapping.update_error"
+    end
+  end
+
+  private
+
+  def set_jurisdiction_integration_requirements_mapping
+    @jurisdiction_integration_requirements_mapping = JurisdictionIntegrationRequirementsMapping.find(params[:id])
+  end
+
+  def jurisdiction_integration_requirements_mapping_params
+    params.require(:jurisdiction_integration_requirements_mapping).permit(simplified_map: {})
+  end
+end

--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -3,7 +3,8 @@ class Api::TemplateVersionsController < Api::ApplicationController
 
   before_action :set_jurisdiction_template_version_customization,
                 only: %i[
-                  show_jurisdiction_template_version_cutomization
+                  show_jurisdiction_template_version_customization
+                  show_jurisdiction_integration_requirements_mapping
                   download_customization_csv
                   download_customization_json
                 ]
@@ -25,7 +26,7 @@ class Api::TemplateVersionsController < Api::ApplicationController
     render_success @template_version, nil, { blueprint: TemplateVersionBlueprint, blueprint_opts: { view: :extended } }
   end
 
-  def show_jurisdiction_template_version_cutomization
+  def show_jurisdiction_template_version_customization
     authorize @template_version, :show?
 
     return head :not_found if @jurisdiction_template_version_customization.blank?
@@ -35,7 +36,7 @@ class Api::TemplateVersionsController < Api::ApplicationController
     render_success @jurisdiction_template_version_customization
   end
 
-  def create_or_update_jurisdiction_template_version_cutomization
+  def create_or_update_jurisdiction_template_version_customization
     authorize @template_version, :show?
 
     @jurisdiction_template_version_customization =
@@ -57,6 +58,23 @@ class Api::TemplateVersionsController < Api::ApplicationController
                        error_message: @jurisdiction_template_version_customization.errors.full_messages.join(", "),
                      }
       end
+    end
+  end
+
+  def show_jurisdiction_integration_requirements_mapping
+    authorize @template_version, :show?
+
+    @jurisdiction_integration_requirements_mapping =
+      @template_version.jurisdiction_integration_requirements_mappings.find_by(
+        jurisdiction_id: params[:jurisdiction_id],
+      )
+
+    authorize @jurisdiction_integration_requirements_mapping, policy_class: TemplateVersionPolicy
+
+    if @jurisdiction_integration_requirements_mapping.present?
+      render_success @jurisdiction_integration_requirements_mapping
+    else
+      render_error "jurisdiction_integration_requirements_mapping.not_found_error", status: 404
     end
   end
 

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -163,7 +163,10 @@ class Jurisdiction < ApplicationRecord
     return unless external_api_enabled?
 
     relevant_template_versions =
-      TemplateVersion.published.or(TemplateVersion.deprecated.where(deprecation_reason: "new_publish"))
+      TemplateVersion
+        .published
+        .or(TemplateVersion.deprecated.where(deprecation_reason: "new_publish"))
+        .order(version_date: :asc)
 
     existing_mapping_template_ids = jurisdiction_integration_requirements_mappings.pluck(:template_version_id)
 

--- a/app/models/jurisdiction_integration_requirements_mapping.rb
+++ b/app/models/jurisdiction_integration_requirements_mapping.rb
@@ -18,15 +18,36 @@ class JurisdictionIntegrationRequirementsMapping < ApplicationRecord
 
   before_create :initialize_requirements_mapping
 
+  after_save :sync_changes_with_other_currently_active_mappings
+
+  attr_accessor :simplified_map_to_sync
+
   # Updates the requirements mapping of the current model instance.
   # This method takes a simplified map of the requirements and updates the existing mapping accordingly.
   # The simplified map should be a hash where each key is a requirement block SKU and the value is another hash.
   # The inner hash should have requirement codes as keys and local system mapping as values.
+  #
+  # Unless explicitly ignored, the method will also set the simplified_map_to_sync attribute to the given simplified_map,
+  # which will be used to sync the changes with other currently active mappings.
+  #
   # Note: mappings which does now exist in the original mapping will not be created.
   # @param simplified_map [Hash] the simplified map of requirements
+  # @param skip_sync [Boolean] whether to ignore syncing the changes with other currently active mappings
   # @return [Boolean] true if the update was successful, false otherwise
-  def update_requirements_mapping(simplified_map)
-    JurisdictionIntegrationRequirementsMappingService.new(self).update_requirements_mapping(simplified_map)
+  def update_requirements_mapping(simplified_map, skip_sync = false)
+    self.with_lock do
+      new_requirements_mapping =
+        JurisdictionIntegrationRequirementsMappingService.new(self).get_updated_requirements_mapping(simplified_map)
+
+      unless new_requirements_mapping.blank? || self.requirements_mapping == new_requirements_mapping
+        self.simplified_map_to_sync = simplified_map unless skip_sync
+        self.requirements_mapping = new_requirements_mapping
+
+        return self.save
+      end
+    end
+
+    false
   end
 
   # This method is used to return a copyable record with existing mapping
@@ -50,5 +71,27 @@ class JurisdictionIntegrationRequirementsMapping < ApplicationRecord
 
   def initialize_requirements_mapping
     JurisdictionIntegrationRequirementsMappingService.new(self).initialize_requirements_mapping!
+  end
+
+  # Synchronizes changes with other currently active mappings for published template versions.
+  # This method is called after the requirements mapping of the current instance is updated.
+  # It iterates over all other active mappings for the same jurisdiction that are associated with a published template version.
+  # For each of these mappings, it updates their requirements mapping with the simplified map of the current instance.
+  # The simplified map is a hash where each key is a requirement block SKU and the value is another hash.
+  # The inner hash has requirement codes as keys and local system mapping as values.
+  # The method ignores the current instance during this process and also marks the other mapping to not do the same syncing process.
+  # Note: This method does nothing if the simplified map to sync is not present or is not a hash.
+  #
+  # @return [void]
+  def sync_changes_with_other_currently_active_mappings
+    return unless simplified_map_to_sync.present? && simplified_map_to_sync.is_a?(Hash)
+
+    active_mappings =
+      JurisdictionIntegrationRequirementsMapping
+        .joins(:template_version)
+        .where(jurisdiction_id: jurisdiction_id, template_versions: { status: "published" })
+        .where.not(id: id)
+
+    active_mappings.each { |mapping| mapping.update_requirements_mapping(simplified_map_to_sync, true) }
   end
 end

--- a/app/models/jurisdiction_integration_requirements_mapping.rb
+++ b/app/models/jurisdiction_integration_requirements_mapping.rb
@@ -18,6 +18,17 @@ class JurisdictionIntegrationRequirementsMapping < ApplicationRecord
 
   before_create :initialize_requirements_mapping
 
+  # Updates the requirements mapping of the current model instance.
+  # This method takes a simplified map of the requirements and updates the existing mapping accordingly.
+  # The simplified map should be a hash where each key is a requirement block SKU and the value is another hash.
+  # The inner hash should have requirement codes as keys and local system mapping as values.
+  # Note: mappings which does now exist in the original mapping will not be created.
+  # @param simplified_map [Hash] the simplified map of requirements
+  # @return [Boolean] true if the update was successful, false otherwise
+  def update_requirements_mapping(simplified_map)
+    JurisdictionIntegrationRequirementsMappingService.new(self).update_requirements_mapping(simplified_map)
+  end
+
   # This method is used to return a copyable record with existing mapping
   # for a given requirement block sku and requirement code.
   # It returns the first record with a published template version if it exists,
@@ -38,6 +49,6 @@ class JurisdictionIntegrationRequirementsMapping < ApplicationRecord
   private
 
   def initialize_requirements_mapping
-    JurisdictionIntegrationRequirementsMappingService.new(self).initialize_requirements_mapping
+    JurisdictionIntegrationRequirementsMappingService.new(self).initialize_requirements_mapping!
   end
 end

--- a/app/models/jurisdiction_integration_requirements_mapping.rb
+++ b/app/models/jurisdiction_integration_requirements_mapping.rb
@@ -27,81 +27,17 @@ class JurisdictionIntegrationRequirementsMapping < ApplicationRecord
   # @param requirement_code [String] the code of the requirement
   #
   # @return [JurisdictionIntegrationRequirementsMapping] the copyable record with existing mapping
+
   def copyable_record_with_existing_mapping(requirement_block_sku, requirement_code)
-    records_with_existing_mapping =
-      JurisdictionIntegrationRequirementsMapping
-        .joins(:template_version)
-        .where(jurisdiction: jurisdiction)
-        .where.not(id: id)
-        .where(
-          "requirements_mapping -> :requirement_block_sku -> 'requirements' -> :requirement_code ->> 'local_system_mapping' IS NOT NULL AND " \
-            "requirements_mapping -> :requirement_block_sku -> 'requirements' -> :requirement_code ->> 'local_system_mapping' <> ''",
-          requirement_block_sku: requirement_block_sku,
-          requirement_code: requirement_code,
-        )
-        .order("template_versions.version_date DESC")
-
-    return nil if records_with_existing_mapping.empty?
-
-    records_with_published_template_version =
-      records_with_existing_mapping.joins(:template_version).where(template_versions: { status: "published" })
-
-    # prefer the record with a published template version with the same requirement template
-    # if it exists, otherwise return the first record with any published template version
-    record_with_preferred_published_template_version =
-      records_with_published_template_version
-        .joins(:template_version)
-        .where(template_versions: { requirement_template_id: template_version.requirement_template_id })
-        .first || records_with_published_template_version.first
-
-    # binding.pry if requirement_code == "code4"
-
-    # return the first record with a preferred published template version if it exists, otherwise return the first record
-    record_with_preferred_published_template_version ||
-      records_with_existing_mapping
-        .joins(:template_version)
-        .where(template_versions: { requirement_template_id: template_version.requirement_template_id })
-        .first || records_with_existing_mapping.first
+    JurisdictionIntegrationRequirementsMappingService.new(self).copyable_record_with_existing_mapping(
+      requirement_block_sku,
+      requirement_code,
+    )
   end
 
   private
 
-  # This method is used to initialize the requirements mapping for a new record.
-  # It copies existing requirements mapping from existing records with the same jurisdiction
   def initialize_requirements_mapping
-    return unless requirements_mapping.empty?
-
-    new_mappings = {}
-
-    # iterate over each requirement block blueprint in the template version
-    template_version.requirement_blocks_json.each do |requirement_block_id, requirement_block_blueprint|
-      requirements = requirement_block_blueprint["requirements"]
-      next if requirements.blank?
-
-      requirement_block_sku = requirement_block_blueprint["sku"]
-
-      new_mappings[requirement_block_sku] = { "id" => requirement_block_id, "requirements" => {} } unless new_mappings[
-        requirement_block_sku
-      ].present?
-
-      requirements.each do |requirement_blueprint|
-        requirement_id = requirement_blueprint["id"]
-        requirement_code = requirement_blueprint["requirement_code"]
-        copyable_existing_mapping =
-          copyable_record_with_existing_mapping(requirement_block_sku, requirement_code)&.requirements_mapping || {}
-        new_mappings[requirement_block_sku]["requirements"][requirement_code] = {
-          "id" => requirement_id,
-          "local_system_mapping" =>
-            copyable_existing_mapping.dig(
-              requirement_block_sku,
-              "requirements",
-              requirement_code,
-              "local_system_mapping",
-            ) || "",
-        }
-      end
-    end
-
-    self.requirements_mapping = new_mappings
+    JurisdictionIntegrationRequirementsMappingService.new(self).initialize_requirements_mapping
   end
 end

--- a/app/models/jurisdiction_integration_requirements_mapping.rb
+++ b/app/models/jurisdiction_integration_requirements_mapping.rb
@@ -39,7 +39,10 @@ class JurisdictionIntegrationRequirementsMapping < ApplicationRecord
       new_requirements_mapping =
         JurisdictionIntegrationRequirementsMappingService.new(self).get_updated_requirements_mapping(simplified_map)
 
-      unless new_requirements_mapping.blank? || self.requirements_mapping == new_requirements_mapping
+      # nothing to update, so returns true
+      return true if self.requirements_mapping == new_requirements_mapping
+
+      unless new_requirements_mapping.blank?
         self.simplified_map_to_sync = simplified_map unless skip_sync
         self.requirements_mapping = new_requirements_mapping
 

--- a/app/models/jurisdiction_integration_requirements_mapping.rb
+++ b/app/models/jurisdiction_integration_requirements_mapping.rb
@@ -1,0 +1,107 @@
+class JurisdictionIntegrationRequirementsMapping < ApplicationRecord
+  # The JurisdictionIntegrationRequirementsMapping model represents the mapping
+  # between jurisdictions local system fields and template versions fields.
+
+  # The schema of the request_mapping is as follows:
+  # {
+  #  [requirement_block_sku]: {
+  #   id: [requirement_block_id],
+  #  requirements: {
+  #   [requirement_code]: {
+  #   id: [requirement_id],
+  #  local_system_mapping: local_system_field_attribute}
+  # }
+  belongs_to :jurisdiction
+  belongs_to :template_version
+
+  validates_uniqueness_of :template_version_id, scope: :jurisdiction_id
+
+  before_create :initialize_requirements_mapping
+
+  # This method is used to return a copyable record with existing mapping
+  # for a given requirement block sku and requirement code.
+  # It returns the first record with a published template version if it exists,
+  # otherwise it returns the first record.
+  #
+  # @param requirement_block_sku [String] the sku of the requirement block
+  # @param requirement_code [String] the code of the requirement
+  #
+  # @return [JurisdictionIntegrationRequirementsMapping] the copyable record with existing mapping
+  def copyable_record_with_existing_mapping(requirement_block_sku, requirement_code)
+    records_with_existing_mapping =
+      JurisdictionIntegrationRequirementsMapping
+        .joins(:template_version)
+        .where(jurisdiction: jurisdiction)
+        .where.not(id: id)
+        .where(
+          "requirements_mapping -> :requirement_block_sku -> 'requirements' -> :requirement_code ->> 'local_system_mapping' IS NOT NULL AND " \
+            "requirements_mapping -> :requirement_block_sku -> 'requirements' -> :requirement_code ->> 'local_system_mapping' <> ''",
+          requirement_block_sku: requirement_block_sku,
+          requirement_code: requirement_code,
+        )
+        .order("template_versions.version_date DESC")
+
+    return nil if records_with_existing_mapping.empty?
+
+    records_with_published_template_version =
+      records_with_existing_mapping.joins(:template_version).where(template_versions: { status: "published" })
+
+    # prefer the record with a published template version with the same requirement template
+    # if it exists, otherwise return the first record with any published template version
+    record_with_preferred_published_template_version =
+      records_with_published_template_version
+        .joins(:template_version)
+        .where(template_versions: { requirement_template_id: template_version.requirement_template_id })
+        .first || records_with_published_template_version.first
+
+    # binding.pry if requirement_code == "code4"
+
+    # return the first record with a preferred published template version if it exists, otherwise return the first record
+    record_with_preferred_published_template_version ||
+      records_with_existing_mapping
+        .joins(:template_version)
+        .where(template_versions: { requirement_template_id: template_version.requirement_template_id })
+        .first || records_with_existing_mapping.first
+  end
+
+  private
+
+  # This method is used to initialize the requirements mapping for a new record.
+  # It copies existing requirements mapping from existing records with the same jurisdiction
+  def initialize_requirements_mapping
+    return unless requirements_mapping.empty?
+
+    new_mappings = {}
+
+    # iterate over each requirement block blueprint in the template version
+    template_version.requirement_blocks_json.each do |requirement_block_id, requirement_block_blueprint|
+      requirements = requirement_block_blueprint["requirements"]
+      next if requirements.blank?
+
+      requirement_block_sku = requirement_block_blueprint["sku"]
+
+      new_mappings[requirement_block_sku] = { "id" => requirement_block_id, "requirements" => {} } unless new_mappings[
+        requirement_block_sku
+      ].present?
+
+      requirements.each do |requirement_blueprint|
+        requirement_id = requirement_blueprint["id"]
+        requirement_code = requirement_blueprint["requirement_code"]
+        copyable_existing_mapping =
+          copyable_record_with_existing_mapping(requirement_block_sku, requirement_code)&.requirements_mapping || {}
+        new_mappings[requirement_block_sku]["requirements"][requirement_code] = {
+          "id" => requirement_id,
+          "local_system_mapping" =>
+            copyable_existing_mapping.dig(
+              requirement_block_sku,
+              "requirements",
+              requirement_code,
+              "local_system_mapping",
+            ) || "",
+        }
+      end
+    end
+
+    self.requirements_mapping = new_mappings
+  end
+end

--- a/app/models/template_version.rb
+++ b/app/models/template_version.rb
@@ -6,6 +6,7 @@ class TemplateVersion < ApplicationRecord
   has_many :jurisdiction_template_version_customizations
   has_many :permit_applications
   has_many :submitters, through: :permit_applications
+  has_many :jurisdiction_integration_requirements_mappings
 
   delegate :permit_type, to: :requirement_template
   delegate :activity, to: :requirement_template
@@ -21,6 +22,7 @@ class TemplateVersion < ApplicationRecord
   before_validation :set_default_deprecation_reason
 
   after_save :reindex_requirement_template_if_published, if: :status_changed?
+  after_save :create_integration_requirements_mappings
 
   def label
     "#{permit_type.name} #{activity.name} (#{version_date.to_s})"
@@ -66,6 +68,20 @@ class TemplateVersion < ApplicationRecord
   end
 
   private
+
+  def create_integration_requirements_mappings
+    return unless published? && saved_change_to_status?
+
+    api_enabled_jurisdictions = Jurisdiction.where(external_api_enabled: true)
+
+    existing_mapping_jurisdiction_ids = jurisdiction_integration_requirements_mappings.pluck(:jurisdiction_id)
+
+    jurisdictions_without_mappings = api_enabled_jurisdictions.where.not(id: existing_mapping_jurisdiction_ids)
+
+    jurisdictions_without_mappings.each do |jurisdiction|
+      jurisdiction_integration_requirements_mappings.create(jurisdiction: jurisdiction)
+    end
+  end
 
   def set_default_deprecation_reason
     return unless deprecated? && deprecation_reason.nil?

--- a/app/policies/jurisdiction_integration_requirements_mapping_policy.rb
+++ b/app/policies/jurisdiction_integration_requirements_mapping_policy.rb
@@ -1,0 +1,8 @@
+class JurisdictionIntegrationRequirementsMappingPolicy < ApplicationPolicy
+  def update?
+    (
+      (user.review_manager? || user.regional_review_manager?) && record.jurisdiction.external_api_enabled? &&
+        user.jurisdictions.find(record.jurisdiction_id)
+    )
+  end
+end

--- a/app/policies/template_version_policy.rb
+++ b/app/policies/template_version_policy.rb
@@ -28,8 +28,7 @@ class TemplateVersionPolicy < ApplicationPolicy
   end
 
   def show_jurisdiction_integration_requirements_mapping?
-    user.super_admin? ||
-      ((user.review_manager? || user.regional_review_manager?) && user.jurisdictions.find(record.jurisdiction_id))
+    ((user.review_manager? || user.regional_review_manager?) && user.jurisdictions.find(record.jurisdiction_id))
   end
 
   def compare_requirements?

--- a/app/policies/template_version_policy.rb
+++ b/app/policies/template_version_policy.rb
@@ -7,7 +7,7 @@ class TemplateVersionPolicy < ApplicationPolicy
     !record.scheduled? || user.super_admin?
   end
 
-  def show_jurisdiction_template_version_cutomization?
+  def show_jurisdiction_template_version_customization?
     true
   end
 
@@ -23,8 +23,13 @@ class TemplateVersionPolicy < ApplicationPolicy
     download_summary_csv?
   end
 
-  def create_or_update_jurisdiction_template_version_cutomization?
+  def create_or_update_jurisdiction_template_version_customization?
     (user.review_manager? || user.regional_review_manager?) && user.jurisdictions.find(record.jurisdiction_id)
+  end
+
+  def show_jurisdiction_integration_requirements_mapping?
+    user.super_admin? ||
+      ((user.review_manager? || user.regional_review_manager?) && user.jurisdictions.find(record.jurisdiction_id))
   end
 
   def compare_requirements?

--- a/app/services/jurisdiction_integration_requirements_mapping_service.rb
+++ b/app/services/jurisdiction_integration_requirements_mapping_service.rb
@@ -11,7 +11,7 @@ class JurisdictionIntegrationRequirementsMappingService
   # @param simplified_map [Hash] the simplified map of requirements
   # @return requirement_mapping [HASH] updated requirements mapping hash
   def get_updated_requirements_mapping(simplified_map)
-    return unless simplified_map.present? && simplified_map.is_a?(Hash)
+    return unless simplified_map.is_a?(Hash)
 
     updated_mapping = @mapping.requirements_mapping.deep_dup
 

--- a/app/services/jurisdiction_integration_requirements_mapping_service.rb
+++ b/app/services/jurisdiction_integration_requirements_mapping_service.rb
@@ -1,0 +1,94 @@
+class JurisdictionIntegrationRequirementsMappingService
+  def initialize(jurisdiction_integration_requirements_mapping)
+    @mapping = jurisdiction_integration_requirements_mapping
+  end
+
+  def initialize_requirements_mapping
+    return unless @mapping.requirements_mapping.empty?
+
+    new_mappings = {}
+
+    @mapping.template_version.requirement_blocks_json.each do |requirement_block_id, requirement_block_blueprint|
+      requirements = requirement_block_blueprint["requirements"]
+      next if requirements.blank?
+
+      requirement_block_sku = requirement_block_blueprint["sku"]
+
+      new_mappings[requirement_block_sku] = { "id" => requirement_block_id, "requirements" => {} } unless new_mappings[
+        requirement_block_sku
+      ].present?
+
+      requirements.each do |requirement_blueprint|
+        requirement_id = requirement_blueprint["id"]
+        requirement_code = requirement_blueprint["requirement_code"]
+        copyable_existing_mapping =
+          copyable_record_with_existing_mapping(requirement_block_sku, requirement_code)&.requirements_mapping || {}
+        new_mappings[requirement_block_sku]["requirements"][requirement_code] = {
+          "id" => requirement_id,
+          "local_system_mapping" =>
+            copyable_existing_mapping.dig(
+              requirement_block_sku,
+              "requirements",
+              requirement_code,
+              "local_system_mapping",
+            ) || "",
+        }
+      end
+    end
+
+    @mapping.requirements_mapping = new_mappings
+  end
+
+  # This method is used to return a copyable record with existing mapping
+  # for a given requirement block sku and requirement code.
+  # It returns the first record with a published template version if it exists,
+  # otherwise it returns the first record.
+  #
+  # @param requirement_block_sku [String] the sku of the requirement block
+  # @param requirement_code [String] the code of the requirement
+  #
+  # @return [JurisdictionIntegrationRequirementsMapping] the copyable record with existing mapping
+
+  def copyable_record_with_existing_mapping(requirement_block_sku, requirement_code)
+    records_with_existing_mapping = fetch_records_with_existing_mapping(requirement_block_sku, requirement_code)
+    return nil if records_with_existing_mapping.empty?
+
+    fetch_preferred_mapping_record_for_copy(records_with_existing_mapping)
+  end
+
+  private
+
+  def fetch_records_with_existing_mapping(requirement_block_sku, requirement_code)
+    JurisdictionIntegrationRequirementsMapping
+      .joins(:template_version)
+      .where(jurisdiction: @mapping.jurisdiction)
+      .where.not(id: @mapping.id)
+      .where(
+        "requirements_mapping -> :requirement_block_sku -> 'requirements' -> :requirement_code ->> 'local_system_mapping' IS NOT NULL AND " \
+          "requirements_mapping -> :requirement_block_sku -> 'requirements' -> :requirement_code ->> 'local_system_mapping' <> ''",
+        requirement_block_sku: requirement_block_sku,
+        requirement_code: requirement_code,
+      )
+      .order("template_versions.version_date DESC")
+  end
+
+  def fetch_preferred_mapping_record_for_copy(records_with_existing_mapping)
+    records_with_published_template_version =
+      records_with_existing_mapping.joins(:template_version).where(template_versions: { status: "published" })
+
+    # prefer the record with a published template version with the same requirement template
+    # if it exists, otherwise return the first record with any published template version
+    record_with_preferred_published_template_version =
+      records_with_published_template_version
+        .joins(:template_version)
+        .where(template_versions: { requirement_template_id: @mapping.template_version.requirement_template_id })
+        .first || records_with_published_template_version.first
+
+    # return the first record with a preferred published template version if it exists, otherwise return the first record
+    record_with_preferred_published_template_version ||
+      records_with_existing_mapping
+        .joins(:template_version)
+        .where(template_versions: { requirement_template_id: @mapping.template_version.requirement_template_id })
+        .first || records_with_existing_mapping.first
+  end
+end

--- a/app/services/jurisdiction_integration_requirements_mapping_service.rb
+++ b/app/services/jurisdiction_integration_requirements_mapping_service.rb
@@ -3,33 +3,31 @@ class JurisdictionIntegrationRequirementsMappingService
     @mapping = jurisdiction_integration_requirements_mapping
   end
 
-  # Updates the requirements mapping of the jurisdiction integration requirements mapping instance.
-  # This method takes a simplified map of the requirements and updates the existing mapping accordingly.
+  # Returns an new requirements mapping hash for the jurisdiction_integration_requirements_mapping instance.
+  # This method takes a simplified map of the requirements and returns an updated requirements mapping hash.
   # The simplified map should be a hash where each key is a requirement block SKU and the value is another hash.
   # The inner hash should have requirement codes as keys and local system mapping as values.
-  # Note: mappings which does now exist in the original mapping will not be created.
+  # Note: mappings which does now exist in the original mapping will not be added to the returned hash.
   # @param simplified_map [Hash] the simplified map of requirements
-  # @return [Boolean] true if the update was successful, false otherwise
-  def update_requirements_mapping(simplified_map)
+  # @return requirement_mapping [HASH] updated requirements mapping hash
+  def get_updated_requirements_mapping(simplified_map)
     return unless simplified_map.present? && simplified_map.is_a?(Hash)
 
     updated_mapping = @mapping.requirements_mapping.deep_dup
 
-    updated_mapping.with_lock do
-      simplified_map.each do |requirement_block_sku, requirements|
-        next unless requirements.is_a?(Hash) && updated_mapping[requirement_block_sku].present?
+    simplified_map.each do |requirement_block_sku, requirements|
+      next unless requirements.is_a?(Hash) && updated_mapping[requirement_block_sku].present?
 
-        requirements.each do |requirement_code, local_system_mapping|
-          next unless updated_mapping[requirement_block_sku]["requirements"][requirement_code].present?
+      requirements.each do |requirement_code, local_system_mapping|
+        next unless updated_mapping[requirement_block_sku]["requirements"][requirement_code].present?
 
-          updated_mapping[requirement_block_sku]["requirements"][requirement_code][
-            "local_system_mapping"
-          ] = local_system_mapping
-        end
+        updated_mapping[requirement_block_sku]["requirements"][requirement_code][
+          "local_system_mapping"
+        ] = local_system_mapping
       end
     end
 
-    @mapping.update(requirements_mapping: updated_mapping)
+    updated_mapping
   end
 
   # Initializes the requirements mapping of the jurisdiction integration requirements mapping instance.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -404,6 +404,12 @@ en:
         title: Error
         message: "Something went wrong updating Jurisdiction Customization"
     jurisdiction_integration_requirements_mapping:
+      update_success:
+        title: ""
+        message: "integrations mapping updated!"
+      update_error:
+        title: Error
+        message: "Something went wrong updating integration requirements mapping"
       not_found_error:
         title: "Error"
         message: 404 - The requested resource could not be found

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,6 +403,10 @@ en:
       update_error:
         title: Error
         message: "Something went wrong updating Jurisdiction Customization"
+    jurisdiction_integration_requirements_mapping:
+      not_found_error:
+        title: "Error"
+        message: 404 - The requested resource could not be found
   services:
     auto_compliance_configuration:
       digital_seal_validator:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,17 +76,21 @@ Rails.application.routes.draw do
 
     resources :template_versions, only: %i[index show] do
       get "compare_requirements", to: "template_versions#compare_requirements", on: :member
-    end
+      get "download_requirement_summary_csv", to: "template_versions#download_summary_csv", on: :member
 
-    get "template_versions/:id/jurisdictions/:jurisdiction_id/jurisdiction_template_version_customization" =>
-          "template_versions#show_jurisdiction_template_version_cutomization"
-    post "template_versions/:id/jurisdictions/:jurisdiction_id/jurisdiction_template_version_customization" =>
-           "template_versions#create_or_update_jurisdiction_template_version_cutomization"
-    get "template_versions/:id/download_requirement_summary_csv" => "template_versions#download_summary_csv"
-    get "template_versions/:id/jurisdictions/:jurisdiction_id/download_customization_csv" =>
-          "template_versions#download_customization_csv"
-    get "template_versions/:id/jurisdictions/:jurisdiction_id/download_customization_json" =>
-          "template_versions#download_customization_json"
+      member do
+        resources :jurisdictions, only: [] do
+          get "jurisdiction_template_version_customization",
+              to: "template_versions#show_jurisdiction_template_version_customization"
+          post "jurisdiction_template_version_customization",
+               to: "template_versions#create_or_update_jurisdiction_template_version_customization"
+          get "download_customization_csv", to: "template_versions#download_customization_csv"
+          get "download_customization_json", to: "template_versions#download_customization_json"
+          get "integration_requirements_mapping",
+              to: "template_versions#show_jurisdiction_integration_requirements_mapping"
+        end
+      end
+    end
 
     resources :jurisdictions, only: %i[index update show create] do
       post "search", on: :collection, to: "jurisdictions#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,8 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :jurisdiction_integration_requirements_mappings, only: [:update]
+
     resources :jurisdictions, only: %i[index update show create] do
       post "search", on: :collection, to: "jurisdictions#index"
       post "users/search", on: :member, to: "jurisdictions#search_users"

--- a/db/data/20240605235009_add_integration_mappings_for_jurisdictions.rb
+++ b/db/data/20240605235009_add_integration_mappings_for_jurisdictions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddIntegrationMappingsForJurisdictions < ActiveRecord::Migration[7.1]
+  def up
+    jurisdictions_wit_api_enabled = Jurisdiction.where(external_api_enabled: true)
+
+    jurisdictions_wit_api_enabled.each { |jurisdiction| jurisdiction.create_integration_requirements_mappings }
+  end
+
+  def down
+    JurisdictionIntegrationRequirementsMapping.destroy_all
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20_240_521_222_127)
+DataMigrate::Data.define(version: 20_240_605_235_009)

--- a/db/migrate/20240603205846_create_jurisdiction_integration_requirements_mappings.rb
+++ b/db/migrate/20240603205846_create_jurisdiction_integration_requirements_mappings.rb
@@ -1,0 +1,11 @@
+class CreateJurisdictionIntegrationRequirementsMappings < ActiveRecord::Migration[7.1]
+  def change
+    create_table :jurisdiction_integration_requirements_mappings, id: :uuid do |t|
+      t.jsonb :requirements_mapping, null: false, default: {}
+      t.references :jurisdiction, null: false, foreign_key: true, type: :uuid
+      t.references :template_version, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -99,6 +99,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_183218) do
     t.index ["token"], name: "index_external_api_keys_on_token", unique: true
   end
 
+  create_table "jurisdiction_integration_requirements_mappings",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
+    t.jsonb "requirements_mapping", default: {}, null: false
+    t.uuid "jurisdiction_id", null: false
+    t.uuid "template_version_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["jurisdiction_id"], name: "idx_on_jurisdiction_id_e287ac2c12"
+    t.index ["template_version_id"],
+            name: "idx_on_template_version_id_a52f2ccce5"
+  end
+
   create_table "jurisdiction_memberships",
                id: :uuid,
                default: -> { "gen_random_uuid()" },
@@ -697,6 +711,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_04_183218) do
 
   add_foreign_key "allowlisted_jwts", "users", on_delete: :cascade
   add_foreign_key "external_api_keys", "jurisdictions"
+  add_foreign_key "jurisdiction_integration_requirements_mappings",
+                  "jurisdictions"
+  add_foreign_key "jurisdiction_integration_requirements_mappings",
+                  "template_versions"
   add_foreign_key "jurisdiction_memberships", "jurisdictions"
   add_foreign_key "jurisdiction_memberships", "users"
   add_foreign_key "jurisdiction_template_version_customizations",

--- a/spec/factories/jurisdiction_integration_requirements_mapping.rb
+++ b/spec/factories/jurisdiction_integration_requirements_mapping.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :jurisdiction_integration_requirements_mapping do
+    requirements_mapping { {} }
+    association :jurisdiction, factory: :sub_district
+    association :template_version
+  end
+end

--- a/spec/factories/sub_districts.rb
+++ b/spec/factories/sub_districts.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     checklist_html { "<p>Some checklist</p>" }
     look_out_html { "<p>Some lookout</p>" }
     contact_summary_html { "<p>Some lookout</p>" }
+    external_api_enabled { false }
 
     after(:create) do |jurisdiction|
       create(:permit_type_submission_contact, jurisdiction: jurisdiction)

--- a/spec/factories/template_versions.rb
+++ b/spec/factories/template_versions.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :template_version do
-    denormalized_template_json { "{}" }
-    form_json { "{}" }
-    requirement_blocks_json { "{}" }
-    version_diff { "{}" }
+    denormalized_template_json { {} }
+    form_json { {} }
+    requirement_blocks_json { {} }
+    version_diff { {} }
     version_date { "2024-02-15" }
     status { 1 }
     requirement_template { RequirementTemplate.first || association(:requirement_template) }

--- a/spec/models/jurisdiction_integration_requirements_mapping_spec.rb
+++ b/spec/models/jurisdiction_integration_requirements_mapping_spec.rb
@@ -1,0 +1,339 @@
+require "rails_helper"
+
+RSpec.describe JurisdictionIntegrationRequirementsMapping, type: :model do
+  let(:jurisdiction) { create(:sub_district) }
+  let(:mapping) { create(:jurisdiction_integration_requirements_mapping, jurisdiction: jurisdiction) }
+  let(:mock_mapping) do
+    {
+      "sku" => {
+        "id" => "1",
+        "requirements" => {
+          "code" => {
+            "id" => "1",
+            "local_system_mapping" => "test_field",
+          },
+        },
+      },
+    }
+  end
+
+  describe "#copyable_record_with_existing_mapping" do
+    context "when there are no existing mappings" do
+      it "returns nil" do
+        expect(mapping.copyable_record_with_existing_mapping("sku", "code")).to be_nil
+      end
+    end
+
+    context "when there are existing mappings but none are published" do
+      let!(:existing_mapping) do
+        create(
+          :jurisdiction_integration_requirements_mapping,
+          jurisdiction: jurisdiction,
+          requirements_mapping: mock_mapping,
+          template_version:
+            create(:template_version, status: "deprecated", deprecation_reason: "new_publish", version_date: Time.now),
+        )
+        create(
+          :jurisdiction_integration_requirements_mapping,
+          jurisdiction: jurisdiction,
+          requirements_mapping: mock_mapping,
+          template_version:
+            create(
+              :template_version,
+              status: "deprecated",
+              deprecation_reason: "new_publish",
+              version_date: Time.now + 1.day,
+            ),
+        )
+      end
+      let!(:same_mapping_different_jurisdiction) do
+        create(:jurisdiction_integration_requirements_mapping, requirements_mapping: mock_mapping)
+      end
+
+      it "returns the latest version existing mapping for the jurisdiction" do
+        expect(mapping.copyable_record_with_existing_mapping("sku", "code")).to eq(existing_mapping)
+      end
+    end
+
+    context "when there are existing mappings and some are published" do
+      let!(:published_mapping) do
+        create(
+          :jurisdiction_integration_requirements_mapping,
+          jurisdiction: jurisdiction,
+          requirements_mapping: mock_mapping,
+        )
+      end
+      let!(:existing_mapping) do
+        create(
+          :jurisdiction_integration_requirements_mapping,
+          jurisdiction: jurisdiction,
+          requirements_mapping: mock_mapping,
+          template_version: create(:template_version, status: "deprecated", deprecation_reason: "new_publish"),
+        )
+      end
+
+      it "returns the first published mapping" do
+        expect(mapping.copyable_record_with_existing_mapping("sku", "code")).to eq(published_mapping)
+      end
+    end
+  end
+
+  describe "#initialize_requirements_mapping" do
+    context "when requirements_mapping is not empty" do
+      it "does not change requirements_mapping" do
+        mapping = create(:jurisdiction_integration_requirements_mapping, requirements_mapping: mock_mapping)
+        expect(mapping.requirements_mapping).to eq(mock_mapping)
+      end
+    end
+
+    context "when requirements_mapping is empty and there is no existing mappings for the jurisdiction" do
+      it "initializes requirements_mapping from template requirements_block_json" do
+        template_version =
+          create(
+            :template_version,
+            requirement_blocks_json: {
+              "1" => {
+                "id" => "1",
+                "sku" => "sku",
+                "requirements" => [
+                  { "id" => "1", "requirement_code" => "code" },
+                  { "id" => "2", "requirement_code" => "code2" },
+                ],
+              },
+              "2" => {
+                "id" => "2",
+                "sku" => "sku2",
+                "requirements" => [
+                  { "id" => "3", "requirement_code" => "code3" },
+                  { "id" => "4", "requirement_code" => "code4" },
+                ],
+              },
+            },
+          )
+        expected_mapping = {
+          "sku" => {
+            "id" => "1",
+            "requirements" => {
+              "code" => {
+                "id" => "1",
+                "local_system_mapping" => "",
+              },
+              "code2" => {
+                "id" => "2",
+                "local_system_mapping" => "",
+              },
+            },
+          },
+          "sku2" => {
+            "id" => "2",
+            "requirements" => {
+              "code3" => {
+                "id" => "3",
+                "local_system_mapping" => "",
+              },
+              "code4" => {
+                "id" => "4",
+                "local_system_mapping" => "",
+              },
+            },
+          },
+        }
+        mapping = create(:jurisdiction_integration_requirements_mapping, template_version: template_version)
+
+        expect(mapping.requirements_mapping).to eq(expected_mapping)
+      end
+    end
+
+    context "when requirements_mapping is empty and there is existing mappings to copy over for the jurisdiction" do
+      let!(:template_version) do
+        create(
+          :template_version,
+          requirement_blocks_json: {
+            "1" => {
+              "id" => "1",
+              "sku" => "sku",
+              "requirements" => [
+                { "id" => "1", "requirement_code" => "code" },
+                { "id" => "2", "requirement_code" => "code2" },
+              ],
+            },
+            "2" => {
+              "id" => "2",
+              "sku" => "sku2",
+              "requirements" => [
+                { "id" => "3", "requirement_code" => "code3" },
+                { "id" => "4", "requirement_code" => "code4" },
+              ],
+            },
+          },
+        )
+      end
+
+      # in test there is only one requirement template created, because of unique permit classification
+      # so we manually create a new one for this tests purposes
+      let!(:different_req_template) do
+        create(
+          :requirement_template,
+          activity: create(:activity, code: :addition_alteration_renovation),
+          permit_type: create(:permit_type, code: :demolition),
+        )
+      end
+
+      # mapping of a deprecated template version
+      let!(:existing_mapping_deprecated_ver) do
+        create(
+          :jurisdiction_integration_requirements_mapping,
+          jurisdiction: jurisdiction,
+          requirements_mapping: {
+            "sku" => {
+              "id" => "1",
+              "requirements" => {
+                "code" => {
+                  "id" => "1",
+                  "local_system_mapping" => "should_be_copied_deprecated",
+                },
+                "code2" => {
+                  "id" => "2",
+                  "local_system_mapping" => "shouldnt_be_copied",
+                },
+              },
+            },
+            "sku2" => {
+              "id" => "2",
+              "requirements" => {
+                "code3" => {
+                  "id" => "3",
+                  "local_system_mapping" => "shouldnt_be_copied",
+                },
+                "code4" => {
+                  "id" => "4",
+                  "local_system_mapping" => "shouldnt_be_copied",
+                },
+              },
+            },
+          },
+          template_version:
+            create(
+              :template_version,
+              requirement_template: different_req_template,
+              status: "deprecated",
+              deprecation_reason: "new_publish",
+            ),
+        )
+      end
+
+      # mapping of a deprecated template version from same requirement template
+      let!(:existing_mapping_deprecated_same_req_template_ver) do
+        create(
+          :jurisdiction_integration_requirements_mapping,
+          jurisdiction: jurisdiction,
+          requirements_mapping: {
+            "sku" => {
+              "id" => "1",
+              "requirements" => {
+                "code2" => {
+                  "id" => "2",
+                  "local_system_mapping" => "should_be_copied_deprecated_same_template",
+                },
+              },
+            },
+            "sku2" => {
+              "id" => "2",
+              "requirements" => {
+                "code3" => {
+                  "id" => "3",
+                  "local_system_mapping" => "shouldnt_be_copied",
+                },
+                "code4" => {
+                  "id" => "4",
+                  "local_system_mapping" => "shouldnt_be_copied",
+                },
+              },
+            },
+          },
+          template_version:
+            create(
+              :template_version,
+              requirement_template: template_version.requirement_template,
+              status: "deprecated",
+              deprecation_reason: "new_publish",
+            ),
+        )
+      end
+
+      # mapping of a published template version
+      let!(:existing_mapping_published_ver) do
+        create(
+          :jurisdiction_integration_requirements_mapping,
+          jurisdiction: jurisdiction,
+          requirements_mapping: {
+            "sku2" => {
+              "id" => "2",
+              "requirements" => {
+                "code3" => {
+                  "id" => "3",
+                  "local_system_mapping" => "should_be_copied_published",
+                },
+                "code4" => {
+                  "id" => "4",
+                  "local_system_mapping" => "shouldnt_be_copied",
+                },
+              },
+            },
+          },
+          template_version: create(:template_version, requirement_template: different_req_template),
+        )
+      end
+      # mapping of a published template version from same requirement template
+      let!(:existing_mapping_published_same_req_template_ver) do
+        create(
+          :jurisdiction_integration_requirements_mapping,
+          jurisdiction: jurisdiction,
+          requirements_mapping: {
+            "sku2" => {
+              "id" => "2",
+              "requirements" => {
+                "code4" => {
+                  "id" => "4",
+                  "local_system_mapping" => "should_be_copied_published_same_req_template",
+                },
+              },
+            },
+          },
+          template_version: create(:template_version, requirement_template: template_version.requirement_template),
+        )
+      end
+
+      let!(:new_mapping) do
+        create(
+          :jurisdiction_integration_requirements_mapping,
+          template_version: template_version,
+          jurisdiction: jurisdiction,
+        )
+      end
+
+      it "initializes requirements_mapping and successfully copies mapping from current published template from same requirement template" do
+        expect(new_mapping.requirements_mapping.dig("sku2", "requirements", "code4", "local_system_mapping")).to eq(
+          "should_be_copied_published_same_req_template",
+        )
+      end
+
+      it "initializes requirements_mapping and successfully copies mapping from any current published template when there is no published template from same requirement template" do
+        expect(new_mapping.requirements_mapping.dig("sku2", "requirements", "code3", "local_system_mapping")).to eq(
+          "should_be_copied_published",
+        )
+      end
+
+      it "initializes requirements_mapping and successfully copies mapping from deprecated template from same requirement template when there is no published template" do
+        expect(new_mapping.requirements_mapping.dig("sku", "requirements", "code2", "local_system_mapping")).to eq(
+          "should_be_copied_deprecated_same_template",
+        )
+      end
+      it "initializes requirements_mapping and successfully copies mapping from any deprecated template when there is no published template or deprecated template from same requirement template" do
+        expect(new_mapping.requirements_mapping.dig("sku", "requirements", "code", "local_system_mapping")).to eq(
+          "should_be_copied_deprecated",
+        )
+      end
+    end
+  end
+end

--- a/spec/models/jurisdiction_spec.rb
+++ b/spec/models/jurisdiction_spec.rb
@@ -9,4 +9,56 @@ RSpec.describe Jurisdiction, type: :model do
     # Testing has_many :through association
     it { should have_many(:submitters).through(:permit_applications).source(:submitter) }
   end
+
+  describe "#create_integration_requirements_mappings after_save callback on new jurisdiction" do
+    let!(:template_version_published) { create(:template_version, status: "published") }
+    let!(:template_version_deprecated) do
+      create(:template_version, status: "deprecated", deprecation_reason: "new_publish")
+    end
+    let!(:template_version_deprecated_other) do
+      create(:template_version, status: "deprecated", deprecation_reason: "unscheduled", deprecated_by: create(:user))
+    end
+
+    context "when external_api_enabled is true" do
+      let(:jurisdiction) { create(:sub_district, external_api_enabled: true) }
+      it "creates mappings for published template versions" do
+        expect(jurisdiction.jurisdiction_integration_requirements_mappings.count).to eq(2)
+        expect(jurisdiction.jurisdiction_integration_requirements_mappings.pluck(:template_version_id)).to match_array(
+          [template_version_published.id, template_version_deprecated.id],
+        )
+      end
+    end
+
+    context "when external_api_enabled is false" do
+      let(:jurisdiction) { create(:sub_district) }
+
+      it "does not create any mappings" do
+        expect(jurisdiction.jurisdiction_integration_requirements_mappings.count).to eq(0)
+      end
+    end
+  end
+
+  describe "#create_integration_requirements_mappings after_save callback on existing jurisdiction" do
+    context "when external_api_enabled is changed to true" do
+      let!(:jurisdiction) { create(:sub_district) }
+      let!(:template_version_published) { create(:template_version, status: "published") }
+      let!(:template_version_deprecated) do
+        create(:template_version, status: "deprecated", deprecation_reason: "new_publish")
+      end
+      let!(:template_version_deprecated_other) do
+        create(:template_version, status: "deprecated", deprecation_reason: "unscheduled", deprecated_by: create(:user))
+      end
+
+      it "creates mappings for published template versions" do
+        expect(jurisdiction.jurisdiction_integration_requirements_mappings.count).to eq(0)
+
+        jurisdiction.update(external_api_enabled: true)
+
+        expect(jurisdiction.jurisdiction_integration_requirements_mappings.count).to eq(2)
+        expect(jurisdiction.jurisdiction_integration_requirements_mappings.pluck(:template_version_id)).to match_array(
+          [template_version_published.id, template_version_deprecated.id],
+        )
+      end
+    end
+  end
 end

--- a/spec/models/template_version_spec.rb
+++ b/spec/models/template_version_spec.rb
@@ -1,5 +1,53 @@
 require "rails_helper"
 
 RSpec.describe TemplateVersion, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#create_integration_requirements_mappings callback" do
+    context "when the template version is published and status has changed" do
+      let!(:jurisdiction) { create(:sub_district, external_api_enabled: true) }
+      let!(:disabled_api_jurisdiction) { create(:sub_district, external_api_enabled: false) }
+      let!(:template_version) { create(:template_version, status: "scheduled") }
+      let!(:existing_mapping) do
+        create(:jurisdiction_integration_requirements_mapping, template_version: template_version)
+      end
+
+      it "creates integration requirements mappings for jurisdictions without mapping and whose api keys are enabled" do
+        expect { template_version.update(status: "published") }.to change {
+          JurisdictionIntegrationRequirementsMapping.count
+        }.by(1)
+
+        expect(
+          JurisdictionIntegrationRequirementsMapping.find_by(
+            template_version: template_version,
+            jurisdiction: jurisdiction,
+          ),
+        ).to be_present
+
+        expect(
+          JurisdictionIntegrationRequirementsMapping.find_by_jurisdiction_id(disabled_api_jurisdiction.id),
+        ).not_to be_present
+      end
+    end
+
+    context "when the template version is not published" do
+      let!(:jurisdiction) { create(:sub_district, external_api_enabled: true) }
+      let!(:existing_mapping) do
+        create(:jurisdiction_integration_requirements_mapping, template_version: template_version)
+      end
+      let!(:template_version) { build(:template_version, status: "scheduled") }
+
+      it "does not create integration requirements mappings" do
+        expect { template_version.save }.not_to change { JurisdictionIntegrationRequirementsMapping.count }
+      end
+    end
+
+    context "when the template version status has not changed" do
+      let(:template_version) { create(:template_version, status: :published) }
+
+      before { template_version.save! }
+
+      it "does not create integration requirements mappings" do
+        expect { template_version.touch }.not_to change { JurisdictionIntegrationRequirementsMapping.count }
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
- Add back-end model and data migration to add `JurisdictionIntegrationRequirementsMapping`
- Adds backend call back logic to:
    - Initializes mapping and copies over existing mappings from other templates when a new `JurisdictionIntegrationRequirementsMapping` instance is created
    - Creates mappings for any template version which already does not have a mapping, when api is enabled in jurisdiction
    - Creates missing mapping for any Jurisdiction with api enabled for the template version when the template version in published
    - Syncs common mappings between templates of the same jurisdiction
 - Adds `GET {base_rote}/template_versions/:id/jurisdictions/:jurisdiction_id/jurisdiction_integration_requirements_mapping` and `PATCH {base_rote}/jurisdiction_integration_requirements_mapping`
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1510
https://hous-bssb.atlassian.net/browse/BPHH-1511
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Run `rails db:migrate:with_data`
- Ensure there is a published template version
- Update any Jurisdiction to enable the api. `@jurisdiction.update(external_api_enabled: true`
- Run `bundle exec rspec` to verify call back specs are passing
- You should be able to make the following requests via post man now:
<img width="1732" alt="Screenshot 2024-06-06 at 3 06 01 PM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/b937e9f5-7b3b-4a7d-b71e-5759a56f9983">

<img width="1731" alt="Screenshot 2024-06-06 at 4 55 26 PM" src="https://github.com/bcgov/HOUS-permit-portal/assets/32022335/3cfc496e-0bcf-4c14-83f3-58e6ecdda3af">
