### PR TITLE
[BPHH-1982] CSRF Token Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 /public/packs
 /public/packs-test
 /node_modules
+/node_modules.*
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
@@ -39,9 +40,7 @@ yarn-debug.log*
 public/uploads/
 
 .env
-.env.qa
-.env.staging
-.env.production
+.env.*
 
 dump.rdb
 
@@ -59,3 +58,10 @@ node_modules
 deleteme.*
 
 /devops/docker/**/*.tar.gz
+
+/allure-report/
+/allure-results/
+/cypress/downloads/
+/cypress/screenshots/
+
+.npm/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,2 @@
 class ApplicationController < ActionController::Base
-  skip_before_action :verify_authenticity_token
 end

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -77,6 +77,13 @@ export class Api {
     })
 
     this.client.addRequestTransform((request) => {
+      // csrfToken is set as readable cookie by backend, send it in every request
+      const csrfToken = document.cookie
+        .split("; ")
+        .find((row) => row.startsWith("CSRF-TOKEN="))
+        ?.split("=")[1]
+
+      request.headers["X-CSRF-Token"] = csrfToken
       request.params = decamelizeRequest(request.params)
       request.data = decamelizeRequest(request.data)
     })


### PR DESCRIPTION
## Description

…in CSRF protection so that we would be safe from those attacks. This change makes the backend set a CSRF-TOKEN cookie which is then read on the requestTransform in the frontend and set so that we can maintain security

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Implements https://hous-bssb.atlassian.net/jira/software/projects/BPHH/boards/1?issueParent=10320&selectedIssue=BPHH-1982

## Steps to QA
As long as you can login as use the app (submit various forms, etc.) as usual there should be no impact on user experience. As a developer, inspect the headers to see that CSRF token is indeed passed.
