### PR TITLE
reverse order of filter merge in search

### DIFF
--- a/app/controllers/api/concerns/search/permit_applications.rb
+++ b/app/controllers/api/concerns/search/permit_applications.rb
@@ -61,8 +61,7 @@ module Api::Concerns::Search::PermitApplications
     else
       where = { submitter_id: current_user.id }
     end
-
-    where.merge!(filters.to_h.deep_symbolize_keys.compact) if filters.present?
+    (filters&.to_h || {}).deep_symbolize_keys.compact.merge!(where)
 
     where
   end

--- a/app/policies/permit_application_policy.rb
+++ b/app/policies/permit_application_policy.rb
@@ -4,7 +4,7 @@ class PermitApplicationPolicy < ApplicationPolicy
     if user.super_admin? || record.submitter == user
       true
     elsif user.review_staff?
-      user.jurisdictions.find(record.jurisdiction.id).present?
+      user.jurisdictions.find(record.jurisdiction.id).present? && record.submitted?
     end
   end
 

--- a/spec/policies/permit_application_policy_spec.rb
+++ b/spec/policies/permit_application_policy_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe PermitApplicationPolicy do
   context "for a review manager with correct jurisdiction" do
     let(:user) { FactoryBot.create(:user, :review_manager, jurisdiction:) }
 
-    it "permits search" do
-      expect(subject.index?).to be true
+    it "Does not permit search on draft" do
+      expect(subject.index?).to be false
     end
   end
 


### PR DESCRIPTION
## Description

Fix a bug that was causing the permit application status filter default (draft) to override the where clause in the search concern, causing the inbox to show draft applications.

Also add a stipulation to the policy that allows review staff to only view submitted applications if they are not the submitter.
