### PR TITLE
Fix issue inviting existing super admins

### DIFF
--- a/app/services/jurisdiction/user_inviter.rb
+++ b/app/services/jurisdiction/user_inviter.rb
@@ -20,7 +20,7 @@ class Jurisdiction::UserInviter
       user = User.where.not(role: :submitter).find_by(email: user_params[:email].strip)
       is_regional_rm = user&.regional_review_manager? || (user && user_params[:role].to_sym == :regional_review_manager)
 
-      if user.present? && !user.discarded? && user.confirmed? && !is_regional_rm
+      if user.present? && !user.discarded? && user.confirmed? && (!is_regional_rm || user.super_admin?)
         self.results[:email_taken] << user
       elsif user && is_regional_rm && jurisdiction_id = user_params[:jurisdiction_id]
         user.update(role: :regional_review_manager) if !user.regional_review_manager?


### PR DESCRIPTION
## Description

Existing super admins should not be invitable. This fixes a bug where super admins could be invited as regional RMs and then converted to a regional RM loosing their admin access.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

[BPHH-1893](https://hous-bssb.atlassian.net/browse/BPHH-1893)

## Steps to QA

Login as a super admin. Try to invite an existing super admin as a regional review manager. This should trigger an error and the invitation should not be sent.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a