### PR TITLE
add null check for latest template version in blueprint

### DIFF
--- a/app/blueprints/template_version_blueprint.rb
+++ b/app/blueprints/template_version_blueprint.rb
@@ -11,7 +11,7 @@ class TemplateVersionBlueprint < Blueprinter::Base
     fields :denormalized_template_json, :form_json, :requirement_blocks_json
 
     field :latest_version_id do |template_version|
-      template_version.latest_version.id
+      template_version.latest_version&.id
     end
   end
 


### PR DESCRIPTION
## Description

simple fix for:

A NoMethodError occurred in template_versions#show: undefined method `id' for nil:NilClass app/blueprints/template_version_blueprint.rb:14