### PR TITLE
Chore/bphh 1816/new tab links

### DIFF
--- a/app/frontend/components/domains/misc/contact-screen.tsx
+++ b/app/frontend/components/domains/misc/contact-screen.tsx
@@ -69,6 +69,7 @@ export const ContactScreen = () => {
         <Link
           href="https://www2.gov.bc.ca/gov/content/home/get-help-with-government-services"
           target="_blank"
+          rel="noopener noreferrer"
           isExternal
           ml="1"
         >

--- a/app/frontend/components/shared/editor/custom-extensions/link-blot.ts
+++ b/app/frontend/components/shared/editor/custom-extensions/link-blot.ts
@@ -12,6 +12,7 @@ export class CustomLinkBlot extends Inline {
 
     node.setAttribute("href", value?.href)
     node.setAttribute("target", "_blank")
+    node.setAttribute("rel", "noopener noreferrer")
 
     Object.getOwnPropertyNames(value).forEach((attributeName) => {
       if (attributeName.includes("data-")) {
@@ -25,6 +26,8 @@ export class CustomLinkBlot extends Inline {
   static value(node: HTMLAnchorElement) {
     const val = {
       href: node.getAttribute("href"),
+      target: node.getAttribute("target"),
+      rel: node.getAttribute("rel"),
     }
 
     node.getAttributeNames().forEach((attributeName) => {

--- a/app/models/concerns/html_sanitize_attributes.rb
+++ b/app/models/concerns/html_sanitize_attributes.rb
@@ -15,7 +15,13 @@ module HtmlSanitizeAttributes
   end
 
   def sanitize_html(html)
-    ActionController::Base.helpers.sanitize(html)
+    # This allows target="_blank" and rel="noopener noreferrer" to be set.
+
+    ActionController::Base.helpers.sanitize(
+      html,
+      tags: Rails::Html::WhiteListSanitizer.allowed_tags,
+      attributes: Rails::Html::WhiteListSanitizer.allowed_attributes + %w[target rel],
+    )
   end
 
   class_methods do

--- a/app/views/permit_hub_mailer/02a_notify_reviewer_application_received_email.html.erb
+++ b/app/views/permit_hub_mailer/02a_notify_reviewer_application_received_email.html.erb
@@ -227,7 +227,7 @@ table[class="body"] .article {
                     <p style="font-family: 'Open Sans', sans-serif; font-weight: normal; margin: 0; margin-bottom: 24px; color: #464341; font-size: 14px; text-align: left; line-height: 20px;">
                       <a href="<%= @root_url %>" target="_blank" style="text-decoration: underline; color: #464341; font-size: 14px; text-align: left; line-height: 20px; margin-right: 20px;">Home</a> 
                       <a href="<%= FrontendUrlHelper.frontend_url("/contact") %>" target="_blank" style="text-decoration: underline; color: #464341; font-size: 14px; text-align: left; line-height: 20px; margin-right: 20px;">Contact us</a>
-                      <a href="https://www2.gov.bc.ca/gov/content/housing-tenancy/building-or-renovating/permits/building-permit-hub" target="_blank" style="text-decoration: underline; color: #464341; font-size: 14px; text-align: left; line-height: 20px; margin-right: 20px;">Help</a>
+                      <a href="https://www2.gov.bc.ca/gov/content/housing-tenancy/building-or-renovating/permits/building-permit-hub" target="_blank" rel="noopener noreferrer" style="text-decoration: underline; color: #464341; font-size: 14px; text-align: left; line-height: 20px; margin-right: 20px;">Help</a>
                       <a href="<%= FrontendUrlHelper.frontend_url("/login") %>" target="_blank" style="text-decoration: underline; color: #464341; font-size: 14px; text-align: left; line-height: 20px; margin-right: 20px;">Login</a>
                     </p>
                     <hr style="border: 0; border-bottom: 1px solid #dddddd; margin: 24px 0; border-color: #464341;">


### PR DESCRIPTION
## Description

Links in wysiwyg editor created text was lacking the target="_blank" attribute. This is because this attribute was missed in the link-blot.ts value method. This fix will make all future text created in the editor include this text. Additionally after fixing this the value was being filtered out in sanitization. The attribute is now being whitelisted.

PLEASE NOTE: This fix does not retroactively apply to all published template versions. A new template version must be published in order to apply this fix to all existing templates.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1816

## Steps to QA

see card

