### PR TITLE
[bphh-1746] Refactor integration mapping creation callbacks into background jobs

### DIFF
--- a/app/jobs/model_callback_job.rb
+++ b/app/jobs/model_callback_job.rb
@@ -1,0 +1,17 @@
+class ModelCallbackJob
+  include Sidekiq::Worker
+  sidekiq_options lock: :until_and_while_executing,
+                  queue: :model_callbacks,
+                  on_conflict: {
+                    client: :log,
+                    server: :reject,
+                  }
+
+  def perform(model_name, model_id, callback_name)
+    model = model_name.constantize.find(model_id)
+
+    return if model.blank?
+
+    model.send(callback_name)
+  end
+end

--- a/app/models/integration_mapping.rb
+++ b/app/models/integration_mapping.rb
@@ -18,7 +18,7 @@ class IntegrationMapping < ApplicationRecord
 
   before_create :initialize_requirements_mapping
 
-  after_save :sync_changes_with_other_currently_active_mappings
+  after_update :sync_changes_with_other_currently_active_mappings
 
   attr_accessor :simplified_map_to_sync
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -16,7 +16,7 @@ if Rails.env.production? && ENV["SKIP_DEPENDENCY_INITIALIZERS"].blank? # skip th
 
   Sidekiq.configure_server do |config|
     config.redis = redis_cfg
-    config.queues = %w[file_processing webhooks websocket default]
+    config.queues = %w[file_processing webhooks websocket model_callbacks default]
     config.concurrency = ENV["SIDEKIQ_CONCURRENCY"].to_i
 
     config.client_middleware { |chain| chain.add SidekiqUniqueJobs::Middleware::Client }


### PR DESCRIPTION
## Description
There is a callback logic to create integration mappings for a jurisdiction, when a template enables it’s API. This callback logic is very expensive and the time taken increases significantly as the template versions in the system grows.

 The immediate quick fix is to background the call backs into a background job, and this PR implements it. A future refactor will take place to further rearchitect this to improve performance for the callbacks [BPHH-1747](https://hous-bssb.atlassian.net/browse/BPHH-1747).
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
 [BPHH-1746](https://hous-bssb.atlassian.net/browse/BPHH-1746)
