### PR TITLE
add migration for changing tleil-watuth name

### DIFF
--- a/db/data/20240621170056_update_first_nations_names.rb
+++ b/db/data/20240621170056_update_first_nations_names.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class UpdateFirstNationsNames < ActiveRecord::Migration[7.1]
+  def up
+    Jurisdiction.find_by_name("Tsleil-Waututh Nation")&.update(name: "Tsleil-Waututh (tSLAY-way-tooth) səlilwətaɬ")
+  end
+
+  def down
+    Jurisdiction.find_by_name("Tsleil-Waututh (tSLAY-way-tooth) səlilwətaɬ")&.update(name: "Tsleil-Waututh Nation")
+  end
+end


### PR DESCRIPTION
## Description

A simple migration to change Tseil-Watuth name

Note that the redundant "Nation" has been dropped in favor of relying on the locality type "First Nation of"

so it will appear as:
Tsleil-Waututh (tSLAY-way-tooth) səlilwətaɬ, First Nation of