### PR TITLE
fix handlers on editable

### DIFF
--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -285,7 +285,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
                             },
                           }),
 
-                          onBlur: () => {
+                          onSubmit: () => {
                             handleSave()
                           },
                           "aria-label": "Edit Nickname",

--- a/app/frontend/components/shared/editable-input-with-controls.tsx
+++ b/app/frontend/components/shared/editable-input-with-controls.tsx
@@ -72,7 +72,7 @@ function EditableControls({
         <Button {...getSubmitButtonProps()} variant={"primary"} {...saveButtonProps}>
           {saveTextContent}
         </Button>
-        <Button {...getCancelButtonProps()} variant={"secondary"} {...cancelButtonProps}>
+        <Button {...getCancelButtonProps()} variant={"primaryInverse"} {...cancelButtonProps}>
           {cancelTextContent}
         </Button>
       </ButtonGroup>
@@ -137,13 +137,14 @@ export const EditableInputWithControls = observer(function EditableInputWithCont
         setIsInEditMode(false)
         onCancel?.(previousValue)
       }}
-      onBlur={(e) => {
+      onBlur={(value) => {
         setIsInEditMode(false)
-        onBlur?.(e)
+        onBlur?.(value)
       }}
-      onSubmit={(e) => {
+      onSubmit={(value) => {
         setIsInEditMode(false)
-        editableProps.onSubmit?.(e)
+        // @ts-ignore
+        editableInputProps.onSubmit?.(value)
       }}
       {...editableProps}
     >


### PR DESCRIPTION
## Description

Editable was using the wrong prop for onSubmit, and edit forms use should provide to said callback.
Also fix variable naming and color (as black button does not show up on blue background)

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-2039