### PR TITLE
direct reviewers to new instead of old template on template update

### DIFF
--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -352,7 +352,7 @@ const options = {
           },
           updateToNewVersion: "Update my application",
           reviewOutdatedSubmissionLink: "View draft applications",
-          reviewOutdatedEditLink: "View template",
+          reviewUpdatedEditLink: "View template",
           reviewOutdatedTitle: "Filters applied to show applications that are outdated",
           reviewOutdatedMessage: "Filters have been applied. Please review and acknowledge the actions required below.",
           reviewCustomizedSubmissionLink: "View draft applications",

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -47,8 +47,8 @@ export const NotificationStoreModel = types
         ]
         if (currentUser.isManager) {
           linkData.push({
-            text: t("permitApplication.reviewOutdatedEditLink"),
-            href: `/digital-building-permits/${objectData.previousTemplateVersionId}/edit?compare=true`,
+            text: t("permitApplication.reviewUpdatedEditLink"),
+            href: `/digital-building-permits/${objectData.templateVersionId}/edit?compare=true`,
           })
         }
 


### PR DESCRIPTION
Rebased quick fix for fixing reviewer notifications on template update