### PR TITLE
[bphh-1800] Fix bug with url embedding on a re block from edit template page causing the modal to close preventing ability to save

### DIFF
--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
@@ -184,7 +184,14 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
         <Modal onClose={handleClose} isOpen>
           <ModalOverlay />
           <FormProvider {...formProps}>
-            <ModalContent as={"form"} w={"min(1170px, 95%)"} maxW={"full"} py={9} pb={12}>
+            <ModalContent
+              as={"form"}
+              w={"min(1170px, 95%)"}
+              maxW={"full"}
+              py={9}
+              pb={12}
+              onClick={(e) => e.stopPropagation()}
+            >
               <ModalCloseButton fontSize={"11px"} />
               {(requirementBlock as IRequirementBlock)?.isDiscarded && (
                 <Tag


### PR DESCRIPTION
## Description
[bphh-1800] Fix bug with URL embedding on a req block from the edit template page, causing the modal to close, preventing the ability to save

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-1800
<!--
Please use this format to link: Implements/Fixes Story/Issue [story_id](story_link).
-->

## Steps to QA

https://github.com/user-attachments/assets/08acc0e7-26cd-43f5-a0fe-b384079025d0
