### PR TITLE
Feature/bphh 516/mapping external api

### DIFF
--- a/app/blueprints/integration_mapping_blueprint.rb
+++ b/app/blueprints/integration_mapping_blueprint.rb
@@ -1,9 +1,17 @@
 class IntegrationMappingBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :jurisdiction_id, :template_version_id, :requirements_mapping
+  view :base do
+    fields :jurisdiction_id, :template_version_id, :requirements_mapping
 
-  field :requirements_mapping_json do |integration_mapping|
-    integration_mapping.requirements_mapping.to_json
+    field :requirements_mapping_json do |integration_mapping|
+      integration_mapping.requirements_mapping.to_json
+    end
+  end
+
+  view :external_api do
+    field :requirements_mapping
+
+    association :template_version, blueprint: TemplateVersionBlueprint, view: :external_api, name: :permit_version
   end
 end

--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -69,7 +69,7 @@ class PermitApplicationBlueprint < Blueprinter::Base
     end
 
     association :template_version, blueprint: TemplateVersionBlueprint, view: :external_api, name: :permit_version
-    association :submitter, blueprint: UserBlueprint, view: :external_api
+    association :submitter, blueprint: UserBlueprint, view: :external_api, name: :account_holder
     association :permit_type, blueprint: PermitClassificationBlueprint
     association :activity, blueprint: PermitClassificationBlueprint, name: :activity_type
   end

--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -56,6 +56,8 @@ class PermitApplicationBlueprint < Blueprinter::Base
     identifier :id
     fields :status, :number, :full_address, :pid, :pin, :reference_number, :submitted_at
 
+    association :template_version, blueprint: TemplateVersionBlueprint, view: :external_api, name: :version
+
     field :submission_data do |pa, _options|
       pa.formatted_submission_data_for_external_use
     end
@@ -70,6 +72,6 @@ class PermitApplicationBlueprint < Blueprinter::Base
 
     association :submitter, blueprint: UserBlueprint, view: :external_api
     association :permit_type, blueprint: PermitClassificationBlueprint
-    association :activity, blueprint: PermitClassificationBlueprint
+    association :activity, blueprint: PermitClassificationBlueprint, name: :activity_type
   end
 end

--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -56,8 +56,6 @@ class PermitApplicationBlueprint < Blueprinter::Base
     identifier :id
     fields :status, :number, :full_address, :pid, :pin, :reference_number, :submitted_at
 
-    association :template_version, blueprint: TemplateVersionBlueprint, view: :external_api, name: :version
-
     field :submission_data do |pa, _options|
       pa.formatted_submission_data_for_external_use
     end
@@ -70,6 +68,7 @@ class PermitApplicationBlueprint < Blueprinter::Base
       pa.formatted_raw_h2k_files_for_external_use
     end
 
+    association :template_version, blueprint: TemplateVersionBlueprint, view: :external_api, name: :permit_version
     association :submitter, blueprint: UserBlueprint, view: :external_api
     association :permit_type, blueprint: PermitClassificationBlueprint
     association :activity, blueprint: PermitClassificationBlueprint, name: :activity_type

--- a/app/blueprints/template_version_blueprint.rb
+++ b/app/blueprints/template_version_blueprint.rb
@@ -1,6 +1,6 @@
 class TemplateVersionBlueprint < Blueprinter::Base
   identifier :id
-  fields :status, :deprecation_reason, :version_date, :created_at, :updated_at, :version_date, :label
+  fields :status, :deprecation_reason, :created_at, :updated_at, :version_date, :label
 
   field :version_date do |template_version|
     # Parse version date in BC time
@@ -9,5 +9,9 @@ class TemplateVersionBlueprint < Blueprinter::Base
 
   view :extended do
     fields :denormalized_template_json, :form_json, :requirement_blocks_json
+  end
+
+  view :external_api do
+    excludes :deprecation_reason, :created_at, :updated_at, :label
   end
 end

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -22,7 +22,7 @@ class UserBlueprint < Blueprinter::Base
   end
 
   view :external_api do
-    fields :email
+    fields :email, :first_name, :last_name
   end
 
   view :current_user do

--- a/app/controllers/api/integration_mappings_controller.rb
+++ b/app/controllers/api/integration_mappings_controller.rb
@@ -7,7 +7,9 @@ class Api::IntegrationMappingsController < Api::ApplicationController
     authorize @integration_mapping
 
     if @integration_mapping.update_requirements_mapping(integration_mapping_params.to_h[:simplified_map])
-      render_success @integration_mapping, "integration_mapping.update_success"
+      render_success @integration_mapping,
+                     "integration_mapping.update_success",
+                     { blueprint: IntegrationMappingBlueprint, blueprint_opts: { view: :base } }
     else
       render_error "integration_mapping.update_error"
     end

--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -69,7 +69,9 @@ class Api::TemplateVersionsController < Api::ApplicationController
     authorize @integration_mapping, policy_class: TemplateVersionPolicy
 
     if @integration_mapping.present?
-      render_success @integration_mapping
+      render_success @integration_mapping,
+                     nil,
+                     { blueprint: IntegrationMappingBlueprint, blueprint_opts: { view: :base } }
     else
       render_error "integration_mapping.not_found_error", status: 404
     end

--- a/app/policies/external_api/permit_application_policy.rb
+++ b/app/policies/external_api/permit_application_policy.rb
@@ -7,6 +7,10 @@ class ExternalApi::PermitApplicationPolicy < ExternalApi::ApplicationPolicy
     index?
   end
 
+  def show_integration_mapping?
+    external_api_key.jurisdiction == record.jurisdiction
+  end
+
   class Scope < Scope
     def resolve
       scope.where(submitter: user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,11 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :permit_applications, only: %i[show] do
         post "search", on: :collection, to: "permit_applications#index"
+        collection do
+          resources :versions, as: "template_versions", only: [] do
+            get "integration_mapping", to: "permit_applications#show_integration_mapping"
+          end
+        end
       end
     end
   end

--- a/spec/requests/external_api/v1/permit_applications_spec.rb
+++ b/spec/requests/external_api/v1/permit_applications_spec.rb
@@ -118,16 +118,16 @@ RSpec.describe "external_api/v1/permit_applications", type: :request, openapi_sp
   end
 
   path "/permit_applications/{id}" do
-    parameter name: "id", in: :path, type: :string, description: "Submitted permit application id"
-
-    let(:id) { submitted_permit_applications.first.id }
-
     get(
       "This endpoint retrieves detailed information about a specific permit application using its unique identifier (ID). Please note that requests to this endpoint are subject to rate limiting to ensure optimal performance and fair usage.",
     ) do
+      parameter name: "id", in: :path, type: :string, description: "Submitted permit application id"
       tags "Permit applications"
       consumes "application/json"
       produces "application/json"
+
+      let(:id) { submitted_permit_applications.first.id }
+
       response(200, "Successful") do
         schema type: :object,
                properties: {
@@ -165,20 +165,20 @@ RSpec.describe "external_api/v1/permit_applications", type: :request, openapi_sp
   end
 
   path "/permit_applications/versions/{version_id}/integration_mapping" do
-    parameter name: "version_id",
-              in: :path,
-              type: :string,
-              description:
-                "This identifier corresponds to a specific version of the permit template, distinct from the permit application ID, which uniquely identifies an individual permit application."
-
-    let(:version_id) { submitted_permit_applications.first.template_version.id }
-
     get(
       "This endpoint retrieves the integration mapping between the Building Permit Hub system and the local jurisdiction’s integration system. It uses a unique ID associated with a specific version of the permit template.",
     ) do
+      parameter name: "version_id",
+                in: :path,
+                type: :string,
+                description:
+                  "This identifier corresponds to a specific version of the permit template, distinct from the permit application ID, which uniquely identifies an individual permit application."
+
       tags "Permit applications"
       consumes "application/json"
       produces "application/json"
+
+      let(:version_id) { submitted_permit_applications.first.template_version.id }
       response(200, "Successful") do
         schema type: :object,
                properties: {

--- a/spec/requests/external_api/v1/permit_applications_spec.rb
+++ b/spec/requests/external_api/v1/permit_applications_spec.rb
@@ -104,7 +104,10 @@ RSpec.describe "external_api/v1/permit_applications", type: :request, openapi_sp
         end
       end
 
-      response(429, "Rate limit exceeded") do
+      response(
+        429,
+        "Rate limit exceeded. Note: The rate limit is 100 requests per minute per API key and 300 requests per IP in a 3 minute interval",
+      ) do
         schema "$ref" => "#/components/schemas/ResponseError"
         around { |example| with_temporary_rate_limit("external_api/ip", limit: 3, period: 1.minute) { example.run } }
         before { 5.times { get search_v1_permit_applications_path, headers: { Authorization: "Bearer #{token}" } } }
@@ -166,12 +169,12 @@ RSpec.describe "external_api/v1/permit_applications", type: :request, openapi_sp
               in: :path,
               type: :string,
               description:
-                "The id of the permit application version. Note: this is different from the permit application id."
+                "This identifier corresponds to a specific version of the permit template, distinct from the permit application ID, which uniquely identifies an individual permit application."
 
     let(:version_id) { submitted_permit_applications.first.template_version.id }
 
     get(
-      "This endpoint retrieves the integration mapping between the Building Permit Hub system and the local jurisdiction integration system using a permit version unique identifier (ID). Please note that requests to this endpoint are subject to rate limiting to ensure optimal performance and fair usage.",
+      "This endpoint retrieves the integration mapping between the Building Permit Hub system and the local jurisdiction’s integration system. It uses a unique ID associated with a specific version of the permit template.",
     ) do
       tags "Permit applications"
       consumes "application/json"
@@ -199,7 +202,10 @@ RSpec.describe "external_api/v1/permit_applications", type: :request, openapi_sp
         run_test! { |response| expect(response.status).to eq(404) }
       end
 
-      response(429, "Rate limit exceeded") do
+      response(
+        429,
+        "Rate limit exceeded. Note: The rate limit is 100 requests per minute per API key and 300 requests per IP in a 3 minute interval",
+      ) do
         schema "$ref" => "#/components/schemas/ResponseError"
         around { |example| with_temporary_rate_limit("external_api/ip", limit: 3, period: 1.minute) { example.run } }
         before do

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -161,6 +161,8 @@ in this document.
               },
               permit_classifications: {
                 type: :string,
+                description:
+                  "This is the combined permit type and activity type of the permit application. This is derived as `${permit_type.name} - ${activity_type.name}` e.g. '4+ Unit housing - New Construction'",
               },
               permit_type: {
                 "$ref" => "#/components/schemas/PermitClassification",
@@ -170,6 +172,9 @@ in this document.
               },
               submitter: {
                 "$ref" => "#/components/schemas/Submitter",
+              },
+              version: {
+                "$ref" => "#/components/schemas/Version",
               },
               submission_data: {
                 "$ref" => "#/components/schemas/SubmissionData",
@@ -246,6 +251,7 @@ in this document.
           },
           PermitClassification: {
             type: :object,
+            description: "This object represents a permit classification. e.g. a permit type or activity type.",
             properties: {
               id: {
                 type: :string,
@@ -263,10 +269,32 @@ in this document.
               },
             },
           },
+          Version: {
+            type: :object,
+            description: "The object represents the permit application version.",
+            properties: {
+              id: {
+                type: :string,
+                description:
+                  "The ID of the version. This can be used to retrieve the integration mapping of the Jurisdiction for this version.",
+              },
+              version_date: {
+                type: :integer,
+                format: :int64,
+                description:
+                  "The version date in milliseconds since the epoch (UNIX time). This is meant to be parsed as PST.",
+              },
+              status: {
+                type: :string,
+                enum: %w[published deprecated],
+                description: "The status of the version.",
+              },
+            },
+          },
           MultiOptionSubmissionValue: {
             type: :object,
             description:
-              "The submission value for requirement input types, which are limited to a set of options. e.g. an option from a select drop down, or checkboxes",
+              "The submission value for requirement input types, which are limited to a set of options. e.g. an option from a select drop down, or checkboxes.",
             additionalProperties: {
               type: :boolean,
               description:
@@ -275,7 +303,7 @@ in this document.
           },
           ContactSubmissionValue: {
             type: :array,
-            description: "The contact submission value. It is an array of contact objects",
+            description: "The contact submission value. It is an array of contact objects.",
             items: {
               type: :object,
               properties: {
@@ -312,7 +340,7 @@ in this document.
           },
           FileSubmissionValue: {
             description:
-              "The file submission value. It is an array of file objects. Note: the urls are signed and will expire after 1 hour .",
+              "The file submission value. It is an array of file objects. Note: the urls are signed and will expire after 1 hour.",
             type: :array,
             items: {
               "$ref" => "#/components/schemas/File",
@@ -356,6 +384,14 @@ in this document.
                 type: :string,
                 description: "The email of the submitter.",
               },
+              first_name: {
+                type: :string,
+                description: "The first name of the submitter.",
+              },
+              last_name: {
+                type: :string,
+                description: "The last name of the submitter.",
+              },
             },
           },
           ResponseError: {
@@ -387,19 +423,20 @@ in this document.
               event: {
                 type: :string,
                 enum: %w[permit_submitted],
-                description: "The event type",
+                description: "The event type.",
               },
               payload: {
                 type: :object,
                 properties: {
                   permit_id: {
                     type: :string,
-                    description: "The permit application ID",
+                    description: "The permit application ID.",
                   },
                   submitted_at: {
-                    type: :string,
-                    format: "date-time",
-                    description: "The date and time the permit application was submitted",
+                    type: :integer,
+                    format: "int64",
+                    description:
+                      "The timestamp of when the permit application was submitted. This is in milliseconds since the epoch (UNIX time).",
                   },
                 },
               },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -173,8 +173,8 @@ in this document.
               submitter: {
                 "$ref" => "#/components/schemas/Submitter",
               },
-              version: {
-                "$ref" => "#/components/schemas/Version",
+              permit_version: {
+                "$ref" => "#/components/schemas/PermitVersion",
               },
               submission_data: {
                 "$ref" => "#/components/schemas/SubmissionData",
@@ -198,15 +198,19 @@ in this document.
               properties: {
                 id: {
                   type: :string,
+                  description: "The ID of the requirement block.",
                 },
                 requirement_block_code: {
                   type: :string,
+                  description: "The code of the requirement block. This is unique within the permit application.",
                 },
                 name: {
                   type: :string,
+                  description: "The name/label of the requirement block.",
                 },
                 description: {
                   type: :string,
+                  description: "The description of the requirement block.",
                   nullable: true,
                 },
                 requirements: {
@@ -217,13 +221,16 @@ in this document.
                     properties: {
                       id: {
                         type: :string,
+                        description: "The ID of the requirement.",
                       },
                       name: {
                         type: :string,
+                        description: "The name/label of the requirement.",
                       },
                       requirement_code: {
                         type: :string,
-                        description: "The requirement code for this requirement.",
+                        description:
+                          "The requirement code for this requirement. This is unique within the requirement block.",
                       },
                       type: {
                         type: :string,
@@ -269,9 +276,9 @@ in this document.
               },
             },
           },
-          Version: {
+          PermitVersion: {
             type: :object,
-            description: "The object represents the permit application version.",
+            description: "The object represents the permit version.",
             properties: {
               id: {
                 type: :string,
@@ -289,6 +296,58 @@ in this document.
                 enum: %w[published deprecated],
                 description: "The status of the version.",
               },
+            },
+          },
+          IntegrationMapping: {
+            type: :object,
+            description: "The integration mapping of the jurisdiction for a specific permit version.",
+            properties: {
+              id: {
+                type: :string,
+                description: "The ID of the integration mapping.",
+              },
+              permit_version: {
+                "$ref" => "#/components/schemas/PermitVersion",
+              },
+              requirements_mapping: {
+                "$ref" => "#/components/schemas/RequirementsMapping",
+              },
+            },
+          },
+          RequirementsMapping: {
+            type: :object,
+            description:
+              "The mapping of the requirements between the Building Permit Hub system and local jurisdiction integration system. Note: the top level keys are the requirement block codes.",
+            additionalProperties: {
+              type: :object,
+              description:
+                "The requirement block mapping. This contains a requirements hash, where the keys are the requirement codes and the value is another hash containing the field mapping to the local jurisdiction system.",
+              properties: {
+                id: {
+                  type: :string,
+                  description: "The ID of the requirement block.",
+                },
+                requirements: {
+                  type: :object,
+                  description: "A hash of the requirement code to the local jurisdiction system field mapping.",
+                  additionalProperties: {
+                    type: :object,
+                    properties: {
+                      id: {
+                        type: :string,
+                        description: "The ID of the requirement.",
+                      },
+                      local_system_mapping: {
+                        type: :string,
+                        description:
+                          "The local jurisdiction integration system field mapping for this requirement. This should be the field name of the requirement in your system.",
+                      },
+                    },
+                    required: %w[id local_system_mapping],
+                  },
+                },
+              },
+              required: %w[id requirements],
             },
           },
           MultiOptionSubmissionValue: {

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -162,7 +162,7 @@ in this document.
               permit_classifications: {
                 type: :string,
                 description:
-                  "This is the combined permit type and activity type of the permit application. This is derived as `${permit_type.name} - ${activity_type.name}` e.g. '4+ Unit housing - New Construction'",
+                  "This is the combined permit type and activity (work) type of the permit application. This is derived as `${permit_type.name} - ${activity_type.name}` e.g. '4+ Unit housing - New Construction'",
               },
               permit_type: {
                 "$ref" => "#/components/schemas/PermitClassification",
@@ -170,8 +170,8 @@ in this document.
               activity: {
                 "$ref" => "#/components/schemas/PermitClassification",
               },
-              submitter: {
-                "$ref" => "#/components/schemas/Submitter",
+              account_holder: {
+                "$ref" => "#/components/schemas/AccountHolder",
               },
               permit_version: {
                 "$ref" => "#/components/schemas/PermitVersion",
@@ -230,7 +230,7 @@ in this document.
                       requirement_code: {
                         type: :string,
                         description:
-                          "The requirement code for this requirement. This is unique within the requirement block.",
+                          "The requirement code for this requirement field. This is unique within the requirement block.",
                       },
                       type: {
                         type: :string,
@@ -258,7 +258,7 @@ in this document.
           },
           PermitClassification: {
             type: :object,
-            description: "This object represents a permit classification. e.g. a permit type or activity type.",
+            description: "This object represents a permit classification. e.g. a permit type or activity (work) type.",
             properties: {
               id: {
                 type: :string,
@@ -431,25 +431,25 @@ in this document.
               },
             },
           },
-          Submitter: {
+          AccountHolder: {
             type: :object,
-            description: "The submitter of the permit application.",
+            description: "The account holder of the permit application.",
             properties: {
               id: {
                 type: :string,
-                description: "The ID of the submitter.",
+                description: "The ID of the account holder.",
               },
               email: {
                 type: :string,
-                description: "The email of the submitter.",
+                description: "The email of the account holder.",
               },
               first_name: {
                 type: :string,
-                description: "The first name of the submitter.",
+                description: "The first name of the account holder.",
               },
               last_name: {
                 type: :string,
-                description: "The last name of the submitter.",
+                description: "The last name of the account holder.",
               },
             },
           },

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -110,7 +110,8 @@ paths:
                 - data
                 - meta
         '429':
-          description: Rate limit exceeded
+          description: 'Rate limit exceeded. Note: The rate limit is 100 requests
+            per minute per API key and 300 requests per IP in a 3 minute interval'
           content:
             application/json:
               schema:
@@ -190,16 +191,16 @@ paths:
     parameters:
     - name: version_id
       in: path
-      description: 'The id of the permit application version. Note: this is different
-        from the permit application id.'
+      description: This identifier corresponds to a specific version of the permit
+        template, distinct from the permit application ID, which uniquely identifies
+        an individual permit application.
       required: true
       schema:
         type: string
     get:
       summary: This endpoint retrieves the integration mapping between the Building
-        Permit Hub system and the local jurisdiction integration system using a permit
-        version unique identifier (ID). Please note that requests to this endpoint
-        are subject to rate limiting to ensure optimal performance and fair usage.
+        Permit Hub system and the local jurisdiction’s integration system. It uses
+        a unique ID associated with a specific version of the permit template.
       tags:
       - Permit applications
       responses:
@@ -217,7 +218,8 @@ paths:
         '404':
           description: Accessing a integration mapping which does not exist
         '429':
-          description: Rate limit exceeded
+          description: 'Rate limit exceeded. Note: The rate limit is 100 requests
+            per minute per API key and 300 requests per IP in a 3 minute interval'
           content:
             application/json:
               schema:
@@ -272,15 +274,15 @@ components:
           description: Datetime in milliseconds since the epoch (Unix time)
         permit_classifications:
           type: string
-          description: This is the combined permit type and activity type of the permit
-            application. This is derived as `${permit_type.name} - ${activity_type.name}`
+          description: This is the combined permit type and activity (work) type of
+            the permit application. This is derived as `${permit_type.name} - ${activity_type.name}`
             e.g. '4+ Unit housing - New Construction'
         permit_type:
           "$ref": "#/components/schemas/PermitClassification"
         activity:
           "$ref": "#/components/schemas/PermitClassification"
-        submitter:
-          "$ref": "#/components/schemas/Submitter"
+        account_holder:
+          "$ref": "#/components/schemas/AccountHolder"
         permit_version:
           "$ref": "#/components/schemas/PermitVersion"
         submission_data:
@@ -328,8 +330,8 @@ components:
                   description: The name/label of the requirement.
                 requirement_code:
                   type: string
-                  description: The requirement code for this requirement. This is
-                    unique within the requirement block.
+                  description: The requirement code for this requirement field. This
+                    is unique within the requirement block.
                 type:
                   type: string
                   enum:
@@ -374,7 +376,7 @@ components:
     PermitClassification:
       type: object
       description: This object represents a permit classification. e.g. a permit type
-        or activity type.
+        or activity (work) type.
       properties:
         id:
           type: string
@@ -512,22 +514,22 @@ components:
           type: string
           format: url
           description: The signed URL to download the file.
-    Submitter:
+    AccountHolder:
       type: object
-      description: The submitter of the permit application.
+      description: The account holder of the permit application.
       properties:
         id:
           type: string
-          description: The ID of the submitter.
+          description: The ID of the account holder.
         email:
           type: string
-          description: The email of the submitter.
+          description: The email of the account holder.
         first_name:
           type: string
-          description: The first name of the submitter.
+          description: The first name of the account holder.
         last_name:
           type: string
-          description: The last name of the submitter.
+          description: The last name of the account holder.
     ResponseError:
       type: object
       properties:

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -186,6 +186,42 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ResponseError"
+  "/permit_applications/versions/{version_id}/integration_mapping":
+    parameters:
+    - name: version_id
+      in: path
+      description: 'The id of the permit application version. Note: this is different
+        from the permit application id.'
+      required: true
+      schema:
+        type: string
+    get:
+      summary: This endpoint retrieves the integration mapping between the Building
+        Permit Hub system and the local jurisdiction integration system using a permit
+        version unique identifier (ID). Please note that requests to this endpoint
+        are subject to rate limiting to ensure optimal performance and fair usage.
+      tags:
+      - Permit applications
+      responses:
+        '200':
+          description: Successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    "$ref": "#/components/schemas/IntegrationMapping"
+                required:
+                - data
+        '404':
+          description: Accessing a integration mapping which does not exist
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ResponseError"
 servers:
 - url: "/external_api/v1"
   description: Current environment server
@@ -245,8 +281,8 @@ components:
           "$ref": "#/components/schemas/PermitClassification"
         submitter:
           "$ref": "#/components/schemas/Submitter"
-        version:
-          "$ref": "#/components/schemas/Version"
+        permit_version:
+          "$ref": "#/components/schemas/PermitVersion"
         submission_data:
           "$ref": "#/components/schemas/SubmissionData"
         raw_h2k_files:
@@ -265,12 +301,17 @@ components:
         properties:
           id:
             type: string
+            description: The ID of the requirement block.
           requirement_block_code:
             type: string
+            description: The code of the requirement block. This is unique within
+              the permit application.
           name:
             type: string
+            description: The name/label of the requirement block.
           description:
             type: string
+            description: The description of the requirement block.
             nullable: true
           requirements:
             type: array
@@ -281,11 +322,14 @@ components:
               properties:
                 id:
                   type: string
+                  description: The ID of the requirement.
                 name:
                   type: string
+                  description: The name/label of the requirement.
                 requirement_code:
                   type: string
-                  description: The requirement code for this requirement.
+                  description: The requirement code for this requirement. This is
+                    unique within the requirement block.
                 type:
                   type: string
                   enum:
@@ -342,9 +386,9 @@ components:
         code:
           type: string
           description: The code of the permit classification.
-    Version:
+    PermitVersion:
       type: object
-      description: The object represents the permit application version.
+      description: The object represents the permit version.
       properties:
         id:
           type: string
@@ -361,6 +405,53 @@ components:
           - published
           - deprecated
           description: The status of the version.
+    IntegrationMapping:
+      type: object
+      description: The integration mapping of the jurisdiction for a specific permit
+        version.
+      properties:
+        id:
+          type: string
+          description: The ID of the integration mapping.
+        permit_version:
+          "$ref": "#/components/schemas/PermitVersion"
+        requirements_mapping:
+          "$ref": "#/components/schemas/RequirementsMapping"
+    RequirementsMapping:
+      type: object
+      description: 'The mapping of the requirements between the Building Permit Hub
+        system and local jurisdiction integration system. Note: the top level keys
+        are the requirement block codes.'
+      additionalProperties:
+        type: object
+        description: The requirement block mapping. This contains a requirements hash,
+          where the keys are the requirement codes and the value is another hash containing
+          the field mapping to the local jurisdiction system.
+        properties:
+          id:
+            type: string
+            description: The ID of the requirement block.
+          requirements:
+            type: object
+            description: A hash of the requirement code to the local jurisdiction
+              system field mapping.
+            additionalProperties:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: The ID of the requirement.
+                local_system_mapping:
+                  type: string
+                  description: The local jurisdiction integration system field mapping
+                    for this requirement. This should be the field name of the requirement
+                    in your system.
+              required:
+              - id
+              - local_system_mapping
+        required:
+        - id
+        - requirements
     MultiOptionSubmissionValue:
       type: object
       description: The submission value for requirement input types, which are limited

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -236,12 +236,17 @@ components:
           description: Datetime in milliseconds since the epoch (Unix time)
         permit_classifications:
           type: string
+          description: This is the combined permit type and activity type of the permit
+            application. This is derived as `${permit_type.name} - ${activity_type.name}`
+            e.g. '4+ Unit housing - New Construction'
         permit_type:
           "$ref": "#/components/schemas/PermitClassification"
         activity:
           "$ref": "#/components/schemas/PermitClassification"
         submitter:
           "$ref": "#/components/schemas/Submitter"
+        version:
+          "$ref": "#/components/schemas/Version"
         submission_data:
           "$ref": "#/components/schemas/SubmissionData"
         raw_h2k_files:
@@ -324,6 +329,8 @@ components:
         - requirements
     PermitClassification:
       type: object
+      description: This object represents a permit classification. e.g. a permit type
+        or activity type.
       properties:
         id:
           type: string
@@ -335,17 +342,36 @@ components:
         code:
           type: string
           description: The code of the permit classification.
+    Version:
+      type: object
+      description: The object represents the permit application version.
+      properties:
+        id:
+          type: string
+          description: The ID of the version. This can be used to retrieve the integration
+            mapping of the Jurisdiction for this version.
+        version_date:
+          type: integer
+          format: int64
+          description: The version date in milliseconds since the epoch (UNIX time).
+            This is meant to be parsed as PST.
+        status:
+          type: string
+          enum:
+          - published
+          - deprecated
+          description: The status of the version.
     MultiOptionSubmissionValue:
       type: object
       description: The submission value for requirement input types, which are limited
-        to a set of options. e.g. an option from a select drop down, or checkboxes
+        to a set of options. e.g. an option from a select drop down, or checkboxes.
       additionalProperties:
         type: boolean
         description: The key is the option value, and the value is a boolean indicating
           if the option was selected.
     ContactSubmissionValue:
       type: array
-      description: The contact submission value. It is an array of contact objects
+      description: The contact submission value. It is an array of contact objects.
       items:
         type: object
         properties:
@@ -372,7 +398,7 @@ components:
             description: The organization of the contact.
     FileSubmissionValue:
       description: 'The file submission value. It is an array of file objects. Note:
-        the urls are signed and will expire after 1 hour .'
+        the urls are signed and will expire after 1 hour.'
       type: array
       items:
         "$ref": "#/components/schemas/File"
@@ -405,6 +431,12 @@ components:
         email:
           type: string
           description: The email of the submitter.
+        first_name:
+          type: string
+          description: The first name of the submitter.
+        last_name:
+          type: string
+          description: The last name of the submitter.
     ResponseError:
       type: object
       properties:
@@ -428,17 +460,18 @@ components:
           type: string
           enum:
           - permit_submitted
-          description: The event type
+          description: The event type.
         payload:
           type: object
           properties:
             permit_id:
               type: string
-              description: The permit application ID
+              description: The permit application ID.
             submitted_at:
-              type: string
-              format: date-time
-              description: The date and time the permit application was submitted
+              type: integer
+              format: int64
+              description: The timestamp of when the permit application was submitted.
+                This is in milliseconds since the epoch (UNIX time).
 formats:
 - json
 - yaml

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -151,18 +151,18 @@ paths:
                       description: 'Less than or equal to: submitted date is less
                         than or equal to this date'
   "/permit_applications/{id}":
-    parameters:
-    - name: id
-      in: path
-      description: Submitted permit application id
-      required: true
-      schema:
-        type: string
     get:
       summary: This endpoint retrieves detailed information about a specific permit
         application using its unique identifier (ID). Please note that requests to
         this endpoint are subject to rate limiting to ensure optimal performance and
         fair usage.
+      parameters:
+      - name: id
+        in: path
+        description: Submitted permit application id
+        required: true
+        schema:
+          type: string
       tags:
       - Permit applications
       responses:
@@ -188,19 +188,19 @@ paths:
               schema:
                 "$ref": "#/components/schemas/ResponseError"
   "/permit_applications/versions/{version_id}/integration_mapping":
-    parameters:
-    - name: version_id
-      in: path
-      description: This identifier corresponds to a specific version of the permit
-        template, distinct from the permit application ID, which uniquely identifies
-        an individual permit application.
-      required: true
-      schema:
-        type: string
     get:
       summary: This endpoint retrieves the integration mapping between the Building
         Permit Hub system and the local jurisdiction’s integration system. It uses
         a unique ID associated with a specific version of the permit template.
+      parameters:
+      - name: version_id
+        in: path
+        description: This identifier corresponds to a specific version of the permit
+          template, distinct from the permit application ID, which uniquely identifies
+          an individual permit application.
+        required: true
+        schema:
+          type: string
       tags:
       - Permit applications
       responses:


### PR DESCRIPTION
## Description
Add external api to retrieve integration mapping based on template version id
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1516
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
Prerequisite:
- Enable api for jurisdiction of choice
- Generate an api key for the jurisdiction and note the token
- Ensure there is a published template version, and note it's id
Steps:
- visit `/integrations/api_docs`
- click "Authorize" button and enter the token noted previously
- Open the `"/permit_applications/versions/{version_id}/integration_mapping` request accordion
- Click "Try out", enter the version id noted previously and click "Execute"
- Should get a response with the integration mapping data
![Screenshot 2024-06-17 at 11 43 44 AM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/a5a4b31e-614f-48cd-aed4-2b5b350ccf7f)
![Screenshot 2024-06-17 at 12 08 21 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/d66f7f04-c43a-4499-bf46-818dda5714eb)
