### PR TITLE
fix step code report to match new modeling

### DIFF
--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -155,14 +155,10 @@ class Jurisdiction < ApplicationRecord
     external_api_keys.active
   end
 
-  def permit_type_required_steps_by_classification(activity = nil, permit_type = nil)
-    return JurisdictionTemplateStepCode.none unless activity && permit_type
+  def permit_type_required_steps_by_classification(permit_type = nil)
+    return PermitTypeRequiredStep.none unless permit_type
 
-    requirement_template = RequirementTemplate.find_by(activity: activity, permit_type: permit_type, discarded_at: nil)
-
-    return JurisdictionTemplateStepCode.none unless requirement_template
-
-    permit_type_required_steps.where(requirement_template: requirement_template)
+    permit_type_required_steps.where(permit_type: permit_type)
   end
 
   def create_integration_mappings

--- a/app/models/jurisdiction_template_step_code.rb
+++ b/app/models/jurisdiction_template_step_code.rb
@@ -1,2 +1,0 @@
-class JurisdictionTemplateStepCode < ApplicationRecord
-end

--- a/app/services/step_code_export_service.rb
+++ b/app/services/step_code_export_service.rb
@@ -4,28 +4,17 @@ class StepCodeExportService
       csv << I18n.t("export.step_code_summary_csv_headers").split(",")
       jurisdictions = Jurisdiction.all
       permit_types = PermitType.all
-      activities = Activity.all
 
       jurisdictions.each do |j|
         permit_types.each do |pt|
-          activities.each do |a|
-            jurisdiction_name = j.qualified_name
-            permit_type = pt.name
-            work_type = a.name
-            permit_type_required_steps = j.permit_type_required_steps_by_classification(a, pt)
-            permit_type_required_steps.each do |jtsc|
-              energy_step_required = jtsc.energy_step_required
-              zero_carbon_step_required = jtsc.zero_carbon_step_required
-              enabled = energy_step_required.positive? || zero_carbon_step_required.positive?
-              csv << [
-                jurisdiction_name,
-                permit_type,
-                work_type,
-                enabled,
-                energy_step_required,
-                zero_carbon_step_required,
-              ]
-            end
+          jurisdiction_name = j.qualified_name
+          permit_type = pt.name
+          permit_type_required_steps = j.permit_type_required_steps_by_classification(pt)
+          permit_type_required_steps.each do |jtsc|
+            energy_step_required = jtsc.energy_step_required
+            zero_carbon_step_required = jtsc.zero_carbon_step_required
+            enabled = energy_step_required.positive? || zero_carbon_step_required.positive?
+            csv << [jurisdiction_name, permit_type, enabled, energy_step_required, zero_carbon_step_required]
           end
         end
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -516,4 +516,4 @@ en:
   export:
     template_version_csv_headers: "Requirement Block,Requirement block tip,Question,Requirement code,Input type,Optional,Is elective,Elective enabled,Elective reason"
     requirement_summary_csv_headers: "Field Name,Is Elective,Used By (Number of Jurisdictions),Reason: Bylaw Count, Reason: Zoning count,Reason: Policy Count"
-    step_code_summary_csv_headers: "Jurisdiction,Permit type,Work type,Enabled/disabled,Energy step code level,Zero carbon level "
+    step_code_summary_csv_headers: "Jurisdiction,Permit type,Enabled/disabled,Energy step code level,Zero carbon level"


### PR DESCRIPTION
## Description

JurisdictionTemplateStepCode is no longer used, so removed.
permit_type_required_steps cannot be queried by requirement template or activity, instead only by permit type.
removed the Work Type header from the report