### PR TITLE
Fix error when step code is optional

### DIFF
--- a/app/services/permit_application/form_json_service.rb
+++ b/app/services/permit_application/form_json_service.rb
@@ -34,12 +34,21 @@ class PermitApplication::FormJsonService
 
   def set_step_code_requirement(hash = form_json)
     if hash.is_a?(Hash)
-      if hash["key"]&.end_with?("energy_step_code_method")
+      if energy_step_keys.any? { |key| hash["key"]&.end_with?(key) }
         hash["validate"] = { "required" => permit_application.energy_step_code_required? }
       end
     end
 
     hash["components"].each { |component| set_step_code_requirement(component) } if hash["components"].is_a?(Array)
+  end
+
+  def energy_step_keys
+    @energy_step_keys ||= %w[
+      energy_step_code_method
+      energy_step_code_tool_part_9
+      energy_step_code_report_file
+      energy_step_code_h2000_file
+    ]
   end
 
   def empty_block_ids


### PR DESCRIPTION
## Description

If step code is optional, allow application to be submitted even if user selects a step code upload option.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

[BPHH-1489](https://hous-bssb.atlassian.net/browse/BPHH-1489)

## Steps to QA

Set both energy and zero carbon steps for a jurisdiction as not required. Create a permit application for that jurisdiction and go to the step code section. The field should not be required along with the sub fields that show up if the user selects the compliance tool or file upload options.

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a