### PR TITLE
Filter out inactive requirement blocks and sections from permit application form json

### DIFF
--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -59,7 +59,7 @@ class PermitApplication < ApplicationRecord
       component["components"].delete_if { |sub_component| block_ids_to_remove.include?(sub_component["id"]) }
     end
 
-    processed_json
+    remove_empty_sections_from_form_json!(processed_json)
   end
 
   def force_update_published_template_version
@@ -326,6 +326,12 @@ class PermitApplication < ApplicationRecord
     if pin.blank? && pid.blank?
       errors.add(:base, I18n.t("activerecord.errors.models.permit_application.attributes.pid_or_pin"))
     end
+  end
+
+  def remove_empty_sections_from_form_json!(form_json)
+    form_json["components"].delete_if { |component| component["components"].blank? || component["components"].empty? }
+
+    form_json
   end
 
   def get_requirement_block_ids_to_remove


### PR DESCRIPTION
## Description
-[bphh-1488] - Change to filters out requirement blocks which only have elective requirements with none of them enabled by the jurisdiction
-[bphh-1857] As a consequence of the previous point, filters out form sections, which do not have any visible requirement blocks.
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
- https://hous-bssb.atlassian.net/browse/BPHH-1488
- https://hous-bssb.atlassian.net/browse/BPHH-1857
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
### [bphh-1488]
- As a super admin
  - Create a requirement block with only elective fields
  - Add the above requirement block to any requirement template then force publish
 - As a submitter
   - Start a permit application with the newly published template
   - The template should have that requirement block filtered out as none of the elective fields were enabled by the jurisdiction
 - As a review manager
   - Edit the the newly published template, and enable one of the elective fields in the above requirement block and publish
 - As a submitter
   -  Go back to the previous permit application and refresh
   - The permit application should now show the requirement block with the elective field enabled

### [bphh-1857]
- As a super admin
    - Building from the previous steps, add the requirement block with only electives to a new empty section in a requirement template
    - Force publish the requirement template
  - As a review manager
      - Ensure none of the elective fields are enabled
 - As a submitter
      - Start a new permit application with the new template version
      - The permit application should have the empty section filtered out
