### PR TITLE
[bphh-1815] Fixes bug where email was being sent to only one submission contact when there are multiple for permit application submission notification

### DIFF
--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -160,13 +160,15 @@ class PermitApplication < ApplicationRecord
     "#{activity.name} - #{permit_type.name}".strip
   end
 
-  def permit_type_submission_contact
-    jurisdiction.permit_type_submission_contacts.find_by(permit_type: permit_type)
+  def confirmed_permit_type_submission_contacts
+    jurisdiction.permit_type_submission_contacts.where(permit_type: permit_type).where.not(confirmed_at: nil)
   end
 
   def send_submit_notifications
     PermitHubMailer.notify_submitter_application_submitted(submitter, self).deliver_later
-    PermitHubMailer.notify_reviewer_application_received(permit_type_submission_contact, self).deliver_later
+    confirmed_permit_type_submission_contacts.each do |permit_type_submission_contact|
+      PermitHubMailer.notify_reviewer_application_received(permit_type_submission_contact, self).deliver_later
+    end
   end
 
   def formatted_submission_data_for_external_use


### PR DESCRIPTION
## Description
[bphh-1815] Fixes bug where email was being sent to only one submission contact when there are multiple for permit application submission notification
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)
- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1815

<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->



## Steps to QA
- As a review manager, setup multiple contact for a permit type
<img width="1713" alt="Screenshot 2024-07-16 at 10 33 22 AM" src="https://github.com/user-attachments/assets/c4ef66e2-ee30-436c-bb6b-4632f38797b3">
- As a submitter submit a permit application for the jurisdiction of the review manager
- You should get emails for all emails setup, as they are confirmed