### PR TITLE
add latest published template version id and fix go to latest button

### DIFF
--- a/app/blueprints/template_version_blueprint.rb
+++ b/app/blueprints/template_version_blueprint.rb
@@ -9,6 +9,10 @@ class TemplateVersionBlueprint < Blueprinter::Base
 
   view :extended do
     fields :denormalized_template_json, :form_json, :requirement_blocks_json
+
+    field :latest_version_id do |template_version|
+      template_version.latest_version.id
+    end
   end
 
   view :external_api do

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -31,7 +31,7 @@ export const NotificationStoreModel = types
       const currentUser = self.rootStore.userStore.currentUser
       if (notification.actionType === ENotificationActionType.newTemplateVersionPublish) {
         if (currentUser.isManager) {
-          return `/digital-building-permits/${notification.objectData.templateVersionId}/edit?compare=true`
+          return `/digital-building-permits/${notification.objectData.previousTemplateVersionId}/edit?compare=true`
         }
         if (currentUser.isSubmitter) {
           return `/?requirementTemplateId=${notification.objectData.requirementTemplateId}&status=draft`

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -225,6 +225,15 @@ class TemplateVersioningService
       .first
   end
 
+  def self.latest_published_version(template_version)
+    template_version
+      .requirement_template
+      .template_versions
+      .where(status: TemplateVersion.statuses[:published])
+      .order(version_date: :desc, created_at: :desc)
+      .last
+  end
+
   private
 
   def self.copy_jurisdiction_customizations_to_template_version(


### PR DESCRIPTION
## Description

fixes go to latest button on deprecated edit template version views for managers. This view can only be reached by publishing a new version as admin, then clicking the link in the generated notification as review manager.



## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1691

## Steps to QA

see card
