### PR TITLE
[bphh-1769] HotFix bug with landing screen displaying all jurisdictions instead of jurisdiction's with inbox setup

### DIFF
--- a/app/controllers/api/concerns/search/jurisdictions.rb
+++ b/app/controllers/api/concerns/search/jurisdictions.rb
@@ -17,9 +17,7 @@ module Api::Concerns::Search::Jurisdictions
     }
 
     # Conditionally add the `where` clause
-    unless jurisdiction_search_params[:submission_inbox_set_up].nil?
-      search_params[:where] = { submission_inbox_set_up: jurisdiction_search_params[:submission_inbox_set_up] }
-    end
+    search_params[:where] = jurisdiction_where_clause unless jurisdiction_where_clause.nil?
 
     @search = Jurisdiction.search(jurisdiction_query, **search_params)
   end
@@ -27,7 +25,7 @@ module Api::Concerns::Search::Jurisdictions
   private
 
   def jurisdiction_search_params
-    params.permit(:query, :page, :per_page, :submission_inbox_set_up, sort: %i[field direction])
+    params.permit(:query, :page, :per_page, filters: [:submission_inbox_set_up], sort: %i[field direction])
   end
 
   def jurisdiction_query
@@ -40,5 +38,9 @@ module Api::Concerns::Search::Jurisdictions
     else
       { name: { order: :asc, unmapped_type: "long" } }
     end
+  end
+
+  def jurisdiction_where_clause
+    jurisdiction_search_params[:filters]
   end
 end


### PR DESCRIPTION
## Description
Fix bug with landing screen displaying all jurisdictions instead of jurisdiction's with inbox setup
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1769
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Navigate to landing page
- The following info box should only show jurisdictions whose inboxes are setup
![Uploading Screenshot 2024-06-26 at 2.14.29 PM.png…]()
