### PR TITLE
[bphh-1682] hotfix to regenerate missing pdfs on user view and push websocket update

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -49,7 +49,7 @@ class PermitApplicationBlueprint < Blueprinter::Base
   view :supporting_docs_update do
     identifier :id
 
-    field :missing_pdfs
+    fields :missing_pdfs, :zipfile_size, :zipfile_name, :zipfile_url
 
     association :supporting_documents, blueprint: SupportingDocumentBlueprint
   end

--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -14,7 +14,8 @@ class PermitApplicationBlueprint < Blueprinter::Base
            :zipfile_name,
            :zipfile_url,
            :reference_number,
-           :submitted_at
+           :submitted_at,
+           :missing_pdfs
     association :permit_type, blueprint: PermitClassificationBlueprint
     association :activity, blueprint: PermitClassificationBlueprint
   end
@@ -43,5 +44,13 @@ class PermitApplicationBlueprint < Blueprinter::Base
   view :compliance_update do
     identifier :id
     fields :formatted_compliance_data, :front_end_form_update
+  end
+
+  view :supporting_docs_update do
+    identifier :id
+
+    field :missing_pdfs
+
+    association :supporting_documents, blueprint: SupportingDocumentBlueprint
   end
 end

--- a/app/channels/user_channel.rb
+++ b/app/channels/user_channel.rb
@@ -1,7 +1,8 @@
 class UserChannel < ApplicationCable::Channel
   def subscribed
-    stream_from "#{Constants::Channels::USER_CHANNEL_PREFIX}-#{current_user.id}"
+    stream_from "#{Constants::Websockets::Channels::USER_CHANNEL_PREFIX}-#{current_user.id}"
   end
+
   def unsubscribed
     # Any cleanup needed when channel is unsubscribed
     stop_all_streams

--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -120,7 +120,7 @@ class Api::PermitApplicationsController < Api::ApplicationController
   def generate_missing_pdfs
     authorize @permit_application
 
-    PdfGenerationJob.perform_async(@permit_application.id, false)
+    ZipfileJob.perform_async(@permit_application.id, false)
 
     head :ok
   end

--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -1,7 +1,8 @@
 class Api::PermitApplicationsController < Api::ApplicationController
   include Api::Concerns::Search::PermitApplications
 
-  before_action :set_permit_application, only: %i[show update submit upload_supporting_document mark_as_viewed]
+  before_action :set_permit_application,
+                only: %i[show update submit upload_supporting_document mark_as_viewed generate_missing_pdfs]
   skip_after_action :verify_policy_scoped, only: [:index]
 
   def index
@@ -114,6 +115,14 @@ class Api::PermitApplicationsController < Api::ApplicationController
                      error_message: @permit_application.errors.full_messages.join(", "),
                    }
     end
+  end
+
+  def generate_missing_pdfs
+    authorize @permit_application
+
+    PdfGenerationJob.perform_async(@permit_application.id, false)
+
+    head :ok
   end
 
   private

--- a/app/frontend/components/domains/permit-application/submission-download-modal.tsx
+++ b/app/frontend/components/domains/permit-application/submission-download-modal.tsx
@@ -30,9 +30,6 @@ export interface ISubmissionDownloadModalProps {
   renderTrigger?: (onOpen: () => void) => React.ReactNode
 }
 
-const missingPdfKeyToLabel = {
-  permit_application_pdf: "permit application pdf",
-}
 export const SubmissionDownloadModal = observer(
   ({ permitApplication, renderTrigger }: ISubmissionDownloadModalProps) => {
     const { t } = useTranslation()
@@ -56,7 +53,7 @@ export const SubmissionDownloadModal = observer(
     }, [checklist?.isLoaded])
 
     useEffect(() => {
-      if (!permitApplication?.isFullyLoaded || (checklist && !checklist?.isLoaded)) {
+      if (!permitApplication?.isFullyLoaded) {
         return
       }
 
@@ -162,6 +159,11 @@ const FileDownloadLink = function ApplicationFileDownloadLink({ url, name, size 
 
 function MissingPdf({ pdfKey }: { pdfKey: "permit_application_pdf" }) {
   const { t } = useTranslation()
+
+  const missingPdfKeyToLabel = {
+    permit_application_pdf: t("permitApplication.show.missingPdfLabels.permitApplication"),
+    step_code_checklist_pdf: t("permitApplication.show.missingPdfLabels.stepCode"),
+  }
   return (
     <Flex w="full" align="center" justify="space-between" pl={1}>
       <HStack spacing={3}>

--- a/app/frontend/components/domains/permit-application/submission-download-modal.tsx
+++ b/app/frontend/components/domains/permit-application/submission-download-modal.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Flex,
+  HStack,
   Heading,
   Link,
   Modal,
@@ -14,7 +15,7 @@ import {
   VStack,
   useDisclosure,
 } from "@chakra-ui/react"
-import { Download, FileArrowDown, FileZip } from "@phosphor-icons/react"
+import { Download, FileArrowDown, FileZip, Gear } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React, { useEffect } from "react"
 import { useTranslation } from "react-i18next"
@@ -22,11 +23,16 @@ import { IPermitApplication } from "../../../models/permit-application"
 import { useMst } from "../../../setup/root"
 import { formatBytes } from "../../../utils/utility-functions"
 import { SharedSpinner } from "../../shared/base/shared-spinner"
+import { LoadingIcon } from "../../shared/loading-icon"
+
 export interface ISubmissionDownloadModalProps {
   permitApplication: IPermitApplication
   renderTrigger?: (onOpen: () => void) => React.ReactNode
 }
 
+const missingPdfKeyToLabel = {
+  permit_application_pdf: "permit application pdf",
+}
 export const SubmissionDownloadModal = observer(
   ({ permitApplication, renderTrigger }: ISubmissionDownloadModalProps) => {
     const { t } = useTranslation()
@@ -48,6 +54,18 @@ export const SubmissionDownloadModal = observer(
       const fetch = async () => await checklist.load()
       checklist && !checklist.isLoaded && fetch()
     }, [checklist?.isLoaded])
+
+    useEffect(() => {
+      if (!permitApplication?.isFullyLoaded || (checklist && !checklist?.isLoaded)) {
+        return
+      }
+
+      if (!permitApplication.isSubmitted || !permitApplication.missingPdfs.length) {
+        return
+      }
+
+      permitApplication.generateMissingPdfs()
+    }, [permitApplication?.isFullyLoaded, permitApplication?.missingPdfs, checklist?.isLoaded])
 
     return (
       <>
@@ -84,6 +102,9 @@ export const SubmissionDownloadModal = observer(
                 <ModalBody>
                   <Flex direction="column" gap={3} borderRadius="lg" borderWidth={1} borderColor="border.light" p={4}>
                     <VStack align="flex-start" w="full">
+                      {permitApplication.missingPdfs.map((pdfKey) => (
+                        <MissingPdf key={pdfKey} pdfKey={pdfKey} />
+                      ))}
                       {supportingDocuments.map((doc) => (
                         <FileDownloadLink key={doc.fileUrl} url={doc.fileUrl} name={doc.fileName} size={doc.fileSize} />
                       ))}
@@ -134,6 +155,21 @@ const FileDownloadLink = function ApplicationFileDownloadLink({ url, name, size 
       <Text color="greys.grey01" textAlign="right" fontSize="xs">
         {formatBytes(size)}
       </Text>
+    </Flex>
+  )
+}
+
+function MissingPdf({ pdfKey }: { pdfKey: "permit_application_pdf" }) {
+  return (
+    <Flex w="full" align="center" justify="space-between" pl={1}>
+      <HStack spacing={3}>
+        <FileArrowDown size={16} />
+        <Text as={"span"} color={"semantic.error"}>
+          Generating {missingPdfKeyToLabel[pdfKey] || pdfKey}...
+        </Text>
+      </HStack>
+
+      <LoadingIcon icon={<Gear />} />
     </Flex>
   )
 }

--- a/app/frontend/components/domains/permit-application/submission-download-modal.tsx
+++ b/app/frontend/components/domains/permit-application/submission-download-modal.tsx
@@ -160,12 +160,13 @@ const FileDownloadLink = function ApplicationFileDownloadLink({ url, name, size 
 }
 
 function MissingPdf({ pdfKey }: { pdfKey: "permit_application_pdf" }) {
+  const { t } = useTranslation()
   return (
     <Flex w="full" align="center" justify="space-between" pl={1}>
       <HStack spacing={3}>
         <FileArrowDown size={16} />
         <Text as={"span"} color={"semantic.error"}>
-          Generating {missingPdfKeyToLabel[pdfKey] || pdfKey}...
+          {t("permitApplication.show.fetchingMissingPdf", { missingPdf: missingPdfKeyToLabel[pdfKey] || pdfKey })}
         </Text>
       </HStack>
 

--- a/app/frontend/components/domains/permit-application/submission-download-modal.tsx
+++ b/app/frontend/components/domains/permit-application/submission-download-modal.tsx
@@ -121,6 +121,7 @@ export const SubmissionDownloadModal = observer(
                       download={zipfileName}
                       textDecoration="none"
                       leftIcon={<FileZip />}
+                      isDisabled={!zipfileUrl}
                       _hover={{ textDecoration: "none" }}
                     >
                       {t("permitApplication.show.downloadZip")}

--- a/app/frontend/components/shared/loading-icon.tsx
+++ b/app/frontend/components/shared/loading-icon.tsx
@@ -1,0 +1,24 @@
+import { Box, BoxProps, PropsOf } from "@chakra-ui/react"
+import { CustomDomComponent, motion } from "framer-motion"
+import React from "react"
+
+const MotionBox = motion<Omit<BoxProps, "transition">>(Box)
+
+interface IProps extends PropsOf<CustomDomComponent<Omit<BoxProps, "transition">>> {
+  icon: JSX.Element
+}
+
+export const LoadingIcon = ({ icon, ...rest }: IProps) => (
+  <MotionBox
+    display="inline-block"
+    animate={{ rotate: [0, 360], scale: [1, 1.2, 1], opacity: [1, 0.8, 1] }}
+    transition={{
+      repeat: Infinity,
+      duration: 2,
+      ease: "easeInOut",
+    }}
+    {...rest}
+  >
+    {icon}
+  </MotionBox>
+)

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -415,6 +415,7 @@ const options = {
             submittingTo: "You're applying to the {{ jurisdictionName }}",
             contactsSummary: "Contacts summary",
             downloadApplication: "Download application",
+            fetchingMissingPdf: "Fetching {{missingPdf}}...",
             contactSummaryHeading: "List of all contacts on this application",
             downloadHeading: "Download application",
             downloadPrompt: "Choose specific files or entire package:",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -416,6 +416,10 @@ const options = {
             contactsSummary: "Contacts summary",
             downloadApplication: "Download application",
             fetchingMissingPdf: "Fetching {{missingPdf}}...",
+            missingPdfLabels: {
+              permitApplication: "permit application pdf",
+              stepCode: "step code checklist pdf",
+            },
             contactSummaryHeading: "List of all contacts on this application",
             downloadHeading: "Download application",
             downloadPrompt: "Choose specific files or entire package:",

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -350,6 +350,9 @@ export const PermitApplicationModel = types
     handleSocketSupportingDocsUpdate: (data: IPermitApplicationSupportingDocumentsUpdate) => {
       self.missingPdfs = cast(data.missingPdfs)
       self.supportingDocuments = data.supportingDocuments
+      self.zipfileSize = data.zipfileSize
+      self.zipfileName = data.zipfileName
+      self.zipfileUrl = data.zipfileUrl
     },
   }))
 

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -1,5 +1,5 @@
 import { t } from "i18next"
-import { Instance, SnapshotIn, flow, types } from "mobx-state-tree"
+import { Instance, SnapshotIn, cast, flow, types } from "mobx-state-tree"
 import * as R from "ramda"
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
@@ -10,6 +10,7 @@ import {
   IDownloadableFile,
   IFormIOBlock,
   IFormJson,
+  IPermitApplicationSupportingDocumentsUpdate,
   ISubmissionData,
   ITemplateCustomization,
 } from "../types/types"
@@ -48,6 +49,7 @@ export const PermitApplicationModel = types
     zipfileName: types.maybeNull(types.string),
     zipfileUrl: types.maybeNull(types.string),
     referenceNumber: types.maybeNull(types.string),
+    missingPdfs: types.maybeNull(types.array(types.string)),
     isFullyLoaded: types.optional(types.boolean, false),
     isDirty: types.optional(types.boolean, false),
   })
@@ -338,6 +340,16 @@ export const PermitApplicationModel = types
         },
       }
       self.setSubmissionData(newData)
+    },
+    generateMissingPdfs: flow(function* () {
+      const response = yield self.environment.api.generatePermitApplicationMissingPdfs(self.id)
+      return response.ok
+    }),
+  }))
+  .actions((self) => ({
+    handleSocketSupportingDocsUpdate: (data: IPermitApplicationSupportingDocumentsUpdate) => {
+      self.missingPdfs = cast(data.missingPdfs)
+      self.supportingDocuments = data.supportingDocuments
     },
   }))
 

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -229,7 +229,9 @@ export class Api {
   }
 
   async submitPermitApplication(id, params) {
-    return this.client.post(`/permit_applications/${id}/submit`)
+    return this.client.post<ApiResponse<IPermitApplication>>(`/permit_applications/${id}/submit`, {
+      permitApplication: params,
+    })
   }
 
   async fetchRequirementTemplates(params?: TSearchParams<ERequirementTemplateSortFields>) {

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -224,10 +224,12 @@ export class Api {
     })
   }
 
+  async generatePermitApplicationMissingPdfs(id: string) {
+    return this.client.post<never>(`/permit_applications/${id}/generate_missing_pdfs`)
+  }
+
   async submitPermitApplication(id, params) {
-    return this.client.post<ApiResponse<IPermitApplication>>(`/permit_applications/${id}/submit`, {
-      permitApplication: params,
-    })
+    return this.client.post(`/permit_applications/${id}/submit`)
   }
 
   async fetchRequirementTemplates(params?: TSearchParams<ERequirementTemplateSortFields>) {

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -10,7 +10,11 @@ import { IJurisdiction } from "../models/jurisdiction"
 import { IPermitApplication, PermitApplicationModel } from "../models/permit-application"
 import { IUser } from "../models/user"
 import { ECustomEvents, EPermitApplicationSocketEventTypes, EPermitApplicationSortFields } from "../types/enums"
-import { IPermitApplicationComplianceUpdate, IUserPushPayload } from "../types/types"
+import {
+  IPermitApplicationComplianceUpdate,
+  IPermitApplicationSupportingDocumentsUpdate,
+  IUserPushPayload,
+} from "../types/types"
 
 export const PermitApplicationStoreModel = types
   .compose(
@@ -176,7 +180,7 @@ export const PermitApplicationStoreModel = types
           document.dispatchEvent(event)
           break
         case EPermitApplicationSocketEventTypes.updateSupportingDocuments:
-          payloadData = payload.data as IPermitApplicationComplianceUpdate
+          payloadData = payload.data as IPermitApplicationSupportingDocumentsUpdate
 
           self.permitApplicationMap.get(payloadData?.id)?.handleSocketSupportingDocsUpdate(payloadData)
           break

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -1,5 +1,5 @@
 import { t } from "i18next"
-import { Instance, flow, types } from "mobx-state-tree"
+import { flow, Instance, types } from "mobx-state-tree"
 import * as R from "ramda"
 import { TCreatePermitApplicationFormData } from "../components/domains/permit-application/new-permit-application-screen"
 import { createSearchModel } from "../lib/create-search-model"
@@ -9,8 +9,8 @@ import { withRootStore } from "../lib/with-root-store"
 import { IJurisdiction } from "../models/jurisdiction"
 import { IPermitApplication, PermitApplicationModel } from "../models/permit-application"
 import { IUser } from "../models/user"
-import { ECustomEvents, EPermitApplicationSortFields, ESocketEventTypes } from "../types/enums"
-import { IPermitApplicationUpdate, IUserPushPayload } from "../types/types"
+import { ECustomEvents, EPermitApplicationSocketEventTypes, EPermitApplicationSortFields } from "../types/enums"
+import { IPermitApplicationComplianceUpdate, IUserPushPayload } from "../types/types"
 
 export const PermitApplicationStoreModel = types
   .compose(
@@ -164,15 +164,21 @@ export const PermitApplicationStoreModel = types
     },
     processWebsocketChange: flow(function* (payload: IUserPushPayload) {
       //based on the eventType do stuff
-      switch (payload.eventType) {
-        case ESocketEventTypes.update:
-          const payloadData = payload.data as IPermitApplicationUpdate
+      let payloadData
+      switch (payload.eventType as EPermitApplicationSocketEventTypes) {
+        case EPermitApplicationSocketEventTypes.updateCompliance:
+          payloadData = payload.data as IPermitApplicationComplianceUpdate
           const event = new CustomEvent(ECustomEvents.handlePermitApplicationUpdate, { detail: payloadData })
 
           self.permitApplicationMap
             .get(payloadData?.id)
             ?.setFormattedComplianceData(payloadData?.formattedComplianceData)
           document.dispatchEvent(event)
+          break
+        case EPermitApplicationSocketEventTypes.updateSupportingDocuments:
+          payloadData = payload.data as IPermitApplicationComplianceUpdate
+
+          self.permitApplicationMap.get(payloadData?.id)?.handleSocketSupportingDocsUpdate(payloadData)
           break
         default:
           import.meta.env.DEV && console.log(`Unknown event type ${payload.eventType}`)

--- a/app/frontend/types/dom.d.ts
+++ b/app/frontend/types/dom.d.ts
@@ -1,9 +1,9 @@
 // modified from https://stackoverflow.com/questions/43001679/how-do-you-create-custom-event-in-typescript
 import { ECustomEvents } from "./enums"
-import { IPermitApplicationUpdate } from "./types"
+import { IPermitApplicationComplianceUpdate } from "./types"
 
 export interface ICustomEventMap {
-  [ECustomEvents.handlePermitApplicationUpdate]: CustomEvent<IPermitApplicationUpdate>
+  [ECustomEvents.handlePermitApplicationUpdate]: CustomEvent<IPermitApplicationComplianceUpdate>
 }
 
 declare global {

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -279,6 +279,11 @@ export enum ESocketEventTypes {
   update = "update",
 }
 
+export enum EPermitApplicationSocketEventTypes {
+  updateCompliance = "update_compliance",
+  updateSupportingDocuments = "update_supporting_documents",
+}
+
 export enum EEnabledElectiveFieldReason {
   bylaw = "bylaw",
   zoning = "zoning",

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -233,6 +233,9 @@ export interface IPermitApplicationSupportingDocumentsUpdate {
   id: string
   supportingDocuments: IPermitApplication["supportingDocuments"]
   missingPdfs: string[]
+  zipfileSize: null | number
+  zipfileName: null | string
+  zipfileUrl: null | string
 }
 
 export interface IUserPushPayload {

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -9,6 +9,7 @@ import {
   EFossilFuelsPresence,
   EHotWaterPerformanceType,
   ENumberUnit,
+  EPermitApplicationSocketEventTypes,
   ERequirementType,
   ESZeroCarbonStep,
   ESocketDomainTypes,
@@ -222,16 +223,22 @@ export interface INotification {
   at: string
 }
 
-export interface IPermitApplicationUpdate {
-  id
+export interface IPermitApplicationComplianceUpdate {
+  id: string
   frontEndFormUpdate: Object
   formattedComplianceData: Object
 }
 
+export interface IPermitApplicationSupportingDocumentsUpdate {
+  id: string
+  supportingDocuments: IPermitApplication["supportingDocuments"]
+  missingPdfs: string[]
+}
+
 export interface IUserPushPayload {
   domain: ESocketDomainTypes
-  eventType: ESocketEventTypes
-  data: INotification | IPermitApplicationUpdate
+  eventType: ESocketEventTypes | EPermitApplicationSocketEventTypes
+  data: INotification | IPermitApplicationComplianceUpdate
 }
 
 export interface ISiteConfiguration {

--- a/app/jobs/automated_compliance/autopopulate_job.rb
+++ b/app/jobs/automated_compliance/autopopulate_job.rb
@@ -9,16 +9,16 @@ class AutomatedCompliance::AutopopulateJob
 
     if unfilled.length > 0
       unfilled.each { |cm_name| match(cm_name, permit_application) }
-      #In the future start a sidekiq batch to kick these things off
+      # In the future start a sidekiq batch to kick these things off
 
-      #set front end form updates, force these to get picked up for processing
-      #these are for forms already loaded and rendered
+      # set front end form updates, force these to get picked up for processing
+      # these are for forms already loaded and rendered
       permit_application.assign_attributes(front_end_form_update: permit_application.formatted_compliance_data)
 
       WebsocketBroadcaster.push_update_to_relevant_users(
         permit_application.collaborators,
-        "permit_application",
-        "update",
+        Constants::Websockets::Events::PermitApplication::DOMAIN,
+        Constants::Websockets::Events::PermitApplication::TYPES[:update_compliance],
         PermitApplicationBlueprint.render_as_hash(permit_application, { view: :compliance_update }),
       )
     end
@@ -26,11 +26,11 @@ class AutomatedCompliance::AutopopulateJob
 
   def match(compliance_module_name, permit_application)
     unless (%w[DigitalSealValidator ParcelInfoExtractor HistoricSite PermitApplication]).include? compliance_module_name
-      #AlrValidator
+      # AlrValidator
       Rails.logger.error "unsafe compliance module called #{compliance_module_name}"
       return
     end
-    #looks for a matching job, if not, runs the module directly
+    # looks for a matching job, if not, runs the module directly
     if Object.const_defined?("AutomatedCompliance::#{compliance_module_name}Job")
       "AutomatedCompliance::#{compliance_module_name}Job".safe_constantize.perform_async(permit_application.id)
     else

--- a/app/jobs/automated_compliance/digital_seal_validator_job.rb
+++ b/app/jobs/automated_compliance/digital_seal_validator_job.rb
@@ -11,8 +11,8 @@ class AutomatedCompliance::DigitalSealValidatorJob
 
     WebsocketBroadcaster.push_update_to_relevant_users(
       permit_application.collaborators,
-      "permit_application",
-      "update",
+      Constants::Websockets::Events::PermitApplication::DOMAIN,
+      Constants::Websockets::Events::PermitApplication::TYPES[:update_compliance],
       PermitApplicationBlueprint.render_as_hash(permit_application, { view: :compliance_update }),
     )
   end

--- a/app/jobs/pdf_generation_job.rb
+++ b/app/jobs/pdf_generation_job.rb
@@ -5,7 +5,7 @@ require "fileutils"
 class PdfGenerationJob
   include Sidekiq::Worker
   sidekiq_options lock: :until_and_while_executing,
-                  queue: :pdf_generation,
+                  queue: :file_processing,
                   on_conflict: {
                     client: :log,
                     server: :reject,
@@ -85,13 +85,6 @@ class PdfGenerationJob
 
             File.delete(path)
           end
-
-          WebsocketBroadcaster.push_update_to_relevant_users(
-            permit_application.collaborators,
-            Constants::Websockets::Events::PermitApplication::DOMAIN,
-            Constants::Websockets::Events::PermitApplication::TYPES[:update_supporting_documents],
-            PermitApplicationBlueprint.render_as_hash(permit_application.reload, { view: :supporting_docs_update }),
-          )
         else
           err = "Pdf generation process failed: #{exit_status}"
           Rails.logger.error err

--- a/app/jobs/zipfile_job.rb
+++ b/app/jobs/zipfile_job.rb
@@ -1,9 +1,31 @@
 class ZipfileJob
   include Sidekiq::Worker
-  sidekiq_options queue: :file_processing
+  sidekiq_options lock: :until_and_while_executing,
+                  queue: :file_processing,
+                  on_conflict: {
+                    client: :log,
+                    server: :reject,
+                  }
 
-  def perform(permit_application_id)
-    PdfGenerationJob.new.perform(permit_application_id)
+  def self.lock_args(args)
+    ## only lock on the first argument, which is the permit application id
+    ## this will prevent multiple jobs from running for the same permit application
+    [args[0]]
+  end
+
+  def perform(permit_application_id, regenerate_all_pdfs = true)
+    PdfGenerationJob.new.perform(permit_application_id, regenerate_all_pdfs)
     SupportingDocumentsZipper.new(permit_application_id).perform
+
+    permit_application = PermitApplication.find_by_id(permit_application_id)
+
+    if permit_application.present?
+      WebsocketBroadcaster.push_update_to_relevant_users(
+        permit_application.collaborators,
+        Constants::Websockets::Events::PermitApplication::DOMAIN,
+        Constants::Websockets::Events::PermitApplication::TYPES[:update_supporting_documents],
+        PermitApplicationBlueprint.render_as_hash(permit_application.reload, { view: :supporting_docs_update }),
+      )
+    end
   end
 end

--- a/app/models/supporting_document.rb
+++ b/app/models/supporting_document.rb
@@ -7,6 +7,9 @@ class SupportingDocument < ApplicationRecord
   scope :file_ids_with_regex, ->(regex_pattern) { where("file_data ->> 'id' ~ ?", regex_pattern) }
   scope :without_compliance, -> { where("compliance_data = '{}' OR compliance_data IS NULL") }
 
+  APPLICATION_PDF_DATA_KEY = :permit_application_pdf
+  CHECKLIST_PDF_DATA_KEY = :step_code_checklist_pdf
+
   def last_signer
     if compliance_data["result"] &&
          signer = compliance_data["result"].sort_by { |signer| signer.dig("signatureTimestamp", "date") }&.last

--- a/app/policies/permit_application_policy.rb
+++ b/app/policies/permit_application_policy.rb
@@ -32,6 +32,10 @@ class PermitApplicationPolicy < ApplicationPolicy
     update?
   end
 
+  def generate_missing_pdfs?
+    true
+  end
+
   # we may want to separate an admin update to a secondary policy
 
   class Scope < Scope

--- a/app/policies/permit_application_policy.rb
+++ b/app/policies/permit_application_policy.rb
@@ -33,7 +33,9 @@ class PermitApplicationPolicy < ApplicationPolicy
   end
 
   def generate_missing_pdfs?
-    true
+    # TODO: update this when remerged into develop, as there is a change roles and jurisdiction to support regional managers
+    user.super_admin? || (user.submitter? && record.submitter == user) ||
+      ((user.review_manager? || user.reviewer?) && record.jurisdiction == user.jurisdiction)
   end
 
   # we may want to separate an admin update to a secondary policy

--- a/app/services/constants/channels.rb
+++ b/app/services/constants/channels.rb
@@ -1,5 +1,0 @@
-module Constants
-  module Channels
-    USER_CHANNEL_PREFIX = "user_channel"
-  end
-end

--- a/app/services/constants/websockets.rb
+++ b/app/services/constants/websockets.rb
@@ -1,0 +1,17 @@
+module Constants
+  module Websockets
+    module Channels
+      USER_CHANNEL_PREFIX = "user_channel"
+    end
+
+    module Events
+      module PermitApplication
+        DOMAIN = :permit_application
+        TYPES = {
+          update_compliance: :update_compliance,
+          update_supporting_documents: :update_supporting_documents,
+        }.freeze
+      end
+    end
+  end
+end

--- a/app/services/websocket_broadcaster.rb
+++ b/app/services/websocket_broadcaster.rb
@@ -1,7 +1,7 @@
 class WebsocketBroadcaster
   # Current data is passed via the CurrentAttributes on AcitveSupport
   def self.user_channel(user_id)
-    "#{Constants::Channels::USER_CHANNEL_PREFIX}-#{user_id}"
+    "#{Constants::Websockets::Channels::USER_CHANNEL_PREFIX}-#{user_id}"
   end
 
   def self.broadcast_ready?

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -15,7 +15,7 @@ if Rails.env.production? && ENV["SKIP_DEPENDENCY_INITIALIZERS"].blank? # skip th
 
   Sidekiq.configure_server do |config|
     config.redis = redis_cfg
-    config.queues = %w[file_processing pdf_generation default]
+    config.queues = %w[file_processing default]
     config.concurrency = ENV["SIDEKIQ_CONCURRENCY"].to_i
 
     config.client_middleware { |chain| chain.add SidekiqUniqueJobs::Middleware::Client }

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -15,7 +15,7 @@ if Rails.env.production? && ENV["SKIP_DEPENDENCY_INITIALIZERS"].blank? # skip th
 
   Sidekiq.configure_server do |config|
     config.redis = redis_cfg
-    config.queues = %w[file_processing default]
+    config.queues = %w[file_processing pdf_generation default]
     config.concurrency = ENV["SIDEKIQ_CONCURRENCY"].to_i
 
     config.client_middleware { |chain| chain.add SidekiqUniqueJobs::Middleware::Client }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
     end
 
     resources :permit_applications, only: %i[create update show] do
+      post "generate_missing_pdfs", on: :member, to: "permit_applications#generate_missing_pdfs"
       post "search", on: :collection, to: "permit_applications#index"
       post "submit", on: :member
       post "mark_as_viewed", on: :member


### PR DESCRIPTION
## Description
Right now there is no error handling to retry failed generation of pdf files.  This is due a limitation of the architecture as we are using a node process to generate the files

To mitigate the problem, this PR implements a hotfix to regenerate any missing pdfs, when a user opens the submiteted permit application
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🔥 Hotfix
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1682
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Difficult to manually test. Posting a video, when a missing pdf was forcefully produced via code

https://github.com/bcgov/HOUS-permit-portal/assets/32022335/89dfba68-a006-46cd-a509-6e60c4f24445

