### PR TITLE
Chore/bphh 2106/block upgrades

### DIFF
--- a/app/frontend/components/domains/requirements-library/block-setup-options-menu.tsx
+++ b/app/frontend/components/domains/requirements-library/block-setup-options-menu.tsx
@@ -1,28 +1,32 @@
-import { Button, Menu, MenuButton, MenuList } from "@chakra-ui/react"
-import { Archive, CaretDown, ClockClockwise } from "@phosphor-icons/react"
+import { Button, Divider, Menu, MenuButton, MenuList } from "@chakra-ui/react"
+import { Archive, CaretDown, ClockClockwise, Copy } from "@phosphor-icons/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
 import React from "react"
-import { ISearch } from "../../../lib/create-search-model"
 import { IRequirementBlock } from "../../../models/requirement-block"
+import { useMst } from "../../../setup/root"
 import { ManageMenuItemButton } from "../../shared/base/manage-menu-item"
 import { RemoveConfirmationModal } from "../../shared/modals/remove-confirmation-modal"
 
-interface IProps<TSearchModel extends ISearch> {
+interface IBlockSetupOptionsMenuProps {
   requirementBlock: IRequirementBlock
-  searchModel?: TSearchModel
 }
 
-export const BlockSetupOptionsMenu = observer(function BlockSetupOptionsMenu<TSearchModel extends ISearch>({
+export const BlockSetupOptionsMenu = observer(function BlockSetupOptionsMenu({
   requirementBlock,
-  searchModel,
-}: IProps<TSearchModel>) {
+}: IBlockSetupOptionsMenuProps) {
+  const { requirementBlockStore } = useMst()
+
   const handleRemove = async () => {
-    if (await requirementBlock.destroy()) searchModel?.search()
+    if (await requirementBlock.destroy()) requirementBlockStore?.search()
   }
 
   const handleRestore = async () => {
-    if (await requirementBlock.restore()) searchModel?.search()
+    if (await requirementBlock.restore()) requirementBlockStore?.search()
+  }
+
+  const handleCopy = async () => {
+    if (await requirementBlockStore.copyRequirementBlock(requirementBlock)) requirementBlockStore?.search()
   }
 
   return (
@@ -42,6 +46,10 @@ export const BlockSetupOptionsMenu = observer(function BlockSetupOptionsMenu<TSe
       </MenuButton>
 
       <MenuList>
+        <ManageMenuItemButton onClick={handleCopy} leftIcon={<Copy size={16} />}>
+          {t("requirementsLibrary.modals.edit.copy")}
+        </ManageMenuItemButton>
+        <Divider color="border.light" />
         {requirementBlock.isDiscarded ? (
           <ManageMenuItemButton
             color="semantic.success"

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/block-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/block-setup.tsx
@@ -139,9 +139,7 @@ export const BlockSetup = observer(function BlockSetup({
             {t("requirementsLibrary.fieldDescriptions.requirementSku")}
           </FormHelperText>
         </FormControl>
-        {requirementBlock && withOptionsMenu && (
-          <BlockSetupOptionsMenu requirementBlock={requirementBlock} searchModel={requirementBlockStore} />
-        )}
+        {requirementBlock && withOptionsMenu && <BlockSetupOptionsMenu requirementBlock={requirementBlock} />}
       </VStack>
     </Box>
   )

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -232,6 +232,7 @@ const options = {
           acknowledgeAndDismiss: "Acknowledge and dismiss",
           markedForRemoval: 'Click "Save changes" to confirm removal',
           proceed: "Proceed",
+          copyNoun: "Copy",
         },
         notification: {
           title: "Notifications",
@@ -669,6 +670,7 @@ const options = {
             edit: {
               title: "Edit requirement block",
               options: "Options",
+              copy: "Copy this block",
               removeConfirmationModal: {
                 title: "Confirm you want to archive this requirement block.",
                 body: "Archiving this requirement blocks will remove it from all draft templates. This action cannot be undone.",

--- a/app/frontend/stores/requirement-block-store.ts
+++ b/app/frontend/stores/requirement-block-store.ts
@@ -4,7 +4,7 @@ import { createSearchModel } from "../lib/create-search-model"
 import { withEnvironment } from "../lib/with-environment"
 import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
-import { RequirementBlockModel } from "../models/requirement-block"
+import { IRequirementBlock, RequirementBlockModel } from "../models/requirement-block"
 import { IRequirementBlockParams } from "../types/api-request"
 import {
   EAutoComplianceModule,
@@ -136,11 +136,9 @@ export const RequirementBlockStoreModel = types
 
         // Get latest data for current page, sort and filters
         yield self.fetchRequirementBlocks()
-
-        return true
       }
 
-      return false
+      return response.ok
     }),
     searchAssociations: flow(function* (query: string) {
       const response = yield* toGenerator(
@@ -168,6 +166,22 @@ export const RequirementBlockStoreModel = types
       self.isAutoComplianceModuleOptionsLoading = false
 
       return self.autoComplianceModuleConfigurations
+    }),
+  }))
+  .actions((self) => ({
+    copyRequirementBlock: flow(function* (requirementBlock: IRequirementBlock) {
+      const { id, requirements, ...copyableRequirementsAttributes } = requirementBlock
+
+      const clonedParams: IRequirementBlockParams = {
+        ...copyableRequirementsAttributes,
+        requirementsAttributes: requirementBlock.requirements?.map((attr) => {
+          const { id, ...rest } = attr
+          return rest
+        }),
+        name: `${requirementBlock.name} ${t("ui.copyNoun")}`,
+      }
+
+      return yield self.createRequirementBlock(clonedParams)
     }),
   }))
 

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -5,9 +5,24 @@ class PermitApplication < ApplicationRecord
   include ZipfileUploader.Attachment(:zipfile)
   include PermitApplicationStatus
 
-  SEARCH_INCLUDES = %i[permit_type submission_versions step_code activity jurisdiction submitter permit_collaborations]
+  SEARCH_INCLUDES = %i[
+    permit_type
+    submission_versions
+    step_code
+    activity
+    jurisdiction
+    submitter
+    permit_collaborations
+  ]
 
-  searchkick word_middle: %i[nickname full_address permit_classifications submitter status review_delegatee_name],
+  searchkick word_middle: %i[
+               nickname
+               full_address
+               permit_classifications
+               submitter
+               status
+               review_delegatee_name
+             ],
              text_end: %i[number]
 
   belongs_to :submitter, class_name: "User"
@@ -48,16 +63,24 @@ class PermitApplication < ApplicationRecord
 
   after_commit :reindex_jurisdiction_permit_application_size
   after_commit :send_submitted_webhook, if: :saved_change_to_status?
-  after_commit :notify_user_reference_number_updated, if: :saved_change_to_reference_number?
+  after_commit :notify_user_reference_number_updated,
+               if: :saved_change_to_reference_number?
 
-  scope :unviewed, -> { where(status: :submitted, viewed_at: nil).order(submitted_at: :asc) }
+  scope :unviewed,
+        -> do
+          where(status: :submitted, viewed_at: nil).order(submitted_at: :asc)
+        end
 
   COMPLETION_SECTION_KEY = "section-completion-key"
 
-  def supporting_documents_for_submitter_based_on_user_permissions(supporting_documents, user: nil)
+  def supporting_documents_for_submitter_based_on_user_permissions(
+    supporting_documents,
+    user: nil
+  )
     return supporting_documents if user.blank?
 
-    permissions = submission_requirement_block_edit_permissions(user_id: user.id)
+    permissions =
+      submission_requirement_block_edit_permissions(user_id: user.id)
 
     return supporting_documents if permissions == :all
 
@@ -73,17 +96,23 @@ class PermitApplication < ApplicationRecord
   end
 
   def formatted_submission_data(current_user: nil)
-    PermitApplication::SubmissionDataService.new(self).formatted_submission_data(current_user: current_user)
+    PermitApplication::SubmissionDataService.new(
+      self
+    ).formatted_submission_data(current_user: current_user)
   end
 
-  def users_by_collaboration_options(collaboration_type:, collaborator_type: nil, assigned_requirement_block_id: nil)
+  def users_by_collaboration_options(
+    collaboration_type:,
+    collaborator_type: nil,
+    assigned_requirement_block_id: nil
+  )
     base_where_clause = {
       collaborations: {
         permit_collaborations: {
           collaboration_type: collaboration_type,
-          permit_application_id: id,
-        },
-      },
+          permit_application_id: id
+        }
+      }
     }
 
     base_where_clause[:collaborations][:permit_collaborations][
@@ -94,7 +123,10 @@ class PermitApplication < ApplicationRecord
       :assigned_requirement_block_id
     ] = assigned_requirement_block_id if assigned_requirement_block_id.present?
 
-    User.joins(collaborations: :permit_collaborations).where(base_where_clause).distinct
+    User
+      .joins(collaborations: :permit_collaborations)
+      .where(base_where_clause)
+      .distinct
   end
 
   # Helper method to get the latest SubmissionVersion
@@ -112,7 +144,11 @@ class PermitApplication < ApplicationRecord
   end
 
   def form_json(current_user: nil)
-    result = PermitApplication::FormJsonService.new(permit_application: self, current_user:).call
+    result =
+      PermitApplication::FormJsonService.new(
+        permit_application: self,
+        current_user:
+      ).call
     result.form_json
   end
 
@@ -121,14 +157,20 @@ class PermitApplication < ApplicationRecord
     # for development purposes only
 
     current_published_template_version.update(
-      form_json: current_published_template_version.requirement_template.to_form_json,
+      form_json:
+        current_published_template_version.requirement_template.to_form_json
     )
   end
 
-  def update_with_submission_data_merge(permit_application_params:, current_user: nil)
-    PermitApplication::SubmissionDataService.new(self).update_with_submission_data_merge(
+  def update_with_submission_data_merge(
+    permit_application_params:,
+    current_user: nil
+  )
+    PermitApplication::SubmissionDataService.new(
+      self
+    ).update_with_submission_data_merge(
       permit_application_params:,
-      current_user:,
+      current_user:
     )
   end
 
@@ -149,21 +191,37 @@ class PermitApplication < ApplicationRecord
       created_at: created_at,
       using_current_template_version: using_current_template_version,
       user_ids_with_submission_edit_permissions:
-        [submitter.id] + users_by_collaboration_options(collaboration_type: :submission).pluck(:id),
+        [submitter.id] +
+          users_by_collaboration_options(collaboration_type: :submission).pluck(
+            :id
+          ),
       review_delegatee_name:
-        users_by_collaboration_options(collaboration_type: :review, collaborator_type: :delegatee).first&.name,
+        users_by_collaboration_options(
+          collaboration_type: :review,
+          collaborator_type: :delegatee
+        ).first&.name
     }
   end
 
   def collaborator?(user_id:, collaboration_type:, collaborator_type: nil)
-    users_by_collaboration_options(collaboration_type:, collaborator_type:).exists?(id: user_id)
+    users_by_collaboration_options(
+      collaboration_type:,
+      collaborator_type:
+    ).exists?(id: user_id)
   end
 
   def submission_requirement_block_edit_permissions(user_id:)
-    return nil if submitter_id != user_id && !collaborator?(user_id:, collaboration_type: :submission)
+    if submitter_id != user_id &&
+         !collaborator?(user_id:, collaboration_type: :submission)
+      return nil
+    end
 
     if submitter_id == user_id ||
-         collaborator?(user_id:, collaboration_type: :submission, collaborator_type: :delegatee)
+         collaborator?(
+           user_id:,
+           collaboration_type: :submission,
+           collaborator_type: :delegatee
+         )
       return :all
     end
 
@@ -188,7 +246,11 @@ class PermitApplication < ApplicationRecord
 
   def current_published_template_version
     # this will eventually be different, if there is a new version it should notify the user
-    RequirementTemplate.published_requirement_template_version(activity, permit_type, first_nations)
+    RequirementTemplate.published_requirement_template_version(
+      activity,
+      permit_type,
+      first_nations
+    )
   end
 
   def form_customizations
@@ -214,16 +276,25 @@ class PermitApplication < ApplicationRecord
   def notifiable_users
     relevant_collaborators = [submitter]
     designated_submitter =
-      users_by_collaboration_options(collaboration_type: :submission, collaborator_type: :delegatee).first
+      users_by_collaboration_options(
+        collaboration_type: :submission,
+        collaborator_type: :delegatee
+      ).first
 
-    relevant_collaborators << designated_submitter if designated_submitter.present?
+    if designated_submitter.present?
+      relevant_collaborators << designated_submitter
+    end
 
     if submitted?
       relevant_collaborators =
-        relevant_collaborators + jurisdiction.review_managers if jurisdiction.review_managers.present?
+        relevant_collaborators +
+          jurisdiction.review_managers if jurisdiction.review_managers.present?
       relevant_collaborators =
-        relevant_collaborators + jurisdiction.regional_review_managers if jurisdiction.regional_review_managers.present?
-      relevant_collaborators = relevant_collaborators + jurisdiction.reviewers if jurisdiction.reviewers.present?
+        relevant_collaborators +
+          jurisdiction.regional_review_managers if jurisdiction.regional_review_managers.present?
+      relevant_collaborators =
+        relevant_collaborators +
+          jurisdiction.reviewers if jurisdiction.reviewers.present?
     end
 
     relevant_collaborators
@@ -273,19 +344,27 @@ class PermitApplication < ApplicationRecord
   end
 
   def confirmed_permit_type_submission_contacts
-    jurisdiction.permit_type_submission_contacts.where(permit_type: permit_type).where.not(confirmed_at: nil)
+    jurisdiction
+      .permit_type_submission_contacts
+      .where(permit_type: permit_type)
+      .where.not(confirmed_at: nil)
   end
 
   def send_submit_notifications
     # All submission related emails and in-app notifications are handled by this method
     NotificationService.publish_application_submission_event(self)
     confirmed_permit_type_submission_contacts.each do |permit_type_submission_contact|
-      PermitHubMailer.notify_reviewer_application_received(permit_type_submission_contact, self).deliver_later
+      PermitHubMailer.notify_reviewer_application_received(
+        permit_type_submission_contact,
+        self
+      ).deliver_later
     end
   end
 
   def formatted_submission_data_for_external_use
-    ExternalPermitApplicationService.new(self).formatted_submission_data_for_external_use
+    ExternalPermitApplicationService.new(
+      self
+    ).formatted_submission_data_for_external_use
   end
 
   def formatted_raw_h2k_files_for_external_use
@@ -297,7 +376,9 @@ class PermitApplication < ApplicationRecord
 
     jurisdiction
       .active_external_api_keys
-      .where.not(webhook_url: [nil, ""]) # Only send webhooks to keys with a webhook URL
+      .where.not(
+        webhook_url: [nil, ""]
+      ) # Only send webhooks to keys with a webhook URL
       .each do |external_api_key|
         PermitWebhookJob.perform_async(
           external_api_key.id,
@@ -308,7 +389,7 @@ class PermitApplication < ApplicationRecord
               Constants::Webhooks::Events::PermitApplication::PERMIT_RESUBMITTED
             end
           ),
-          id,
+          id
         )
       end
   end
@@ -355,24 +436,27 @@ class PermitApplication < ApplicationRecord
 
     {
       "id" => SecureRandom.uuid,
-      "action_type" => Constants::NotificationActionTypes::APPLICATION_SUBMISSION,
-      "action_text" => "#{I18n.t(i18n_key, number: number, jurisdiction_name: jurisdiction_name)}",
+      "action_type" =>
+        Constants::NotificationActionTypes::APPLICATION_SUBMISSION,
+      "action_text" =>
+        "#{I18n.t(i18n_key, number: number, jurisdiction_name: jurisdiction_name)}",
       "object_data" => {
-        "permit_application_id" => id,
-      },
+        "permit_application_id" => id
+      }
     }
   end
 
   def revisions_request_event_notification_data
     {
       "id" => SecureRandom.uuid,
-      "action_type" => Constants::NotificationActionTypes::APPLICATION_REVISIONS_REQUEST,
+      "action_type" =>
+        Constants::NotificationActionTypes::APPLICATION_REVISIONS_REQUEST,
       "action_text" =>
         "#{I18n.t("notification.permit_application.revisions_request_notification", number: number, jurisdiction_name: jurisdiction_name)}",
       "object_data" => {
         "permit_application_id" => id,
-        "permit_application_number" => number,
-      },
+        "permit_application_number" => number
+      }
     }
   end
 
@@ -383,20 +467,21 @@ class PermitApplication < ApplicationRecord
       "action_text" =>
         "#{I18n.t("notification.permit_application.view_notification", number: number, jurisdiction_name: jurisdiction_name)}",
       "object_data" => {
-        "permit_application_id" => id,
-      },
+        "permit_application_id" => id
+      }
     }
   end
 
   def application_reference_updated_event_notification_data
     {
       "id" => SecureRandom.uuid,
-      "action_type" => Constants::NotificationActionTypes::APPLICATION_REFERENCE_UPDATED,
+      "action_type" =>
+        Constants::NotificationActionTypes::APPLICATION_REFERENCE_UPDATED,
       "action_text" =>
         "#{I18n.t("notification.permit_application.reference_updated_notification", number: number, jurisdiction_name: jurisdiction_name)}",
       "object_data" => {
-        "permit_application_id" => id,
-      },
+        "permit_application_id" => id
+      }
     }
   end
 
@@ -407,7 +492,26 @@ class PermitApplication < ApplicationRecord
   def energy_step_code_required?
     custom_requirements = step_code_requirements.customizations
 
-    custom_requirements.empty? || custom_requirements.any? { |r| r.energy_step_required || r.zero_carbon_step_required }
+    custom_requirements.empty? ||
+      custom_requirements.any? do |r|
+        r.energy_step_required || r.zero_carbon_step_required
+      end
+  end
+
+  def self.count_by_jurisdiction_and_status
+    Jurisdiction.all.map do |j|
+      row =
+        PermitApplication
+          .with_submitter_role
+          .where(jurisdiction: j)
+          .group(:status)
+          .count
+
+      {
+        "draft" => (row["new_draft"] || 0) + (row["revisions_requested"] || 0), # nil defaults to 0
+        "submitted" => (row["newly_submitted"] || 0) + (row["resubmitted"] || 0)
+      }.merge({ name: j.qualified_name })
+    end
   end
 
   private
@@ -417,7 +521,8 @@ class PermitApplication < ApplicationRecord
   end
 
   def assign_default_nickname
-    self.nickname = "#{jurisdiction_qualified_name}: #{full_address || pid || pin || id}" if self.nickname.blank?
+    self.nickname =
+      "#{jurisdiction_qualified_name}: #{full_address || pid || pin || id}" if self.nickname.blank?
   end
 
   def assign_unique_number
@@ -456,7 +561,7 @@ class PermitApplication < ApplicationRecord
           number_prefix,
           new_integer / 1_000_000 % 1000,
           new_integer / 1000 % 1000,
-          new_integer % 1000,
+          new_integer % 1000
         )
     else
       # Start with the initial number if there are no previous numbers
@@ -498,24 +603,37 @@ class PermitApplication < ApplicationRecord
     unless submitter&.submitter?
       errors.add(
         :submitter,
-        I18n.t("activerecord.errors.models.permit_application.attributes.submitter.incorrect_role"),
+        I18n.t(
+          "activerecord.errors.models.permit_application.attributes.submitter.incorrect_role"
+        )
       )
     end
   end
 
   def jurisdiction_has_matching_submission_contact
-    matching_contacts = PermitTypeSubmissionContact.where(jurisdiction: jurisdiction, permit_type: permit_type)
+    matching_contacts =
+      PermitTypeSubmissionContact.where(
+        jurisdiction: jurisdiction,
+        permit_type: permit_type
+      )
     if matching_contacts.empty?
       errors.add(
         :jurisdiction,
-        I18n.t("activerecord.errors.models.permit_application.attributes.jurisdiction.no_contact"),
+        I18n.t(
+          "activerecord.errors.models.permit_application.attributes.jurisdiction.no_contact"
+        )
       )
     end
   end
 
   def pid_or_pin_presence
     if pin.blank? && pid.blank?
-      errors.add(:base, I18n.t("activerecord.errors.models.permit_application.attributes.pid_or_pin"))
+      errors.add(
+        :base,
+        I18n.t(
+          "activerecord.errors.models.permit_application.attributes.pid_or_pin"
+        )
+      )
     end
   end
 end

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -17,7 +17,7 @@ class RequirementBlock < ApplicationRecord
   enum reviewer_role: { any: 0 }, _prefix: true
 
   validates :sku, uniqueness: true, presence: true
-  validates :name, uniqueness: true, presence: true
+  validates :name, presence: true, uniqueness: { scope: :first_nations }
   validates :display_name, presence: true
   validate :validate_step_code_dependencies
   validate :validate_requirements_conditional

--- a/db/migrate/20240920173324_change_block_name_uniqueness_scope.rb
+++ b/db/migrate/20240920173324_change_block_name_uniqueness_scope.rb
@@ -1,0 +1,9 @@
+class ChangeBlockNameUniquenessScope < ActiveRecord::Migration[7.1]
+  def change
+    remove_index "requirement_blocks", name: "index_requirement_blocks_on_name"
+    add_index :requirement_blocks,
+              %i[name first_nations],
+              unique: true,
+              name: "index_requirement_blocks_on_name_and_first_nations"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_12_190655) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_20_173324) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -396,7 +396,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_12_190655) do
     t.boolean "first_nations", default: false
     t.datetime "discarded_at"
     t.index ["discarded_at"], name: "index_requirement_blocks_on_discarded_at"
-    t.index ["name"], name: "index_requirement_blocks_on_name", unique: true
+    t.index %w[name first_nations],
+            name: "index_requirement_blocks_on_name_and_first_nations",
+            unique: true
     t.index ["sku"], name: "index_requirement_blocks_on_sku", unique: true
   end
 


### PR DESCRIPTION
## Description

1. Blocks now can have the same name if they are different first_nation status
2. Add a method for getting useful submission info for permit applications (may be turned into a CSV report at a later date)
3. Add copy block feature

## To test:

Log in as super admin, open requirement blocks, open a block, click options, click copy

Rename the block to the same thing as another one. It should fail if they are both first nations (or both not) and succeed if one is and one isn't.

https://hous-bssb.atlassian.net/browse/BPHH-2107

https://hous-bssb.atlassian.net/browse/BPHH-2106
