### PR TITLE
Feature/bphh 1946/filter further collaboration data

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -67,7 +67,6 @@ class PermitApplicationBlueprint < Blueprinter::Base
     association :step_code, blueprint: StepCodeBlueprint
     association :permit_collaborations, blueprint: PermitCollaborationBlueprint, view: :base
     association :permit_block_statuses, blueprint: PermitBlockStatusBlueprint
-    # TODO: filter out data based on collaborator/user permissions
     association :submission_versions, blueprint: SubmissionVersionBlueprint, view: :extended
   end
 

--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -61,8 +61,9 @@ class PermitApplicationBlueprint < Blueprinter::Base
     association :template_version, blueprint: TemplateVersionBlueprint
     association :published_template_version, blueprint: TemplateVersionBlueprint
 
-    # TODO: filter out data based on collaborator/user permissions
-    association :supporting_documents, blueprint: SupportingDocumentBlueprint
+    association :supporting_documents, blueprint: SupportingDocumentBlueprint do |pa, options|
+      pa.supporting_documents_for_submitter_based_on_user_permissions(user: options[:current_user])
+    end
     association :jurisdiction, blueprint: JurisdictionBlueprint, view: :base
     association :step_code, blueprint: StepCodeBlueprint
     association :permit_collaborations, blueprint: PermitCollaborationBlueprint, view: :base
@@ -72,6 +73,12 @@ class PermitApplicationBlueprint < Blueprinter::Base
 
   view :jurisdiction_review_extended do
     include_view :extended
+    # reinclude fields to show all data for reviewers, which were filtered out in the extended view due to collaboration
+    field :form_json
+    field :submission_data do |pa, options|
+      pa.formatted_submission_data
+    end
+    association :supporting_documents, blueprint: SupportingDocumentBlueprint
     association :submission_versions, blueprint: SubmissionVersionBlueprint, view: :review_extended
   end
 

--- a/app/blueprints/submission_version_blueprint.rb
+++ b/app/blueprints/submission_version_blueprint.rb
@@ -6,8 +6,13 @@ class SubmissionVersionBlueprint < Blueprinter::Base
 
   view :extended do
     include_view :base
-    fields :form_json, :submission_data
-    association :revision_requests, blueprint: RevisionRequestBlueprint, view: :base
+    fields :form_json
+    field :submission_data do |submission_version, options|
+      submission_version.formatted_submission_data(current_user: options[:current_user])
+    end
+    association :revision_requests, blueprint: RevisionRequestBlueprint, view: :base do |submission_version, options|
+      submission_version.revision_requests_for_submitter_based_on_user_permissions(user: options[:current_user])
+    end
   end
 
   view :review_extended do

--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -338,7 +338,11 @@ class Api::PermitApplicationsController < Api::ApplicationController
   private
 
   def show_blueprint_view_for(user)
-    user.review_staff? ? :jurisdiction_review_extended : :extended
+    if params[:review] && user.review_staff?
+      :jurisdiction_review_extended
+    else
+      :extended
+    end
   end
 
   def set_permit_application

--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -326,7 +326,9 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
                   permitApplication={currentPermitApplication}
                   collaborationType={ECollaborationType.submission}
                 />
-                <SubmissionDownloadModal permitApplication={currentPermitApplication} />
+                {doesUserHaveSubmissionPermission && (
+                  <SubmissionDownloadModal permitApplication={currentPermitApplication} />
+                )}
                 <Button rightIcon={<CaretRight />} onClick={() => navigate("/")}>
                   {t("permitApplication.show.backToInbox")}
                 </Button>

--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -236,7 +236,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
   const { permitTypeAndActivity, formJson, number, isSubmitted, isDirty, setIsDirty, isRevisionsRequested } =
     currentPermitApplication
 
-  const canCurrentUserSubmit =
+  const doesUserHaveSubmissionPermission =
     currentUser?.id === currentPermitApplication.submitter?.id ||
     currentUser?.id ===
       currentPermitApplication?.getCollaborationDelegatee(ECollaborationType.submission)?.collaborator?.user?.id
@@ -267,11 +267,11 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
                         w="full"
                         initialHint={t("permitApplication.edit.clickToWriteNickname")}
                         value={nicknameWatch || ""}
-                        isDisabled={!canCurrentUserSubmit || isSubmitted}
+                        isDisabled={!doesUserHaveSubmissionPermission || isSubmitted}
                         controlsProps={{
                           iconButtonProps: {
                             color: "greys.white",
-                            display: !canCurrentUserSubmit || isSubmitted ? "none" : "block",
+                            display: !doesUserHaveSubmissionPermission || isSubmitted ? "none" : "block",
                           },
                         }}
                         editableInputProps={{

--- a/app/frontend/components/domains/permit-application/review-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/review-permit-application-screen.tsx
@@ -27,7 +27,7 @@ interface IReferenceNumberForm {
 }
 
 export const ReviewPermitApplicationScreen = observer(() => {
-  const { currentPermitApplication, error } = usePermitApplication()
+  const { currentPermitApplication, error } = usePermitApplication({ review: true })
   const { t } = useTranslation()
   const formRef = useRef(null)
   const { requirementBlockAssignmentNodes, updateRequirementBlockAssignmentNode } = useCollaborationAssignmentNodes({

--- a/app/frontend/hooks/resources/use-permit-application.ts
+++ b/app/frontend/hooks/resources/use-permit-application.ts
@@ -4,7 +4,7 @@ import { useLocation, useParams } from "react-router-dom"
 import { useMst } from "../../setup/root"
 import { isUUID } from "../../utils/utility-functions"
 
-export const usePermitApplication = () => {
+export const usePermitApplication = ({ review }: { review?: boolean } = {}) => {
   const { permitApplicationId } = useParams()
   const { pathname } = useLocation()
   const { permitApplicationStore } = useMst()
@@ -19,7 +19,7 @@ export const usePermitApplication = () => {
       try {
         setCurrentPermitApplication(null)
         if (isUUID(permitApplicationId)) {
-          let permitApplication = await fetchPermitApplication(permitApplicationId)
+          let permitApplication = await fetchPermitApplication(permitApplicationId, review)
           if (permitApplication) {
             setCurrentPermitApplication(permitApplicationId)
           }

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -574,6 +574,8 @@ const options = {
           show: {
             wasSubmitted: "Application was submitted on {{ date }} to {{ jurisdictionName }}",
             submittingTo: "You're applying to the {{ jurisdictionName }}",
+            versionDiffContactWarning:
+              "A new version of the permit is available. Please ask author or designated submitter to review and acknowledge changes to proceed.",
             contactsSummary: "Contacts summary",
             downloadApplication: "Download application",
             fetchingMissingPdf: "Fetching {{missingPdf}}...",

--- a/app/frontend/models/user.ts
+++ b/app/frontend/models/user.ts
@@ -71,9 +71,6 @@ export const UserModel = types
         self.jurisdictions[0]
       )
     },
-    get shouldSeeApplicationDiff() {
-      return self.role == EUserRoles.submitter
-    },
   }))
   .actions((self) => ({
     destroy: flow(function* () {

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -122,8 +122,8 @@ export class Api {
     return this.client.get<ApiResponse<IJurisdiction>>(`/jurisdictions/${id}`)
   }
 
-  async fetchPermitApplication(id) {
-    return this.client.get<ApiResponse<IPermitApplication>>(`/permit_applications/${id}`)
+  async fetchPermitApplication(id: string, review?: boolean) {
+    return this.client.get<ApiResponse<IPermitApplication>>(`/permit_applications/${id}`, { review })
   }
 
   async viewPermitApplication(id) {

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -232,9 +232,9 @@ export const PermitApplicationStoreModel = types
       }
       return response.ok
     }),
-    fetchPermitApplication: flow(function* (id: string) {
+    fetchPermitApplication: flow(function* (id: string, review?: boolean) {
       // If the user is review staff, we still need to hit the show endpoint to update viewedAt
-      const { ok, data: response } = yield self.environment.api.fetchPermitApplication(id)
+      const { ok, data: response } = yield self.environment.api.fetchPermitApplication(id, review)
       if (ok && response.data) {
         const permitApplication = response.data
 

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -56,6 +56,24 @@ class PermitApplication < ApplicationRecord
 
   COMPLETION_SECTION_KEY = "section-completion-key"
 
+  def supporting_documents_for_submitter_based_on_user_permissions(user: nil)
+    return supporting_documents if user.blank?
+
+    permissions = submission_requirement_block_edit_permissions(user_id: user.id)
+
+    return supporting_documents if permissions == :all
+
+    return [] if permissions.blank?
+
+    supporting_documents.select do |s|
+      return false if s.data_key.blank?
+
+      rb_id = s.data_key[/RB([a-zA-Z0-9\-]+)/, 1]
+
+      permissions.include?(rb_id)
+    end
+  end
+
   def formatted_submission_data(current_user: nil)
     PermitApplication::SubmissionDataService.new(self).formatted_submission_data(current_user: current_user)
   end

--- a/app/models/submission_version.rb
+++ b/app/models/submission_version.rb
@@ -6,6 +6,30 @@ class SubmissionVersion < ApplicationRecord
 
   after_commit :notify_user_application_viewed
 
+  def formatted_submission_data(current_user: nil)
+    PermitApplication::SubmissionDataService.new(permit_application).formatted_submission_data(
+      current_user: current_user,
+      submission_data: submission_data,
+    )
+  end
+
+  def revision_requests_for_submitter_based_on_user_permissions(user: nil)
+    return revision_requests if user.blank?
+
+    permissions = permit_application.submission_requirement_block_edit_permissions(user_id: user.id)
+
+    return revision_requests if permissions == :all
+
+    return [] if permissions.blank?
+
+    revision_requests.select do |r|
+      return false if r.requirement_json["key"].blank?
+
+      rb_id = r.requirement_json["key"][/RB([a-zA-Z0-9\-]+)/, 1]
+      permissions.include?(rb_id)
+    end
+  end
+
   def notify_user_application_viewed
     return if new_record?
     viewed_at_change = previous_changes.dig("viewed_at")

--- a/app/policies/permit_application_policy.rb
+++ b/app/policies/permit_application_policy.rb
@@ -30,7 +30,14 @@ class PermitApplicationPolicy < ApplicationPolicy
   end
 
   def update_version?
-    record.draft? ? record.submitter == user : user.review_staff?
+    permit_application = record
+    designated_submitter =
+      permit_application.users_by_collaboration_options(
+        collaboration_type: :submission,
+        collaborator_type: :delegatee,
+      ).first
+
+    record.draft? ? (record.submitter == user || designated_submitter == user) : user.review_staff?
   end
 
   def update_revision_requests?

--- a/app/services/permit_application/form_json_service.rb
+++ b/app/services/permit_application/form_json_service.rb
@@ -85,16 +85,8 @@ class PermitApplication::FormJsonService
         end
         .compact
 
-    # If the user is not passed in, or the user is a review staff in the same jurisdiction and the permit application is submitted
-    # then we don't remove requirement blocks based on further collaboration permissions. This is because review staff
-    # in the same jurisdiction should be able to all the blocks during review.
-    if current_user.blank? ||
-         (
-           current_user.review_staff? && permit_application.submitted? &&
-             current_user.jurisdictions.find_by(id: permit_application.jurisdiction_id).present?
-         )
-      return @empty_block_ids
-    end
+    # If the user is not passed in then we don't remove requirement blocks based on further collaboration permissions.
+    return @empty_block_ids if current_user.blank?
 
     permissions = permit_application.submission_requirement_block_edit_permissions(user_id: current_user.id)
 

--- a/app/services/permit_application/submission_data_service.rb
+++ b/app/services/permit_application/submission_data_service.rb
@@ -5,8 +5,8 @@ class PermitApplication::SubmissionDataService
     @permit_application = permit_application
   end
 
-  def formatted_submission_data(current_user:)
-    submission_data = permit_application.submission_data
+  def formatted_submission_data(current_user:, submission_data: nil)
+    submission_data ||= permit_application.submission_data
 
     filtered_submission =
       filter_submission_data_based_on_user_permissions(submission_data: submission_data, user: current_user)

--- a/app/services/permit_application/submission_data_service.rb
+++ b/app/services/permit_application/submission_data_service.rb
@@ -61,13 +61,7 @@ class PermitApplication::SubmissionDataService
 
     permissions = permit_application.submission_requirement_block_edit_permissions(user_id: user.id)
 
-    if permissions == :all ||
-         (
-           permit_application.submitted? && user.review_staff? &&
-             user.jurisdictions.find_by(id: permit_application.jurisdiction_id).present?
-         )
-      return formatted_data
-    end
+    return formatted_data if permissions == :all
 
     return {} if permissions.blank?
 


### PR DESCRIPTION
## Description
Includes:
- Filtering out data from submission version, revision requests, which collaborator does not have permissions to
- Filtering out returned files, which collaborator does not have permissions to
- Allow designated submitter to accept new permit version and show callout banner for assignees to contact author/ designated submitter in case of new version
- Hides the download button for non authors/designated submitters
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)
https://hous-bssb.atlassian.net/browse/BPHH-1946
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1946
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Revision request same permit:
Author:
![Screenshot 2024-08-13 at 1 53 35 PM](https://github.com/user-attachments/assets/5f962495-2b5b-4821-8397-efe075b66e73)
Collaboration Assignee:
![Screenshot 2024-08-13 at 1 53 42 PM](https://github.com/user-attachments/assets/c84794e9-be03-418b-abbd-52958e273416)

- New permit version viewed as an assignee (i.e. does not have submit permissions)
![Screenshot 2024-08-13 at 1 53 42 PM](https://github.com/user-attachments/assets/30210b65-a4b4-4d5d-ba56-2d71c8e4d763)

- Hidden download button for assignee (i.e. does not have submit permissions)
![Screenshot 2024-08-13 at 1 54 10 PM](https://github.com/user-attachments/assets/bdc7c2b0-6f48-4a2d-940d-8c2522ba2a80)

