### PR TITLE
complete classification seeder with all enabled and add data migration

### DIFF
--- a/app/services/permit_classification_seeder.rb
+++ b/app/services/permit_classification_seeder.rb
@@ -13,14 +13,14 @@ class PermitClassificationSeeder
         name: "4+ Unit housing",
         code: "medium_residential",
         description: "Part 9 townhouses, small apartment buildings",
-        enabled: false,
+        enabled: true,
         type: "PermitType",
       },
       {
         name: "High density appartment buildings",
         code: "high_residential",
         description: "Highest density residential structures",
-        enabled: false,
+        enabled: true,
         type: "PermitType",
       },
       {
@@ -36,21 +36,23 @@ class PermitClassificationSeeder
         code: "addition_alteration_renovation",
         description:
           "Modification of an existing residential dwelling to include a (secondary) suite (within the existing building footprint).",
-        enabled: false,
+        enabled: true,
         type: "Activity",
       },
       {
         name: "Site Alteration",
         code: "site_alteration",
-        description: "Lorem ipsum TODO add description",
-        enabled: false,
+        description:
+          "Modifies land contours through grading, excavation, or preparation for construction projects. This process involves adjusting the earth to support new structures or landscaping.",
+        enabled: true,
         type: "Activity",
       },
       {
         name: "Demolition",
         code: "demolition",
-        description: "Lorem ipsum TODO add description",
-        enabled: false,
+        description:
+          "Involves the systematic tearing down of buildings and other structures, including clearing debris and preparing the site for future construction or restoration activities.",
+        enabled: true,
         type: "Activity",
       },
     ]

--- a/db/data/20240813164119_enable_all_permit_classifications.rb
+++ b/db/data/20240813164119_enable_all_permit_classifications.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class EnableAllPermitClassifications < ActiveRecord::Migration[7.1]
+  def up
+    PermitClassificationSeeder.seed
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20_240_716_232_716)
+DataMigrate::Data.define(version: 20_240_813_164_119)


### PR DESCRIPTION
## Description

This completes the classification seeder and adds a data migration to enable the remaining work and permit types.

Run this in the console after deploy to reap its effects:

```
sh -c 'set -a; . /vault/secrets/secrets.env; set +a; RAILS_ENV=production bundle exec rails data:migrate'
```

Testing instructions in card. Seeing one disabled template means that we forgot to run the data migration or something went wrong.