### PR TITLE
[HOTFIX] Skip csrf protection in external api controller as it's api only and does not require it

### DIFF
--- a/app/controllers/external_api/application_controller.rb
+++ b/app/controllers/external_api/application_controller.rb
@@ -10,6 +10,9 @@ class ExternalApi::ApplicationController < ActionController::API
 
   rescue_from Pundit::NotAuthorizedError, with: :external_api_key_not_authorized
 
+  # skip because this is API only controller, not connecting to any SPA
+  skip_forgery_protection
+
   def pundit_user
     current_external_api_key
   end


### PR DESCRIPTION
## Description
[HOTFIX] Skip csrf protection in external api controller as it's api only and does not require it
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
