### PR TITLE
[bphh-1995] Fixed bug with collaborator assignment popover not closing on blur after a collaborator has been assigned

### DIFF
--- a/app/frontend/components/domains/permit-application/collaborator-management/collaborator-assignment-popover.tsx
+++ b/app/frontend/components/domains/permit-application/collaborator-management/collaborator-assignment-popover.tsx
@@ -76,6 +76,10 @@ export const CollaboratorAssignmentPopover = observer(function AssignmentPopover
     }
   }, [isOpen])
 
+  useEffect(() => {
+    contentRef?.current?.focus()
+  }, [currentScreen])
+
   const onPopoverClose = () => {
     if (openAssignmentConfirmationModals.size > 0 || createConfirmationModalDisclosureProps.isOpen) {
       return
@@ -91,6 +95,9 @@ export const CollaboratorAssignmentPopover = observer(function AssignmentPopover
     setOpenAssignmentConfirmationModals((prev) => {
       const newSet = new Set([...prev])
       newSet.delete(collaboratorId)
+
+      contentRef.current?.focus()
+
       return newSet
     })
   }
@@ -130,7 +137,17 @@ export const CollaboratorAssignmentPopover = observer(function AssignmentPopover
               transitionToAssign={
                 canManage ? () => changeScreen(EAssignmentPopoverScreen.collaborationAssignment) : undefined
               }
-              onUnassign={canManage ? permitApplication.unassignPermitCollaboration : undefined}
+              onUnassign={
+                canManage
+                  ? async (permitCollaborationId) => {
+                      try {
+                        await permitApplication.unassignPermitCollaboration(permitCollaborationId)
+                      } finally {
+                        contentRef.current?.focus()
+                      }
+                    }
+                  : undefined
+              }
               onReinvite={permitApplication.reinvitePermitCollaboration}
             />
           )}

--- a/app/frontend/components/domains/permit-application/collaborator-management/collaborator-invite-popover-content.tsx
+++ b/app/frontend/components/domains/permit-application/collaborator-management/collaborator-invite-popover-content.tsx
@@ -41,6 +41,9 @@ export const CollaboratorInvite = observer(function CollaboratorCreate({
 
   const onSubmit = handleSubmit(async (values) => {
     const response = await onInvite?.(values)
+
+    confirmationModalDisclosureProps?.onClose?.()
+
     response && onInviteSuccess()
   })
 


### PR DESCRIPTION
## Description
[bphh-1995] Fixed bug with collaborator assignment popover not closing on blur after a collaborator has been assigned
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1995
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA


https://github.com/user-attachments/assets/e44b245b-a692-4db0-a9d9-ab16cd997207






