### PR TITLE
Add overridable required step screen with dynamic form and selectors

### DIFF
--- a/app/blueprints/jurisdiction_blueprint.rb
+++ b/app/blueprints/jurisdiction_blueprint.rb
@@ -25,7 +25,7 @@ class JurisdictionBlueprint < Blueprinter::Base
 
     association :contacts, blueprint: ContactBlueprint
     association :permit_type_submission_contacts, blueprint: PermitTypeSubmissionContactBlueprint
-    association :jurisdiction_template_required_steps, blueprint: JurisdictionTemplateRequiredStepBlueprint
+    association :permit_type_required_steps, blueprint: PermitTypeRequiredStepBlueprint
   end
 
   view :minimal do

--- a/app/blueprints/jurisdiction_template_required_step_blueprint.rb
+++ b/app/blueprints/jurisdiction_template_required_step_blueprint.rb
@@ -1,9 +1,0 @@
-class JurisdictionTemplateRequiredStepBlueprint < Blueprinter::Base
-  identifier :id
-
-  fields :requirement_template_id, :energy_step_required, :zero_carbon_step_required
-
-  field :requirement_template_label do |jtr_step, _options|
-    jtr_step.requirement_template_label
-  end
-end

--- a/app/blueprints/permit_type_required_step_blueprint.rb
+++ b/app/blueprints/permit_type_required_step_blueprint.rb
@@ -1,0 +1,9 @@
+class PermitTypeRequiredStepBlueprint < Blueprinter::Base
+  identifier :id
+
+  fields :permit_type_id, :energy_step_required, :zero_carbon_step_required
+
+  field :permit_type_name do |ptr_step, _options|
+    ptr_step.permit_type_name
+  end
+end

--- a/app/blueprints/permit_type_required_step_blueprint.rb
+++ b/app/blueprints/permit_type_required_step_blueprint.rb
@@ -1,7 +1,10 @@
 class PermitTypeRequiredStepBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :permit_type_id, :energy_step_required, :zero_carbon_step_required
+  fields :permit_type_id,
+         :energy_step_required,
+         :zero_carbon_step_required,
+         :default
 
   field :permit_type_name do |ptr_step, _options|
     ptr_step.permit_type_name

--- a/app/controllers/api/concerns/search/jurisdictions.rb
+++ b/app/controllers/api/concerns/search/jurisdictions.rb
@@ -20,8 +20,7 @@ module Api::Concerns::Search::Jurisdictions
     unless jurisdiction_search_params[:submission_inbox_set_up].nil?
       search_params[:where] = { submission_inbox_set_up: jurisdiction_search_params[:submission_inbox_set_up] }
     end
-
-    @search = Jurisdiction.includes(Jurisdiction::BASE_INCLUDES).search(jurisdiction_query, **search_params)
+    @search = Jurisdiction.search(jurisdiction_query, **search_params, includes: Jurisdiction::BASE_INCLUDES)
   end
 
   private

--- a/app/controllers/api/jurisdictions_controller.rb
+++ b/app/controllers/api/jurisdictions_controller.rb
@@ -183,6 +183,7 @@ class Api::JurisdictionsController < Api::ApplicationController
       permit_type_required_steps_attributes: %i[
         id
         permit_type_id
+        default
         energy_step_required
         zero_carbon_step_required
         _destroy

--- a/app/controllers/api/jurisdictions_controller.rb
+++ b/app/controllers/api/jurisdictions_controller.rb
@@ -30,10 +30,10 @@ class Api::JurisdictionsController < Api::ApplicationController
     authorize @jurisdiction
     if jurisdiction_params[:contacts_attributes]
       # Get current contact ids from the params
-      payload_contact_ids = jurisdiction_params[:contacts_attributes].map { |c| c[:id] }
+      payload_record_ids = jurisdiction_params[:contacts_attributes].map { |c| c[:id] }
       # Mark contacts not included in the current payload for destruction
       @jurisdiction.contacts.each do |contact|
-        contact.mark_for_destruction unless payload_contact_ids.include?(contact.id.to_s)
+        contact.mark_for_destruction unless payload_record_ids.include?(contact.id.to_s)
       end
     end
     if @jurisdiction.update(jurisdiction_params)
@@ -180,6 +180,13 @@ class Api::JurisdictionsController < Api::ApplicationController
       users_attributes: %i[first_name last_name role email],
       contacts_attributes: %i[id first_name last_name department title phone cell email],
       permit_type_submission_contacts_attributes: %i[id email permit_type_id _destroy],
+      permit_type_required_steps_attributes: %i[
+        id
+        permit_type_id
+        energy_step_required
+        zero_carbon_step_required
+        _destroy
+      ],
     )
   end
 

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/energy-step-select.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/energy-step-select.tsx
@@ -23,16 +23,9 @@ interface IProps {
   value: EEnergyStep
   isDisabled?: boolean
   allowZero?: boolean
-  showFirstOnly?: boolean
 }
 
-export const EnergyStepSelect = observer(function EnergyStepSelect({
-  showFirstOnly,
-  onChange,
-  value,
-  isDisabled,
-  allowZero,
-}: IProps) {
+export const EnergyStepSelect = observer(function EnergyStepSelect({ onChange, value, isDisabled, allowZero }: IProps) {
   const {
     stepCodeStore: { getEnergyStepOptions },
   } = useMst()
@@ -54,9 +47,7 @@ export const EnergyStepSelect = observer(function EnergyStepSelect({
                 shadow="base"
                 isDisabled={isDisabled}
               >
-                {!R.isNil(value)
-                  ? t(`${i18nPrefix}.stepRequired.energy.options.${showFirstOnly ? options[0] : value}`)
-                  : t(`ui.selectPlaceholder`)}
+                {!R.isNil(value) ? t(`${i18nPrefix}.stepRequired.energy.options.${value}`) : t(`ui.selectPlaceholder`)}
               </Input>
               <InputRightElement children={<CaretDown color="gray.300" />} />
             </InputGroup>
@@ -74,7 +65,7 @@ export const EnergyStepSelect = observer(function EnergyStepSelect({
                     px={2}
                     py={1.5}
                     w="full"
-                    borderTop={i === options.length - 1 ? "1px solid" : undefined}
+                    borderTopWidth={value === "0" ? 1 : undefined}
                     borderColor="border.light"
                     cursor="pointer"
                     _hover={{ bg: "hover.blue" }}

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/energy-step-select.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/energy-step-select.tsx
@@ -7,12 +7,12 @@ import {
   PopoverContent,
   PopoverTrigger,
   Portal,
-  StackDivider,
   VStack,
 } from "@chakra-ui/react"
 import { CaretDown } from "@phosphor-icons/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
+import * as R from "ramda"
 import React from "react"
 import { useMst } from "../../../../../../../setup/root"
 import { EEnergyStep } from "../../../../../../../types/enums"
@@ -22,13 +22,21 @@ interface IProps {
   onChange: (event: any) => void
   value: EEnergyStep
   isDisabled?: boolean
+  allowZero?: boolean
+  showFirstOnly?: boolean
 }
 
-export const EnergyStepSelect = observer(function EnergyStepSelect({ onChange, value, isDisabled }: IProps) {
+export const EnergyStepSelect = observer(function EnergyStepSelect({
+  showFirstOnly,
+  onChange,
+  value,
+  isDisabled,
+  allowZero,
+}: IProps) {
   const {
-    stepCodeStore: { selectOptions },
+    stepCodeStore: { getEnergyStepOptions },
   } = useMst()
-
+  const options = getEnergyStepOptions(allowZero)
   return (
     <Popover placement="bottom-end">
       {({ onClose }) => (
@@ -46,15 +54,17 @@ export const EnergyStepSelect = observer(function EnergyStepSelect({ onChange, v
                 shadow="base"
                 isDisabled={isDisabled}
               >
-                {value ? t(`${i18nPrefix}.stepRequired.energy.options.${value}`) : t(`ui.selectPlaceholder`)}
+                {!R.isNil(value)
+                  ? t(`${i18nPrefix}.stepRequired.energy.options.${showFirstOnly ? options[0] : value}`)
+                  : t(`ui.selectPlaceholder`)}
               </Input>
               <InputRightElement children={<CaretDown color="gray.300" />} />
             </InputGroup>
           </PopoverTrigger>
           <Portal>
             <PopoverContent>
-              <VStack align="start" spacing={0} divider={<StackDivider borderColor="border.light" />}>
-                {selectOptions.energySteps.map((value) => (
+              <VStack align="start" spacing={0}>
+                {options.map((value, i) => (
                   <Flex
                     key={value}
                     onClick={() => {
@@ -64,6 +74,8 @@ export const EnergyStepSelect = observer(function EnergyStepSelect({ onChange, v
                     px={2}
                     py={1.5}
                     w="full"
+                    borderTop={i === options.length - 1 ? "1px solid" : undefined}
+                    borderColor="border.light"
                     cursor="pointer"
                     _hover={{ bg: "hover.blue" }}
                   >

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/index.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/index.tsx
@@ -1,14 +1,14 @@
-import { Box, Button, Flex, FormControl, FormLabel, IconButton, Input, Stack, Text } from "@chakra-ui/react"
+import { Box, Button, Flex, FormControl, FormLabel, IconButton, Input, Text, VStack } from "@chakra-ui/react"
 import { Pencil, Plus, X } from "@phosphor-icons/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
-import React, { useEffect, useState } from "react"
-import { Controller, useFormContext } from "react-hook-form"
-import { useJurisdiction } from "../../../../../../../hooks/resources/use-jurisdiction"
+import * as R from "ramda"
+import React, { useState } from "react"
+import { Controller, useFieldArray, useForm } from "react-hook-form"
+import { IJurisdiction } from "../../../../../../../models/jurisdiction"
 import { IPermitTypeRequiredStep } from "../../../../../../../types/types"
 import { generateUUID } from "../../../../../../../utils/utility-functions"
 import { CustomMessageBox } from "../../../../../../shared/base/custom-message-box"
-import { ErrorScreen } from "../../../../../../shared/base/error-screen"
 import { EditableBlockContainer, EditableBlockHeading } from "../../shared/editable-block"
 import { i18nPrefix } from "../i18n-prefix"
 import { EnergyStepSelect } from "./energy-step-select"
@@ -17,161 +17,134 @@ import { ZeroCarbonStepSelect } from "./zero-carbon-step-select"
 interface IProps {
   heading: string
   permitTypeId: string
-  fields: IPermitTypeRequiredStep[]
-  fieldArrayName: string
-  append: any
-  remove: any
-  update: any
-  getIndex: (field: IPermitTypeRequiredStep) => number
-  reset: () => any
+  jurisdiction: IJurisdiction
 }
 
 export const EnergyStepEditableBlock = observer(function EnergyStepEditableBlock({
   heading,
   permitTypeId,
-  fields,
-  fieldArrayName,
-  reset,
-  append,
-  remove,
-  update,
-  getIndex,
+  jurisdiction,
 }: IProps) {
-  const isCustomizingDefault = () => {
-    return fields.length > 1 || fields[0].energyStepRequired === 0 || fields[0].zeroCarbonStepRequired === 0
+  type TPermitTypeRequiredStepField = IPermitTypeRequiredStep & { _destroy?: boolean }
+  const getDefaultValues = () => ({
+    permitTypeRequiredStepsAttributes: [...(jurisdiction.permitTypeRequiredSteps as TPermitTypeRequiredStepField[])],
+  })
+
+  interface IFormValues {
+    permitTypeRequiredStepsAttributes: TPermitTypeRequiredStepField[]
+  }
+  const { handleSubmit, reset, formState, trigger, register, control, watch } = useForm<IFormValues>({
+    mode: "onChange",
+    defaultValues: getDefaultValues(),
+  })
+
+  const onSubmit = async (values) => {
+    await jurisdiction.update(values)
+    setIsEditing(false)
   }
 
+  const handleReset = () => {
+    reset(getDefaultValues())
+  }
+
+  const { isSubmitting, isSubmitted, isValid } = formState
+  const fieldArrayName = "permitTypeRequiredStepsAttributes"
+  const { fields, append, insert, remove, update } = useFieldArray({
+    control,
+    name: fieldArrayName,
+    keyName: "key",
+  })
+
+  const permitTypeFields = R.filter((f) => f.permitTypeId == permitTypeId, fields as TPermitTypeRequiredStepField[])
+  const customFields = R.filter((f) => !f.default, permitTypeFields)
+  const getIndex = (field) => R.findIndex((f) => f.id == field.id, fields)
+  const defaultIndex = getIndex(R.find((f) => f.default, permitTypeFields))
+
+  const defaultIsCustomizing = !R.isEmpty(customFields)
+
   const [isEditing, setIsEditing] = useState(false)
-  const [isCustomizing, setIsCustomizing] = useState(isCustomizingDefault())
-
-  const { currentJurisdiction, error } = useJurisdiction()
-
-  const getRequiredStep = currentJurisdiction?.getRequiredStep
-
-  const { formState, trigger, getValues, setValue, control } = useFormContext()
-  const { errors, isSubmitting, isSubmitted, isValid } = formState
+  const [isCustomizing, setIsCustomizing] = useState(defaultIsCustomizing)
 
   const handleClickCancel = () => {
-    reset()
+    handleReset()
     setIsEditing(false)
   }
 
   const onAdd = () => {
-    append({ permitTypeId, energyStepRequired: null, zeroCarbonStepRequired: null })
+    append({ permitTypeId, energyStepRequired: null, zeroCarbonStepRequired: null, default: null })
   }
 
-  const onRemove = (index: number, rs?: IPermitTypeRequiredStep) => {
-    if (index === unremovableIndex) return
-    if (rs) {
-      update(index, { _destroy: true, id: rs.id })
+  const onRemove = (index: number, field?: TPermitTypeRequiredStepField) => {
+    if (field) {
+      update(index, R.mergeRight(field, { _destroy: true }))
     } else {
       remove(index)
     }
   }
 
-  const onRemoveArray = (objectsWithIndecies: IIndexAndRequiredStep[]) => {
-    const updateParams = []
-    const removeIndecies = []
-    objectsWithIndecies.forEach((obj) => {
-      const { trueIndex: index, requiredStep: rs } = obj
-      if (index === unremovableIndex) return
-      if (rs) {
-        updateParams.push([index, { _destroy: true, id: rs.id }])
-      } else {
-        removeIndecies.push(index)
-      }
-    })
-    remove(removeIndecies)
-    updateParams.forEach((arr) => update(...arr))
+  const handleClickCustomize = () => {
+    onAdd()
+    setIsCustomizing(true)
   }
 
-  useEffect(() => {
-    isSubmitted && setIsEditing(false)
-  }, [isSubmitted])
-
-  useEffect(() => {
-    !!!isEditing && isSubmitted && reset()
-  }, [isEditing])
-
-  useEffect(() => {
-    isEditing && trigger()
-  }, [isEditing, fields.length])
-
   const handleClickDeleteCustomization = () => {
-    const objectsWithIndecies = fields.map((f) => getTrueIndexAndObjectFromField(f))
-    onRemoveArray(objectsWithIndecies)
+    customFields.forEach((f) => {
+      const index = getIndex(f)
+      onRemove(index, f)
+    })
+
     setIsCustomizing(false)
   }
 
-  const unremovableIndex = getIndex(fields[0])
-
-  interface IIndexAndRequiredStep {
-    trueIndex: number
-    requiredStep: IPermitTypeRequiredStep
-  }
-
-  const getTrueIndexAndObjectFromField = (field): IIndexAndRequiredStep => {
-    const trueIndex = getIndex(field)
-    const requiredStepId = getValues(`${fieldArrayName}.${trueIndex}.id`)
-    const requiredStep = requiredStepId && getRequiredStep && getRequiredStep(requiredStepId)
-
-    return { trueIndex, requiredStep }
-  }
-
-  return error ? (
-    <ErrorScreen error={error} />
-  ) : (
-    <EditableBlockContainer>
-      <Flex direction="column" w="20%" alignSelf="flex-start">
-        <Text textTransform="uppercase" color="text.secondary" fontSize="sm" mb={4}>
-          {t(`${i18nPrefix}.stepRequired.permitTypeHeading`)}
-        </Text>
-        <EditableBlockHeading>{heading}</EditableBlockHeading>
-      </Flex>
-      <Flex flex={1} direction="column" gap={4}>
-        <Flex
-          direction="column"
-          p={4}
-          gap={4}
-          flex={1}
-          border="1px solid"
-          borderColor="border.light"
-          borderRadius="md"
-          bg={isEditing && !isCustomizing ? "greys.white" : "transparent"}
-        >
-          <Text fontWeight="bold">{t(`${i18nPrefix}.stepRequired.standardToPass`)}</Text>
-          <Flex gap={4}>
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} style={{ width: "100%" }}>
+      <EditableBlockContainer>
+        <Flex direction="column" w="20%" alignSelf="flex-start">
+          <Text textTransform="uppercase" color="text.secondary" fontSize="sm" mb={4}>
+            {t(`${i18nPrefix}.stepRequired.permitTypeHeading`)}
+          </Text>
+          <EditableBlockHeading>{heading}</EditableBlockHeading>
+        </Flex>
+        <Flex flex={1} direction="column" gap={4}>
+          <Flex
+            direction="column"
+            p={4}
+            gap={4}
+            flex={1}
+            border="1px solid"
+            borderColor="border.light"
+            borderRadius="md"
+            bg={isEditing && !isCustomizing ? "greys.white" : "transparent"}
+          >
+            <Text fontWeight="bold">{t(`${i18nPrefix}.stepRequired.standardToPass`)}</Text>
             <Flex gap={14} flex={1}>
-              <FormControl w="50%">
+              <Input type="hidden" {...register(`${fieldArrayName}.${defaultIndex}.id`)} />
+              <Input type="hidden" {...register(`${fieldArrayName}.${defaultIndex}.permitTypeId`)} />
+              <Input type="hidden" {...register(`${fieldArrayName}.${defaultIndex}.default`)} />
+              <FormControl>
                 <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.energy.title`)}</FormLabel>
                 <Controller
                   control={control}
                   rules={{ required: true }}
-                  name={`${fieldArrayName}.${unremovableIndex}.energyStepRequired`}
+                  name={`${fieldArrayName}.${defaultIndex}.energyStepRequired`}
                   render={({ field: { onChange, value } }) => {
                     return (
-                      <EnergyStepSelect
-                        onChange={onChange}
-                        value={value}
-                        showFirstOnly={isCustomizing}
-                        isDisabled={!isEditing || isCustomizing}
-                      />
+                      <EnergyStepSelect onChange={onChange} value={value} isDisabled={!isEditing || isCustomizing} />
                     )
                   }}
                 />
               </FormControl>
-              <FormControl w="50%">
+              <FormControl>
                 <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.zeroCarbon.title`)}</FormLabel>
                 <Controller
                   control={control}
                   rules={{ required: true }}
-                  name={`${fieldArrayName}.${unremovableIndex}.zeroCarbonStepRequired`}
+                  name={`${fieldArrayName}.${defaultIndex}.zeroCarbonStepRequired`}
                   render={({ field: { onChange, value } }) => {
                     return (
                       <ZeroCarbonStepSelect
                         onChange={onChange}
                         value={value}
-                        showFirstOnly={isCustomizing}
                         isDisabled={!isEditing || isCustomizing}
                       />
                     )
@@ -179,128 +152,133 @@ export const EnergyStepEditableBlock = observer(function EnergyStepEditableBlock
                 />
               </FormControl>
             </Flex>
-            <Box w={10} />
-          </Flex>
-          {isCustomizing && (
-            <CustomMessageBox status="warning" description={t(`${i18nPrefix}.overriddenWarning`)} p={1} />
-          )}
-        </Flex>
-
-        {isCustomizing ? (
-          <Flex
-            direction="column"
-            p={4}
-            gap={1}
-            flex={1}
-            border="1px solid"
-            borderColor="border.light"
-            borderRadius="md"
-            bg={isEditing ? "greys.white" : "transparent"}
-          >
-            <Text fontWeight="bold" mb={3}>
-              {t(`${i18nPrefix}.stepRequired.customizedMinimum`)}
-            </Text>
-            {fields.map((f, index) => {
-              const { trueIndex, requiredStep } = getTrueIndexAndObjectFromField(f)
-              return (
-                <React.Fragment key={f.id || generateUUID()}>
-                  <Input type="hidden" name={`${fieldArrayName}.${trueIndex}.id`} value={requiredStep?.id} />
-                  <Input type="hidden" name={`${fieldArrayName}.${trueIndex}.permitTypeId`} value={permitTypeId} />
-                  <Flex gap={4}>
-                    <Flex gap={4} flex={1}>
-                      <FormControl flex={1}>
-                        <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.energy.title`)}</FormLabel>
-                        <Controller
-                          control={control}
-                          rules={{ required: true }}
-                          name={`${fieldArrayName}.${trueIndex}.energyStepRequired`}
-                          render={({ field: { onChange, value } }) => {
-                            return (
-                              <EnergyStepSelect onChange={onChange} value={value} isDisabled={!isEditing} allowZero />
-                            )
-                          }}
-                        />
-                      </FormControl>
-                      <Text color="text.secondary" fontStyle="italic" alignSelf="flex-end" mb={2}>
-                        {t("ui.and")}
-                      </Text>
-                      <FormControl flex={1}>
-                        <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.zeroCarbon.title`)}</FormLabel>
-                        <Controller
-                          control={control}
-                          rules={{ required: true }}
-                          name={`${fieldArrayName}.${trueIndex}.zeroCarbonStepRequired`}
-                          render={({ field: { onChange, value } }) => {
-                            return (
-                              <ZeroCarbonStepSelect
-                                onChange={onChange}
-                                value={value}
-                                isDisabled={!isEditing}
-                                allowZero
-                              />
-                            )
-                          }}
-                        />
-                      </FormControl>
-                    </Flex>
-                    {isEditing && trueIndex !== unremovableIndex ? (
-                      <IconButton
-                        alignSelf="flex-end"
-                        variant="ghost"
-                        icon={<X />}
-                        onClick={() => onRemove(trueIndex, requiredStep)}
-                        aria-label={"remove customization"}
-                      />
-                    ) : (
-                      <Box w={10} />
-                    )}
-                  </Flex>
-                  <Text fontWeight="bold" textTransform="uppercase" my={2}>
-                    {index !== fields.length - 1 && t("ui.or")}
-                  </Text>
-                </React.Fragment>
-              )
-            })}
-            {isEditing && (
-              <Flex w="full" justify="space-between">
-                <Button size="sm" variant="primary" leftIcon={<Plus />} onClick={onAdd}>
-                  {t(`${i18nPrefix}.addStep`)}
-                </Button>
-
-                <Button
-                  size="sm"
-                  variant="link"
-                  color="semantic.error"
-                  leftIcon={<X />}
-                  onClick={handleClickDeleteCustomization}
-                >
-                  {t(`${i18nPrefix}.deleteCustomization`)}
-                </Button>
-              </Flex>
+            {isCustomizing && (
+              <CustomMessageBox status="warning" description={t(`${i18nPrefix}.overriddenWarning`)} p={1} />
             )}
           </Flex>
-        ) : (
-          isEditing && (
-            <Button variant="secondary" onClick={() => setIsCustomizing(true)}>
-              {t("ui.customize")}
+
+          {isCustomizing ? (
+            <Flex
+              direction="column"
+              p={4}
+              gap={1}
+              flex={1}
+              border="1px solid"
+              borderColor="border.light"
+              borderRadius="md"
+              bg={isEditing ? "greys.white" : "transparent"}
+            >
+              <Text fontWeight="bold" mb={3}>
+                {t(`${i18nPrefix}.stepRequired.customizedMinimum`)}
+              </Text>
+              {R.filter((f) => !f._destroy, customFields).map((f, index) => {
+                const trueIndex = getIndex(f)
+                return (
+                  <React.Fragment key={f.id || generateUUID()}>
+                    <Input type="hidden" name={`${fieldArrayName}.${trueIndex}.id`} value={f?.id} />
+                    <Input type="hidden" name={`${fieldArrayName}.${trueIndex}.permitTypeId`} value={permitTypeId} />
+                    <Flex gap={4}>
+                      <Flex gap={4} flex={1}>
+                        <FormControl flex={1}>
+                          <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.energy.title`)}</FormLabel>
+                          <Controller
+                            control={control}
+                            rules={{ required: true }}
+                            name={`${fieldArrayName}.${trueIndex}.energyStepRequired`}
+                            render={({ field: { onChange, value } }) => {
+                              return (
+                                <EnergyStepSelect onChange={onChange} value={value} isDisabled={!isEditing} allowZero />
+                              )
+                            }}
+                          />
+                        </FormControl>
+                        <Text color="text.secondary" fontStyle="italic" alignSelf="flex-end" mb={2}>
+                          {t("ui.and")}
+                        </Text>
+                        <FormControl flex={1}>
+                          <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.zeroCarbon.title`)}</FormLabel>
+                          <Controller
+                            control={control}
+                            rules={{ required: true }}
+                            name={`${fieldArrayName}.${trueIndex}.zeroCarbonStepRequired`}
+                            render={({ field: { onChange, value } }) => {
+                              return (
+                                <ZeroCarbonStepSelect
+                                  onChange={onChange}
+                                  value={value}
+                                  isDisabled={!isEditing}
+                                  allowZero
+                                />
+                              )
+                            }}
+                          />
+                        </FormControl>
+                      </Flex>
+                      {isEditing && customFields.length > 1 ? (
+                        <IconButton
+                          alignSelf="flex-end"
+                          variant="ghost"
+                          icon={<X />}
+                          onClick={() => onRemove(trueIndex, f)}
+                          aria-label={"remove customization"}
+                        />
+                      ) : (
+                        <Box w={10} />
+                      )}
+                    </Flex>
+                    <Text fontWeight="bold" textTransform="uppercase" my={2}>
+                      {index !== customFields.length - 1 && t("ui.or")}
+                    </Text>
+                  </React.Fragment>
+                )
+              })}
+              {isEditing && (
+                <Flex w="full" justify="space-between">
+                  <Button size="sm" variant="primary" leftIcon={<Plus />} onClick={onAdd}>
+                    {t(`${i18nPrefix}.addStep`)}
+                  </Button>
+
+                  <Button
+                    size="sm"
+                    variant="link"
+                    color="semantic.error"
+                    leftIcon={<X />}
+                    onClick={handleClickDeleteCustomization}
+                  >
+                    {t(`${i18nPrefix}.deleteCustomization`)}
+                  </Button>
+                </Flex>
+              )}
+            </Flex>
+          ) : (
+            isEditing && (
+              <Button variant="secondary" onClick={handleClickCustomize}>
+                {t("ui.customize")}
+              </Button>
+            )
+          )}
+        </Flex>
+        {isEditing ? (
+          <VStack alignSelf="start">
+            <Button
+              variant="primary"
+              w="full"
+              type="submit"
+              isLoading={isSubmitting}
+              isDisabled={isSubmitting || !isValid}
+            >
+              {t("ui.onlySave")}
             </Button>
-          )
+            <Button variant="secondary" w="full" onClick={handleClickCancel} isDisabled={isSubmitting}>
+              {t("ui.cancel")}
+            </Button>
+          </VStack>
+        ) : (
+          <Button alignSelf="start" variant="primary" leftIcon={<Pencil />} onClick={() => setIsEditing(true)}>
+            {t("ui.edit")}
+          </Button>
         )}
-      </Flex>
-      {isEditing ? (
-        <Stack direction={{ base: "column", lg: "row" }} alignSelf="start">
-          <Button variant="primary" type="submit" isLoading={isSubmitting} isDisabled={isSubmitting || !isValid}>
-            {t("ui.onlySave")}
-          </Button>
-          <Button variant="secondary" onClick={handleClickCancel} isDisabled={isSubmitting}>
-            {t("ui.cancel")}
-          </Button>
-        </Stack>
-      ) : (
-        <Button alignSelf="start" variant="primary" leftIcon={<Pencil />} onClick={() => setIsEditing(true)}>
-          {t("ui.edit")}
-        </Button>
-      )}
-    </EditableBlockContainer>
+      </EditableBlockContainer>
+    </form>
   )
 })

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/index.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/index.tsx
@@ -1,78 +1,306 @@
+import { Box, Button, Flex, FormControl, FormLabel, IconButton, Input, Stack, Text } from "@chakra-ui/react"
+import { Pencil, Plus, X } from "@phosphor-icons/react"
+import { t } from "i18next"
 import { observer } from "mobx-react-lite"
-import React, { Suspense } from "react"
+import React, { useEffect, useState } from "react"
+import { Controller, useFormContext } from "react-hook-form"
 import { useJurisdiction } from "../../../../../../../hooks/resources/use-jurisdiction"
+import { IPermitTypeRequiredStep } from "../../../../../../../types/types"
+import { generateUUID } from "../../../../../../../utils/utility-functions"
+import { CustomMessageBox } from "../../../../../../shared/base/custom-message-box"
 import { ErrorScreen } from "../../../../../../shared/base/error-screen"
-import { LoadingScreen } from "../../../../../../shared/base/loading-screen"
+import { EditableBlockContainer, EditableBlockHeading } from "../../shared/editable-block"
+import { i18nPrefix } from "../i18n-prefix"
+import { EnergyStepSelect } from "./energy-step-select"
+import { ZeroCarbonStepSelect } from "./zero-carbon-step-select"
 
-export const EnergyStepEditableBlock = observer(function EnergyStepEditableBlock() {
+interface IProps {
+  heading: string
+  permitTypeId: string
+  fields: IPermitTypeRequiredStep[]
+  fieldArrayName: string
+  append: any
+  remove: any
+  update: any
+  getIndex: (field: IPermitTypeRequiredStep) => number
+  reset: () => any
+}
+
+export const EnergyStepEditableBlock = observer(function EnergyStepEditableBlock({
+  heading,
+  permitTypeId,
+  fields,
+  fieldArrayName,
+  reset,
+  append,
+  remove,
+  update,
+  getIndex,
+}: IProps) {
+  const isCustomizingDefault = () => {
+    return fields.length > 1 || fields[0].energyStepRequired === 0 || fields[0].zeroCarbonStepRequired === 0
+  }
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [isCustomizing, setIsCustomizing] = useState(isCustomizingDefault())
+
   const { currentJurisdiction, error } = useJurisdiction()
+
+  const getRequiredStep = currentJurisdiction?.getRequiredStep
+
+  const { formState, trigger, getValues, setValue, control } = useFormContext()
+  const { errors, isSubmitting, isSubmitted, isValid } = formState
+
+  const handleClickCancel = () => {
+    reset()
+    setIsEditing(false)
+  }
+
+  const onAdd = () => {
+    append({ permitTypeId, energyStepRequired: null, zeroCarbonStepRequired: null })
+  }
+
+  const onRemove = (index: number, rs?: IPermitTypeRequiredStep) => {
+    if (index === unremovableIndex) return
+    if (rs) {
+      update(index, { _destroy: true, id: rs.id })
+    } else {
+      remove(index)
+    }
+  }
+
+  const onRemoveArray = (objectsWithIndecies: IIndexAndRequiredStep[]) => {
+    const updateParams = []
+    const removeIndecies = []
+    objectsWithIndecies.forEach((obj) => {
+      const { trueIndex: index, requiredStep: rs } = obj
+      if (index === unremovableIndex) return
+      if (rs) {
+        updateParams.push([index, { _destroy: true, id: rs.id }])
+      } else {
+        removeIndecies.push(index)
+      }
+    })
+    remove(removeIndecies)
+    updateParams.forEach((arr) => update(...arr))
+  }
+
+  useEffect(() => {
+    isSubmitted && setIsEditing(false)
+  }, [isSubmitted])
+
+  useEffect(() => {
+    !!!isEditing && isSubmitted && reset()
+  }, [isEditing])
+
+  useEffect(() => {
+    isEditing && trigger()
+  }, [isEditing, fields.length])
+
+  const handleClickDeleteCustomization = () => {
+    const objectsWithIndecies = fields.map((f) => getTrueIndexAndObjectFromField(f))
+    onRemoveArray(objectsWithIndecies)
+    setIsCustomizing(false)
+  }
+
+  const unremovableIndex = getIndex(fields[0])
+
+  interface IIndexAndRequiredStep {
+    trueIndex: number
+    requiredStep: IPermitTypeRequiredStep
+  }
+
+  const getTrueIndexAndObjectFromField = (field): IIndexAndRequiredStep => {
+    const trueIndex = getIndex(field)
+    const requiredStepId = getValues(`${fieldArrayName}.${trueIndex}.id`)
+    const requiredStep = requiredStepId && getRequiredStep && getRequiredStep(requiredStepId)
+
+    return { trueIndex, requiredStep }
+  }
 
   return error ? (
     <ErrorScreen error={error} />
   ) : (
-    <Suspense fallback={<LoadingScreen />}>
-      {/* TODO: Upgrade form */}
-      {/* {currentJurisdiction && <Form jurisdiction={currentJurisdiction} />} */}
-    </Suspense>
+    <EditableBlockContainer>
+      <Flex direction="column" w="20%" alignSelf="flex-start">
+        <Text textTransform="uppercase" color="text.secondary" fontSize="sm" mb={4}>
+          {t(`${i18nPrefix}.stepRequired.permitTypeHeading`)}
+        </Text>
+        <EditableBlockHeading>{heading}</EditableBlockHeading>
+      </Flex>
+      <Flex flex={1} direction="column" gap={4}>
+        <Flex
+          direction="column"
+          p={4}
+          gap={4}
+          flex={1}
+          border="1px solid"
+          borderColor="border.light"
+          borderRadius="md"
+          bg={isEditing && !isCustomizing ? "greys.white" : "transparent"}
+        >
+          <Text fontWeight="bold">{t(`${i18nPrefix}.stepRequired.standardToPass`)}</Text>
+          <Flex gap={4}>
+            <Flex gap={14} flex={1}>
+              <FormControl w="50%">
+                <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.energy.title`)}</FormLabel>
+                <Controller
+                  control={control}
+                  rules={{ required: true }}
+                  name={`${fieldArrayName}.${unremovableIndex}.energyStepRequired`}
+                  render={({ field: { onChange, value } }) => {
+                    return (
+                      <EnergyStepSelect
+                        onChange={onChange}
+                        value={value}
+                        showFirstOnly={isCustomizing}
+                        isDisabled={!isEditing || isCustomizing}
+                      />
+                    )
+                  }}
+                />
+              </FormControl>
+              <FormControl w="50%">
+                <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.zeroCarbon.title`)}</FormLabel>
+                <Controller
+                  control={control}
+                  rules={{ required: true }}
+                  name={`${fieldArrayName}.${unremovableIndex}.zeroCarbonStepRequired`}
+                  render={({ field: { onChange, value } }) => {
+                    return (
+                      <ZeroCarbonStepSelect
+                        onChange={onChange}
+                        value={value}
+                        showFirstOnly={isCustomizing}
+                        isDisabled={!isEditing || isCustomizing}
+                      />
+                    )
+                  }}
+                />
+              </FormControl>
+            </Flex>
+            <Box w={10} />
+          </Flex>
+          {isCustomizing && (
+            <CustomMessageBox status="warning" description={t(`${i18nPrefix}.overriddenWarning`)} p={1} />
+          )}
+        </Flex>
+
+        {isCustomizing ? (
+          <Flex
+            direction="column"
+            p={4}
+            gap={1}
+            flex={1}
+            border="1px solid"
+            borderColor="border.light"
+            borderRadius="md"
+            bg={isEditing ? "greys.white" : "transparent"}
+          >
+            <Text fontWeight="bold" mb={3}>
+              {t(`${i18nPrefix}.stepRequired.customizedMinimum`)}
+            </Text>
+            {fields.map((f, index) => {
+              const { trueIndex, requiredStep } = getTrueIndexAndObjectFromField(f)
+              return (
+                <React.Fragment key={f.id || generateUUID()}>
+                  <Input type="hidden" name={`${fieldArrayName}.${trueIndex}.id`} value={requiredStep?.id} />
+                  <Input type="hidden" name={`${fieldArrayName}.${trueIndex}.permitTypeId`} value={permitTypeId} />
+                  <Flex gap={4}>
+                    <Flex gap={4} flex={1}>
+                      <FormControl flex={1}>
+                        <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.energy.title`)}</FormLabel>
+                        <Controller
+                          control={control}
+                          rules={{ required: true }}
+                          name={`${fieldArrayName}.${trueIndex}.energyStepRequired`}
+                          render={({ field: { onChange, value } }) => {
+                            return (
+                              <EnergyStepSelect onChange={onChange} value={value} isDisabled={!isEditing} allowZero />
+                            )
+                          }}
+                        />
+                      </FormControl>
+                      <Text color="text.secondary" fontStyle="italic" alignSelf="flex-end" mb={2}>
+                        {t("ui.and")}
+                      </Text>
+                      <FormControl flex={1}>
+                        <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.zeroCarbon.title`)}</FormLabel>
+                        <Controller
+                          control={control}
+                          rules={{ required: true }}
+                          name={`${fieldArrayName}.${trueIndex}.zeroCarbonStepRequired`}
+                          render={({ field: { onChange, value } }) => {
+                            return (
+                              <ZeroCarbonStepSelect
+                                onChange={onChange}
+                                value={value}
+                                isDisabled={!isEditing}
+                                allowZero
+                              />
+                            )
+                          }}
+                        />
+                      </FormControl>
+                    </Flex>
+                    {isEditing && trueIndex !== unremovableIndex ? (
+                      <IconButton
+                        alignSelf="flex-end"
+                        variant="ghost"
+                        icon={<X />}
+                        onClick={() => onRemove(trueIndex, requiredStep)}
+                        aria-label={"remove customization"}
+                      />
+                    ) : (
+                      <Box w={10} />
+                    )}
+                  </Flex>
+                  <Text fontWeight="bold" textTransform="uppercase" my={2}>
+                    {index !== fields.length - 1 && t("ui.or")}
+                  </Text>
+                </React.Fragment>
+              )
+            })}
+            {isEditing && (
+              <Flex w="full" justify="space-between">
+                <Button size="sm" variant="primary" leftIcon={<Plus />} onClick={onAdd}>
+                  {t(`${i18nPrefix}.addStep`)}
+                </Button>
+
+                <Button
+                  size="sm"
+                  variant="link"
+                  color="semantic.error"
+                  leftIcon={<X />}
+                  onClick={handleClickDeleteCustomization}
+                >
+                  {t(`${i18nPrefix}.deleteCustomization`)}
+                </Button>
+              </Flex>
+            )}
+          </Flex>
+        ) : (
+          isEditing && (
+            <Button variant="secondary" onClick={() => setIsCustomizing(true)}>
+              {t("ui.customize")}
+            </Button>
+          )
+        )}
+      </Flex>
+      {isEditing ? (
+        <Stack direction={{ base: "column", lg: "row" }} alignSelf="start">
+          <Button variant="primary" type="submit" isLoading={isSubmitting} isDisabled={isSubmitting || !isValid}>
+            {t("ui.onlySave")}
+          </Button>
+          <Button variant="secondary" onClick={handleClickCancel} isDisabled={isSubmitting}>
+            {t("ui.cancel")}
+          </Button>
+        </Stack>
+      ) : (
+        <Button alignSelf="start" variant="primary" leftIcon={<Pencil />} onClick={() => setIsEditing(true)}>
+          {t("ui.edit")}
+        </Button>
+      )}
+    </EditableBlockContainer>
   )
 })
-
-// const Form = function JursidictionEnergyStepRequirementsForm({ jurisdiction }) {
-//   const { energyStepRequired, zeroCarbonStepRequired, update } = jurisdiction
-
-//   const { handleSubmit, control, formState } = useForm({
-//     defaultValues: { energyStepRequired, zeroCarbonStepRequired },
-//   })
-
-//   const { isSubmitting } = formState
-//   const [isEditing, setIsEditing] = useState(false)
-
-//   const onSubmit = async (values) => {
-//     const result = await update(values)
-//     result && setIsEditing(false)
-//   }
-
-//   return (
-//     <form onSubmit={handleSubmit(onSubmit)} style={{ width: "100%" }}>
-//       <EditableBlockContainer>
-//         <EditableBlockHeading>{t(`${i18nPrefix}.part9Building`)}</EditableBlockHeading>
-//         <Flex gap={6}>
-//           <FormControl w="max-content">
-//             <FormLabel>{t(`${i18nPrefix}.stepRequired.energy.title`)}</FormLabel>
-//             <Controller
-//               control={control}
-//               name="energyStepRequired"
-//               render={({ field: { onChange, value } }) => {
-//                 return <EnergyStepSelect onChange={onChange} value={value} isDisabled={!isEditing} />
-//               }}
-//             />
-//           </FormControl>
-//           <FormControl w="max-content">
-//             <FormLabel>{t(`${i18nPrefix}.stepRequired.zeroCarbon.title`)}</FormLabel>
-//             <Controller
-//               control={control}
-//               name="zeroCarbonStepRequired"
-//               render={({ field: { onChange, value } }) => {
-//                 return <ZeroCarbonStepSelect onChange={onChange} value={value} isDisabled={!isEditing} />
-//               }}
-//             />
-//           </FormControl>
-//         </Flex>
-//         {isEditing ? (
-//           <HStack alignSelf="end">
-//             <Button variant="primary" type="submit" isLoading={isSubmitting} isDisabled={isSubmitting}>
-//               {t("ui.save")}
-//             </Button>
-//             <Button variant="secondary" onClick={() => setIsEditing(false)} isDisabled={isSubmitting}>
-//               {t("ui.cancel")}
-//             </Button>
-//           </HStack>
-//         ) : (
-//           <Button alignSelf="end" variant="primary" leftIcon={<Pencil />} onClick={() => setIsEditing(true)}>
-//             {t("ui.edit")}
-//           </Button>
-//         )}
-//       </EditableBlockContainer>
-//     </form>
-//   )
-// }

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/zero-carbon-step-select.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/zero-carbon-step-select.tsx
@@ -23,7 +23,6 @@ interface IProps {
   value: EZeroCarbonStep
   isDisabled?: boolean
   allowZero?: boolean
-  showFirstOnly?: boolean
 }
 
 export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({
@@ -31,7 +30,6 @@ export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({
   value,
   isDisabled,
   allowZero,
-  showFirstOnly,
 }: IProps) {
   const {
     stepCodeStore: { getZeroCarbonStepOptions },
@@ -57,7 +55,7 @@ export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({
                 isDisabled={isDisabled}
               >
                 {!R.isNil(value)
-                  ? t(`${i18nPrefix}.stepRequired.zeroCarbon.options.${showFirstOnly ? options[0] : value}`)
+                  ? t(`${i18nPrefix}.stepRequired.zeroCarbon.options.${value}`)
                   : t(`ui.selectPlaceholder`)}
               </Input>
               <InputRightElement children={<CaretDown color="gray.300" />} />
@@ -76,12 +74,11 @@ export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({
                     px={2}
                     py={1.5}
                     w="full"
-                    borderTop={i === options.length - 1 ? "1px solid" : undefined}
+                    borderTopWidth={value == "0" ? 1 : undefined}
                     borderColor="border.light"
                     cursor="pointer"
                     _hover={{ bg: "hover.blue" }}
                   >
-                    {/* @ts-ignore */}
                     {t(`${i18nPrefix}.stepRequired.zeroCarbon.options.${value}`)}
                   </Flex>
                 ))}

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/zero-carbon-step-select.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/zero-carbon-step-select.tsx
@@ -7,27 +7,37 @@ import {
   PopoverContent,
   PopoverTrigger,
   Portal,
-  StackDivider,
   VStack,
 } from "@chakra-ui/react"
 import { CaretDown } from "@phosphor-icons/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
+import * as R from "ramda"
 import React from "react"
 import { useMst } from "../../../../../../../setup/root"
-import { ESZeroCarbonStep } from "../../../../../../../types/enums"
+import { EZeroCarbonStep } from "../../../../../../../types/enums"
 import { i18nPrefix } from "../i18n-prefix"
 
 interface IProps {
   onChange: (event: any) => void
-  value: ESZeroCarbonStep
+  value: EZeroCarbonStep
   isDisabled?: boolean
+  allowZero?: boolean
+  showFirstOnly?: boolean
 }
 
-export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({ onChange, value, isDisabled }: IProps) {
+export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({
+  onChange,
+  value,
+  isDisabled,
+  allowZero,
+  showFirstOnly,
+}: IProps) {
   const {
-    stepCodeStore: { selectOptions },
+    stepCodeStore: { getZeroCarbonStepOptions },
   } = useMst()
+
+  const options = getZeroCarbonStepOptions(allowZero)
 
   return (
     <Popover placement="bottom-end">
@@ -46,15 +56,17 @@ export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({ onC
                 shadow="base"
                 isDisabled={isDisabled}
               >
-                {value ? t(`${i18nPrefix}.stepRequired.zeroCarbon.options.${value}`) : t(`ui.selectPlaceholder`)}
+                {!R.isNil(value)
+                  ? t(`${i18nPrefix}.stepRequired.zeroCarbon.options.${showFirstOnly ? options[0] : value}`)
+                  : t(`ui.selectPlaceholder`)}
               </Input>
               <InputRightElement children={<CaretDown color="gray.300" />} />
             </InputGroup>
           </PopoverTrigger>
           <Portal>
             <PopoverContent>
-              <VStack align="start" spacing={0} divider={<StackDivider borderColor="border.light" />}>
-                {selectOptions.zeroCarbonSteps.map((value) => (
+              <VStack align="start" spacing={0}>
+                {options.map((value, i) => (
                   <Flex
                     key={value}
                     onClick={() => {
@@ -64,9 +76,12 @@ export const ZeroCarbonStepSelect = observer(function ZeroCarbonStepSelect({ onC
                     px={2}
                     py={1.5}
                     w="full"
+                    borderTop={i === options.length - 1 ? "1px solid" : undefined}
+                    borderColor="border.light"
                     cursor="pointer"
                     _hover={{ bg: "hover.blue" }}
                   >
+                    {/* @ts-ignore */}
                     {t(`${i18nPrefix}.stepRequired.zeroCarbon.options.${value}`)}
                   </Flex>
                 ))}

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/form.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/form.tsx
@@ -1,0 +1,75 @@
+import { VStack } from "@chakra-ui/react"
+import { observer } from "mobx-react-lite"
+import * as R from "ramda"
+import React from "react"
+import { FormProvider, useFieldArray, useForm } from "react-hook-form"
+import { IJurisdiction } from "../../../../../../models/jurisdiction"
+import { useMst } from "../../../../../../setup/root"
+
+import { IPermitTypeRequiredStep } from "../../../../../../types/types"
+import { EnergyStepEditableBlock } from "./energy-step-editable-block"
+
+interface IFormProps {
+  jurisdiction: IJurisdiction
+}
+
+interface IFormValues {
+  permitTypeRequiredStepsAttributes: IPermitTypeRequiredStep[]
+}
+
+export const Form = observer(function EnergyStepSetupForm({ jurisdiction }: IFormProps) {
+  const {
+    permitClassificationStore: { permitTypes },
+  } = useMst()
+
+  const getDefaultValues = () => ({
+    permitTypeRequiredStepsAttributes: [...(jurisdiction.permitTypeRequiredSteps as IPermitTypeRequiredStep[])],
+  })
+
+  const fieldArrayName = "permitTypeRequiredStepsAttributes"
+  const formMethods = useForm<IFormValues>({
+    mode: "onChange",
+    defaultValues: getDefaultValues(),
+  })
+  const { handleSubmit, reset, control } = formMethods
+  const { fields, append, remove, update } = useFieldArray({
+    control,
+    name: fieldArrayName,
+  })
+
+  const getIndex = (field) => R.findIndex((f) => f.id == field.id, fields)
+
+  const onSubmit = async (values) => {
+    return await jurisdiction.update(values)
+  }
+
+  const handleReset = () => {
+    reset(getDefaultValues())
+  }
+
+  return (
+    <FormProvider {...formMethods}>
+      <form onSubmit={handleSubmit(onSubmit)} style={{ width: "100%" }}>
+        <VStack spacing={5}>
+          {permitTypes.map((permitType) => {
+            const permitTypeFields = R.filter((f) => f.permitTypeId == permitType.id, fields)
+            return (
+              <EnergyStepEditableBlock
+                key={permitType.id}
+                heading={permitType.name}
+                permitTypeId={permitType.id}
+                fields={permitTypeFields}
+                fieldArrayName={fieldArrayName}
+                getIndex={getIndex}
+                append={append}
+                remove={remove}
+                update={update}
+                reset={handleReset}
+              />
+            )
+          })}
+        </VStack>
+      </form>
+    </FormProvider>
+  )
+})

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/form.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/form.tsx
@@ -1,20 +1,13 @@
 import { VStack } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
-import * as R from "ramda"
 import React from "react"
-import { FormProvider, useFieldArray, useForm } from "react-hook-form"
 import { IJurisdiction } from "../../../../../../models/jurisdiction"
 import { useMst } from "../../../../../../setup/root"
 
-import { IPermitTypeRequiredStep } from "../../../../../../types/types"
 import { EnergyStepEditableBlock } from "./energy-step-editable-block"
 
 interface IFormProps {
   jurisdiction: IJurisdiction
-}
-
-interface IFormValues {
-  permitTypeRequiredStepsAttributes: IPermitTypeRequiredStep[]
 }
 
 export const Form = observer(function EnergyStepSetupForm({ jurisdiction }: IFormProps) {
@@ -22,54 +15,18 @@ export const Form = observer(function EnergyStepSetupForm({ jurisdiction }: IFor
     permitClassificationStore: { permitTypes },
   } = useMst()
 
-  const getDefaultValues = () => ({
-    permitTypeRequiredStepsAttributes: [...(jurisdiction.permitTypeRequiredSteps as IPermitTypeRequiredStep[])],
-  })
-
-  const fieldArrayName = "permitTypeRequiredStepsAttributes"
-  const formMethods = useForm<IFormValues>({
-    mode: "onChange",
-    defaultValues: getDefaultValues(),
-  })
-  const { handleSubmit, reset, control } = formMethods
-  const { fields, append, remove, update } = useFieldArray({
-    control,
-    name: fieldArrayName,
-  })
-
-  const getIndex = (field) => R.findIndex((f) => f.id == field.id, fields)
-
-  const onSubmit = async (values) => {
-    return await jurisdiction.update(values)
-  }
-
-  const handleReset = () => {
-    reset(getDefaultValues())
-  }
-
   return (
-    <FormProvider {...formMethods}>
-      <form onSubmit={handleSubmit(onSubmit)} style={{ width: "100%" }}>
-        <VStack spacing={5}>
-          {permitTypes.map((permitType) => {
-            const permitTypeFields = R.filter((f) => f.permitTypeId == permitType.id, fields)
-            return (
-              <EnergyStepEditableBlock
-                key={permitType.id}
-                heading={permitType.name}
-                permitTypeId={permitType.id}
-                fields={permitTypeFields}
-                fieldArrayName={fieldArrayName}
-                getIndex={getIndex}
-                append={append}
-                remove={remove}
-                update={update}
-                reset={handleReset}
-              />
-            )
-          })}
-        </VStack>
-      </form>
-    </FormProvider>
+    <VStack spacing={5}>
+      {permitTypes.map((permitType) => {
+        return (
+          <EnergyStepEditableBlock
+            key={permitType.id}
+            heading={permitType.name}
+            permitTypeId={permitType.id}
+            jurisdiction={jurisdiction}
+          />
+        )
+      })}
+    </VStack>
   )
 })

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/index.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/index.tsx
@@ -1,10 +1,14 @@
-import { Container, Heading, Text, VStack } from "@chakra-ui/react"
+import { Container, Heading, Link, Text, VStack } from "@chakra-ui/react"
+import { ArrowSquareOut } from "@phosphor-icons/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
 import React, { Suspense, useEffect } from "react"
+import { useJurisdiction } from "../../../../../../hooks/resources/use-jurisdiction"
+import { usePermitClassificationsLoad } from "../../../../../../hooks/resources/use-permit-classifications-load"
 import { useMst } from "../../../../../../setup/root"
+import { ErrorScreen } from "../../../../../shared/base/error-screen"
 import { LoadingScreen } from "../../../../../shared/base/loading-screen"
-import { EnergyStepEditableBlock } from "./energy-step-editable-block"
+import { Form } from "./form"
 import { i18nPrefix } from "./i18n-prefix"
 
 export const EnergyStepRequirementsScreen = observer(function EnergyStepRequirementsScreen() {
@@ -12,12 +16,18 @@ export const EnergyStepRequirementsScreen = observer(function EnergyStepRequirem
     stepCodeStore: { isLoaded, fetchStepCodes },
   } = useMst()
 
+  const { isLoaded: isClassificationsLoaded } = usePermitClassificationsLoad()
+
   useEffect(() => {
     const fetch = async () => await fetchStepCodes()
     !isLoaded && fetch()
   }, [isLoaded])
 
-  return (
+  const { currentJurisdiction, error } = useJurisdiction()
+
+  return error ? (
+    <ErrorScreen />
+  ) : (
     <Suspense fallback={<LoadingScreen />}>
       {isLoaded && (
         <Container maxW="container.lg" py={8} px={{ base: 8, xl: 0 }} flexGrow={1}>
@@ -30,7 +40,15 @@ export const EnergyStepRequirementsScreen = observer(function EnergyStepRequirem
                 {t(`${i18nPrefix}.description`)}
               </Text>
             </VStack>
-            <EnergyStepEditableBlock />
+            <Text fontWeight="bold">
+              {t(`${i18nPrefix}.setMinimum`)} <br />{" "}
+              <Link href={t("stepCode.helpLink")} isExternal fontWeight="normal">
+                {t("stepCode.helpLinkText")}
+                <ArrowSquareOut />
+              </Link>
+            </Text>
+
+            {currentJurisdiction && isLoaded && isClassificationsLoaded && <Form jurisdiction={currentJurisdiction} />}
           </VStack>
         </Container>
       )}

--- a/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
@@ -9,6 +9,7 @@ import {
   HStack,
   Heading,
   Input,
+  Link,
   ListItem,
   OrderedList,
   Show,
@@ -21,6 +22,7 @@ import {
   Thead,
   Tr,
 } from "@chakra-ui/react"
+import { ArrowSquareOut } from "@phosphor-icons/react"
 import i18next from "i18next"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useState } from "react"
@@ -184,11 +186,10 @@ export const JurisdictionScreen = observer(() => {
                 <Flex direction="column" p={6} gap={9}>
                   <Flex direction="column" gap={2}>
                     <Text>{t("jurisdiction.edit.stepCode.description")}</Text>
-                    {/* TODO: Add step code help link href */}
-                    {/* <Link href={"#"} isExternal>
-                      {t("jurisdiction.edit.stepCode.helpLinkText")}
+                    <Link href={t("stepCode.helpLink")} isExternal fontWeight="normal">
+                      {t("stepCode.helpLinkText")}
                       <ArrowSquareOut />
-                    </Link> */}
+                    </Link>
                   </Flex>
                   <StepCodeTable currentJurisdiction={currentJurisdiction} />
                 </Flex>
@@ -385,50 +386,52 @@ interface IStepCodeTableProps {
 
 const StepCodeTable: React.FC<IStepCodeTableProps> = ({ currentJurisdiction }) => {
   const { t } = useTranslation()
-  const requiredStepsByTemplate = currentJurisdiction.requiredStepsByTemplate
+  const requiredStepsByPermitType = currentJurisdiction.requiredStepsByPermitType
   return (
     <TableContainer>
       <Table variant="simple">
         <Thead>
           <Tr>
-            <Th textAlign="left">{t("jurisdiction.edit.stepCode.permitTemplate")}</Th>
+            <Th textAlign="left">{t("jurisdiction.edit.stepCode.permitType")}</Th>
             <Th textAlign="center">{t("jurisdiction.edit.stepCode.energyStepRequired")}</Th>
             <Th textAlign="center"></Th>
             <Th textAlign="right">{t("jurisdiction.edit.stepCode.zeroCarbonStepRequired")}</Th>
           </Tr>
         </Thead>
         <Tbody>
-          {Object.keys(requiredStepsByTemplate).map((templateId) => {
+          {Object.keys(requiredStepsByPermitType).map((permitTypeId) => {
             return (
               <>
-                {requiredStepsByTemplate[templateId].map((jtrs, i) => (
+                {requiredStepsByPermitType[permitTypeId].map((ptrs, i) => (
                   <>
                     <Tr>
                       <Td textAlign="left" fontWeight="bold">
-                        {jtrs.requirementTemplateLabel}
+                        {ptrs.permitTypeName}
                       </Td>
                       <Td textAlign="center">
-                        {currentJurisdiction.energyStepRequiredTranslation(jtrs.energyStepRequired)}
+                        {currentJurisdiction.energyStepRequiredTranslation(ptrs.energyStepRequired)}
                       </Td>
                       <Td textAlign="center" textTransform="lowercase" fontStyle="italic">
                         {t("ui.and")}
                       </Td>
                       <Td textAlign="right">
-                        {currentJurisdiction.zeroCarbonLevelTranslation(jtrs.zeroCarbonStepRequired)}
+                        {currentJurisdiction.zeroCarbonLevelTranslation(ptrs.zeroCarbonStepRequired)}
                       </Td>
                     </Tr>
-                    {i !== requiredStepsByTemplate[templateId].length - 1 && (
+                    {i !== requiredStepsByPermitType[permitTypeId].length - 1 && (
                       <Tr>
                         <Td colSpan={4}>
-                          <Center>{t("ui.or")}</Center>
+                          <Center h={0} fontWeight="bold">
+                            {t("ui.or")}
+                          </Center>
                         </Td>
                       </Tr>
                     )}
                   </>
                 ))}
-                <Tr>
-                  <Td colSpan={4}>
-                    <Box borderTop="2px" borderColor="greys.grey02" />
+                <Tr p={0}>
+                  <Td colSpan={4} p={0}>
+                    <Box borderTop="1px" borderColor="greys.grey01" my={8} />
                   </Td>
                 </Tr>
               </>

--- a/app/frontend/components/domains/misc/contact-screen.tsx
+++ b/app/frontend/components/domains/misc/contact-screen.tsx
@@ -72,7 +72,7 @@ export const ContactScreen = () => {
           isExternal
           ml="1"
         >
-          {t("site.contactNeedHelpCTA")} <ArrowSquareOut></ArrowSquareOut>
+          {t("site.contactNeedHelpCTA")} <ArrowSquareOut />
         </Link>
       </Text>
     </Container>

--- a/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
@@ -266,7 +266,7 @@ const DisclaimerInfo = () => {
             <ListItem key={disclaimer.href}>
               <Link href={disclaimer.href} isExternal>
                 {disclaimer.text}
-                <ArrowSquareOut></ArrowSquareOut>
+                <ArrowSquareOut />
               </Link>
             </ListItem>
           )
@@ -275,7 +275,7 @@ const DisclaimerInfo = () => {
       <Text>{t("permitApplication.new.applicationDisclaimerMoreInfo")}</Text>
       <Link href={t("permitApplication.new.applicationDisclaimerMoreInfo_Link")} isExternal>
         {t("permitApplication.new.applicationDisclaimerMoreInfo_CTA")}
-        <ArrowSquareOut></ArrowSquareOut>
+        <ArrowSquareOut />
       </Link>
     </Box>
   )

--- a/app/frontend/components/shared/base/custom-message-box.tsx
+++ b/app/frontend/components/shared/base/custom-message-box.tsx
@@ -1,8 +1,8 @@
-import { Box, Flex, Heading, Text, ToastProps } from "@chakra-ui/react"
+import { Box, Flex, FlexProps, Heading, Text, ToastProps } from "@chakra-ui/react"
 import { CheckCircle, Info, Warning, WarningCircle } from "@phosphor-icons/react"
 import React from "react"
 
-interface ICustomMessageBoxProps extends ToastProps {
+interface ICustomMessageBoxProps extends Omit<ToastProps, "id" | "position" | "title">, FlexProps {
   children?: React.ReactNode
 }
 const iconMap = {
@@ -12,7 +12,7 @@ const iconMap = {
   info: <Info size={24} aria-label={"info icon"} />,
 }
 
-export const CustomMessageBox = ({ title, description, status, children }: ICustomMessageBoxProps) => {
+export const CustomMessageBox = ({ title, description, status, children, ...rest }: ICustomMessageBoxProps) => {
   return (
     <Flex
       direction="column"
@@ -22,6 +22,7 @@ export const CustomMessageBox = ({ title, description, status, children }: ICust
       borderRadius="lg"
       borderColor={`semantic.${status}`}
       p={4}
+      {...rest}
     >
       <Flex align="flex-start" gap={2}>
         <Box color={`semantic.${status}`}>{iconMap[status]}</Box>

--- a/app/frontend/components/shared/form/email-form-control.tsx
+++ b/app/frontend/components/shared/form/email-form-control.tsx
@@ -52,11 +52,15 @@ export const EmailFormControl = ({
   return (
     <FormControl isInvalid={errorMessage && !inputProps?.isDisabled} {...rest}>
       <HStack gap={0}>
-        {!hideLabel && <FormLabel>{label || t("auth.emailLabel")}</FormLabel>}
-        {required && (
-          <Box color="semantic.error" ml={-2} mb={2}>
-            <AsteriskSimple />
-          </Box>
+        {!hideLabel && (
+          <>
+            <FormLabel>{label || t("auth.emailLabel")}</FormLabel>
+            {required && (
+              <Box color="semantic.error" ml={-2} mb={2}>
+                <AsteriskSimple />
+              </Box>
+            )}
+          </>
         )}
       </HStack>
       <Flex>

--- a/app/frontend/components/shared/permit-applications/permit-application-card.tsx
+++ b/app/frontend/components/shared/permit-applications/permit-application-card.tsx
@@ -120,13 +120,13 @@ export const PermitApplicationCard = ({ permitApplication }: IPermitApplicationC
           <Flex direction={{ base: "column", md: "row" }} gap={4}>
             <Link href={t("permitApplication.seeBestPractices_link")} isExternal>
               {t("permitApplication.seeBestPractices_CTA")}
-              <ArrowSquareOut></ArrowSquareOut>
+              <ArrowSquareOut />
             </Link>
             <Show above="md">
               <Text>{"  |  "}</Text>
             </Show>
             <Link href={t("permitApplication.searchKnowledge_link")} isExternal>
-              {t("permitApplication.searchKnowledge_CTA")} <ArrowSquareOut></ArrowSquareOut>
+              {t("permitApplication.searchKnowledge_CTA")} <ArrowSquareOut />
             </Link>
           </Flex>
         </Flex>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -222,6 +222,7 @@ const options = {
           or: "or",
           actionRequired: "Action required",
           resetFilters: "Reset filters",
+          customize: "Customize",
         },
         notification: {
           title: "Notifications",
@@ -285,7 +286,7 @@ const options = {
             stepCode: {
               title: "Step code requirements",
               description: "Below are the step code requirements for each permit template",
-              permitTemplate: "Permit template",
+              permitType: "Permit type",
               energyStepRequired: "Energy step code required",
               zeroCarbonStepRequired: "Zero carbon step required",
               helpLinkText: "What does each step code level mean?",
@@ -662,6 +663,9 @@ const options = {
           title: "Step code auto-compliance tool",
           subTitle: "Automatically generate your BC Energy Step Code compliance report",
           checklistGuide: "See checklist guide",
+          helpLink:
+            "https://www2.gov.bc.ca/gov/content/housing-tenancy/building-or-renovating/permits/building-permit-hub/29065",
+          helpLinkText: "What does each step code level mean?",
           saveAndGoBack: "Save and go back",
           markAsComplete: "Mark as complete",
           back: "Back to permit application",
@@ -1042,21 +1046,29 @@ const options = {
             stepCodeRequirements: {
               title: "Energy Step Code requirements",
               description: "Define step code requirements.",
+              setMinimum:
+                "Set the minimum acceptable levels of Energy Step Code and Zero Carbon Step Code for each permit type below:",
               part9Building: "Part 9 Building",
+              addStep: "Add another requirement combination",
+              deleteCustomization: "Delete customization",
+              overriddenWarning: "This was overridden by your customized requirements below.",
               stepRequired: {
+                permitTypeHeading: "PERMIT TYPE",
+                standardToPass: "Standard Step Code compliance to pass",
+                customizedMinimum: "Customized minimum requirement for submission",
                 energy: {
-                  title: "Energy Step required",
+                  title: "Energy Step Code Level",
                   options: {
-                    "0": "N/A",
+                    "0": "Not required",
                     "3": "3",
                     "4": "4",
                     "5": "5",
                   },
                 },
                 zeroCarbon: {
-                  title: "Zero Carbon Step Code Level required",
+                  title: "Zero Carbon Step Code Level",
                   options: {
-                    "0": "N/A",
+                    "0": "Not required",
                     "1": "EL 1 - Measure Only",
                     "2": "EL 2 - Moderate",
                     "3": "EL 3 - Strong",

--- a/app/frontend/models/jurisdiction.ts
+++ b/app/frontend/models/jurisdiction.ts
@@ -5,7 +5,7 @@ import { withEnvironment } from "../lib/with-environment"
 import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
 import { IExternalApiKeyParams } from "../types/api-request"
-import { IContact, IJurisdictionTemplateRequiredStep, IPermitTypeSubmissionContact, TLatLngTuple } from "../types/types"
+import { IContact, IPermitTypeRequiredStep, IPermitTypeSubmissionContact, TLatLngTuple } from "../types/types"
 import { ExternalApiKeyModel } from "./external-api-key"
 import { PermitApplicationModel } from "./permit-application"
 
@@ -38,7 +38,7 @@ export const JurisdictionModel = types
     mapZoom: types.maybeNull(types.number),
     externalApiEnabled: types.optional(types.boolean, false),
     submissionInboxSetUp: types.boolean,
-    jurisdictionTemplateRequiredSteps: types.array(types.frozen<IJurisdictionTemplateRequiredStep>()),
+    permitTypeRequiredSteps: types.array(types.frozen<IPermitTypeRequiredStep>()),
   })
   .extend(withEnvironment())
   .extend(withRootStore())
@@ -55,9 +55,9 @@ export const JurisdictionModel = types
 
       return sortByCreatedAt(self.contacts)[0]
     },
-    get requiredStepsByTemplate() {
-      return self.jurisdictionTemplateRequiredSteps.reduce((result, jtrs) => {
-        const templateId = jtrs.requirementTemplateId
+    get requiredStepsByPermitType() {
+      return self.permitTypeRequiredSteps.reduce((result, jtrs) => {
+        const templateId = jtrs.permitTypeId
 
         // If the category doesn't exist in the result object, create an array for it
         if (!result[templateId]) {
@@ -73,6 +73,9 @@ export const JurisdictionModel = types
     },
     getPermitTypeSubmissionContact(id: string): IPermitTypeSubmissionContact {
       return self.permitTypeSubmissionContacts.find((c) => c.id == id)
+    },
+    getRequiredStep(id: string): IPermitTypeRequiredStep {
+      return self.permitTypeRequiredSteps.find((rs) => rs.id == id)
     },
     getExternalApiKey(externalApiKeyId: string) {
       return self.externalApiKeysMap.get(externalApiKeyId)

--- a/app/frontend/stores/step-code-store.ts
+++ b/app/frontend/stores/step-code-store.ts
@@ -5,6 +5,7 @@ import { withEnvironment } from "../lib/with-environment"
 import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
 import { IStepCode, StepCodeModel } from "../models/step-code"
+import { EEnergyStep, EZeroCarbonStep } from "../types/enums"
 import { IStepCodeSelectOptions } from "../types/types"
 import { startBlobDownload } from "../utils/utility-functions"
 
@@ -24,6 +25,14 @@ export const StepCodeStoreModel = types
     },
     getStepCode(id: string) {
       return self.stepCodesMap.get(id)
+    },
+    getEnergyStepOptions(allowZero: boolean = false): EEnergyStep[] {
+      const { energySteps } = self.selectOptions
+      return [...energySteps, allowZero && "0"].filter((outFalsy) => outFalsy) as EEnergyStep[]
+    },
+    getZeroCarbonStepOptions(allowZero: boolean = false): EZeroCarbonStep[] {
+      const { zeroCarbonSteps } = self.selectOptions
+      return [...zeroCarbonSteps, allowZero && "0"].filter((outFalsy) => outFalsy) as EZeroCarbonStep[]
     },
   }))
   .actions((self) => ({

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -244,12 +244,14 @@ export enum EFossilFuelsPresence {
 }
 
 export enum EEnergyStep {
+  zero = "0",
   three = "3",
   four = "4",
   five = "5",
 }
 
-export enum ESZeroCarbonStep {
+export enum EZeroCarbonStep {
+  zero = "0",
   one = "1",
   two = "2",
   three = "3",

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -16,7 +16,6 @@ import {
   EPermitApplicationSocketEventTypes,
   EPermitApplicationStatus,
   ERequirementType,
-  ESZeroCarbonStep,
   ESocketDomainTypes,
   ESocketEventTypes,
   ESortDirection,
@@ -26,6 +25,7 @@ import {
   EStepCodeCompliancePath,
   EStepCodeEPCTestingTargetType,
   EWindowsGlazedDoorsPerformanceType,
+  EZeroCarbonStep,
 } from "./enums"
 
 export type TLatLngTuple = [number, number]
@@ -218,7 +218,7 @@ export interface IStepCodeSelectOptions {
   buildingTypes: EStepCodeBuildingType[]
   buildingCharacteristicsSummary: IStepCodeBuildingCharacteristicSummarySelectOptions
   energySteps: EEnergyStep[]
-  zeroCarbonSteps: ESZeroCarbonStep[]
+  zeroCarbonSteps: EZeroCarbonStep[]
 }
 
 export interface IRequirementBlockCustomization {
@@ -430,9 +430,10 @@ export interface ILinkData {
   href: string
 }
 
-export interface IJurisdictionTemplateRequiredStep {
-  requirementTemplateId: string
-  requirementTemplateLabel: string
+export interface IPermitTypeRequiredStep {
+  id?: string
+  permitTypeId: string
+  permitTypeLabel?: string
   energyStepRequired: number
   zeroCarbonStepRequired: number
 }

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -432,8 +432,9 @@ export interface ILinkData {
 
 export interface IPermitTypeRequiredStep {
   id?: string
+  default: boolean
   permitTypeId: string
   permitTypeLabel?: string
-  energyStepRequired: number
-  zeroCarbonStepRequired: number
+  energyStepRequired: EEnergyStep
+  zeroCarbonStepRequired: EZeroCarbonStep
 }

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -38,13 +38,7 @@ class Jurisdiction < ApplicationRecord
                                 allow_destroy: true,
                                 reject_if: proc { |attributes| attributes["email"].blank? }
 
-  accepts_nested_attributes_for :permit_type_required_steps,
-                                allow_destroy: true,
-                                reject_if:
-                                  proc { |attributes|
-                                    attributes["energy_step_required"].blank? ||
-                                      attributes["zero_carbon_step_required"].blank?
-                                  }
+  accepts_nested_attributes_for :permit_type_required_steps, allow_destroy: true
 
   before_create :assign_unique_prefix
 

--- a/app/models/jurisdiction_template_required_step.rb
+++ b/app/models/jurisdiction_template_required_step.rb
@@ -1,8 +1,0 @@
-class JurisdictionTemplateRequiredStep < ApplicationRecord
-  belongs_to :jurisdiction
-  belongs_to :requirement_template
-  delegate :label, to: :requirement_template, prefix: true
-
-  validates :energy_step_required, presence: true
-  validates :zero_carbon_step_required, presence: true
-end

--- a/app/models/permit_type_required_step.rb
+++ b/app/models/permit_type_required_step.rb
@@ -1,0 +1,8 @@
+class PermitTypeRequiredStep < ApplicationRecord
+  belongs_to :jurisdiction
+  belongs_to :permit_type
+  delegate :name, to: :permit_type, prefix: true
+
+  validates :energy_step_required, presence: true
+  validates :zero_carbon_step_required, presence: true
+end

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -14,7 +14,7 @@ class RequirementTemplate < ApplicationRecord
            -> { where(template_versions: { status: "scheduled" }).order(version_date: :desc) },
            class_name: "TemplateVersion"
   has_many :jurisdiction_template_version_customizations
-  has_many :jurisdiction_template_required_steps, dependent: :destroy
+  has_many :permit_type_required_steps, dependent: :destroy
 
   has_one :published_template_version, -> { where(status: "published") }, class_name: "TemplateVersion"
 

--- a/app/services/permit_type_required_step_seeder.rb
+++ b/app/services/permit_type_required_step_seeder.rb
@@ -3,6 +3,7 @@ class PermitTypeRequiredStepSeeder
     Jurisdiction.find_each do |jurisdiction|
       PermitType.find_each do |permit_type|
         PermitTypeRequiredStep.find_or_create_by!(jurisdiction: jurisdiction, permit_type: permit_type) do |ptr_step|
+          ptr_step.default = true
           ptr_step.energy_step_required =
             (
               if jurisdiction.respond_to?(:energy_step_required)

--- a/app/services/permit_type_required_step_seeder.rb
+++ b/app/services/permit_type_required_step_seeder.rb
@@ -1,12 +1,9 @@
-class JurisdictionTemplateRequiredStepSeeder
+class PermitTypeRequiredStepSeeder
   def self.seed
     Jurisdiction.find_each do |jurisdiction|
-      RequirementTemplate.find_each do |requirement_template|
-        JurisdictionTemplateRequiredStep.find_or_create_by!(
-          jurisdiction: jurisdiction,
-          requirement_template: requirement_template,
-        ) do |jtr_step|
-          jtr_step.energy_step_required =
+      PermitType.find_each do |permit_type|
+        PermitTypeRequiredStep.find_or_create_by!(jurisdiction: jurisdiction, permit_type: permit_type) do |ptr_step|
+          ptr_step.energy_step_required =
             (
               if jurisdiction.respond_to?(:energy_step_required)
                 jurisdiction.energy_step_required || 0
@@ -14,7 +11,7 @@ class JurisdictionTemplateRequiredStepSeeder
                 ENV["MIN_ENERGY_STEP"].to_i
               end
             )
-          jtr_step.zero_carbon_step_required =
+          ptr_step.zero_carbon_step_required =
             (
               if jurisdiction.respond_to?(:zero_carbon_step_required)
                 jurisdiction.zero_carbon_step_required || 0

--- a/app/services/step_code_export_service.rb
+++ b/app/services/step_code_export_service.rb
@@ -12,8 +12,8 @@ class StepCodeExportService
             jurisdiction_name = j.qualified_name
             permit_type = pt.name
             work_type = a.name
-            jurisdiction_template_required_steps = j.jurisdiction_template_required_steps_by_classification(a, pt)
-            jurisdiction_template_required_steps.each do |jtsc|
+            permit_type_required_steps = j.permit_type_required_steps_by_classification(a, pt)
+            permit_type_required_steps.each do |jtsc|
               energy_step_required = jtsc.energy_step_required
               zero_carbon_step_required = jtsc.zero_carbon_step_required
               enabled = energy_step_required.positive? || zero_carbon_step_required.positive?

--- a/db/migrate/20240612213911_create_permit_type_required_step.rb
+++ b/db/migrate/20240612213911_create_permit_type_required_step.rb
@@ -1,15 +1,15 @@
-class CreateJurisdictionTemplateRequiredStep < ActiveRecord::Migration[7.1]
+class CreatePermitTypeRequiredStep < ActiveRecord::Migration[7.1]
   def up
-    create_table :jurisdiction_template_required_steps, id: :uuid do |t|
+    create_table :permit_type_required_steps, id: :uuid do |t|
       t.references :jurisdiction, null: false, foreign_key: true, type: :uuid
-      t.references :requirement_template, null: false, foreign_key: true, type: :uuid
+      t.references :permit_type, foreign_key: { to_table: :permit_classifications }, type: :uuid
       t.integer :energy_step_required
       t.integer :zero_carbon_step_required
 
       t.timestamps
     end
 
-    JurisdictionTemplateRequiredStepSeeder.seed
+    PermitTypeRequiredStepSeeder.seed
 
     change_table :jurisdictions do |t|
       t.remove :energy_step_required, :zero_carbon_step_required
@@ -22,6 +22,6 @@ class CreateJurisdictionTemplateRequiredStep < ActiveRecord::Migration[7.1]
       t.integer :zero_carbon_step_required
     end
 
-    drop_table :jurisdiction_template_required_steps
+    drop_table :permit_type_required_steps
   end
 end

--- a/db/migrate/20240612213911_create_permit_type_required_step.rb
+++ b/db/migrate/20240612213911_create_permit_type_required_step.rb
@@ -5,6 +5,7 @@ class CreatePermitTypeRequiredStep < ActiveRecord::Migration[7.1]
       t.references :permit_type, foreign_key: { to_table: :permit_classifications }, type: :uuid
       t.integer :energy_step_required
       t.integer :zero_carbon_step_required
+      t.boolean :default
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_21_234527) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "allowlisted_jwts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "allowlisted_jwts",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "jti", null: false
     t.string "aud"
     t.datetime "exp", null: false
@@ -26,12 +29,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.index ["user_id"], name: "index_allowlisted_jwts_on_user_id"
   end
 
-  create_table "assets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "assets",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "contacts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "contacts",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "title"
     t.string "email"
     t.string "phone"
@@ -51,10 +60,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.string "professional_number"
     t.string "contactable_type"
     t.uuid "contactable_id"
-    t.index ["contactable_type", "contactable_id"], name: "index_contacts_on_contactable"
+    t.index %w[contactable_type contactable_id],
+            name: "index_contacts_on_contactable"
   end
 
-  create_table "end_user_license_agreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "end_user_license_agreements",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.text "content"
     t.boolean "active"
     t.datetime "created_at", null: false
@@ -62,7 +75,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.integer "variant"
   end
 
-  create_table "external_api_keys", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "external_api_keys",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "token", limit: 510, null: false
     t.datetime "expired_at"
     t.datetime "revoked_at"
@@ -72,40 +88,57 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "connecting_application", null: false
-    t.index ["jurisdiction_id"], name: "index_external_api_keys_on_jurisdiction_id"
+    t.index ["jurisdiction_id"],
+            name: "index_external_api_keys_on_jurisdiction_id"
     t.index ["token"], name: "index_external_api_keys_on_token", unique: true
   end
 
-  create_table "integration_mappings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "integration_mappings",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.jsonb "requirements_mapping", default: {}, null: false
     t.uuid "jurisdiction_id", null: false
     t.uuid "template_version_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["jurisdiction_id"], name: "index_integration_mappings_on_jurisdiction_id"
-    t.index ["template_version_id"], name: "index_integration_mappings_on_template_version_id"
+    t.index ["jurisdiction_id"],
+            name: "index_integration_mappings_on_jurisdiction_id"
+    t.index ["template_version_id"],
+            name: "index_integration_mappings_on_template_version_id"
   end
 
-  create_table "jurisdiction_memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "jurisdiction_memberships",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "jurisdiction_id", null: false
     t.uuid "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["jurisdiction_id"], name: "index_jurisdiction_memberships_on_jurisdiction_id"
+    t.index ["jurisdiction_id"],
+            name: "index_jurisdiction_memberships_on_jurisdiction_id"
     t.index ["user_id"], name: "index_jurisdiction_memberships_on_user_id"
   end
 
-  create_table "jurisdiction_template_version_customizations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "jurisdiction_template_version_customizations",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.jsonb "customizations", default: {}
     t.uuid "jurisdiction_id", null: false
     t.uuid "template_version_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["jurisdiction_id"], name: "idx_on_jurisdiction_id_57cd0a7ea7"
-    t.index ["template_version_id"], name: "idx_on_template_version_id_8359a99333"
+    t.index ["template_version_id"],
+            name: "idx_on_template_version_id_8359a99333"
   end
 
-  create_table "jurisdictions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "jurisdictions",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name"
     t.text "description_html"
     t.datetime "created_at", null: false
@@ -124,11 +157,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.integer "map_zoom"
     t.boolean "external_api_enabled", default: false
     t.index ["prefix"], name: "index_jurisdictions_on_prefix", unique: true
-    t.index ["regional_district_id"], name: "index_jurisdictions_on_regional_district_id"
+    t.index ["regional_district_id"],
+            name: "index_jurisdictions_on_regional_district_id"
     t.index ["slug"], name: "index_jurisdictions_on_slug", unique: true
   end
 
-  create_table "mechanical_energy_use_intensity_references", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "mechanical_energy_use_intensity_references",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.int4range "hdd"
     t.numrange "conditioned_space_percent"
     t.integer "step"
@@ -136,10 +173,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.integer "meui"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["hdd", "conditioned_space_percent", "step", "conditioned_space_area"], name: "meui_composite_index", unique: true
+    t.index %w[hdd conditioned_space_percent step conditioned_space_area],
+            name: "meui_composite_index",
+            unique: true
   end
 
-  create_table "permit_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "permit_applications",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.integer "status", default: 0
     t.uuid "submitter_id", null: false
     t.uuid "jurisdiction_id", null: false
@@ -162,14 +204,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.string "reference_number"
     t.jsonb "compliance_data", default: {}, null: false
     t.index ["activity_id"], name: "index_permit_applications_on_activity_id"
-    t.index ["jurisdiction_id"], name: "index_permit_applications_on_jurisdiction_id"
-    t.index ["number"], name: "index_permit_applications_on_number", unique: true
-    t.index ["permit_type_id"], name: "index_permit_applications_on_permit_type_id"
+    t.index ["jurisdiction_id"],
+            name: "index_permit_applications_on_jurisdiction_id"
+    t.index ["number"],
+            name: "index_permit_applications_on_number",
+            unique: true
+    t.index ["permit_type_id"],
+            name: "index_permit_applications_on_permit_type_id"
     t.index ["submitter_id"], name: "index_permit_applications_on_submitter_id"
-    t.index ["template_version_id"], name: "index_permit_applications_on_template_version_id"
+    t.index ["template_version_id"],
+            name: "index_permit_applications_on_template_version_id"
   end
 
-  create_table "permit_classifications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "permit_classifications",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name", null: false
     t.string "type", null: false
     t.datetime "created_at", null: false
@@ -179,32 +229,48 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.integer "code"
   end
 
-  create_table "permit_type_required_steps", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "permit_type_required_steps",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "jurisdiction_id", null: false
     t.uuid "permit_type_id"
     t.integer "energy_step_required"
     t.integer "zero_carbon_step_required"
+    t.boolean "default"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["jurisdiction_id"], name: "index_permit_type_required_steps_on_jurisdiction_id"
-    t.index ["permit_type_id"], name: "index_permit_type_required_steps_on_permit_type_id"
+    t.index ["jurisdiction_id"],
+            name: "index_permit_type_required_steps_on_jurisdiction_id"
+    t.index ["permit_type_id"],
+            name: "index_permit_type_required_steps_on_permit_type_id"
   end
 
-  create_table "permit_type_submission_contacts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "permit_type_submission_contacts",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "jurisdiction_id"
     t.uuid "permit_type_id"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "email", null: false
-    t.index ["jurisdiction_id"], name: "index_permit_type_submission_contacts_on_jurisdiction_id"
-    t.index ["permit_type_id"], name: "index_permit_type_submission_contacts_on_permit_type_id"
+    t.index ["jurisdiction_id"],
+            name: "index_permit_type_submission_contacts_on_jurisdiction_id"
+    t.index ["permit_type_id"],
+            name: "index_permit_type_submission_contacts_on_permit_type_id"
   end
 
-  create_table "preferences", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "preferences",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "user_id", null: false
-    t.boolean "enable_in_app_new_template_version_publish_notification", default: true
-    t.boolean "enable_email_new_template_version_publish_notification", default: true
+    t.boolean "enable_in_app_new_template_version_publish_notification",
+              default: true
+    t.boolean "enable_email_new_template_version_publish_notification",
+              default: true
     t.boolean "enable_in_app_customization_update_notification", default: true
     t.boolean "enable_email_customization_update_notification", default: true
     t.datetime "created_at", null: false
@@ -212,7 +278,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.index ["user_id"], name: "index_preferences_on_user_id"
   end
 
-  create_table "requirement_blocks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "requirement_blocks",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name", null: false
     t.integer "sign_off_role", default: 0, null: false
     t.integer "reviewer_role", default: 0, null: false
@@ -227,16 +296,24 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.index ["sku"], name: "index_requirement_blocks_on_sku", unique: true
   end
 
-  create_table "requirement_template_sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "requirement_template_sections",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name"
     t.uuid "requirement_template_id", null: false
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["requirement_template_id"], name: "index_requirement_template_sections_on_requirement_template_id"
+    t.index ["requirement_template_id"],
+            name:
+              "index_requirement_template_sections_on_requirement_template_id"
   end
 
-  create_table "requirement_templates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "requirement_templates",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "activity_id", null: false
     t.uuid "permit_type_id", null: false
     t.datetime "created_at", null: false
@@ -244,11 +321,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.string "description"
     t.datetime "discarded_at"
     t.index ["activity_id"], name: "index_requirement_templates_on_activity_id"
-    t.index ["discarded_at"], name: "index_requirement_templates_on_discarded_at"
-    t.index ["permit_type_id"], name: "index_requirement_templates_on_permit_type_id"
+    t.index ["discarded_at"],
+            name: "index_requirement_templates_on_discarded_at"
+    t.index ["permit_type_id"],
+            name: "index_requirement_templates_on_permit_type_id"
   end
 
-  create_table "requirements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "requirements",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "requirement_code", null: false
     t.string "label"
     t.integer "input_type", null: false
@@ -263,18 +345,56 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.uuid "requirement_block_id", null: false
     t.integer "position"
     t.boolean "elective", default: false
-    t.index ["requirement_block_id"], name: "index_requirements_on_requirement_block_id"
+    t.index ["requirement_block_id"],
+            name: "index_requirements_on_requirement_block_id"
   end
 
-  create_table "site_configurations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "site_configurations",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.boolean "display_sitewide_message"
     t.text "sitewide_message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.jsonb "help_link_items", default: {"dictionary_link_item"=>{"href"=>"", "show"=>false, "title"=>"Dictionary of terms", "description"=>"See detailed explanations of terms that appear on building permits"}, "user_guide_link_item"=>{"href"=>"", "show"=>false, "title"=>"User and role guides", "description"=>"Step-by-step instructions on how to make the most out of the platform"}, "get_started_link_item"=>{"href"=>"", "show"=>false, "title"=>"Get started on Building Permit Hub", "description"=>"How to submit a building permit application through a streamlined and standardized approach across BC"}, "best_practices_link_item"=>{"href"=>"", "show"=>false, "title"=>"Best practices", "description"=>"How to use the Building Permit Hub efficiently for application submission"}}, null: false
+    t.jsonb "help_link_items",
+            default: {
+              "dictionary_link_item" => {
+                "href" => "",
+                "show" => false,
+                "title" => "Dictionary of terms",
+                "description" =>
+                  "See detailed explanations of terms that appear on building permits"
+              },
+              "user_guide_link_item" => {
+                "href" => "",
+                "show" => false,
+                "title" => "User and role guides",
+                "description" =>
+                  "Step-by-step instructions on how to make the most out of the platform"
+              },
+              "get_started_link_item" => {
+                "href" => "",
+                "show" => false,
+                "title" => "Get started on Building Permit Hub",
+                "description" =>
+                  "How to submit a building permit application through a streamlined and standardized approach across BC"
+              },
+              "best_practices_link_item" => {
+                "href" => "",
+                "show" => false,
+                "title" => "Best practices",
+                "description" =>
+                  "How to use the Building Permit Hub efficiently for application submission"
+              }
+            },
+            null: false
   end
 
-  create_table "step_code_building_characteristics_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "step_code_building_characteristics_summaries",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "step_code_checklist_id", null: false
     t.jsonb "roof_ceilings_lines", default: [{}]
     t.jsonb "above_grade_walls_lines", default: [{}]
@@ -282,20 +402,32 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.jsonb "unheated_floors_lines", default: [{}]
     t.jsonb "below_grade_walls_lines", default: [{}]
     t.jsonb "slabs_lines", default: [{}]
-    t.jsonb "windows_glazed_doors", default: {"lines"=>[{}], "performance_type"=>"usi"}
-    t.jsonb "doors_lines", default: [{"performance_type"=>"rsi"}]
+    t.jsonb "windows_glazed_doors",
+            default: {
+              "lines" => [{}],
+              "performance_type" => "usi"
+            }
+    t.jsonb "doors_lines", default: [{ "performance_type" => "rsi" }]
     t.jsonb "airtightness", default: {}
-    t.jsonb "space_heating_cooling_lines", default: [{"variant"=>"principal"}, {"variant"=>"secondary"}]
-    t.jsonb "hot_water_lines", default: [{"performance_type"=>"ef"}]
+    t.jsonb "space_heating_cooling_lines",
+            default: [
+              { "variant" => "principal" },
+              { "variant" => "secondary" }
+            ]
+    t.jsonb "hot_water_lines", default: [{ "performance_type" => "ef" }]
     t.jsonb "ventilation_lines", default: [{}]
     t.jsonb "other_lines", default: [{}]
     t.jsonb "fossil_fuels", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["step_code_checklist_id"], name: "idx_on_step_code_checklist_id_f0fc711627"
+    t.index ["step_code_checklist_id"],
+            name: "idx_on_step_code_checklist_id_f0fc711627"
   end
 
-  create_table "step_code_checklists", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "step_code_checklists",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "step_code_id"
     t.integer "stage", null: false
     t.datetime "created_at", null: false
@@ -337,7 +469,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.index ["step_code_id"], name: "index_step_code_checklists_on_step_code_id"
   end
 
-  create_table "step_code_data_entries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "step_code_data_entries",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "step_code_id"
     t.integer "stage", null: false
     t.string "model"
@@ -380,30 +515,42 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "h2k_file_data"
-    t.index ["step_code_id"], name: "index_step_code_data_entries_on_step_code_id"
+    t.index ["step_code_id"],
+            name: "index_step_code_data_entries_on_step_code_id"
   end
 
-  create_table "step_codes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "step_codes",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "permit_application_id"
     t.string "plan_author"
     t.string "plan_version"
     t.string "plan_date"
-    t.index ["permit_application_id"], name: "index_step_codes_on_permit_application_id"
+    t.index ["permit_application_id"],
+            name: "index_step_codes_on_permit_application_id"
   end
 
-  create_table "supporting_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "supporting_documents",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "permit_application_id", null: false
     t.jsonb "file_data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "compliance_data", default: {}, null: false
     t.string "data_key"
-    t.index ["permit_application_id"], name: "index_supporting_documents_on_permit_application_id"
+    t.index ["permit_application_id"],
+            name: "index_supporting_documents_on_permit_application_id"
   end
 
-  create_table "taggings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "taggings",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "tag_id"
     t.string "taggable_type"
     t.uuid "taggable_id"
@@ -413,20 +560,30 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.datetime "created_at", precision: nil
     t.string "tenant", limit: 128
     t.index ["context"], name: "index_taggings_on_context"
-    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index %w[tag_id taggable_id taggable_type context tagger_id tagger_type],
+            name: "taggings_idx",
+            unique: true
     t.index ["tag_id"], name: "index_taggings_on_tag_id"
-    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
-    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index %w[taggable_id taggable_type context],
+            name: "taggings_taggable_context_idx"
+    t.index %w[taggable_id taggable_type tagger_id context],
+            name: "taggings_idy"
     t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
-    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+    t.index %w[taggable_type taggable_id],
+            name: "index_taggings_on_taggable_type_and_taggable_id"
     t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
-    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index %w[tagger_id tagger_type],
+            name: "index_taggings_on_tagger_id_and_tagger_type"
     t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
-    t.index ["tagger_type", "tagger_id"], name: "index_taggings_on_tagger_type_and_tagger_id"
+    t.index %w[tagger_type tagger_id],
+            name: "index_taggings_on_tagger_type_and_tagger_id"
     t.index ["tenant"], name: "index_taggings_on_tenant"
   end
 
-  create_table "tags", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "tags",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -434,17 +591,25 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  create_table "template_section_blocks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "template_section_blocks",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "requirement_template_section_id", null: false
     t.uuid "requirement_block_id", null: false
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["requirement_block_id"], name: "index_template_section_blocks_on_requirement_block_id"
-    t.index ["requirement_template_section_id"], name: "idx_on_requirement_template_section_id_5469986497"
+    t.index ["requirement_block_id"],
+            name: "index_template_section_blocks_on_requirement_block_id"
+    t.index ["requirement_template_section_id"],
+            name: "idx_on_requirement_template_section_id_5469986497"
   end
 
-  create_table "template_versions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "template_versions",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.jsonb "denormalized_template_json", default: {}
     t.jsonb "form_json", default: {}
     t.jsonb "requirement_blocks_json", default: {}
@@ -456,11 +621,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.datetime "updated_at", null: false
     t.integer "deprecation_reason"
     t.uuid "deprecated_by_id"
-    t.index ["deprecated_by_id"], name: "index_template_versions_on_deprecated_by_id"
-    t.index ["requirement_template_id"], name: "index_template_versions_on_requirement_template_id"
+    t.index ["deprecated_by_id"],
+            name: "index_template_versions_on_deprecated_by_id"
+    t.index ["requirement_template_id"],
+            name: "index_template_versions_on_requirement_template_id"
   end
 
-  create_table "thermal_energy_demand_intensity_references", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "thermal_energy_demand_intensity_references",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.int4range "hdd"
     t.integer "step"
     t.decimal "ach"
@@ -474,20 +644,27 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.integer "gshl_under_300"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["hdd", "step"], name: "tedi_composite_index", unique: true
+    t.index %w[hdd step], name: "tedi_composite_index", unique: true
   end
 
-  create_table "user_license_agreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "user_license_agreements",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.uuid "user_id", null: false
     t.uuid "agreement_id", null: false
     t.date "accepted_at", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["agreement_id"], name: "index_user_license_agreements_on_agreement_id"
+    t.index ["agreement_id"],
+            name: "index_user_license_agreements_on_agreement_id"
     t.index ["user_id"], name: "index_user_license_agreements_on_user_id"
   end
 
-  create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "users",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
     t.string "email"
     t.string "organization"
     t.boolean "certified", default: false, null: false
@@ -521,15 +698,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
     t.string "unconfirmed_email"
     t.string "omniauth_email"
     t.string "omniauth_username"
-    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["confirmation_token"],
+            name: "index_users_on_confirmation_token",
+            unique: true
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email"
-    t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
+    t.index ["invitation_token"],
+            name: "index_users_on_invitation_token",
+            unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"
-    t.index ["jurisdiction_id"], name: "index_users_on_jurisdiction_id"
-    t.index ["omniauth_provider", "omniauth_uid"], name: "index_users_on_omniauth_provider_and_omniauth_uid", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index %w[invited_by_type invited_by_id], name: "index_users_on_invited_by"
+    t.index %w[omniauth_provider omniauth_uid],
+            name: "index_users_on_omniauth_provider_and_omniauth_uid",
+            unique: true
+    t.index ["reset_password_token"],
+            name: "index_users_on_reset_password_token",
+            unique: true
   end
 
   add_foreign_key "allowlisted_jwts", "users", on_delete: :cascade
@@ -538,24 +722,41 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
   add_foreign_key "integration_mappings", "template_versions"
   add_foreign_key "jurisdiction_memberships", "jurisdictions"
   add_foreign_key "jurisdiction_memberships", "users"
-  add_foreign_key "jurisdiction_template_version_customizations", "jurisdictions"
-  add_foreign_key "jurisdiction_template_version_customizations", "template_versions"
-  add_foreign_key "jurisdictions", "jurisdictions", column: "regional_district_id"
+  add_foreign_key "jurisdiction_template_version_customizations",
+                  "jurisdictions"
+  add_foreign_key "jurisdiction_template_version_customizations",
+                  "template_versions"
+  add_foreign_key "jurisdictions",
+                  "jurisdictions",
+                  column: "regional_district_id"
   add_foreign_key "permit_applications", "jurisdictions"
-  add_foreign_key "permit_applications", "permit_classifications", column: "activity_id"
-  add_foreign_key "permit_applications", "permit_classifications", column: "permit_type_id"
+  add_foreign_key "permit_applications",
+                  "permit_classifications",
+                  column: "activity_id"
+  add_foreign_key "permit_applications",
+                  "permit_classifications",
+                  column: "permit_type_id"
   add_foreign_key "permit_applications", "template_versions"
   add_foreign_key "permit_applications", "users", column: "submitter_id"
   add_foreign_key "permit_type_required_steps", "jurisdictions"
-  add_foreign_key "permit_type_required_steps", "permit_classifications", column: "permit_type_id"
+  add_foreign_key "permit_type_required_steps",
+                  "permit_classifications",
+                  column: "permit_type_id"
   add_foreign_key "permit_type_submission_contacts", "jurisdictions"
-  add_foreign_key "permit_type_submission_contacts", "permit_classifications", column: "permit_type_id"
+  add_foreign_key "permit_type_submission_contacts",
+                  "permit_classifications",
+                  column: "permit_type_id"
   add_foreign_key "preferences", "users"
   add_foreign_key "requirement_template_sections", "requirement_templates"
-  add_foreign_key "requirement_templates", "permit_classifications", column: "activity_id"
-  add_foreign_key "requirement_templates", "permit_classifications", column: "permit_type_id"
+  add_foreign_key "requirement_templates",
+                  "permit_classifications",
+                  column: "activity_id"
+  add_foreign_key "requirement_templates",
+                  "permit_classifications",
+                  column: "permit_type_id"
   add_foreign_key "requirements", "requirement_blocks"
-  add_foreign_key "step_code_building_characteristics_summaries", "step_code_checklists"
+  add_foreign_key "step_code_building_characteristics_summaries",
+                  "step_code_checklists"
   add_foreign_key "step_code_checklists", "step_codes"
   add_foreign_key "step_code_data_entries", "step_codes"
   add_foreign_key "step_codes", "permit_applications"
@@ -565,7 +766,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_14_002722) do
   add_foreign_key "template_section_blocks", "requirement_template_sections"
   add_foreign_key "template_versions", "requirement_templates"
   add_foreign_key "template_versions", "users", column: "deprecated_by_id"
-  add_foreign_key "user_license_agreements", "end_user_license_agreements", column: "agreement_id"
+  add_foreign_key "user_license_agreements",
+                  "end_user_license_agreements",
+                  column: "agreement_id"
   add_foreign_key "user_license_agreements", "users"
-  add_foreign_key "users", "jurisdictions"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -162,7 +162,7 @@ if PermitApplication.first.blank?
 
   RequirementTemplate.reindex
 
-  JurisdictionTemplateRequiredStepSeeder.seed
+  PermitTypeRequiredStepSeeder.seed
 
   # Requrements from seeder are idempotent
   # Requirments block will get created from requiremetms templates


### PR DESCRIPTION
## Description

Add a configuration management screen for managing step code requirements per permit type.
See:
https://www.figma.com/design/OarUownTDVGJcI8ZqYdk0X/BC-Building-Permit-Hub?node-id=6976-82957&t=oqxjhuiLP6O8gWRA-0



## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1490

## Steps to QA

See card
