### PR TITLE
update matching on permit applications

### DIFF
--- a/app/controllers/api/concerns/search/permit_applications.rb
+++ b/app/controllers/api/concerns/search/permit_applications.rb
@@ -5,6 +5,15 @@ module Api::Concerns::Search::PermitApplications
     search_conditions = {
       order: permit_application_order,
       match: :word_start,
+      fields: [
+        { number: :text_end },
+        { nickname: :word_middle },
+        { full_address: :word_middle },
+        { permit_classifications: :word_middle },
+        { submitter: :word_middle },
+        { status: :word_middle },
+        { review_delegatee_name: :word_middle },
+      ],
       where: permit_application_where_clause,
       page: permit_application_search_params[:page],
       per_page:

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -7,8 +7,8 @@ class PermitApplication < ApplicationRecord
 
   SEARCH_INCLUDES = %i[permit_type submission_versions step_code activity jurisdiction submitter permit_collaborations]
 
-  searchkick searchable: %i[number nickname full_address permit_classifications submitter status review_delegatee_name],
-             word_start: %i[number nickname full_address permit_classifications submitter status review_delegatee_name]
+  searchkick word_middle: %i[nickname full_address permit_classifications submitter status review_delegatee_name],
+             text_end: %i[number]
 
   belongs_to :submitter, class_name: "User"
   belongs_to :jurisdiction

--- a/db/data/20240828183220_reindex_permit_application_for_new_matching.rb
+++ b/db/data/20240828183220_reindex_permit_application_for_new_matching.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ReindexPermitApplicationForNewMatching < ActiveRecord::Migration[7.1]
+  def up
+    PermitApplication.reindex
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## Description

Update fields on permit application search to use different kinds of matching. Now follows searchkick >5.3 docs.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-2038
