### PR TITLE
Only require step code if requirements exist

### DIFF
--- a/app/services/permit_application/form_json_service.rb
+++ b/app/services/permit_application/form_json_service.rb
@@ -1,0 +1,78 @@
+class PermitApplication::FormJsonService
+  attr_accessor :form_json
+  attr_reader :permit_application
+
+  def initialize(permit_application:)
+    @permit_application = permit_application
+    @form_json = permit_application.template_version.form_json.deep_dup
+  end
+
+  def call
+    remove_empty_blocks
+    remove_empty_sections
+    set_step_code_requirement
+    return self
+  end
+
+  private
+
+  def remove_empty_blocks
+    return form_json if empty_block_ids.empty?
+
+    form_json["components"].each do |component|
+      next unless component["components"].present?
+
+      component["components"].delete_if { |sub_component| empty_block_ids.include?(sub_component["id"]) }
+    end
+  end
+
+  def remove_empty_sections
+    form_json["components"].delete_if { |component| component["components"].blank? || component["components"].empty? }
+
+    form_json
+  end
+
+  def set_step_code_requirement(hash = form_json)
+    if hash.is_a?(Hash)
+      if hash["key"]&.end_with?("energy_step_code_method")
+        hash["validate"] = { "required" => permit_application.energy_step_code_required? }
+      end
+    end
+
+    hash["components"].each { |component| set_step_code_requirement(component) } if hash["components"].is_a?(Array)
+  end
+
+  def empty_block_ids
+    @empty_block_ids ||=
+      permit_application
+        .template_version
+        .requirement_blocks_json
+        .map do |rb_id, requirement_block|
+          next if requirement_block["requirements"].blank?
+
+          has_only_elective_fields = requirement_block["requirements"].all? { |requirement| requirement["elective"] }
+
+          next unless has_only_elective_fields
+
+          enabled_elective_field_ids =
+            permit_application.form_customizations&.dig(
+              "requirement_block_changes",
+              rb_id,
+              "enabled_elective_field_ids",
+            ) || []
+
+          # remove the block if no elective fields are enabled
+          next rb_id if enabled_elective_field_ids.empty?
+
+          # This check is to ensure that the enabled elective fields are valid, i.e. they exist in the requirement block
+          any_enabled_elective_field_valid =
+            enabled_elective_field_ids.any? do |elective_field_id|
+              requirement_block["requirements"].any? { |requirement| elective_field_id == requirement["id"] }
+            end
+
+          # remove the block if no enabled elective fields are valid
+          rb_id unless any_enabled_elective_field_valid
+        end
+        .compact
+  end
+end


### PR DESCRIPTION
## Description

Refactor form json into a separate service and add in functionality to transform the step code so it is required or not depending on the presence of step requirements.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

[BPHH-1489](https://hous-bssb.atlassian.net/browse/BPHH-1489)

## Steps to QA

Login as a review manager and update step requirements for a permit type so both are "not required". This should remove the validation on the step code field in the permit application form. Setting either energy or zero carbon requirements back to a value should make the step code required again. 

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a
