### PR TITLE
fix help link, new pa spacing, and email input validation

### DIFF
--- a/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
@@ -299,9 +299,9 @@ const DisclaimerInfo = () => {
       p="6"
     >
       <Text fontWeight="bold">{t("permitApplication.new.applicationDisclaimerInstruction")}</Text>
-      <Flex align="center" mt={6} flexDirection={{ base: "column", md: "row" }}>
+      <Flex align="center" my={3} flexDirection={{ base: "column", md: "row" }}>
         <Box w={{ base: "100%", md: "40%" }}>
-          <UnorderedList ml="0" mt="4">
+          <UnorderedList ml="0">
             {applicationDisclaimers.map((disclaimer) => {
               return (
                 <ListItem key={disclaimer.href}>

--- a/app/frontend/components/shared/form/email-form-control.tsx
+++ b/app/frontend/components/shared/form/email-form-control.tsx
@@ -81,7 +81,8 @@ export const EmailFormControl = ({
               register(fieldName, {
                 required: required && t("ui.isRequired", { field: t("auth.emailLabel") }),
                 validate: {
-                  matchesEmailRegex: (str) => !validate || !required || EMAIL_REGEX.test(str) || t("ui.invalidEmail"),
+                  matchesEmailRegex: (str) =>
+                    !validate || (!required && !str) || EMAIL_REGEX.test(str) || t("ui.invalidEmail"),
                 },
               }))}
             bg="greys.white"

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -481,7 +481,7 @@ const options = {
           viewedOn: "Viewed on",
           seeBestPractices_CTA: "See best practices",
           seeBestPractices_link:
-            "https://www2.gov.bc.ca/gov/content/housing-tenancy/building-or-renovating/permits/building-permit-hub-best-practices",
+            "https://www2.gov.bc.ca/gov/content/housing-tenancy/building-or-renovating/permits/building-permit-hub#practices",
           searchKnowledge_CTA: "Ask a question",
           searchKnowledge_link:
             "https://www2.gov.bc.ca/gov/content/housing-tenancy/building-or-renovating/permits/building-permit-hub-search",


### PR DESCRIPTION
## Description

A few improvements:
- the y padding on the list in the new permit application screen seemed off
- Best practices link on each permit application card went nowhere
- Email validation wasnt working correctly when the email field is not required, causing a submit failure and form reset
