### PR TITLE
convert clonedSubmissionData to unsavedSubmissionData local state

### DIFF
--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -18,7 +18,7 @@ import { observer } from "mobx-react-lite"
 
 import { format } from "date-fns"
 import * as R from "ramda"
-import React, { useEffect, useMemo, useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useLocation, useNavigate } from "react-router-dom"
 import { useMountStatus } from "../../../hooks/use-mount-status"
@@ -43,14 +43,7 @@ interface IRequirementFormProps {
 }
 
 export const RequirementForm = observer(
-  ({
-    permitApplication,
-    onCompletedBlocksChange,
-    formRef,
-    triggerSave,
-    showHelpButton = true,
-    isEditing = false,
-  }: IRequirementFormProps) => {
+  ({ permitApplication, onCompletedBlocksChange, formRef, triggerSave, isEditing = false }: IRequirementFormProps) => {
     const {
       jurisdiction,
       submissionData,
@@ -77,7 +70,12 @@ export const RequirementForm = observer(
     const [firstComponentKey, setFirstComponentKey] = useState(null)
     const [isCollapsedAll, setIsCollapsedAllState] = useState(false)
 
-    const clonedSubmissionData = useMemo(() => R.clone(submissionData), [submissionData])
+    const [unsavedSubmissionData, setUnsavedSubmissionData] = useState(R.clone(submissionData))
+
+    const handleSetUnsavedSubmissionData = (data) => {
+      permitApplication.setIsDirty(true)
+      setUnsavedSubmissionData(data)
+    }
 
     const { isOpen: isContactsOpen, onOpen: onContactsOpen, onClose: onContactsClose } = useDisclosure()
 
@@ -357,7 +355,7 @@ export const RequirementForm = observer(
             formReady={formReady}
             /* Needs cloned submissionData otherwise it's not possible to use data grid as mst props
             can't be mutated*/
-            submission={clonedSubmissionData}
+            submission={unsavedSubmissionData}
             onSubmit={onFormSubmit}
             options={permitAppOptions}
             onBlur={onBlur}
@@ -410,7 +408,8 @@ export const RequirementForm = observer(
             onClose={onContactsClose}
             autofillContactKey={autofillContactKey}
             permitApplication={permitApplication}
-            submissionState={submissionData}
+            submissionState={unsavedSubmissionData}
+            setSubmissionState={handleSetUnsavedSubmissionData}
           />
         )}
       </>

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -70,7 +70,7 @@ export const RequirementForm = observer(
     const [firstComponentKey, setFirstComponentKey] = useState(null)
     const [isCollapsedAll, setIsCollapsedAllState] = useState(false)
 
-    const [unsavedSubmissionData, setUnsavedSubmissionData] = useState(R.clone(submissionData))
+    const [unsavedSubmissionData, setUnsavedSubmissionData] = useState(() => R.clone(submissionData))
 
     const handleSetUnsavedSubmissionData = (data) => {
       permitApplication.setIsDirty(true)


### PR DESCRIPTION
## Description

This reworks the way contact forms were trying to update the form data, which previously was to directly set the submission data on the permitApplication model. This is incorrect.

To make setting form data easier, I have converted the clonedSubmissionData to the below:

the Frozen submissionData on the MST model acts as a default value for local state initialization ONLY:
in requirement-form.tsx:

`const [unsavedSubmissionData, setUnsavedSubmissionData] = useState(R.clone(submissionData))`

this will be syncronized with the exact state of  formio.data:

```
    const formio = formRef.current
    const submissionData = formio.data

```
the only difference is now there are TWO booleans to indicate if the form is “dirty” - first there is:

`formio.pristine`

This ONLY becomes true when the user changed the formio submission state in the tradional sense of manually entering in form fields. Therefor, we also need on the permit application:

```
    setIsDirty(isDirty: boolean) {
      self.isDirty = isDirty
    },

```
this separate isDirty boolean
both of these are checked at the same time when saving the form.

Whenever any permit application data changes in a way other than the user manually entering something into the form directly, this is dirty needs to be set true. therefor, instead of ever using

`setUnsavedSubmissionData(newData)`

you must instead use the provided function:

```
    const handleSetUnsavedSubmissionData = (data) => {
      permitApplication.setIsDirty(true)
      setUnsavedSubmissionData(data)
    }

```
this needs to be passed into any component that controls the form unsavedSubmissionData data
