### PR TITLE
[bphh-1950] Fix bug where an error is thrown on step code tool navigation causing the navigation to fail

### DIFF
--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -257,6 +257,7 @@ const AppRoutes = observer(() => {
   const { loggedIn, tokenExpired } = sessionStore
   const location = useLocation()
   const background = location.state && location.state.background
+  const enableStepCodeRoute = location.state?.enableStepCodeRoute
 
   const { currentUser } = userStore
   const { afterLoginPath, setAfterLoginPath, resetAuth } = sessionStore
@@ -455,7 +456,7 @@ const AppRoutes = observer(() => {
         <Route path="/jurisdictions/:jurisdictionId" element={<JurisdictionScreen />} />
         <Route path="*" element={<NotFoundScreen />} />
       </Routes>
-      {background && (
+      {enableStepCodeRoute && (
         <Routes>
           <Route path="/permit-applications/:permitApplicationId/edit/step-code" element={<StepCodeForm />} />
         </Routes>

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -177,7 +177,7 @@ export const RequirementForm = observer(
 
     const handleOpenStepCode = async (_event) => {
       await triggerSave?.()
-      navigate("step-code", { state: { background: location } })
+      navigate("step-code", { state: { enableStepCodeRoute: true } })
     }
 
     const handleOpenContactAutofill = async (event) => {
@@ -392,7 +392,7 @@ export const RequirementForm = observer(
             form={formattedFormJson}
             formReady={formReady}
             /* Needs cloned submissionData otherwise it's not possible to use data grid as mst props
-            can't be mutated*/
+                                                                                                            can't be mutated*/
             submission={unsavedSubmissionData}
             onSubmit={onFormSubmit}
             options={permitAppOptions}


### PR DESCRIPTION
## Description
[bphh-1950] Fixes bug where an error is thrown on step code tool navigation causing the navigation to fail
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1950
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- As a submitter, start any permit application with a step code requirement
- Navigate to Energy step code requirement
- Select "Utilizing the step code tool" from the drop down
- Click "Start"
- This should successfully navigate to step code route
https://github.com/user-attachments/assets/49cfee32-ed68-479e-be22-675423bc16e9