### PR TITLE
direct reviewers to new instead of old template on template update

### DIFF
--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -358,7 +358,7 @@ const options = {
           },
           updateToNewVersion: "Update my application",
           reviewOutdatedSubmissionLink: "View draft applications",
-          reviewOutdatedEditLink: "View template",
+          reviewUpdatedEditLink: "View template",
           reviewOutdatedTitle: "Filters applied to show applications that are outdated",
           reviewOutdatedMessage: "Filters have been applied. Please review and acknowledge the actions required below.",
           reviewCustomizedSubmissionLink: "View draft applications",

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -55,8 +55,8 @@ export const NotificationStoreModel = types
         ]
         if (currentUser.isManager) {
           linkData.push({
-            text: t("permitApplication.reviewOutdatedEditLink"),
-            href: `/digital-building-permits/${objectData.previousTemplateVersionId}/edit?compare=true`,
+            text: t("permitApplication.reviewUpdatedEditLink"),
+            href: `/digital-building-permits/${objectData.templateVersionId}/edit?compare=true`,
           })
         }
 


### PR DESCRIPTION
## Description

Bugfix that stops trying to show the reviewers a busted compare page. Page only works when user is directed to the new template not the old one.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1772

## Steps to QA

See card, disregard the 404 as this is a red herring, just make sure that the page works.

