### PR TITLE
[bphh-1987] Misc collaboration  fixes

### DIFF
--- a/app/frontend/components/domains/permit-application/collaborator-management/collaborator-assignment-popover.tsx
+++ b/app/frontend/components/domains/permit-application/collaborator-management/collaborator-assignment-popover.tsx
@@ -105,7 +105,7 @@ export const CollaboratorAssignmentPopover = observer(function AssignmentPopover
     permitApplication.inviteNewCollaborator(ECollaboratorType.assignee, user, requirementBlockId)
 
   return (
-    <Popover placement={"bottom-start"} isOpen={isOpen} onClose={onPopoverClose} onOpen={onOpen}>
+    <Popover placement={"bottom-start"} isOpen={isOpen} onClose={onPopoverClose} onOpen={onOpen} isLazy>
       <PopoverTrigger>
         <Button
           onClick={(e) => {

--- a/app/frontend/components/domains/permit-application/collaborator-management/designated-collaborator-assignment-popover.tsx
+++ b/app/frontend/components/domains/permit-application/collaborator-management/designated-collaborator-assignment-popover.tsx
@@ -97,7 +97,14 @@ export const DesignatedCollaboratorAssignmentPopover = observer(function Designa
     isDisabled: !canManage,
   }
   return (
-    <Popover placement={"bottom-start"} isOpen={isOpen} onClose={onPopoverClose} onOpen={onOpen} strategy={"fixed"}>
+    <Popover
+      placement={"bottom-start"}
+      isOpen={isOpen}
+      onClose={onPopoverClose}
+      onOpen={onOpen}
+      strategy={"fixed"}
+      isLazy
+    >
       <PopoverTrigger>
         {avatarTrigger ? (
           <IconButton

--- a/app/models/jurisdiction_membership.rb
+++ b/app/models/jurisdiction_membership.rb
@@ -3,8 +3,28 @@ class JurisdictionMembership < ApplicationRecord
   belongs_to :user
 
   after_commit :reindex_jurisdiction, on: %i[create update destroy]
+  after_commit :create_jurisdiction_collaborator, on: %i[create update]
+  after_commit :destroy_jurisdiction_collaborator, on: %i[update]
 
   private
+
+  def create_jurisdiction_collaborator
+    return unless user.review_staff? && user.kept?
+
+    existing_collaborator = jurisdiction.collaborators.find_by(user_id: user.id)
+
+    return if existing_collaborator.present?
+
+    jurisdiction.collaborators.create(user: user)
+  end
+
+  def destroy_jurisdiction_collaborator
+    existing_collaborator = jurisdiction.collaborators.find_by(user_id: user.id)
+
+    return unless existing_collaborator.present?
+
+    existing_collaborator.destroy
+  end
 
   def reindex_jurisdiction
     jurisdiction.reindex

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -5,7 +5,7 @@ class PermitApplication < ApplicationRecord
   include ZipfileUploader.Attachment(:zipfile)
   include PermitApplicationStatus
 
-  SEARCH_INCLUDES = %i[permit_type submission_versions step_code activity jurisdiction submitter]
+  SEARCH_INCLUDES = %i[permit_type submission_versions step_code activity jurisdiction submitter permit_collaborations]
 
   searchkick searchable: %i[number nickname full_address permit_classifications submitter status review_delegatee_name],
              word_start: %i[number nickname full_address permit_classifications submitter status review_delegatee_name]


### PR DESCRIPTION
The original issue mentioned in the card  seems to be just a reindex issue. I'm not sure how it got there, as it's reindexed properly locally, but I just reindexed manually on the deployed environment so there is no code change for that.


While debugging I found some other tangentially related issues, which I is included in this PR

- Making the assignment popover lazy so that the assignment search only occurs when the popover is open reducing the number of round-trip calls

- Include permit_collaboration eagerly for permit_application search

- Callbacks to create/ destroy jurisdiction collaborators when a user is undiscarded/ discarded and when there is a change to their jurisdiction memberships

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1987
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA

The other fixes happen in the background, so not a lot to test.

- When a new user is added or unarchived to a jurisdiction. they should be available in the assignment popover above

- When a user is archived or if they are removed from a jurisdiction, they should no longer be available in the assignment popover above

