### PR TITLE
Fix issue showing custom step requirements

### DIFF
--- a/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
@@ -388,7 +388,7 @@ interface IStepCodeTableProps {
 
 const StepCodeTable: React.FC<IStepCodeTableProps> = ({ currentJurisdiction }) => {
   const { t } = useTranslation()
-  const requiredStepsByPermitType = currentJurisdiction.requiredStepsByPermitType
+  const { requiredStepsByPermitType } = currentJurisdiction
   return (
     <Flex direction="column" gap={4}>
       {Object.keys(requiredStepsByPermitType).map(


### PR DESCRIPTION
## Description

Fix issue where default step requirement shows on jurisdiction about page when the permit type has custom step requirements.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

[BPHH-1826](https://hous-bssb.atlassian.net/browse/BPHH-1826)

## Steps to QA

1. Login as a review manager and configure the jurisdiction so it has multiple step requirements for a permit type
2. Go to the jurisdiction about screen and verify only the customized step requirements show and the default step requirements are hidden.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
