### PR TITLE
Feature/bphh 558/status of requirement block

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -60,6 +60,7 @@ class PermitApplicationBlueprint < Blueprinter::Base
     association :jurisdiction, blueprint: JurisdictionBlueprint, view: :base
     association :step_code, blueprint: StepCodeBlueprint
     association :permit_collaborations, blueprint: PermitCollaborationBlueprint, view: :base
+    association :permit_block_statuses, blueprint: PermitBlockStatusBlueprint
     association :submission_versions, blueprint: SubmissionVersionBlueprint, view: :extended
   end
 

--- a/app/blueprints/permit_block_status_blueprint.rb
+++ b/app/blueprints/permit_block_status_blueprint.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class PermitBlockStatusBlueprint < Blueprinter::Base
+  identifier :id
+  fields :collaboration_type, :requirement_block_id, :status, :created_at, :updated_at
+end

--- a/app/blueprints/permit_block_status_blueprint.rb
+++ b/app/blueprints/permit_block_status_blueprint.rb
@@ -2,5 +2,5 @@
 
 class PermitBlockStatusBlueprint < Blueprinter::Base
   identifier :id
-  fields :collaboration_type, :requirement_block_id, :status, :created_at, :updated_at
+  fields :collaboration_type, :requirement_block_id, :permit_application_id, :status, :created_at, :updated_at
 end

--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -319,6 +319,8 @@ class Api::PermitApplicationsController < Api::ApplicationController
 
     authorize @permit_block_status, policy_class: PermitApplicationPolicy
 
+    @permit_block_status.set_by_user = current_user
+
     @permit_block_status.with_lock do
       if @permit_block_status.update(status: params.require(:status))
         render_success @permit_block_status,

--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -72,7 +72,7 @@ class Api::PermitApplicationsController < Api::ApplicationController
                if is_current_user_submitter
                  permit_application_params
                else
-                 permit_collaboration_params
+                 submission_collaborator_permit_application_params
                end
              ),
            current_user: current_user,
@@ -360,7 +360,16 @@ class Api::PermitApplicationsController < Api::ApplicationController
   end
 
   def submission_collaborator_permit_application_params # permit application params collaborators can update if they are a collaborator during submission
-    params.require(:permit_application).permit(submission_data: {})
+    designated_submitter =
+      @permit_application.users_by_collaboration_options(
+        collaboration_type: :submission,
+        collaborator_type: :delegatee,
+      ).first
+    if designated_submitter&.id == current_user.id
+      params.require(:permit_application).permit(:nickname, submission_data: {})
+    else
+      params.require(:permit_application).permit(submission_data: {})
+    end
   end
 
   def permit_collaboration_params

--- a/app/frontend/components/domains/permit-application/collaborator-management/block-collaborator-assignment-management.tsx
+++ b/app/frontend/components/domains/permit-application/collaborator-management/block-collaborator-assignment-management.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { createPortal } from "react-dom"
 import { IPermitApplication } from "../../../../models/permit-application"
 import { ECollaborationType } from "../../../../types/enums"
+import { BlockStatusSelect } from "../../../shared/select/selectors/block-status-select"
 import { CollaboratorAssignmentPopover } from "./collaborator-assignment-popover"
 
 export interface IRequirementBlockAssignmentNode {
@@ -31,7 +32,8 @@ export const BlockCollaboratorAssignmentManagement = observer(function BlockColl
   return (
     <>
       {createPortal(
-        <HStack mr={6}>
+        <HStack mr={6} spacing={4} onClick={(e) => e.stopPropagation()}>
+          <BlockStatusSelect />
           <CollaboratorAssignmentPopover
             permitApplication={permitApplication}
             collaborationType={collaborationType}

--- a/app/frontend/components/domains/permit-application/collaborator-management/collaborators-sidebar.tsx
+++ b/app/frontend/components/domains/permit-application/collaborator-management/collaborators-sidebar.tsx
@@ -84,7 +84,17 @@ export const CollaboratorsSidebar = observer(function CollaboratorsSidebar({
                 {t("permitCollaboration.sidebar.howItWorksTitle")}
               </Text>
               {/*TODO update copy*/}
-              <Text fontSize={"sm"}>{t("permitCollaboration.sidebar.howItWorksDescription")}</Text>
+              <Text fontSize={"sm"}>
+                {
+                  <Trans
+                    i18nKey={"permitCollaboration.sidebar.howItWorksDescription"}
+                    t={t}
+                    components={{
+                      1: <br />,
+                    }}
+                  />
+                }
+              </Text>
             </Stack>
             <DesignatedSubmitters
               permitApplication={permitApplication}

--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -372,7 +372,13 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
                 </Button>
               </Stack>
             ) : (
-              <HStack gap={4}>
+              <HStack
+                flexDir={{
+                  base: "column",
+                  md: "row",
+                }}
+                gap={4}
+              >
                 <BrowserSearchPrompt />
                 <CollaboratorsSidebar
                   permitApplication={currentPermitApplication}

--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -276,7 +276,11 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
   const { permitTypeAndActivity, formJson, number, isSubmitted, isDirty, setIsDirty, isRevisionsRequested } =
     currentPermitApplication
 
-  const isCurrentUserSubmitter = currentUser?.id === currentPermitApplication.submitter?.id
+  const canCurrentUserSubmit =
+    currentUser?.id === currentPermitApplication.submitter?.id ||
+    currentUser?.id ===
+      currentPermitApplication?.getCollaborationDelegatee(ECollaborationType.submission)?.collaborator?.user?.id
+
   return (
     <Box as="main" id="submitter-view-permit">
       {!isStepCode && (
@@ -303,11 +307,11 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
                         w="full"
                         initialHint={t("permitApplication.edit.clickToWriteNickname")}
                         value={nicknameWatch || ""}
-                        isDisabled={!isCurrentUserSubmitter || isSubmitted}
+                        isDisabled={!canCurrentUserSubmit || isSubmitted}
                         controlsProps={{
                           iconButtonProps: {
                             color: "greys.white",
-                            display: !isCurrentUserSubmitter || isSubmitted ? "none" : "block",
+                            display: !canCurrentUserSubmit || isSubmitted ? "none" : "block",
                           },
                         }}
                         editableInputProps={{

--- a/app/frontend/components/shared/select/selectors/block-status-select.tsx
+++ b/app/frontend/components/shared/select/selectors/block-status-select.tsx
@@ -1,0 +1,109 @@
+import { Button, HStack, Menu, MenuButton, MenuItem, MenuList, Portal, Text } from "@chakra-ui/react"
+import { CaretDown } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React, { useMemo, useRef } from "react"
+import { useTranslation } from "react-i18next"
+import { v4 as uuidv4 } from "uuid"
+import { EPermitBlockStatus } from "../../../../types/enums"
+
+interface IProps {
+  value: EPermitBlockStatus | undefined
+  onChange: (value: EPermitBlockStatus) => void
+  isDisabled?: boolean
+}
+
+const statuses = Object.values(EPermitBlockStatus)
+
+const statusColors = {
+  [EPermitBlockStatus.draft]: "greys.grey03",
+  [EPermitBlockStatus.inProgress]: "semantic.warningLight",
+  [EPermitBlockStatus.ready]: "semantic.successLight",
+}
+
+export const BlockStatusSelect = observer(function BlockStatusSelect({
+  value = EPermitBlockStatus.draft,
+  onChange,
+  isDisabled,
+}: IProps) {
+  const { t } = useTranslation()
+  const btnRef = useRef<HTMLButtonElement>()
+  const getLabel = (status: EPermitBlockStatus | undefined) =>
+    t(`permitCollaboration.blockStatus.${status || EPermitBlockStatus.draft}`)
+  const uniqueId = useMemo(uuidv4, [])
+  const selectId = `block-status-select-${uniqueId}`
+  const labelId = `block-status-select-label-${uniqueId}`
+
+  return (
+    <HStack>
+      <Text
+        as={"label"}
+        htmlFor={selectId}
+        id={labelId}
+        fontWeight={400}
+        textTransform={"uppercase"}
+        fontSize={"0.625rem"}
+        color={"text.secondary"}
+        onClick={() => btnRef.current?.focus()}
+      >
+        {t("permitCollaboration.status")}
+      </Text>
+      <Menu>
+        <MenuButton
+          id={selectId}
+          ref={btnRef}
+          aria-labelledby={labelId}
+          as={Button}
+          aria-haspopup={"listbox"}
+          fontSize={"sm"}
+          lineHeight="27px"
+          borderRadius="sm"
+          px={2}
+          py={0}
+          h={"fit-content"}
+          _disabled={{
+            bg: "greys.grey10",
+          }}
+          border={"1px solid"}
+          borderColor="border.base"
+          bg={statusColors[value]}
+          sx={{
+            "&:focus": { borderColor: "focus" },
+          }}
+          rightIcon={<CaretDown />}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {getLabel(value)}
+        </MenuButton>
+        <Portal>
+          <MenuList
+            aria-multiselectable={false}
+            aria-label={"Unit options"}
+            role={"listbox"}
+            minW={"100px"}
+            w={"100px"}
+            p={0}
+            border={"1px solid"}
+            borderColor={"border.base"}
+            overflow={"hidden"}
+          >
+            {statuses.map((status) => (
+              <MenuItem
+                key={status}
+                fontSize={"sm"}
+                role={"option"}
+                _focus={{ bg: "semantic.infoLight" }}
+                bg={statusColors[status]}
+                onClick={() => onChange(status)}
+                aria-selected={value === status}
+                p={2}
+                isDisabled={isDisabled}
+              >
+                {getLabel(status)}
+              </MenuItem>
+            ))}
+          </MenuList>
+        </Portal>
+      </Menu>
+    </HStack>
+  )
+})

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -353,6 +353,12 @@ const options = {
           view: "View Jurisdiction",
         },
         permitCollaboration: {
+          status: "Status",
+          blockStatus: {
+            draft: "Draft",
+            in_progress: "In progress",
+            ready: "Ready",
+          },
           sidebar: {
             triggerButton: "Collaborators ({{count}})",
             title: "Collaborators",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -366,7 +366,7 @@ const options = {
               "Collaborators can be invited to work on the different areas of the permit application form. Only the author can manage collaborators.",
             howItWorksTitle: "How it works",
             howItWorksDescription:
-              "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+              "The collaboration feature allows the author of a permit application to invite collaborators by email. Invited collaborators must register for an account through BCeID if they do not have one already. Collaborators can view and contribute only to the requirement blocks they are assigned. Notifications are sent to the collaborators when they are assigned to a requirement block, and their avatars are displayed next to the blocks they are assigned to. Additionally, the designated submitter has access to the entire application and can submit it on behalf of the author. The author can manage and remove collaborators as needed.",
             designatedSubmitters: "Designated submitter(s)",
             authorCanSubmitWithOrganization:
               "Author of this application is also allowed to submit: <1>{{author}}</1> ({{organization}}).",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -366,7 +366,7 @@ const options = {
               "Collaborators can be invited to work on the different areas of the permit application form. Only the author can manage collaborators.",
             howItWorksTitle: "How it works",
             howItWorksDescription:
-              "The collaboration feature allows the author of a permit application to invite collaborators by email. Invited collaborators must register for an account through BCeID if they do not have one already. Collaborators can view and contribute only to the requirement blocks they are assigned. Notifications are sent to the collaborators when they are assigned to a requirement block, and their avatars are displayed next to the blocks they are assigned to. Additionally, the designated submitter has access to the entire application and can submit it on behalf of the author. The author can manage and remove collaborators as needed.",
+              "The collaboration feature allows the author of a permit application to invite collaborators by email. Invited collaborators must register for an account through BCeID if they do not have one already.<1/><1/> Collaborators can view and contribute only to the requirement blocks they are assigned. Notifications are sent to the collaborators when they are assigned to a requirement block, and their avatars are displayed next to the blocks they are assigned to.<1/><1/> Additionally, the designated submitter has access to the entire application and can submit it on behalf of the author. The author can manage and remove collaborators as needed.",
             designatedSubmitters: "Designated submitter(s)",
             authorCanSubmitWithOrganization:
               "Author of this application is also allowed to submit: <1>{{author}}</1> ({{organization}}).",

--- a/app/frontend/models/permit-block-status.ts
+++ b/app/frontend/models/permit-block-status.ts
@@ -6,6 +6,7 @@ export const PermitBlockStatusModel = types.model("PermitBlockStatusModel", {
   collaborationType: types.enumeration(Object.values(ECollaborationType)),
   status: types.enumeration(Object.values(EPermitBlockStatus)),
   requirementBlockId: types.string,
+  permitApplicationId: types.string,
   createdAt: types.Date,
   updatedAt: types.Date,
 })

--- a/app/frontend/models/permit-block-status.ts
+++ b/app/frontend/models/permit-block-status.ts
@@ -1,0 +1,13 @@
+import { Instance, types } from "mobx-state-tree"
+import { ECollaborationType, EPermitBlockStatus } from "../types/enums"
+
+export const PermitBlockStatusModel = types.model("PermitBlockStatusModel", {
+  id: types.identifier,
+  collaborationType: types.enumeration(Object.values(ECollaborationType)),
+  status: types.enumeration(Object.values(EPermitBlockStatus)),
+  requirementBlockId: types.string,
+  createdAt: types.Date,
+  updatedAt: types.Date,
+})
+
+export interface IPermitBlockStatus extends Instance<typeof PermitBlockStatusModel> {}

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -40,6 +40,7 @@ import {
   ECollaboratorType,
   EJurisdictionSortFields,
   EPermitApplicationSortFields,
+  EPermitBlockStatus,
   ERequirementLibrarySortFields,
   ERequirementTemplateSortFields,
   ETemplateVersionStatus,
@@ -306,6 +307,28 @@ export class Api {
       {
         collaboratorId,
         collaboratorType,
+        collaborationType,
+      }
+    )
+  }
+
+  async createOrUpdatePermitBlockStatus(
+    permitApplicationId: string,
+    {
+      requirementBlockId,
+      collaborationType,
+      status,
+    }: {
+      requirementBlockId: string
+      collaborationType: ECollaborationType
+      status: EPermitBlockStatus
+    }
+  ) {
+    return this.client.post<ApiResponse<IPermitCollaboration>>(
+      `/permit_applications/${permitApplicationId}/permit_block_status`,
+      {
+        requirementBlockId,
+        status,
         collaborationType,
       }
     )

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -3,10 +3,11 @@ import { flow, Instance, toGenerator, types } from "mobx-state-tree"
 import * as R from "ramda"
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
-import { ENotificationActionType } from "../types/enums"
+import { ECollaborationType, ENotificationActionType } from "../types/enums"
 import {
   ILinkData,
   INotification,
+  IPermitBlockStatusReadyNotificationObjectData,
   IPermitCollaborationNotificationObjectData,
   IPermitNotificationObjectData,
   IUserPushPayload,
@@ -86,6 +87,17 @@ export const NotificationStoreModel = types
           {
             text: t("ui.show"),
             href: `/permit-applications/${collaborationData.permitApplicationId}/edit`,
+          },
+        ]
+      } else if (notification.actionType === ENotificationActionType.permitBlockStatusReady) {
+        const collaborationData = objectData as IPermitBlockStatusReadyNotificationObjectData
+        return [
+          {
+            text: t("ui.show"),
+            href:
+              collaborationData?.collaborationType === ECollaborationType.review
+                ? `/permit-applications/${collaborationData.permitApplicationId}`
+                : `/permit-applications/${collaborationData.permitApplicationId}/edit`,
           },
         ]
       } else if (

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -8,6 +8,7 @@ import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
 import { IJurisdiction } from "../models/jurisdiction"
 import { IPermitApplication, PermitApplicationModel } from "../models/permit-application"
+import { IPermitBlockStatus } from "../models/permit-block-status"
 import { IUser } from "../models/user"
 import {
   ECustomEvents,
@@ -281,6 +282,9 @@ export const PermitApplicationStoreModel = types
 
           self.permitApplicationMap.get(payloadData?.id)?.handleSocketSupportingDocsUpdate(payloadData)
           break
+        case EPermitApplicationSocketEventTypes.updatePermitBlockStatus:
+          payloadData = payload.data as IPermitBlockStatus
+          self.permitApplicationMap.get(payloadData?.permitApplicationId)?.updatePermitBlockStatus(payloadData)
         default:
           import.meta.env.DEV && console.log(`Unknown event type ${payload.eventType}`)
       }

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -381,6 +381,7 @@ export enum ENotificationActionType {
   scheduledTemplateMissingRequirementsMapping = "scheduled_template_missing_requirements_mapping",
   customizationUpdate = "customization_update",
   submissionCollaborationAssignment = "submission_collaboration_assignment",
+  permitBlockStatusReady = "permit_block_status_ready",
   applicationSubmission = "application_submission",
   applicationRevisionsRequest = "application_revisions_request",
   applicationView = "application_view",

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -307,6 +307,7 @@ export enum ESocketEventTypes {
 export enum EPermitApplicationSocketEventTypes {
   updateCompliance = "update_compliance",
   updateSupportingDocuments = "update_supporting_documents",
+  updatePermitBlockStatus = "update_permit_block_status",
 }
 
 export enum EEnabledElectiveFieldReason {

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -168,6 +168,12 @@ export enum ENumberUnit {
   cad = "cad",
 }
 
+export enum EPermitBlockStatus {
+  draft = "draft",
+  inProgress = "in_progress",
+  ready = "ready",
+}
+
 export enum EStepCodeChecklistStage {
   preConstruction = "pre_construction",
   midConstruction = "mid_construction",

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -1,5 +1,6 @@
 import { Theme } from "@chakra-ui/react"
 import { IPermitApplication } from "../models/permit-application"
+import { IPermitBlockStatus } from "../models/permit-block-status"
 import { IActivity, IPermitType } from "../models/permit-classification"
 import { IRequirement } from "../models/requirement"
 import {
@@ -298,6 +299,7 @@ export interface ITemplateVersionUpdate {
 export type TSocketEventData =
   | IPermitApplicationComplianceUpdate
   | IPermitApplicationSupportingDocumentsUpdate
+  | IPermitBlockStatus
   | INotification
   | ITemplateVersionUpdate
 

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -6,6 +6,7 @@ import { IRequirement } from "../models/requirement"
 import {
   EAutoComplianceModule,
   EAutoComplianceType,
+  ECollaborationType,
   ECollaboratorType,
   EDoorsPerformanceType,
   EEnabledElectiveFieldReason,
@@ -276,6 +277,12 @@ export interface IPermitCollaborationNotificationObjectData {
   permitApplicationId?: string
   collaboratorType?: ECollaboratorType
   assignedRequirementBlockName?: string
+}
+
+export interface IPermitBlockStatusReadyNotificationObjectData {
+  permitApplicationId?: string
+  collaborationType: ECollaborationType
+  requirementBlockName?: string
 }
 
 export interface IMissingRequirementsMappingNotificationObjectData {

--- a/app/frontend/utils/utility-functions.ts
+++ b/app/frontend/utils/utility-functions.ts
@@ -194,3 +194,14 @@ export const arrayEqualsAsSet = (a: string[], b: string[]): boolean => {
   }
   return true
 }
+
+export function convertResourceArrayToRecord<
+  ResourceT extends {
+    id: string
+  },
+>(resources: ResourceT[]): Record<string, ResourceT> {
+  return resources.reduce((acc, resource) => {
+    acc[resource.id] = resource
+    return acc
+  }, {})
+}

--- a/app/mailers/permit_hub_mailer.rb
+++ b/app/mailers/permit_hub_mailer.rb
@@ -48,6 +48,14 @@ class PermitHubMailer < ApplicationMailer
     send_user_mail(email: @user.email, template_key: :notify_permit_collaboration)
   end
 
+  def notify_block_status_ready(permit_block_status:, user:, status_set_by: nil)
+    @permit_block_status = permit_block_status
+    @user = user
+    @status_set_by = status_set_by
+
+    send_user_mail(email: @user.email, template_key: :notify_block_status_ready)
+  end
+
   def notify_new_or_unconfirmed_permit_collaboration(permit_collaboration:, user:)
     @permit_collaboration = permit_collaboration
     @user = user

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -23,6 +23,7 @@ class PermitApplication < ApplicationRecord
   has_many :submission_versions, dependent: :destroy
   has_many :permit_collaborations, dependent: :destroy
   has_many :collaborators, through: :permit_collaborations
+  has_many :permit_block_statuses, dependent: :destroy
 
   scope :submitted, -> { joins(:submission_versions).distinct }
 

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -189,6 +189,10 @@ class PermitApplication < ApplicationRecord
 
   def notifiable_users
     relevant_collaborators = [submitter]
+    designated_submitter =
+      users_by_collaboration_options(collaboration_type: :submission, collaborator_type: :delegatee).first
+
+    relevant_collaborators << designated_submitter if designated_submitter.present?
 
     if submitted?
       relevant_collaborators =

--- a/app/models/permit_block_status.rb
+++ b/app/models/permit_block_status.rb
@@ -7,4 +7,34 @@ class PermitBlockStatus < ApplicationRecord
   validates :requirement_block_id, presence: true
   validates :collaboration_type, presence: true
   validates :permit_application_id, uniqueness: { scope: %i[requirement_block_id collaboration_type] }
+
+  after_commit :send_status_change_websocket
+
+  private
+
+  def send_status_change_websocket
+    return unless saved_change_to_status?
+
+    user_ids_to_send = []
+
+    if submission?
+      user_ids_to_send << permit_application.submitter_id
+      user_ids_to_send += permit_application.users_by_collaboration_options(collaboration_type: :submission).pluck(:id)
+    elsif review?
+      user_ids_to_send +=
+        permit_application
+          .jurisdiction
+          .users
+          .kept
+          .where(role: %i[review_manager reviewer regional_review_manager])
+          .pluck(:id)
+    end
+
+    WebsocketBroadcaster.push_update_to_relevant_users(
+      user_ids_to_send,
+      Constants::Websockets::Events::PermitApplication::DOMAIN,
+      Constants::Websockets::Events::PermitApplication::TYPES[:update_permit_block_status],
+      PermitBlockStatusBlueprint.render_as_hash(self),
+    )
+  end
 end

--- a/app/models/permit_block_status.rb
+++ b/app/models/permit_block_status.rb
@@ -9,32 +9,67 @@ class PermitBlockStatus < ApplicationRecord
   validates :permit_application_id, uniqueness: { scope: %i[requirement_block_id collaboration_type] }
 
   after_commit :send_status_change_websocket
+  after_commit :send_status_ready_email
+
+  attr_accessor :set_by_user
+
+  def requirement_block_name
+    permit_application.template_version.requirement_blocks_json.dig(requirement_block_id, "name")
+  end
 
   private
+
+  def notification_users
+  end
 
   def send_status_change_websocket
     return unless saved_change_to_status?
 
-    user_ids_to_send = []
+    user_ids_to_send = users_to_notify_status_ready.pluck(:id)
 
     if submission?
-      user_ids_to_send << permit_application.submitter_id
-      user_ids_to_send += permit_application.users_by_collaboration_options(collaboration_type: :submission).pluck(:id)
-    elsif review?
       user_ids_to_send +=
-        permit_application
-          .jurisdiction
-          .users
-          .kept
-          .where(role: %i[review_manager reviewer regional_review_manager])
-          .pluck(:id)
+        permit_application.users_by_collaboration_options(
+          collaboration_type: :submission,
+          collaborator_type: :assignee,
+        ).pluck(:id)
     end
 
     WebsocketBroadcaster.push_update_to_relevant_users(
-      user_ids_to_send,
+      user_ids_to_send.uniq,
       Constants::Websockets::Events::PermitApplication::DOMAIN,
       Constants::Websockets::Events::PermitApplication::TYPES[:update_permit_block_status],
       PermitBlockStatusBlueprint.render_as_hash(self),
     )
+  end
+
+  def users_to_notify_status_ready
+    users_to_notify = []
+
+    if submission?
+      users_to_notify << permit_application.submitter
+      users_to_notify +=
+        permit_application.users_by_collaboration_options(
+          collaboration_type: :submission,
+          collaborator_type: :delegatee,
+        )
+    else
+      users_to_notify +=
+        permit_application.jurisdiction.users.kept.where(role: %i[review_manager reviewer regional_review_manager])
+    end
+
+    users_to_notify.uniq
+  end
+
+  def send_status_ready_email
+    return unless saved_change_to_status? && ready?
+
+    users_to_notify_status_ready.each do |user|
+      PermitHubMailer.notify_block_status_ready(
+        permit_block_status: self,
+        user:,
+        status_set_by: set_by_user,
+      ).deliver_later
+    end
   end
 end

--- a/app/models/permit_block_status.rb
+++ b/app/models/permit_block_status.rb
@@ -1,0 +1,10 @@
+class PermitBlockStatus < ApplicationRecord
+  belongs_to :permit_application
+
+  enum status: { draft: 0, in_progress: 1, ready: 2 }, _default: 0
+  enum collaboration_type: { submission: 0, review: 1 }, _default: 0
+
+  validates :requirement_block_id, presence: true
+  validates :collaboration_type, presence: true
+  validates :permit_application_id, uniqueness: { scope: %i[requirement_block_id collaboration_type] }
+end

--- a/app/services/constants/notification_action_types.rb
+++ b/app/services/constants/notification_action_types.rb
@@ -3,6 +3,7 @@ module Constants
     NEW_TEMPLATE_VERSION_PUBLISH = "new_template_version_publish"
     CUSTOMIZATION_UPDATE = "customization_update"
     SUBMISSION_COLLABORATION_ASSIGNMENT = "submission_collaboration_assignment"
+    PERMIT_BLOCK_STATUS_READY = "permit_block_status_ready"
     APPLICATION_SUBMISSION = "application_submission"
     APPLICATION_REVISIONS_REQUEST = "application_revisions_request"
     APPLICATION_VIEW = "application_view"

--- a/app/services/constants/websockets.rb
+++ b/app/services/constants/websockets.rb
@@ -10,6 +10,7 @@ module Constants
         TYPES = {
           update_compliance: :update_compliance,
           update_supporting_documents: :update_supporting_documents,
+          update_permit_block_status: :update_permit_block_status,
         }.freeze
       end
 

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -159,6 +159,18 @@ class NotificationService
     NotificationPushJob.perform_async(notification_user_hash)
   end
 
+  def self.publish_permit_block_status_ready_event(permit_block_status)
+    return unless permit_block_status.ready?
+
+    notification_user_hash = {}
+
+    permit_block_status.users_to_notify_status_ready.each do |user|
+      notification_user_hash[user.id] = permit_block_status.status_ready_notification_data
+    end
+
+    NotificationPushJob.perform_async(notification_user_hash)
+  end
+
   def self.publish_application_submission_event(permit_application)
     notification_user_hash = {}
     notification_user_hash[permit_application.submitter_id] = permit_application.submit_event_notification_data

--- a/app/services/permit_collaboration/collaboration_management_service.rb
+++ b/app/services/permit_collaboration/collaboration_management_service.rb
@@ -56,8 +56,8 @@ class PermitCollaboration::CollaborationManagementService
     ActiveRecord::Base.transaction do
       begin
         # check if user exists
-        # Use omniauth_email to find the user because that is the actual email of the associated bceid
-        user = User.find_by(omniauth_email: user_params[:email].strip)
+        user =
+          User.where(omniauth_email: user_params[:email].strip).or(User.where(email: user_params[:email].strip)).first
 
         user ||= create_submission_user!(user_params)
 

--- a/app/views/permit_hub_mailer/notify_block_status_ready.erb
+++ b/app/views/permit_hub_mailer/notify_block_status_ready.erb
@@ -81,7 +81,7 @@
                   <tbody>
                   <tr>
                     <td style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top; border-radius: 5px; text-align: center; background-color: transparent;" valign="top" align="center" bgcolor="transparent">
-                      <a href="<%= FrontendUrlHelper.frontend_url("/login") %>" target="_blank" style="border: solid 1px #003366; border-radius: 4px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 16px; font-weight: normal; line-height: 26px; margin: 0; padding: 6px 12px; text-decoration: none; background-color: #003366; border-color: #003366; color: #ffffff;">Login
+                      <a href="<%= FrontendUrlHelper.frontend_url("/login") %>" target="_blank" rel="noopener" style="border: solid 1px #003366; border-radius: 4px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 16px; font-weight: normal; line-height: 26px; margin: 0; padding: 6px 12px; text-decoration: none; background-color: #003366; border-color: #003366; color: #ffffff;">Login
                         to Building Permit Hub</a></td>
                   </tr>
                   </tbody>

--- a/app/views/permit_hub_mailer/notify_block_status_ready.erb
+++ b/app/views/permit_hub_mailer/notify_block_status_ready.erb
@@ -1,0 +1,106 @@
+<!-- START MAIN CONTENT AREA -->
+<tr>
+  <td class="wrapper" style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top; box-sizing: border-box; padding: 56px 32px;" valign="top">
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; width: 100%;" width="100%">
+      <tr>
+        <!-- START CONTENT ROW -->
+        <td style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top;" valign="top">
+          <h1 style="color: #292929; font-family: 'Open Sans', sans-serif; font-weight: 700; line-height: 1.4; text-align: left; font-size: 28px; margin-top: 0; margin-bottom: 48px;">
+            Requirement block status ready
+          </h1>
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">Dear <%= @user.name %>
+            ,</p>
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
+            A requirement block status has been set to ready in a permit application
+            for <%= @permit_block_status.collaboration_type %>.
+          </p>
+
+          <h2 style="color: #292929; font-family: 'Open Sans', sans-serif; font-weight: 700; line-height: 1.4; margin-top: 24px; margin-bottom: 16px; text-align: left; font-size: 22px;">Application
+            details:</h2>
+
+          <table class="basic-table" role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; width: 100%; background: #f2f2f2; border: 1px solid #d9d9d9; margin-bottom: 32px;" width="100%">
+            <tr>
+              <td style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top;" valign="top">
+                <dl class="table-like" style="margin: 0;">
+
+                  <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Application
+                    #
+                  </dt>
+                  <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 1px solid #d9d9d9;">
+                    <a href="<%= @permit_block_status.submission? ? @permit_block_status.permit_application.submitter_frontend_url : @permit_block_status.permit_application.reviewer_frontend_url %>" style="color: #1a5a96; text-decoration: underline;"><%= @permit_block_status.permit_application.number %></a>
+                  </dd>
+
+                  <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Author</dt>
+                  <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 1px solid #d9d9d9;"><%= @permit_block_status.permit_application.submitter.name %></dd>
+
+                  <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Permit
+                    Type
+                  </dt>
+                  <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 0;"><%= @permit_block_status.permit_application.permit_type_and_activity %></dd>
+                  <% if @permit_block_status.requirement_block_name.present? %>
+
+                    <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Requirement
+                      block
+                    </dt>
+                    <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 0;"><%= @permit_block_status.requirement_block_name %></dd>
+                  <% end %>
+
+                  <% if @status_set_by.present? %>
+                    <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Status
+                      set by
+                    </dt>
+                    <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 1px solid #d9d9d9;"><%= @status_set_by.name %></dd>
+                  <% end %>
+
+                </dl>
+              </td>
+            </tr>
+          </table>
+
+
+          <h2 style="color: #292929; font-family: 'Open Sans', sans-serif; font-weight: 700; line-height: 1.4; margin-top: 24px; margin-bottom: 16px; text-align: left; font-size: 22px;">Review
+            the application:</h2>
+
+          <ol style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px; padding-left: 24px;">
+            <li style="list-style-position: initial; margin-left: 5px;">Log into the
+              <a href="<%= FrontendUrlHelper.frontend_url("/login") %>" style="color: #1a5a96; text-decoration: underline;">Building
+                Permit Hub</a></li>
+            <li style="list-style-position: initial; margin-left: 5px;">Review the requirement block</li>
+          </ol>
+
+
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
+            Your prompt review and action are appreciated to create a smooth and efficient permit application process.
+          </p>
+
+          <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; box-sizing: border-box; width: 100%; margin: 12px auto;" width="100%">
+            <tbody>
+            <tr>
+              <td align="left" style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top; padding-bottom: 15px;" valign="top">
+                <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: auto; width: auto;">
+                  <tbody>
+                  <tr>
+                    <td style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top; border-radius: 5px; text-align: center; background-color: transparent;" valign="top" align="center" bgcolor="transparent">
+                      <a href="<%= FrontendUrlHelper.frontend_url("/login") %>" target="_blank" style="border: solid 1px #003366; border-radius: 4px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 16px; font-weight: normal; line-height: 26px; margin: 0; padding: 6px 12px; text-decoration: none; background-color: #003366; border-color: #003366; color: #ffffff;">Login
+                        to Building Permit Hub</a></td>
+                  </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+          <br><br>
+
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
+            Thank you,<br><br>
+            The Building Permit Hub Team
+          </p>
+        </td>
+        <!-- END OF CONTENT ROW -->
+      </tr>
+    </table>
+  </td>
+</tr>
+
+<!-- END MAIN CONTENT AREA -->

--- a/app/views/permit_hub_mailer/notify_block_status_ready.erb
+++ b/app/views/permit_hub_mailer/notify_block_status_ready.erb
@@ -6,12 +6,13 @@
         <!-- START CONTENT ROW -->
         <td style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top;" valign="top">
           <h1 style="color: #292929; font-family: 'Open Sans', sans-serif; font-weight: 700; line-height: 1.4; text-align: left; font-size: 28px; margin-top: 0; margin-bottom: 48px;">
-            Requirement block status ready
+            Requirement block status <span style="font-style: italic">"ready"</span>
           </h1>
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">Dear <%= @user.name %>
             ,</p>
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
-            A requirement block status has been set to ready in a permit application
+            A requirement block status has been set to <span style="font-style: italic">"ready"</span> in a permit
+            application
             for <%= @permit_block_status.collaboration_type %>.
           </p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,7 @@ en:
       notify_new_integration_mapping: "New API mappings available"
       notify_missing_integration_mapping: "Missing API mappings"
       notify_reviewer_application_received: "New application received: %{permit_application_number}"
+      notify_block_status_ready: "Requirement block status ready"
       notify_application_viewed: "Application update: %{permit_application_number}"
       notify_application_revisions_requested: "Revisions requested on application %{permit_application_number}"
       remind_reviewer: "Your report on outstanding permit applications"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,6 +570,9 @@ en:
     permit_collaboration:
       submission_delegatee_collaboration_notification: "Collaboration request from %{author_name}. You have been assigned as a designated submitter for permit application %{number}."
       submission_assignee_collaboration_notification: 'Collaboration request from %{author_name} on requirement “%{requirement_block_name}” for permit application %{number}'
+    permit_block_status:
+      status_read_by_user: "Requirement “%{requirement_block_name}” status set to ready by %{setter_name} for permit application %{number}"
+      status_ready_no_user: "Requirement “%{requirement_block_name}” status set to ready for permit application %{number}"
     integration_mapping:
       published_template_missing_requirements_mapping: "Missing API mapping: A new version of “%{template_label}” has been published on %{version_date}"
       scheduled_template_missing_requirements_mapping: "Missing API Mapping: A new version of “%{template_label}” has been scheduled for %{version_date}, 01:00hrs PST."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,6 +415,12 @@ en:
       remove_collaborator_collaborations_error:
         title: Error
         message: "There was an error removing collaborator"
+      create_or_update_permit_block_status_success:
+        title: ""
+        message: "Permit block status successfully updated"
+      create_or_update_permit_block_status_error:
+        title: Error
+        message: "There was an error updating permit block status"
     permit_collaboration:
       destroy_success:
         title: ""

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,6 +121,7 @@ Rails.application.routes.draw do
     resources :permit_applications, only: %i[create update show] do
       post "generate_missing_pdfs", on: :member, to: "permit_applications#generate_missing_pdfs"
       post "permit_collaborations", on: :member, to: "permit_applications#create_permit_collaboration"
+      post "permit_block_status", on: :member, to: "permit_applications#create_or_update_permit_block_status"
       delete "permit_collaborations/remove_collaborator_collaborations",
              on: :member,
              to: "permit_applications#remove_collaborator_collaborations"

--- a/db/migrate/20240802180316_create_permit_block_statuses.rb
+++ b/db/migrate/20240802180316_create_permit_block_statuses.rb
@@ -1,0 +1,17 @@
+class CreatePermitBlockStatuses < ActiveRecord::Migration[7.1]
+  def change
+    create_table :permit_block_statuses, id: :uuid do |t|
+      t.belongs_to :permit_application, null: false, foreign_key: true, type: :uuid
+      t.string :requirement_block_id, null: false
+      t.integer :status, null: false, default: 0
+      t.integer :collaboration_type, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :permit_block_statuses,
+              %i[permit_application_id requirement_block_id collaboration_type],
+              unique: true,
+              name: "index_block_statuses_on_app_id_and_block_id_and_collab_type"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_18_160238) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_02_180316) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -237,6 +237,23 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_160238) do
     t.index ["submitter_id"], name: "index_permit_applications_on_submitter_id"
     t.index ["template_version_id"],
             name: "index_permit_applications_on_template_version_id"
+  end
+
+  create_table "permit_block_statuses",
+               id: :uuid,
+               default: -> { "gen_random_uuid()" },
+               force: :cascade do |t|
+    t.uuid "permit_application_id", null: false
+    t.string "requirement_block_id", null: false
+    t.integer "status", default: 0, null: false
+    t.integer "collaboration_type", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index %w[permit_application_id requirement_block_id collaboration_type],
+            name: "index_block_statuses_on_app_id_and_block_id_and_collab_type",
+            unique: true
+    t.index ["permit_application_id"],
+            name: "index_permit_block_statuses_on_permit_application_id"
   end
 
   create_table "permit_classifications",
@@ -852,6 +869,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_160238) do
                   column: "permit_type_id"
   add_foreign_key "permit_applications", "template_versions"
   add_foreign_key "permit_applications", "users", column: "submitter_id"
+  add_foreign_key "permit_block_statuses", "permit_applications"
   add_foreign_key "permit_collaborations", "collaborators"
   add_foreign_key "permit_collaborations", "permit_applications"
   add_foreign_key "permit_type_required_steps", "jurisdictions"


### PR DESCRIPTION
## Description
- Implements setting of status for permit application requirement block by submitter and collaborators
  - Includes websocket update for status change
  - Notification and email when status has been set to ready
  - Permissioning 
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-558
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Status can be set by author, and designated submitter for all blocks. For collaborators they are only settable to the requirement block they are assigned to
- Status ready notification and email are only sent to author and designated submitters for status change during submission and delegatee during review

https://github.com/user-attachments/assets/c12b6ef4-09f5-4557-b079-ba22585cb8f3

