### PR TITLE
[bphh-1713] Add requirement template blueprint optimization to improve load on search page

### DIFF
--- a/app/blueprints/requirement_template_blueprint.rb
+++ b/app/blueprints/requirement_template_blueprint.rb
@@ -4,7 +4,10 @@ class RequirementTemplateBlueprint < Blueprinter::Base
 
   association :permit_type, blueprint: PermitClassificationBlueprint
   association :activity, blueprint: PermitClassificationBlueprint
-  association :template_versions, blueprint: TemplateVersionBlueprint
+  association :last_three_deprecated_template_versions,
+              blueprint: TemplateVersionBlueprint,
+              name: :deprecated_template_versions
+  association :scheduled_template_versions, blueprint: TemplateVersionBlueprint
   association :published_template_version, blueprint: TemplateVersionBlueprint
 
   view :extended do

--- a/app/controllers/api/concerns/search/requirement_templates.rb
+++ b/app/controllers/api/concerns/search/requirement_templates.rb
@@ -5,6 +5,13 @@ module Api::Concerns::Search::RequirementTemplates
     @search =
       RequirementTemplate.search(
         query,
+        includes: %i[
+          activity
+          permit_type
+          last_three_deprecated_template_versions
+          scheduled_template_versions
+          published_template_version
+        ],
         order: order,
         where: {
           discarded: discarded,

--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -157,7 +157,16 @@ class Api::RequirementTemplatesController < Api::ApplicationController
   private
 
   def set_requirement_template
-    @requirement_template = RequirementTemplate.find(params[:id])
+    # eager loading of associations as most of the time we return the extended view
+    @requirement_template =
+      RequirementTemplate.includes(
+        :activity,
+        :permit_type,
+        :published_template_version,
+        :last_three_deprecated_template_versions,
+        :scheduled_template_versions,
+        requirement_template_sections: [template_section_blocks: [requirement_block: :requirements]],
+      ).find(params[:id])
   end
 
   def set_template_version
@@ -182,7 +191,7 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     # This is a workaround needed to validate step code related errors
     if permitted_params[:requirement_template_sections_attributes].present?
       permitted_params[:requirement_template_sections_attributes_copy] = permitted_params[
-        :requirement_template_sections_attributes
+        requirement_template_sections_attributes: :requirements
       ].deep_dup
     end
 

--- a/app/frontend/models/requirement-template.ts
+++ b/app/frontend/models/requirement-template.ts
@@ -1,10 +1,10 @@
 import { addDays, isAfter, isSameDay, max, startOfDay } from "date-fns"
 import { utcToZonedTime } from "date-fns-tz"
 import { Instance, flow, toGenerator, types } from "mobx-state-tree"
+import pluck from "ramda/src/pluck"
 import { vancouverTimeZone } from "../constants"
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
-import { ETemplateVersionStatus } from "../types/enums"
 import { IActivity, IPermitType } from "./permit-classification"
 import { RequirementTemplateSectionModel } from "./requirement-template-section"
 import { TemplateVersionModel } from "./template-version"
@@ -15,20 +15,22 @@ function preProcessor(snapshot) {
     publishedTemplateVersion: snapshot.publishedTemplateVersion?.id,
   }
 
-  if (Array.isArray(snapshot.templateVersions)) {
-    const statusToTemplateVersions =
-      snapshot.templateVersions.reduce((acc, version) => {
-        if (!acc[version.status]) {
-          acc[version.status] = []
-        }
+  if (Array.isArray(snapshot.scheduledTemplateVersions)) {
+    processedSnapShot.scheduledTemplateVersions = pluck(
+      "id",
+      snapshot.scheduledTemplateVersions as Array<{
+        id: "string"
+      }>
+    )
+  }
 
-        acc[version.status].push(version.id)
-
-        return acc
-      }, {}) ?? {}
-
-    processedSnapShot.scheduledTemplateVersions = statusToTemplateVersions[ETemplateVersionStatus.scheduled]
-    processedSnapShot.deprecatedTemplateVersions = statusToTemplateVersions[ETemplateVersionStatus.deprecated]
+  if (Array.isArray(snapshot.deprecatedTemplateVersions)) {
+    processedSnapShot.deprecatedTemplateVersions = pluck(
+      "id",
+      snapshot.deprecatedTemplateVersions as Array<{
+        id: "string"
+      }>
+    )
   }
 
   if (snapshot.requirementTemplateSections) {

--- a/app/frontend/stores/requirement-template-store.ts
+++ b/app/frontend/stores/requirement-template-store.ts
@@ -45,9 +45,21 @@ export const RequirementTemplateStoreModel = types
         })
       }
 
-      if (requirementTemplate.templateVersions?.length > 0) {
-        self.rootStore.templateVersionStore.mergeUpdateAll(requirementTemplate.templateVersions, "templateVersionMap")
+      const templateVersions = []
+
+      if (requirementTemplate.publishedTemplateVersion) {
+        templateVersions.push(requirementTemplate.publishedTemplateVersion)
       }
+
+      if (requirementTemplate.scheduledTemplateVersions?.length > 0) {
+        templateVersions.push(...requirementTemplate.scheduledTemplateVersions)
+      }
+
+      if (requirementTemplate.deprecatedTemplateVersions?.length > 0) {
+        templateVersions.push(...requirementTemplate.deprecatedTemplateVersions)
+      }
+
+      self.rootStore.templateVersionStore.mergeUpdateAll(templateVersions, "templateVersionMap")
 
       return requirementTemplate
     },

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -13,6 +13,9 @@ class RequirementTemplate < ApplicationRecord
   has_many :scheduled_template_versions,
            -> { where(template_versions: { status: "scheduled" }).order(version_date: :desc) },
            class_name: "TemplateVersion"
+  has_many :last_three_deprecated_template_versions,
+           -> { where(template_versions: { status: "deprecated" }).order(version_date: :desc).limit(3) },
+           class_name: "TemplateVersion"
   has_many :jurisdiction_template_version_customizations
 
   has_one :published_template_version, -> { where(status: "published") }, class_name: "TemplateVersion"


### PR DESCRIPTION
## Description
- The query for loading the requirement templates in the permit templates catalogue page is very slow for super admins. This is because:
   1. We were sending more data than necessary e.g. sending all deprecated template versions when the minimal UI only cares about the last three
   2. The associations were not eager loaded causing N + 1 query issue when passed on to the blue print
- Similar to previous point. Individual requirement template screens would  also load pretty slowly

This PR fixes the above issue to optimize the load performance

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1713
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Prequisite:
   - Create a large amount of template versions (specifically) for deprecated templates. In Dev site this is already there
   - Can use the following script to create the deprecated template versions. 
```
 @requirement_template = RequirementTemplate.find("e54b8d14-6514-457d-b399-1fc8751cab7f")

    # repeat this 40 times

    1.upto(500) do |i|
      ActiveRecord::Base.transaction do
        begin
          published_template_version = TemplateVersioningService.force_publish_now!(@requirement_template)
        rescue StandardError => e
          # If there is an error in TemplateVersioningService.schedule!, rollback the transaction
          raise ActiveRecord::Rollback
        end
      end
    end
```
  - Steps:
     - Log in as an admin
     - Navigate to permit templates catalogue
     - The loading of the records should be in the milliseconds rather seconds for low amount of requirement templates

### Test results:
locally load tested with a total of ~ 550 template versions among the requirement_template

#### Index page
Before:
![Screenshot 2024-06-20 at 6 12 41 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/4aa35bb5-8c86-4d1c-ae48-139cc5b42443)
After:
![Screenshot 2024-06-20 at 6 13 48 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/531af460-c0e7-4858-ab38-bbbb31b73c69)

#### Show Page
Before:
![Screenshot 2024-06-20 at 6 32 45 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/7342538a-313b-4344-a92e-2aa646756790)

After:
![Screenshot 2024-06-20 at 6 33 40 PM](https://github.com/bcgov/HOUS-permit-portal/assets/32022335/a8d9e5fa-a9a5-4998-990d-4f2a8ff33c18)