### PR TITLE
add user prop for most recently touched jurisdiction, fix some UI/UX

### DIFF
--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -45,7 +45,7 @@ class UserBlueprint < Blueprinter::Base
     end
 
     association :invited_to_jurisdiction, blueprint: JurisdictionBlueprint, view: :minimal do |user, _options|
-      user.jurisdiction_memberships.order(updated_at: :desc).first.jurisdiction
+      user.jurisdiction_memberships&.order(updated_at: :desc)&.first&.jurisdiction
     end
   end
 end

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -43,5 +43,9 @@ class UserBlueprint < Blueprinter::Base
     field :invited_by_email do |user, _options|
       user.invited_by&.email
     end
+
+    association :invited_to_jurisdiction, blueprint: JurisdictionBlueprint, view: :minimal do |user, _options|
+      user.jurisdiction_memberships.order(updated_at: :desc).first.jurisdiction
+    end
   end
 end

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -85,11 +85,12 @@ function shouldHideSubNavbarForPath(path: string): boolean {
 
 export const NavBar = observer(function NavBar() {
   const { t } = useTranslation()
-  const { sessionStore, userStore, notificationStore } = useMst()
+  const { sessionStore, userStore, notificationStore, uiStore } = useMst()
 
   const { currentUser } = userStore
   const { loggedIn } = sessionStore
   const { criticalNotifications } = notificationStore
+  const { rmJurisdictionSelectKey } = uiStore
 
   const location = useLocation()
   const path = location.pathname
@@ -150,7 +151,7 @@ export const NavBar = observer(function NavBar() {
                   <Text color="whiteAlpha.700" textAlign="right" variant="tiny_uppercase">
                     {t(`user.roles.${currentUser.role as EUserRoles}`)}
                   </Text>
-                  <RegionalRMJurisdictionSelect />
+                  <RegionalRMJurisdictionSelect key={rmJurisdictionSelectKey} />
                 </VStack>
               )}
               {currentUser?.isSuperAdmin && (

--- a/app/frontend/components/domains/navigation/regional-rm-jurisdiction-select.tsx
+++ b/app/frontend/components/domains/navigation/regional-rm-jurisdiction-select.tsx
@@ -46,6 +46,7 @@ export const RegionalRMJurisdictionSelect = observer(function RegionalRMJurisdic
               borderBottomWidth: 0,
               borderColor: "var(--chakra-colors-border-base)",
               boxShadow: "none",
+              //@ts-ignore
               "&:hover": {
                 border: "1px solid var(--chakra-colors-border-base)",
               },

--- a/app/frontend/components/domains/users/accept-invitation-screen.tsx
+++ b/app/frontend/components/domains/users/accept-invitation-screen.tsx
@@ -45,8 +45,7 @@ const Content = observer(function Content({ invitedUser }: Readonly<IProps>) {
   const { sessionStore } = useMst()
   const { loggedIn } = sessionStore
 
-  const { invitedByEmail, jurisdiction, isSuperAdmin, email, role } = invitedUser
-
+  const { invitedByEmail, invitedToJurisdiction, isSuperAdmin, email, role } = invitedUser
   return (
     <CenterContainer>
       <Flex
@@ -59,15 +58,15 @@ const Content = observer(function Content({ invitedUser }: Readonly<IProps>) {
         bg="greys.white"
       >
         <Heading as="h1">{t("user.acceptInvitation")}</Heading>
-        {invitedByEmail && jurisdiction ? (
+        {invitedByEmail && invitedToJurisdiction ? (
           <>
             <Text>
               <Trans i18nKey="user.invitedBy" values={{ email: invitedByEmail }} />
             </Text>
 
-            <VStack spacing={4} w="full" p={4} bg="theme.blueLight" rounded="sm">
+            <VStack spacing={4} w="full" p={4} bg="theme.blueLight" rounded="sm" textAlign="center">
               <Heading as="h2" m={0}>
-                {jurisdiction.qualifiedName}
+                {invitedToJurisdiction.qualifiedName}
               </Heading>
               <Text>{t("user.invitedAs")}</Text>
               <Text fontWeight="bold">{t(`user.roles.${role as EUserRoles}`)}</Text>
@@ -149,12 +148,14 @@ function InvalidTokenMessage() {
 const AcceptInviteForm = observer(function AcceptInviteForm() {
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
-  const { userStore } = useMst()
+  const { userStore, uiStore } = useMst()
+  const { updateRmJurisdictionSelectKey } = uiStore
   const { currentUser } = userStore
   const { handleSubmit, formState } = useForm()
   const { isSubmitting } = formState
 
   const onSubmit = async () => {
+    updateRmJurisdictionSelectKey()
     await currentUser.acceptInvitation(searchParams.get("invitation_token"))
     navigate("/")
   }

--- a/app/frontend/hooks/resources/use-jurisdiction.ts
+++ b/app/frontend/hooks/resources/use-jurisdiction.ts
@@ -24,6 +24,7 @@ export const useJurisdiction = () => {
     "/jurisdictions/:jurisdictionId/configuration-management/submissions-inbox-setup",
     "/jurisdictions/:jurisdictionId/configuration-management/energy-step",
     "/jurisdictions/:jurisdictionId/users",
+    "/jurisdictions/:jurisdictionId/users/invite",
     "/jurisdictions/:jurisdictionId/api-settings",
   ]
 

--- a/app/frontend/models/user.ts
+++ b/app/frontend/models/user.ts
@@ -2,7 +2,7 @@ import { Instance, applySnapshot, flow, types } from "mobx-state-tree"
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
 import { EOmniauthProvider, EUserRoles } from "../types/enums"
-import { JurisdictionModel } from "./jurisdiction"
+import { IJurisdiction, JurisdictionModel } from "./jurisdiction"
 
 export const UserModel = types
   .model("UserModel")
@@ -27,6 +27,7 @@ export const UserModel = types
     eulaAccepted: types.maybeNull(types.boolean),
     invitedByEmail: types.maybeNull(types.string),
     preference: types.frozen<IPreference>(),
+    invitedToJurisdiction: types.maybeNull(types.frozen<IJurisdiction>()),
   })
   .extend(withRootStore())
   .extend(withEnvironment())

--- a/app/frontend/stores/ui-store.ts
+++ b/app/frontend/stores/ui-store.ts
@@ -1,5 +1,6 @@
 import { Instance, types } from "mobx-state-tree"
 import queryString from "query-string"
+import { v4 as uuidv4 } from "uuid"
 import { withRootStore } from "../lib/with-root-store"
 import { FlashMessageModel } from "../models/flash-message"
 
@@ -8,6 +9,7 @@ export const UIStoreModel = types
   .props({
     flashMessage: types.optional(FlashMessageModel, {}),
     currentlySelectedJurisdictionId: types.maybeNull(types.string),
+    rmJurisdictionSelectKey: types.optional(types.string, uuidv4()),
   })
   .extend(withRootStore())
   .views((self) => ({}))
@@ -34,6 +36,9 @@ export const UIStoreModel = types
   .actions((self) => ({
     setCurrentlySelectedJurisdictionId(id: string) {
       self.currentlySelectedJurisdictionId = id
+    },
+    updateRmJurisdictionSelectKey() {
+      self.rmJurisdictionSelectKey = uuidv4()
     },
     afterCreate() {
       self.showQueryParamFlash()


### PR DESCRIPTION

## Description

Regional Review manager invites were showing the wrong jurisdiciton.
Also:
- RM selector dropdown didn't update until page refresh
- RM selector was not working on invite page


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-2015
https://hous-bssb.atlassian.net/browse/BPHH-2018

## Steps to QA

As super admin: Invite RM to multiple jurisdicitons.
Use a different invite email each time in order to see the invite screen (accept the invite using the desired BCEID)