### PR TITLE
only show most recent action required item

### DIFF
--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -174,7 +174,7 @@ export const NavBar = observer(function NavBar() {
           </Flex>
         </Container>
       </Box>
-      {!R.isEmpty(criticalNotifications) && criticalNotifications.map((cn) => <ActionRequiredBox notification={cn} />)}
+      {!R.isEmpty(criticalNotifications) && <ActionRequiredBox notification={criticalNotifications[0]} />}
 
       {!shouldHideSubNavbarForPath(path) && loggedIn && <SubNavBar />}
     </PopoverProvider>


### PR DESCRIPTION
## Description

Prevent action required box from stacking up when the user is not regularly reviewing notifications. This is the best approach as the action required items map to individual notifications that might require extensive logic to group. Limiting to the most recent critical notification will prevent the screen from getting cluttered.

See:
https://hous-bssb.atlassian.net/browse/BPHH-1540