### PR TITLE
prevent request forgery by validating wkid as integer

### DIFF
--- a/app/services/wrappers/ltsa_parcel_map_bc.rb
+++ b/app/services/wrappers/ltsa_parcel_map_bc.rb
@@ -195,6 +195,7 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
           'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]',
       )
     else
+      raise StandardError unless wkid.is_a?(Integer)
       #fetch the proj4 string from website
       espg = Faraday.new("https://epsg.io")
       response_proj4 = espg.get("#{wkid}.proj4")


### PR DESCRIPTION
## Description


prevent request forgery by validating wkid as integer

Fix for security issues:

https://github.com/bcgov/HOUS-permit-portal/security/code-scanning/15
https://github.com/bcgov/HOUS-permit-portal/security/code-scanning/16