### PR TITLE
Bugfix/bphh 1991/pdf generation misc bugs

### DIFF
--- a/app/frontend/components/shared/pdf/index.tsx
+++ b/app/frontend/components/shared/pdf/index.tsx
@@ -2,6 +2,17 @@ import { Document, Font } from "@react-pdf/renderer"
 import React from "react"
 import { theme } from "../../../styles/theme"
 
+const chunkSubstr = (str, size) => {
+  const numChunks = Math.ceil(str.length / size)
+  const chunks = new Array(numChunks)
+
+  for (let i = 0, o = 0; i < numChunks; ++i, o += size) {
+    chunks[i] = str.substring(o, size)
+  }
+
+  return chunks
+}
+
 export function PDFDocument({ assetDirectoryPath, children }) {
   const srcPrefix = import.meta.env.SSR ? assetDirectoryPath : ""
   Font.register({
@@ -39,5 +50,16 @@ export function PDFDocument({ assetDirectoryPath, children }) {
       },
     ],
   })
+
+  Font.registerHyphenationCallback((word) => {
+    word = word || ""
+
+    if (word.length > 16) {
+      return chunkSubstr(word, 14)
+    } else {
+      return [word]
+    }
+  })
+
   return <Document style={{ fontFamily: "BC Sans", color: theme.colors.text.primary }}>{children}</Document>
 }

--- a/app/frontend/components/shared/permit-applications/pdf-content/application/index.tsx
+++ b/app/frontend/components/shared/permit-applications/pdf-content/application/index.tsx
@@ -48,6 +48,7 @@ interface IFormComponentProps {
   component: any
   dataPath?: string[]
 }
+
 const FormComponent = function ApplicationPDFFormComponent({
   permitApplication,
   component,
@@ -149,14 +150,19 @@ const FormComponent = function ApplicationPDFFormComponent({
       )
     }
     case EComponentType.datagrid: {
+      const values: any[] = (R.path([...dataPath, component.key], permitApplication.submissionData.data) ?? []) as any[]
+
+      const dataGridChildComponent = component?.components?.[0]
+
       return (
         <>
-          {component.components &&
-            component.components.map((child) => (
+          {dataGridChildComponent &&
+            Array.isArray(values) &&
+            values.map((value, index) => (
               <FormComponent
                 key={generateUUID()}
-                component={child}
-                dataPath={[...dataPath, component.key, 0]}
+                component={dataGridChildComponent}
+                dataPath={[...dataPath, component.key, index]}
                 permitApplication={permitApplication}
               />
             ))}
@@ -288,7 +294,16 @@ const PanelHeader = function ApplicationPDFPanelHeader({ component }) {
 const ChecklistField = function ApplicationPDFPanelChecklistField({ options, label }) {
   return (
     <View style={{ gap: 4, paddingTop: 4 }} wrap={false}>
-      <Text style={{ fontSize: 12, color: theme.colors.text.primary, paddingBottom: 4, marginBottom: 4 }}>{label}</Text>
+      <Text
+        style={{
+          fontSize: 12,
+          color: theme.colors.text.primary,
+          paddingBottom: 4,
+          marginBottom: 4,
+        }}
+      >
+        {label}
+      </Text>
       <View style={{ gap: 8 }}>
         {Object.keys(options).map((key) => {
           return <Checkbox key={key} isChecked={options[key]} label={key} />

--- a/app/frontend/components/shared/permit-applications/pdf-content/viewer.tsx
+++ b/app/frontend/components/shared/permit-applications/pdf-content/viewer.tsx
@@ -13,7 +13,7 @@ interface IProps {
 export const PermitApplicationPDFViewer = observer(function PermitApplicationPDFViewer({ mode }: IProps) {
   // permitApplication must be passed as props to <Content> due to a limitation of react-pdf
   // see: https://github.com/diegomura/react-pdf/issues/2263#issuecomment-1511800981
-  const { currentPermitApplication } = usePermitApplication()
+  const { currentPermitApplication } = usePermitApplication({ review: true })
 
   return mode == "pdf" ? (
     <PDFViewer height="750px" width="100%">

--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -396,9 +396,9 @@ class RequirementFormJsonService
           [
             get_nested_info_component(:pid, requirement_block_key, "PID", required),
             get_nested_info_component(:folio_number, requirement_block_key, "Folio Number", false),
-            get_nested_info_component(:address, requirement_block_key, "Address", false, :address),
           ],
         ),
+        get_nested_info_component(:address, requirement_block_key, "Address", false, :address),
       ],
     }
     multi_data_grid_form_json(key, component, true, "Add #{requirement.label}")


### PR DESCRIPTION
## Description
- Fixes miscellaneous pdf generation bugs
  - Text overflow wrapping
  - Datagrid with multiple field sets (e.g. contact, multiple pid) previously generated only the first field set values. Fixes the issue so all field set values are printed
  - Fixes multiple PID layout in generated PDF (looks fine in web form)
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1991
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- If in local run `npm run build:ssr` first
- As a submitter, complete a permit application
- Enter long text for some inputs to test overflow
- Ensure the permit application has multiple PID inputs and fill them
- Submit the permit application
- Go to permit application either as submitter or reviewer and download the generated pdf

- Text overflow fix

![Screenshot 2024-08-20 at 1 30 34 PM](https://github.com/user-attachments/assets/9c7016ef-e040-4a2a-954e-95984e6c45c7)

- Multiple fieldset data fix

![Screenshot 2024-08-20 at 2 11 02 PM](https://github.com/user-attachments/assets/d6394aa5-6098-4d44-8bb1-bd4017ff49b8)

-Multiple PID layout fix

![Screenshot 2024-08-20 at 2 27 51 PM](https://github.com/user-attachments/assets/c35cd545-d9bf-48db-aacc-eb910c5ecd04)


