### PR TITLE
CSRF Fixes for the resetting of CSRF token

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,12 +1,7 @@
 class Api::ApplicationController < ActionController::API
-  include ActionController::Cookies
-  include ActionController::RequestForgeryProtection
   include BaseControllerMethods
   include Pundit::Authorization
 
-  protect_from_forgery with: :exception
-
-  before_action :log_csrf_token
   before_action :authenticate_user!
   before_action :check_for_archived_user
   before_action :store_currents
@@ -16,28 +11,11 @@ class Api::ApplicationController < ActionController::API
 
   after_action :verify_authorized, except: %i[index], unless: :skip_pundit?
   after_action :verify_policy_scoped, only: %i[index], unless: :skip_pundit?
-  after_action :set_csrf_cookie
 
   def index
     # This parent application controller throws errors from above after_actions
     # if the subclass does not implement this method. This is provided as a fallback.
     raise NotImplementedError, "The index method is not implemented."
-  end
-
-  private
-
-  def set_csrf_cookie
-    cookies["CSRF-TOKEN"] = {
-      value: form_authenticity_token,
-      secure: Rails.env.production?,
-      httponly: false, # Allow frontend to read the cookie
-      same_site: :lax,
-    }
-  end
-
-  def log_csrf_token
-    Rails.logger.debug "Session CSRF Token: #{session[:_csrf_token]}"
-    Rails.logger.debug "Request CSRF Token: #{request.headers["X-CSRF-Token"]}"
   end
 
   protected

--- a/app/controllers/api/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/omniauth_callbacks_controller.rb
@@ -12,6 +12,7 @@ class Api::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if @user&.valid? && @user&.persisted?
       sign_in(resource_name, @user, store: false)
+      request.reset_csrf_token # explicitly reset the CSRF token here for CSRF Fixation protection (we are not using Devise's config.clean_up_csrf_token_on_authentication because it is causing issues)
       redirect_to root_path
     else
       redirect_to login_path(

--- a/app/controllers/concerns/base_controller_methods.rb
+++ b/app/controllers/concerns/base_controller_methods.rb
@@ -5,8 +5,6 @@ module BaseControllerMethods
     include ActionController::Cookies
     include ActionController::RequestForgeryProtection
 
-    before_action :log_csrf_token
-
     protect_from_forgery with: :exception
     after_action :set_csrf_cookie
   end
@@ -89,10 +87,7 @@ module BaseControllerMethods
     }
   end
 
-  def log_csrf_token
-    Rails.logger.debug "Session CSRF Token: #{session[:_csrf_token]}"
-    Rails.logger.debug "Request CSRF Token: #{request.headers["X-CSRF-Token"]}"
-  end
+  private
 
   def default_meta(message)
     meta = {}

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -136,7 +136,7 @@ Devise.setup do |config|
   # avoid CSRF token fixation attacks. This means that, when using AJAX
   # requests for sign in and sign up, you need to get a new CSRF token
   # from the server. You can disable this option at your own risk.
-  # config.clean_up_csrf_token_on_authentication = true
+  config.clean_up_csrf_token_on_authentication = false
 
   # When false, Devise will not attempt to reload routes on eager load.
   # This can reduce the time taken to boot the app but if your application


### PR DESCRIPTION
## Description

This fixes issues with the CSRF changes in the last patch.
After some debugging, the root of the problem stemmed from two things:

1. We were not including the `set_csrf_cookie` in all controller actions, as such I've moved this into the `BaseControllerMethods` concern so that it will get mixed in accordingly

2. We were having issues with Devise resetting the CSRF cookie, so we've turned that off for now. After some exploration, CSRF fixation shouldn't be a huge issue here since we are using the omniauth controller for handling the signin flow rather than session_controller in Devise. In the `keycloak` function I've added an explicit call to `reset_csrf_token` (and subsequently the controller `after_action` mixin will set the new CSRF cookie for the frontend). This is done because we turned Devise's built in hooks off (`config.clean_up_csrf_token_on_authentication = false`). This should be sufficient to reset the CSRF token and prevent CSRF fixation attacks whilst still keeping the protections we had in place

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

