### PR TITLE
[bphh-2006] Fix bug with force publish still calling synchronus publi…

### DIFF
--- a/app/blueprints/requirement_template_blueprint.rb
+++ b/app/blueprints/requirement_template_blueprint.rb
@@ -8,7 +8,9 @@ class RequirementTemplateBlueprint < Blueprinter::Base
               blueprint: TemplateVersionBlueprint,
               name: :deprecated_template_versions
   association :scheduled_template_versions, blueprint: TemplateVersionBlueprint
-  association :published_template_version, blueprint: TemplateVersionBlueprint
+  association :published_template_version, blueprint: TemplateVersionBlueprint do |rt, options|
+    options[:published_template_version].present? ? options[:published_template_version] : rt.published_template_version
+  end
 
   view :extended do
     association :requirement_template_sections, blueprint: RequirementTemplateSectionBlueprint

--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -113,6 +113,8 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     success = false
     error_message = ""
 
+    published_template_version = nil
+
     ActiveRecord::Base.transaction do
       unless @requirement_template.update(requirement_template_params)
         error_message = @requirement_template.errors.full_messages.join(", ")
@@ -135,7 +137,13 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     if success
       render_success @requirement_template,
                      "requirement_template.force_publish_now_success",
-                     { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
+                     {
+                       blueprint: RequirementTemplateBlueprint,
+                       blueprint_opts: {
+                         view: :extended,
+                         published_template_version: published_template_version,
+                       },
+                     }
     else
       render_error "requirement_template.force_publish_now_error", message_opts: { error_message: error_message }
     end

--- a/app/jobs/model_callback_job.rb
+++ b/app/jobs/model_callback_job.rb
@@ -8,7 +8,7 @@ class ModelCallbackJob
                   }
 
   def perform(model_name, model_id, callback_name)
-    model = model_name.constantize.find(model_id)
+    model = model_name.constantize.find_by_id(model_id)
 
     return if model.blank?
 

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -92,8 +92,6 @@ class TemplateVersioningService
 
     ModelCallbackJob.perform_async(template_version.class.name, template_version.id, "force_publish_now!")
 
-    template_version = publish_version!(template_version, true)
-
     template_version
   end
 


### PR DESCRIPTION
## Description
Fixes bug with force publishes still calling synchronous publish method. Also, fixes force publish returned template versions
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-2006
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Go to any template and force publish, note the template might say "scheduled" initially, but websocket will update it's state
