### PR TITLE
Feature/bphh 1509/api for revision

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -89,7 +89,7 @@ class PermitApplicationBlueprint < Blueprinter::Base
 
   view :external_api do
     identifier :id
-    fields :status, :number, :full_address, :pid, :pin, :reference_number, :submitted_at
+    fields :status, :number, :full_address, :pid, :pin, :reference_number, :submitted_at, :resubmitted_at
 
     field :submission_data do |pa, _options|
       pa.formatted_submission_data_for_external_use

--- a/app/blueprints/preference_blueprint.rb
+++ b/app/blueprints/preference_blueprint.rb
@@ -9,6 +9,8 @@ class PreferenceBlueprint < Blueprinter::Base
          :enable_in_app_application_revisions_request_notification,
          :enable_in_app_collaboration_notification,
          :enable_email_collaboration_notification,
+         :enable_in_app_integration_mapping_notification,
+         :enable_email_integration_mapping_notification,
          :created_at,
          :updated_at
 end

--- a/app/blueprints/requirement_template_blueprint.rb
+++ b/app/blueprints/requirement_template_blueprint.rb
@@ -8,7 +8,9 @@ class RequirementTemplateBlueprint < Blueprinter::Base
               blueprint: TemplateVersionBlueprint,
               name: :deprecated_template_versions
   association :scheduled_template_versions, blueprint: TemplateVersionBlueprint
-  association :published_template_version, blueprint: TemplateVersionBlueprint
+  association :published_template_version, blueprint: TemplateVersionBlueprint do |rt, options|
+    options[:published_template_version].present? ? options[:published_template_version] : rt.published_template_version
+  end
 
   view :extended do
     association :requirement_template_sections, blueprint: RequirementTemplateSectionBlueprint

--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -113,6 +113,8 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     success = false
     error_message = ""
 
+    published_template_version = nil
+
     ActiveRecord::Base.transaction do
       unless @requirement_template.update(requirement_template_params)
         error_message = @requirement_template.errors.full_messages.join(", ")
@@ -135,7 +137,13 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     if success
       render_success @requirement_template,
                      "requirement_template.force_publish_now_success",
-                     { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
+                     {
+                       blueprint: RequirementTemplateBlueprint,
+                       blueprint_opts: {
+                         view: :extended,
+                         published_template_version: published_template_version,
+                       },
+                     }
     else
       render_error "requirement_template.force_publish_now_error", message_opts: { error_message: error_message }
     end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -159,6 +159,8 @@ class Api::UsersController < Api::ApplicationController
         enable_in_app_application_revisions_request_notification
         enable_in_app_collaboration_notification
         enable_email_collaboration_notification
+        enable_in_app_integration_mapping_notification
+        enable_email_integration_mapping_notification
       ],
     )
   end

--- a/app/controllers/external_api/concerns/search/permit_applications.rb
+++ b/app/controllers/external_api/concerns/search/permit_applications.rb
@@ -34,7 +34,12 @@ module ExternalApi::Concerns::Search::PermitApplications
     params.permit(
       :page,
       :per_page,
-      constraints: [:permit_classifications, submitted_at: %i[gt lt gte lte]],
+      constraints: [
+        :permit_classifications,
+        :status,
+        submitted_at: %i[gt lt gte lte],
+        resubmitted_at: %i[gt lt gte lte],
+      ],
       sort: %i[field direction],
     )
   end
@@ -55,7 +60,9 @@ module ExternalApi::Concerns::Search::PermitApplications
   def permit_application_where_clause
     constraints = permit_application_search_params[:constraints]
 
-    where = { status: %i[newly_submitted resubmitted], jurisdiction_id: current_external_api_key.jurisdiction_id }
+    where = { jurisdiction_id: current_external_api_key.jurisdiction_id }
+
+    where[:status] = %i[newly_submitted resubmitted] if constraints.blank? || constraints[:status].blank?
 
     where.merge!(constraints.to_h.deep_symbolize_keys) if constraints.present?
 

--- a/app/frontend/components/domains/users/profile-screen.tsx
+++ b/app/frontend/components/domains/users/profile-screen.tsx
@@ -112,6 +112,11 @@ export const ProfileScreen = observer(({}: IProfileScreenProps) => {
       inAppControl: "preferenceAttributes.enableInAppCollaborationNotification",
       emailControl: "preferenceAttributes.enableEmailCollaborationNotification",
     },
+    {
+      event: t("user.notifications.integrationMapping"),
+      inAppControl: "preferenceAttributes.enableInAppIntegrationMappingNotification",
+      emailControl: "preferenceAttributes.enableEmailIntegrationMappingNotification",
+    },
   ]
 
   return (

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1338,6 +1338,7 @@ const options = {
             applicationViewed: "Application viewed by jurisdiction",
             applicationRevisionsRequested: "Revisions requested by jurisdiction",
             collaboration: "Collaboration",
+            integrationMapping: "API integration mapping",
           },
           emailConfirmed: {
             heading: "Email confirmed!",

--- a/app/frontend/models/user.ts
+++ b/app/frontend/models/user.ts
@@ -143,4 +143,7 @@ export interface IPreference {
 
   enableInAppCollaborationNotification: boolean
   enableEmailCollaborationNotification: boolean
+
+  enableInAppIntegrationMappingNotification: boolean
+  enableEmailIntegrationMappingNotification: boolean
 }

--- a/app/jobs/model_callback_job.rb
+++ b/app/jobs/model_callback_job.rb
@@ -8,7 +8,7 @@ class ModelCallbackJob
                   }
 
   def perform(model_name, model_id, callback_name)
-    model = model_name.constantize.find(model_id)
+    model = model_name.constantize.find_by_id(model_id)
 
     return if model.blank?
 

--- a/app/jobs/permit_webhook_job.rb
+++ b/app/jobs/permit_webhook_job.rb
@@ -7,6 +7,9 @@ class PermitWebhookJob
 
     service = PermitWebhookService.new(external_api_key)
 
-    service.send_submitted_event(permit_application_id) if event_type == "permit_submitted"
+    if event_type == Constants::Webhooks::Events::PermitApplication::PERMIT_SUBMITTED ||
+         event_type == Constants::Webhooks::Events::PermitApplication::PERMIT_RESUBMITTED
+      service.send_submitted_event(permit_application_id)
+    end
   end
 end

--- a/app/mailers/permit_hub_mailer.rb
+++ b/app/mailers/permit_hub_mailer.rb
@@ -27,7 +27,8 @@ class PermitHubMailer < ApplicationMailer
     @user = user
     @template_version = integration_mapping.template_version
 
-    unless integration_mapping.jurisdiction.external_api_enabled? &&
+    unless @user.preference&.enable_email_integration_mapping_notification &&
+             integration_mapping.jurisdiction.external_api_enabled? &&
              (@user.review_manager? || @user.regional_review_manager?) &&
              (@template_version.published? || @template_version.scheduled?)
       return

--- a/app/models/integration_mapping.rb
+++ b/app/models/integration_mapping.rb
@@ -136,7 +136,17 @@ class IntegrationMapping < ApplicationRecord
 
     Rails.cache.write(event_id, true, expires_in: 5.minutes)
 
-    users_to_notify = jurisdiction.users.kept.where(role: %w[review_manager regional_review_manager])
+    users_to_notify =
+      jurisdiction
+        .users
+        .kept
+        .includes(:preference)
+        .where(
+          role: %w[review_manager regional_review_manager],
+          preferences: {
+            enable_email_integration_mapping_notification: true,
+          },
+        )
 
     users_to_notify.each do |u|
       PermitHubMailer.notify_integration_mapping(user: u, integration_mapping: self)&.deliver_later

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -10,6 +10,7 @@ class Jurisdiction < ApplicationRecord
              text_start: %i[name reverse_qualified_name qualified_name]
 
   # Associations
+  has_one :preference
   has_many :permit_applications
   has_many :contacts, as: :contactable, dependent: :destroy
   has_many :jurisdiction_memberships, dependent: :destroy

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -140,6 +140,7 @@ class PermitApplication < ApplicationRecord
       permit_classifications: "#{permit_type.name} #{activity.name}",
       submitter: "#{submitter.name} #{submitter.email}",
       submitted_at: submitted_at,
+      resubmitted_at: resubmitted_at,
       viewed_at: viewed_at,
       status: status,
       jurisdiction_id: jurisdiction.id,
@@ -297,7 +298,19 @@ class PermitApplication < ApplicationRecord
     jurisdiction
       .active_external_api_keys
       .where.not(webhook_url: [nil, ""]) # Only send webhooks to keys with a webhook URL
-      .each { |external_api_key| PermitWebhookJob.perform_async(external_api_key.id, "permit_submitted", id) }
+      .each do |external_api_key|
+        PermitWebhookJob.perform_async(
+          external_api_key.id,
+          (
+            if newly_submitted?
+              Constants::Webhooks::Events::PermitApplication::PERMIT_SUBMITTED
+            else
+              Constants::Webhooks::Events::PermitApplication::PERMIT_RESUBMITTED
+            end
+          ),
+          id,
+        )
+      end
   end
 
   def missing_pdfs

--- a/app/services/constants/webhooks.rb
+++ b/app/services/constants/webhooks.rb
@@ -1,0 +1,10 @@
+module Constants
+  module Webhooks
+    module Events
+      module PermitApplication
+        PERMIT_SUBMITTED = "permit_submitted"
+        PERMIT_RESUBMITTED = "permit_resubmitted"
+      end
+    end
+  end
+end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -105,8 +105,14 @@ class NotificationService
       integration_mapping
         .jurisdiction
         .users
+        .includes(:preference)
         &.kept
-        &.where(role: %i[review_manager regional_review_manager])
+        &.where(
+          role: %i[review_manager regional_review_manager],
+          preferences: {
+            enable_in_app_integration_mapping_notification: true,
+          },
+        )
         &.pluck(:id) || []
 
     notification_hash =

--- a/app/services/permit_webhook_service.rb
+++ b/app/services/permit_webhook_service.rb
@@ -34,7 +34,14 @@ and name: #{external_api_key.name}",
     end
 
     payload = {
-      event: "permit_submitted",
+      event:
+        (
+          if permit_application.newly_submitted?
+            Constants::Webhooks::Events::PermitApplication::PERMIT_SUBMITTED
+          else
+            Constants::Webhooks::Events::PermitApplication::PERMIT_RESUBMITTED
+          end
+        ),
       payload: {
         permit_id: permit_id,
         submitted_at: permit_application.submitted_at,
@@ -52,7 +59,7 @@ and name: #{external_api_key.name}",
       response.success?
     rescue Faraday::Error => e
       raise PermitWebhookError.new(
-              "Failed to send permit_submitted webhook to #{external_api_key.webhook_url}: #{e.message}",
+              "Failed to send #{payload[:event]} webhook to #{external_api_key.webhook_url}: #{e.message}",
             )
     end
   end

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -92,8 +92,6 @@ class TemplateVersioningService
 
     ModelCallbackJob.perform_async(template_version.class.name, template_version.id, "force_publish_now!")
 
-    template_version = publish_version!(template_version, true)
-
     template_version
   end
 

--- a/db/data/20240823213917_reindex_permit_application_for_resubmitted_date.rb
+++ b/db/data/20240823213917_reindex_permit_application_for_resubmitted_date.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ReindexPermitApplicationForResubmittedDate < ActiveRecord::Migration[7.1]
+  def up
+    PermitApplication.reindex
+  end
+
+  def down
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20_240_814_202_522)
+DataMigrate::Data.define(version: 20_240_823_213_917)

--- a/db/migrate/20240823224625_add_integration_notification_to_preference.rb
+++ b/db/migrate/20240823224625_add_integration_notification_to_preference.rb
@@ -1,0 +1,6 @@
+class AddIntegrationNotificationToPreference < ActiveRecord::Migration[7.1]
+  def change
+    add_column :preferences, :enable_in_app_integration_mapping_notification, :boolean, default: true
+    add_column :preferences, :enable_email_integration_mapping_notification, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_20_211514) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_23_224625) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -78,6 +78,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_20_211514) do
     t.uuid "contactable_id"
     t.index %w[contactable_type contactable_id],
             name: "index_contacts_on_contactable"
+  end
+
+  create_table "data_migrations",
+               primary_key: "version",
+               id: :string,
+               force: :cascade do |t|
   end
 
   create_table "end_user_license_agreements",
@@ -350,6 +356,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_20_211514) do
               default: true
     t.boolean "enable_in_app_collaboration_notification", default: true
     t.boolean "enable_email_collaboration_notification", default: true
+    t.boolean "enable_in_app_integration_mapping_notification", default: true
+    t.boolean "enable_email_integration_mapping_notification", default: true
     t.index ["user_id"], name: "index_preferences_on_user_id"
   end
 
@@ -661,6 +669,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_20_211514) do
     t.datetime "viewed_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "step_code_checklist_json", default: {}
     t.index ["permit_application_id"],
             name: "index_submission_versions_on_permit_application_id"
   end
@@ -675,8 +684,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_20_211514) do
     t.datetime "updated_at", null: false
     t.jsonb "compliance_data", default: {}, null: false
     t.string "data_key"
+    t.uuid "submission_version_id"
     t.index ["permit_application_id"],
             name: "index_supporting_documents_on_permit_application_id"
+    t.index ["submission_version_id"],
+            name: "index_supporting_documents_on_submission_version_id"
   end
 
   create_table "taggings",
@@ -903,6 +915,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_20_211514) do
   add_foreign_key "step_codes", "permit_applications"
   add_foreign_key "submission_versions", "permit_applications"
   add_foreign_key "supporting_documents", "permit_applications"
+  add_foreign_key "supporting_documents", "submission_versions"
   add_foreign_key "taggings", "tags"
   add_foreign_key "template_section_blocks", "requirement_blocks"
   add_foreign_key "template_section_blocks", "requirement_template_sections"

--- a/spec/requests/external_api/v1/permit_applications_spec.rb
+++ b/spec/requests/external_api/v1/permit_applications_spec.rb
@@ -31,15 +31,23 @@ RSpec.describe "external_api/v1/permit_applications", type: :request, openapi_sp
                 in: :body,
                 schema: {
                   type: :object,
-                  description: "Filters permit applications by submitted date and permit classifications",
+                  description:
+                    "Filters permit applications by status, submitted date, resubmitted_date and permit classifications",
                   properties: {
                     permit_classifications: {
                       description: "Filters by permit classifications",
                       type: :string,
                     },
+                    status: {
+                      type: :string,
+                      enum: %w[newly_submitted resubmitted],
+                      description:
+                        "Filters by submitted status. Newly submitted: permit applications submitted for the first time. Resubmitted: permit applications resubmitted after a revision request.",
+                    },
                     submitted_at: {
                       type: :object,
-                      description: "Filters by submitted date",
+                      description:
+                        "Filters by submitted date. This is the date the permit application was first submitted. Example format `2024-04-30T13:22:41-07:00`",
                       properties: {
                         gt: {
                           type: :string,
@@ -60,6 +68,34 @@ RSpec.describe "external_api/v1/permit_applications", type: :request, openapi_sp
                           type: :string,
                           format: "date-time",
                           description: "Less than or equal to: submitted date is less than or equal to this date",
+                        },
+                      },
+                    },
+                    resubmitted_at: {
+                      type: :object,
+                      description:
+                        "Filters by resubmitted date. This is the date the permit application was most recently resubmitted. Example format `2024-04-30T13:22:41-07:00`",
+                      properties: {
+                        gt: {
+                          type: :string,
+                          format: "date-time",
+                          description: "Greater than: resubmitted date is greater than this date",
+                        },
+                        lt: {
+                          type: :string,
+                          format: "date-time",
+                          description: "Less than: resubmitted date is less than this date",
+                        },
+                        gte: {
+                          type: :string,
+                          format: "date-time",
+                          description:
+                            "Greater than or equal to: resubmitted date is greater than or equal to this date",
+                        },
+                        lte: {
+                          type: :string,
+                          format: "date-time",
+                          description: "Less than or equal to: resubmitted date is less than or equal to this date",
                         },
                       },
                     },

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
         version: "v1",
         description: <<-DESC,
 ### API documentation overview
-This document provides detailed information about the APIs available for external integrators to query and retrieve submitted permit applications.
+This document provides detailed information about the APIs available for external integrators to query and retrieve submitted and resubmitted permit applications.
 It also includes specifications on webhook events that notify your systems in real-time.
 
 ### Data scope:
@@ -68,6 +68,10 @@ During your integration testing phase, you have the flexibility to use custom UR
 tailor the API environment to better suit your development needs. Ensure that your custom URLs are configured correctly to avoid any connectivity or data access issues.
 
 ### Special considerations:
+A returned permit application will have a status of either `newly_submitted` for permit applications submitted for the first time, or `resubmitted` for
+permit applications that have been resubmitted due to revision requests. The `resubmitted_at` field will indicate the timestamp of the latest resubmission.
+While there may be multiple resubmissions, the submission data payload returned will reflect the most recent submission data. 
+
 For security purposes, any API response that includes a file URL will have a signed URL. These files will be available for download for a limited time (1 hour).
 We recommend downloading the file immediately upon receiving the URL to avoid any issues. If necessary, you can always call the API again to retrieve a
 new file URL.
@@ -85,6 +89,35 @@ in this document.
               description:
                 "### Request body:\nThis webhook sends information about a recently submitted permit
         application in a JSON format to the webhook URL specified by the external integrator.\nIt includes
+        the permit application ID, which can be used to fetch the complete details of the permit application using the
+        `GET/permit_applications/{id}` endpoint.\n\n### Retries:\nIf the webhook does not receive a 200 status response
+        from the external integrator, it will attempt to resend the notification up to 8 times using an exponential backoff
+        strategy. This ensures multiple attempts to deliver the webhook in case of temporary issues on the receiving end.\n\n
+### Expected responses:\nThe external integrator is expected to return a 200 status code to confirm successful receipt
+        of the data. This acknowledgment indicates that the payload was received and processed without issues",
+              content: {
+                "application/json" => {
+                  schema: {
+                    "$ref" => "#/components/schemas/WebhookPayload",
+                  },
+                },
+              },
+            },
+            responses: {
+              "200" => {
+                description:
+                  "The external integrator should return a 200 status to indicate that the data was received successfully.",
+              },
+            },
+          },
+        },
+        permit_resubmitted: {
+          tags: ["Webhooks"],
+          post: {
+            requestBody: {
+              description:
+                "### Request body:\nThis webhook sends information about a recently resubmitted permit
+        application. A permit can be resubmitted due to revision requests. After resubmission a payload is sent in JSON format to the webhook URL specified by the external integrator.\nIt includes
         the permit application ID, which can be used to fetch the complete details of the permit application using the
         `GET/permit_applications/{id}` endpoint.\n\n### Retries:\nIf the webhook does not receive a 200 status response
         from the external integrator, it will attempt to resend the notification up to 8 times using an exponential backoff
@@ -157,7 +190,15 @@ in this document.
               submitted_at: {
                 type: :number,
                 format: :int64, # Indicates that it's an integer representing time in milliseconds since epoch
-                description: "Datetime in milliseconds since the epoch (Unix time)",
+                description:
+                  "Datetime in milliseconds since the epoch (Unix time). This is the timestamp when the permit application was first submitted.",
+              },
+              resubmitted_at: {
+                type: :number,
+                format: :int64, # Indicates that it's an integer representing time in milliseconds since epoch
+                description:
+                  "Datetime in milliseconds since the epoch (Unix time). This is the timestamp when the permit application was last resubmitted due to a revision request. Note: there might be multiple resubmissions for a permit application, but this date is the last resubmission date.",
+                nullable: true,
               },
               permit_classifications: {
                 type: :string,
@@ -192,7 +233,8 @@ in this document.
           },
           SubmissionData: {
             type: :object,
-            description: "The submitted permit application data. Note: the keys are the requirement block codes.",
+            description:
+              "The submitted permit application data. This will reflect the most recent submitted data in case of resubmission. Note: the keys are the requirement block codes.",
             additionalProperties: {
               type: :object,
               properties: {
@@ -481,7 +523,7 @@ in this document.
             properties: {
               event: {
                 type: :string,
-                enum: %w[permit_submitted],
+                enum: %w[permit_submitted permit_resubmitted],
                 description: "The event type.",
               },
               payload: {
@@ -495,7 +537,7 @@ in this document.
                     type: :integer,
                     format: "int64",
                     description:
-                      "The timestamp of when the permit application was submitted. This is in milliseconds since the epoch (UNIX time).",
+                      "The timestamp of when the permit application was submitted or resubmitted. This is in milliseconds since the epoch (UNIX time).",
                   },
                 },
               },

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -5,38 +5,43 @@ info:
   version: v1
   description: "### API documentation overview\nThis document provides detailed information
     about the APIs available for external integrators to query and retrieve submitted
-    permit applications.\nIt also includes specifications on webhook events that notify
-    your systems in real-time.\n\n### Data scope:\nThe permit applications returned
-    by these APIs are limited to those within the jurisdiction associated with the
-    API key used for the request. This\nensures that each integrator has access solely
-    to relevant data.\n\n### Integration steps:\nTo integrate with our APIs, please
-    contact the Building Permit Hub team to enable your API access. Your local jurisdiction
-    can then obtain the API key\nand register your webhook URL in their configuration
-    settings on the building permit hub. You can reach us directly at <digital.codes.permits@gov.bc.ca>\nfor
-    further assistance.\n\n### Authentication and authorization: \nAccess to these
-    APIs is controlled via an API key, which must be included in the Authorization
-    header as a Bearer token like so:\n```\nAuthorization: Bearer {Your_API_Key_Here}\n```\nPlease
-    note that a unique API key is required for each jurisdiction you wish to access,
-    enhancing security and data integrity.\n\n### Rate limits:\nTo ensure fair usage,
-    the API is rate-limited to 100 requests per minute per API key and 300 requests
-    per IP in a 3 minute interval. Exceeding these\nlimits will result in a 429 response.
-    If this occurs, we recommend spacing out your requests. Continued exceeding of
-    rate limits\nmay necessitate further contact with the building permit hub team.\n\n###
-    Api base path:\nThe base path for all API endpoints is `/external_api/v1`.\n\n###
-    Server information for testing:\nBy default the requests from the documentation
-    will be sent to the current environment servers. For testing purposes, you can
-    specify a different server using the {serverUrl} variable. \nDuring your integration
-    testing phase, you have the flexibility to use custom URLs by configuring the
-    serverUrl variable. This allows you to\ntailor the API environment to better suit
-    your development needs. Ensure that your custom URLs are configured correctly
-    to avoid any connectivity or data access issues.\n\n### Special considerations:\nFor
-    security purposes, any API response that includes a file URL will have a signed
-    URL. These files will be available for download for a limited time (1 hour).\nWe
-    recommend downloading the file immediately upon receiving the URL to avoid any
-    issues. If necessary, you can always call the API again to retrieve a \nnew file
-    URL.\n\n### Visual aids and examples:\nFor a better understanding of how our APIs
-    work, including webhook setups and request handling, please refer to the code
-    examples included later\nin this document.\n"
+    and resubmitted permit applications.\nIt also includes specifications on webhook
+    events that notify your systems in real-time.\n\n### Data scope:\nThe permit applications
+    returned by these APIs are limited to those within the jurisdiction associated
+    with the API key used for the request. This\nensures that each integrator has
+    access solely to relevant data.\n\n### Integration steps:\nTo integrate with our
+    APIs, please contact the Building Permit Hub team to enable your API access. Your
+    local jurisdiction can then obtain the API key\nand register your webhook URL
+    in their configuration settings on the building permit hub. You can reach us directly
+    at <digital.codes.permits@gov.bc.ca>\nfor further assistance.\n\n### Authentication
+    and authorization:\nAccess to these APIs is controlled via an API key, which must
+    be included in the Authorization header as a Bearer token like so:\n```\nAuthorization:
+    Bearer {Your_API_Key_Here}\n```\nPlease note that a unique API key is required
+    for each jurisdiction you wish to access, enhancing security and data integrity.\n\n###
+    Rate limits:\nTo ensure fair usage, the API is rate-limited to 100 requests per
+    minute per API key and 300 requests per IP in a 3 minute interval. Exceeding these\nlimits
+    will result in a 429 response. If this occurs, we recommend spacing out your requests.
+    Continued exceeding of rate limits\nmay necessitate further contact with the building
+    permit hub team.\n\n### Api base path:\nThe base path for all API endpoints is
+    `/external_api/v1`.\n\n### Server information for testing:\nBy default the requests
+    from the documentation will be sent to the current environment servers. For testing
+    purposes, you can specify a different server using the {serverUrl} variable.\nDuring
+    your integration testing phase, you have the flexibility to use custom URLs by
+    configuring the serverUrl variable. This allows you to\ntailor the API environment
+    to better suit your development needs. Ensure that your custom URLs are configured
+    correctly to avoid any connectivity or data access issues.\n\n### Special considerations:\nA
+    returned permit application will have a status of either `newly_submitted` for
+    permit applications submitted for the first time, or `resubmitted` for\npermit
+    applications that have been resubmitted due to revision requests. The `resubmitted_at`
+    field will indicate the timestamp of the latest resubmission.\nWhile there may
+    be multiple resubmissions, the submission data payload returned will reflect the
+    most recent submission data. \n\nFor security purposes, any API response that
+    includes a file URL will have a signed URL. These files will be available for
+    download for a limited time (1 hour).\nWe recommend downloading the file immediately
+    upon receiving the URL to avoid any issues. If necessary, you can always call
+    the API again to retrieve a\nnew file URL.\n\n### Visual aids and examples:\nFor
+    a better understanding of how our APIs work, including webhook setups and request
+    handling, please refer to the code examples included later\nin this document.\n"
 webhooks:
   permit_submitted:
     tags:
@@ -47,6 +52,36 @@ webhooks:
           ### Request body:
           This webhook sends information about a recently submitted permit
                   application in a JSON format to the webhook URL specified by the external integrator.
+          It includes
+                  the permit application ID, which can be used to fetch the complete details of the permit application using the
+                  `GET/permit_applications/{id}` endpoint.
+
+          ### Retries:
+          If the webhook does not receive a 200 status response
+                  from the external integrator, it will attempt to resend the notification up to 8 times using an exponential backoff
+                  strategy. This ensures multiple attempts to deliver the webhook in case of temporary issues on the receiving end.
+
+
+          ### Expected responses:
+          The external integrator is expected to return a 200 status code to confirm successful receipt
+                  of the data. This acknowledgment indicates that the payload was received and processed without issues
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/WebhookPayload"
+      responses:
+        '200':
+          description: The external integrator should return a 200 status to indicate
+            that the data was received successfully.
+  permit_resubmitted:
+    tags:
+    - Webhooks
+    post:
+      requestBody:
+        description: |-
+          ### Request body:
+          This webhook sends information about a recently resubmitted permit
+                  application. A permit can be resubmitted due to revision requests. After resubmission a payload is sent in JSON format to the webhook URL specified by the external integrator.
           It includes
                   the permit application ID, which can be used to fetch the complete details of the permit application using the
                   `GET/permit_applications/{id}` endpoint.
@@ -121,15 +156,24 @@ paths:
           application/json:
             schema:
               type: object
-              description: Filters permit applications by submitted date and permit
-                classifications
+              description: Filters permit applications by status, submitted date,
+                resubmitted_date and permit classifications
               properties:
                 permit_classifications:
                   description: Filters by permit classifications
                   type: string
+                status:
+                  type: string
+                  enum:
+                  - newly_submitted
+                  - resubmitted
+                  description: 'Filters by submitted status. Newly submitted: permit
+                    applications submitted for the first time. Resubmitted: permit
+                    applications resubmitted after a revision request.'
                 submitted_at:
                   type: object
-                  description: Filters by submitted date
+                  description: Filters by submitted date. This is the date the permit
+                    application was first submitted. Example format `2024-04-30T13:22:41-07:00`
                   properties:
                     gt:
                       type: string
@@ -149,6 +193,31 @@ paths:
                       type: string
                       format: date-time
                       description: 'Less than or equal to: submitted date is less
+                        than or equal to this date'
+                resubmitted_at:
+                  type: object
+                  description: Filters by resubmitted date. This is the date the permit
+                    application was most recently resubmitted. Example format `2024-04-30T13:22:41-07:00`
+                  properties:
+                    gt:
+                      type: string
+                      format: date-time
+                      description: 'Greater than: resubmitted date is greater than
+                        this date'
+                    lt:
+                      type: string
+                      format: date-time
+                      description: 'Less than: resubmitted date is less than this
+                        date'
+                    gte:
+                      type: string
+                      format: date-time
+                      description: 'Greater than or equal to: resubmitted date is
+                        greater than or equal to this date'
+                    lte:
+                      type: string
+                      format: date-time
+                      description: 'Less than or equal to: resubmitted date is less
                         than or equal to this date'
   "/permit_applications/{id}":
     get:
@@ -271,7 +340,16 @@ components:
         submitted_at:
           type: number
           format: int64
-          description: Datetime in milliseconds since the epoch (Unix time)
+          description: Datetime in milliseconds since the epoch (Unix time). This
+            is the timestamp when the permit application was first submitted.
+        resubmitted_at:
+          type: number
+          format: int64
+          description: 'Datetime in milliseconds since the epoch (Unix time). This
+            is the timestamp when the permit application was last resubmitted due
+            to a revision request. Note: there might be multiple resubmissions for
+            a permit application, but this date is the last resubmission date.'
+          nullable: true
         permit_classifications:
           type: string
           description: This is the combined permit type and activity (work) type of
@@ -296,8 +374,9 @@ components:
           nullable: true
     SubmissionData:
       type: object
-      description: 'The submitted permit application data. Note: the keys are the
-        requirement block codes.'
+      description: 'The submitted permit application data. This will reflect the most
+        recent submitted data in case of resubmission. Note: the keys are the requirement
+        block codes.'
       additionalProperties:
         type: object
         properties:
@@ -352,6 +431,7 @@ components:
                   - energy_step_code
                   - general_contact
                   - professional_contact
+                  - pid_info
                   description: The input type for this requirement.
                 value:
                   description: The submitted value for this requirement.
@@ -553,6 +633,7 @@ components:
           type: string
           enum:
           - permit_submitted
+          - permit_resubmitted
           description: The event type.
         payload:
           type: object
@@ -563,8 +644,8 @@ components:
             submitted_at:
               type: integer
               format: int64
-              description: The timestamp of when the permit application was submitted.
-                This is in milliseconds since the epoch (UNIX time).
+              description: The timestamp of when the permit application was submitted
+                or resubmitted. This is in milliseconds since the epoch (UNIX time).
 formats:
 - json
 - yaml


### PR DESCRIPTION
## Description
- External API changes implemented due to revision feature:
  - The permit application payload is mostly the same. We send the submitted data of the most recent submission (in case of resubmission)
  - Permit application status now is an enum, with newly_submitted and resubmitted
  - A resubmitted_at date has been added to indicate the most recent resubmission date
  - The search endpoint has been updated
     - A status filter has been added to filter permit applications to retrieve resubmitted permit applications.
     - A resubmitted_at filter has been added to filter permit applications by their latest resubmission date.
  - A new webhook event is sent on resubmission called `permit_resubmitted`
  - External API swagger docs have been updated with the latest documentation for the above changes
- New user preference has been added for API integration mapping notifications/emails 
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1509
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA
- Ensure db and data migrations are run
- For external API changes, visit `/integrations/api_docs/` to view updated docs and see the endpoints and webhook events
- For user preference, go to the user profile
![Screenshot 2024-08-23 at 4 22 02 PM](https://github.com/user-attachments/assets/dc19660f-49ca-4aab-8511-fad79cdbb5a5)


 

