### PR TITLE
BPHH-1527 + BPHH-1685: draft filter and notification link toast

### DIFF
--- a/app/controllers/api/concerns/search/permit_applications.rb
+++ b/app/controllers/api/concerns/search/permit_applications.rb
@@ -62,7 +62,5 @@ module Api::Concerns::Search::PermitApplications
       where = { submitter_id: current_user.id }
     end
     (filters&.to_h || {}).deep_symbolize_keys.compact.merge!(where)
-
-    where
   end
 end

--- a/app/frontend/components/domains/permit-application/index.tsx
+++ b/app/frontend/components/domains/permit-application/index.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 import { useSearch } from "../../../hooks/use-search"
 
+import { useFlashQueryParam } from "../../../hooks/use-flash-query-param"
 import { useResetQueryParams } from "../../../hooks/use-reset-query-params"
 import { IPermitApplication } from "../../../models/permit-application"
 import { useMst } from "../../../setup/root"
@@ -38,6 +39,7 @@ export const PermitApplicationIndexScreen = observer(({}: IPermitApplicationInde
   } = permitApplicationStore
 
   useSearch(permitApplicationStore, [])
+  useFlashQueryParam()
   const resetQueryParams = useResetQueryParams()
 
   return (

--- a/app/frontend/hooks/use-flash-query-param.tsx
+++ b/app/frontend/hooks/use-flash-query-param.tsx
@@ -1,0 +1,11 @@
+import queryString from "query-string"
+import { useEffect } from "react"
+import { useMst } from "../setup/root"
+
+export const useFlashQueryParam = () => {
+  const { uiStore } = useMst()
+
+  useEffect(() => {
+    uiStore.showQueryParamFlash()
+  }, [queryString.parse(location.search)])
+}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -345,6 +345,8 @@ const options = {
         },
         permitApplication: {
           updateToNewVersion: "Update my application",
+          reviewOutdatedTitle: "Filters applied to show applications that are outdated",
+          reviewOutdatedMessage: "Filters have been applied. Please review and acknowledge the actions required below.",
           newVersionPublished: "New verson of template has been published - please review changes",
           referenceNumber: "Reference #",
           pdf: {

--- a/app/frontend/stores/jurisdiction-store.ts
+++ b/app/frontend/stores/jurisdiction-store.ts
@@ -8,7 +8,7 @@ import { withRootStore } from "../lib/with-root-store"
 import { IJurisdiction, JurisdictionModel } from "../models/jurisdiction"
 import { EJurisdictionSortFields } from "../types/enums"
 import { IJurisdictionFilters } from "../types/types"
-import { isUUID, toCamelCase } from "../utils/utility-functions"
+import { isUUID, setQueryParam, toCamelCase } from "../utils/utility-functions"
 
 export const JurisdictionStoreModel = types
   .compose(
@@ -133,7 +133,9 @@ export const JurisdictionStoreModel = types
   }))
   .actions((self) => ({
     searchEnabledJurisdictions: flow(function* (countPerPage: number = 10) {
-      return self.searchJurisdictions({ reset: true, page: 1, countPerPage }, true)
+      const result = self.searchJurisdictions({ reset: true, page: 1, countPerPage }, true)
+      setQueryParam("currentPage", null)
+      return result
     }),
   }))
 

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -1,3 +1,4 @@
+import { t } from "i18next"
 import { flow, Instance, toGenerator, types } from "mobx-state-tree"
 import * as R from "ramda"
 import { withEnvironment } from "../lib/with-environment"
@@ -34,7 +35,7 @@ export const NotificationStoreModel = types
           return `/digital-building-permits/${notification.objectData.previousTemplateVersionId}/edit?compare=true`
         }
         if (currentUser.isSubmitter) {
-          return `/?requirementTemplateId=${notification.objectData.requirementTemplateId}&status=draft`
+          return `/?requirementTemplateId=${notification.objectData.requirementTemplateId}&status=draft&flash=%7B%20%22type%22%3A%20%22success%22%2C%20%22title%22%3A%20%22${t("permitApplication.reviewOutdatedTitle")}%22%2C%20%22message%22%3A%20%22${t("permitApplication.reviewOutdatedMessage")}%22%20%7D`
         }
 
         return "/permit-applications"

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -35,7 +35,7 @@ export const NotificationStoreModel = types
           return `/digital-building-permits/${notification.objectData.previousTemplateVersionId}/edit?compare=true`
         }
         if (currentUser.isSubmitter) {
-          return `/?requirementTemplateId=${notification.objectData.requirementTemplateId}&status=draft&flash=%7B%20%22type%22%3A%20%22success%22%2C%20%22title%22%3A%20%22${t("permitApplication.reviewOutdatedTitle")}%22%2C%20%22message%22%3A%20%22${t("permitApplication.reviewOutdatedMessage")}%22%20%7D`
+          return `/?requirementTemplateId=${notification.objectData.requirementTemplateId}&status=draft&flash=${encodeURIComponent(JSON.stringify({ type: "success", title: t("permitApplication.reviewOutdatedTitle"), message: t("permitApplication.reviewOutdatedMessage") }))}`
         }
 
         return "/permit-applications"

--- a/app/frontend/stores/ui-store.ts
+++ b/app/frontend/stores/ui-store.ts
@@ -12,19 +12,31 @@ export const UIStoreModel = types
   .extend(withRootStore())
   .views((self) => ({}))
   .actions((self) => ({
-    setCurrentlySelectedJurisdictionId(id: string) {
-      self.currentlySelectedJurisdictionId = id
-    },
-    afterCreate() {
+    showQueryParamFlash() {
       // check if there are any messages to show in the URL params
       const query = queryString.parse(location.search)
 
       if (query.flash) {
         const { type, title, message } = JSON.parse(query.flash as any)
-        self.flashMessage.show(type, title, message, 5000) // show flash messages from the backend for longer
-        // remove the frontend flash message from URL
-        window.history.replaceState({}, "", location.pathname)
+        self.flashMessage.show(type, title, message, 5000) // show flash messages from the query param for longer
+        // Remove the "flash" parameter
+        delete query.flash
+
+        // Reconstruct the query string without the "flash" parameter
+        const newQueryString = queryString.stringify(query)
+
+        // Update the URL
+        const newUrl = `${location.pathname}${newQueryString ? "?" + newQueryString : ""}`
+        window.history.replaceState({}, "", newUrl)
       }
+    },
+  }))
+  .actions((self) => ({
+    setCurrentlySelectedJurisdictionId(id: string) {
+      self.currentlySelectedJurisdictionId = id
+    },
+    afterCreate() {
+      self.showQueryParamFlash()
     },
   }))
 

--- a/app/frontend/utils/utility-functions.ts
+++ b/app/frontend/utils/utility-functions.ts
@@ -61,7 +61,8 @@ export function setQueryParam(key: string, value: string) {
   } else {
     searchParams.set(key, encodeURIComponent(value))
   }
-  window.history.replaceState({}, "", `${window.location.pathname}?${searchParams.toString()}`)
+  const stringParams = searchParams.toString()
+  window.history.replaceState({}, "", `${window.location.pathname}${stringParams ? "?" + stringParams : ""}`)
 }
 
 export function isMultiOptionRequirement(requirementType: ERequirementType): boolean {


### PR DESCRIPTION
## Description

Fix bug where status filter was not being applied to permit applications

Add feature to show a toast message when the user clicks the GO link on the permit application version update notification link

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1527
https://hous-bssb.atlassian.net/browse/BPHH-1685

## Steps to QA

See cards
Permit application index should be properly filtering by submitted or draft
