### PR TITLE
Robots.txt CSRF error message prevention

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,4 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
+User-agent: *
+Disallow: /api/


### PR DESCRIPTION
Tell webcrawlers not to post to the api endpoint because csrf will stop them anyway

## Description

Prevent webcrawlers from triggering errors on our /api endpoints

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ x] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-2092
