### PR TITLE
fix customization sandbox UI and enable promotion

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -47,7 +47,7 @@ class Api::ApplicationController < ActionController::API
   # Method to retrieve the current sandbox ID from request headers
 
   def current_sandbox
-    if current_user.review_staff?
+    if !current_user.submitter?
       @current_sandbox ||= Sandbox.find_by_id(request.headers["X-Sandbox-ID"])
     else
       @current_sandbox = nil

--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -197,9 +197,7 @@ class Api::PermitApplicationsController < Api::ApplicationController
 
   def create
     @permit_application =
-      PermitApplication.build(
-        permit_application_params.to_h.merge(submitter: current_user, sandbox_id: determine_sandbox_id),
-      )
+      PermitApplication.build(permit_application_params.to_h.merge(submitter: current_user, sandbox: current_sandbox))
     authorize @permit_application
     if @permit_application.save
       if !Rails.env.development? || ENV["RUN_COMPLIANCE_ON_SAVE"] == "true"
@@ -339,12 +337,6 @@ class Api::PermitApplicationsController < Api::ApplicationController
   end
 
   private
-
-  def determine_sandbox_id
-    return permit_application_params[:sandbox_id] if current_user.super_admin?
-
-    current_sandbox&.id
-  end
 
   def show_blueprint_view_for(user)
     if params[:review] && user.review_staff?

--- a/app/controllers/api/permit_classifications_controller.rb
+++ b/app/controllers/api/permit_classifications_controller.rb
@@ -11,7 +11,7 @@ class Api::PermitClassificationsController < Api::ApplicationController
         if classification_option_params[:published].present?
           query =
             RequirementTemplate
-              .with_published_version
+              .with_scoped_version(current_sandbox)
               .joins(:permit_type)
               .joins(:activity)
               .where(permit_classifications: { enabled: true })

--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -5,6 +5,7 @@ class Api::TemplateVersionsController < Api::ApplicationController
                 only: %i[
                   show_jurisdiction_template_version_customization
                   create_or_update_jurisdiction_template_version_customization
+                  promote_jurisdiction_template_version_customization
                   show_integration_mapping
                   download_customization_csv
                   download_customization_json
@@ -54,6 +55,26 @@ class Api::TemplateVersionsController < Api::ApplicationController
                        { blueprint: JurisdictionTemplateVersionCustomizationBlueprint }
       else
         render_error "jurisdiction_template_version_customization.update_error",
+                     message_opts: {
+                       error_message: @jurisdiction_template_version_customization.errors.full_messages.join(", "),
+                     }
+      end
+    end
+  end
+
+  def promote_jurisdiction_template_version_customization
+    authorize @template_version, :show?
+
+    authorize @jurisdiction_template_version_customization, policy_class: TemplateVersionPolicy
+
+    # add a db lock in case multiple reviewers are updating this db row
+    @jurisdiction_template_version_customization.with_lock do
+      if @jurisdiction_template_version_customization.promote
+        render_success @jurisdiction_template_version_customization,
+                       "jurisdiction_template_version_customization.promote_success",
+                       { blueprint: JurisdictionTemplateVersionCustomizationBlueprint }
+      else
+        render_error "jurisdiction_template_version_customization.promote_error",
                      message_opts: {
                        error_message: @jurisdiction_template_version_customization.errors.full_messages.join(", "),
                      }

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -130,7 +130,6 @@ export const NavBar = observer(function NavBar() {
                 {t("site.beta")}
               </Text>
               <Spacer />
-              {currentUser?.isReviewStaff && <NavSandboxSelect />}
             </Show>
             <HStack gap={3} w="full" justify="flex-end">
               {!loggedIn && <HelpDrawer />}
@@ -176,6 +175,7 @@ export const NavBar = observer(function NavBar() {
               )}
               <NavBarMenu />
             </HStack>
+            {currentUser?.isReviewStaff && <NavSandboxSelect />}
           </Flex>
         </Container>
       </Box>

--- a/app/frontend/components/domains/navigation/nav-sandbox-select.tsx
+++ b/app/frontend/components/domains/navigation/nav-sandbox-select.tsx
@@ -13,7 +13,7 @@ export const NavSandboxSelect = observer(function NavSandboxSelect() {
 
   return (
     <FormControl display="flex" alignItems="center">
-      <FormLabel htmlFor="sandbox-switch" mb="0" color="white">
+      <FormLabel htmlFor="sandbox-select" mb="0" color="white">
         {t("sandbox.formLabel")}
       </FormLabel>
       <SandboxSelect

--- a/app/frontend/components/domains/permit-application/new-permit-application-sandbox-select.tsx
+++ b/app/frontend/components/domains/permit-application/new-permit-application-sandbox-select.tsx
@@ -1,0 +1,25 @@
+import { observer } from "mobx-react-lite"
+import React, { useEffect } from "react"
+import { useTranslation } from "react-i18next"
+import { useMst } from "../../../setup/root"
+import { IOption } from "../../../types/types"
+import { SandboxSelect } from "../../shared/select/selectors/sandbox-select"
+
+interface INewPermitApplicationSandboxSelectProps {
+  options: IOption[]
+}
+
+export const NewPermitApplicationSandboxSelect = observer(function NavSandboxSelect({
+  options,
+}: INewPermitApplicationSandboxSelectProps) {
+  const { sandboxStore } = useMst()
+  const { currentSandboxId, setCurrentSandboxId, clearSandboxId } = sandboxStore
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    //When the component unmounts, clear the currentSandboxId
+    return () => clearSandboxId()
+  }, [])
+
+  return <SandboxSelect onChange={setCurrentSandboxId} value={currentSandboxId} options={options} />
+})

--- a/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
@@ -30,9 +30,9 @@ import { BackButton } from "../../shared/buttons/back-button"
 import { ActivityList } from "../../shared/permit-classification/activity-list"
 import { PermitTypeRadioSelect } from "../../shared/permit-classification/permit-type-radio-select"
 import { JurisdictionSelect } from "../../shared/select/selectors/jurisdiction-select"
-import { SandboxSelect } from "../../shared/select/selectors/sandbox-select"
 import { SitesSelect } from "../../shared/select/selectors/sites-select"
 import { Can } from "../../shared/user/can"
+import { NewPermitApplicationSandboxSelect } from "./new-permit-application-sandbox-select"
 
 export type TSearchAddressFormData = {
   addressString: string
@@ -66,12 +66,13 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
       sandboxId: null,
     },
   })
-  const { handleSubmit, formState, control, watch, register, setValue } = formMethods
+  const { handleSubmit, formState, control, watch, setValue } = formMethods
   const { isSubmitting } = formState
-  const { permitClassificationStore, permitApplicationStore, geocoderStore, jurisdictionStore } = useMst()
+  const { permitClassificationStore, permitApplicationStore, geocoderStore, jurisdictionStore, sandboxStore } = useMst()
   const { fetchGeocodedJurisdiction, fetchingPids, fetchSiteDetailsFromPid } = geocoderStore
   const { fetchPermitTypeOptions, fetchActivityOptions } = permitClassificationStore
   const { getJurisdictionById } = jurisdictionStore
+  const { currentSandboxId } = sandboxStore
   const navigate = useNavigate()
 
   const [pinMode, setPinMode] = useState(false)
@@ -169,20 +170,7 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
                           {t("permitApplication.new.sandboxIdHeading")}
                         </Heading>
 
-                        <Controller
-                          name="sandboxId"
-                          control={control}
-                          defaultValue={null} // Set a default value if necessary
-                          render={({ field: { onChange, value } }) => (
-                            <FormControl display="flex" alignItems="center">
-                              <FormLabel htmlFor="intoSandbox" mb="0">
-                                {t("permitApplication.new.selectSandboxLabel")}
-                              </FormLabel>
-
-                              <SandboxSelect value={value} onChange={onChange} options={jurisdiction?.sandboxOptions} />
-                            </FormControl>
-                          )}
-                        />
+                        <NewPermitApplicationSandboxSelect options={jurisdiction.sandboxOptions} />
                       </Flex>
                     </Can>
                   )}
@@ -222,7 +210,7 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
                               fetchOptions={() => {
                                 return fetchPermitTypeOptions(true, firstNationsWatch, pidWatch, jurisdiction)
                               }}
-                              dependencyArray={[firstNationsWatch, pidWatch, jurisdictionIdWatch]}
+                              dependencyArray={[firstNationsWatch, pidWatch, jurisdictionIdWatch, currentSandboxId]}
                               onChange={onChange}
                               value={value}
                             />

--- a/app/frontend/components/shared/select/selectors/sandbox-select.tsx
+++ b/app/frontend/components/shared/select/selectors/sandbox-select.tsx
@@ -14,7 +14,13 @@ export const SandboxSelect = observer(function SandboxSelect({ onChange, value, 
   const { t } = useTranslation()
 
   return (
-    <Select aria-label="Select a sandbox" w={56} onChange={(e) => onChange(e.target.value)} value={value || ""}>
+    <Select
+      id="sandbox-select"
+      aria-label="Select a sandbox"
+      w={56}
+      onChange={(e) => onChange(e.target.value)}
+      value={value || ""}
+    >
       <option value={""}>{t("sandbox.live")}</option>
       {options.map((s) => (
         <option key={s.value} value={s.value}>

--- a/app/frontend/hooks/resources/use-jurisdiction-template-version-customization.ts
+++ b/app/frontend/hooks/resources/use-jurisdiction-template-version-customization.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ITemplateVersion } from "../../models/template-version"
+import { useMst } from "../../setup/root"
 
 interface IOptions {
   templateVersion: ITemplateVersion | undefined
@@ -16,6 +17,9 @@ export const useJurisdictionTemplateVersionCustomization = ({
   const jurisdictionTemplateVersionCustomization =
     templateVersion?.getJurisdictionTemplateVersionCustomization(jurisdictionId)
   const [error, setError] = useState<Error | undefined>(undefined)
+  const { sandboxStore } = useMst()
+  const { currentSandbox } = sandboxStore
+
   const { t } = useTranslation()
 
   useEffect(() => {
@@ -29,6 +33,8 @@ export const useJurisdictionTemplateVersionCustomization = ({
           // and we don't want to show an error message in that case
           if (!response.ok && response.status !== 404) {
             setError(new Error(customErrorMessage ?? t("errors.fetchJurisdictionTemplateVersionCustomization")))
+          } else {
+            setError(null)
           }
         } catch (e) {
           setError(
@@ -39,7 +45,7 @@ export const useJurisdictionTemplateVersionCustomization = ({
         }
       })()
     }
-  }, [templateVersion?.id, jurisdictionId])
+  }, [templateVersion?.id, jurisdictionId, currentSandbox?.id])
 
   return { jurisdictionTemplateVersionCustomization, error }
 }

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -137,6 +137,7 @@ const options = {
           delete: "Delete",
           confirmDelete: "Confirm delete",
           confirmation: "Are you sure you want to proceed?",
+          confirmOverwrite: "Are you sure you want to save and overwrite this item?",
           sureDelete: "Are you sure you want to delete this item?",
           disable: "Disable",
           ok: "OK",
@@ -1398,6 +1399,9 @@ const options = {
               copyTips: "Import tips from ({{ templateLabel }})",
               copyElectives: "Import electives from ({{ templateLabel }})",
             },
+            promoteElectives: "Save and promote",
+            promoteElectivesMessage:
+              "This will publish your sandboxed customizations and overwrite your non-sandboxed live electives!",
             clickToWriteDescription: "Click to write description",
             title: "Permit Application Builder",
             dndTitle: "Drag to reorder",

--- a/app/frontend/models/template-version.ts
+++ b/app/frontend/models/template-version.ts
@@ -172,6 +172,22 @@ export const TemplateVersionModel = types
 
       return self.getJurisdictionTemplateVersionCustomization(jurisdictionId)
     }),
+    promoteJurisdictionTemplateVersionCustomization: flow(function* (jurisdictionId: string) {
+      const response = yield* toGenerator(
+        self.environment.api.promoteJurisdictionTemplateVersionCustomization(self.id, jurisdictionId)
+      )
+      if (!response.ok) {
+        return response.ok
+      }
+
+      const customization = response.data.data
+
+      if (customization) {
+        self.setJurisdictionTemplateVersionCustomization(jurisdictionId, customization)
+      }
+
+      return self.getJurisdictionTemplateVersionCustomization(jurisdictionId)
+    }),
     downloadExport: flow(function* (jurisdictionId: string, format: EExportFormat) {
       const jurisdiction = self.rootStore.jurisdictionStore.getJurisdictionById(jurisdictionId)
       const mimeTypes = {

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -517,6 +517,12 @@ export class Api {
     )
   }
 
+  async promoteJurisdictionTemplateVersionCustomization(templateId: string, jurisdictionId: string) {
+    return this.client.post<ApiResponse<IJurisdictionTemplateVersionCustomization>>(
+      `/template_versions/${templateId}/jurisdictions/${jurisdictionId}/jurisdiction_template_version_customization/promote`
+    )
+  }
+
   async unscheduleTemplateVersion(templateId: string) {
     return this.client.post<ApiResponse<ITemplateVersion>>(
       `requirement_templates/template_versions/${templateId}/unschedule`

--- a/app/models/jurisdiction_template_version_customization.rb
+++ b/app/models/jurisdiction_template_version_customization.rb
@@ -86,6 +86,18 @@ class JurisdictionTemplateVersionCustomization < ApplicationRecord
       .count
   end
 
+  def promote
+    # Find or create a record with same jurisdiction_id and template_version_id but with sandbox_id == nil
+    target_record =
+      JurisdictionTemplateVersionCustomization.find_or_create_by(
+        jurisdiction_id: self.jurisdiction_id,
+        template_version_id: self.template_version_id,
+        sandbox_id: nil,
+      )
+    target_record.customizations = self.customizations
+    target_record.save!
+  end
+
   private
 
   def reindex_jurisdiction_templates_used_size

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -22,7 +22,14 @@ class RequirementTemplate < ApplicationRecord
   has_one :published_template_version, -> { where(status: "published") }, class_name: "TemplateVersion"
 
   # Scope to get RequirementTemplates with a published template version
-  scope :with_published_version, -> { joins(:published_template_version) }
+  scope :with_scoped_version,
+        ->(sandbox) do
+          joins(:template_versions).where(
+            template_versions: {
+              status: sandbox&.template_version_status_scope || :published,
+            },
+          )
+        end
 
   after_commit :refresh_search_index, if: :saved_change_to_discarded_at
 

--- a/app/policies/template_version_policy.rb
+++ b/app/policies/template_version_policy.rb
@@ -32,7 +32,11 @@ class TemplateVersionPolicy < ApplicationPolicy
   end
 
   def show_integration_mapping?
-    ((user.review_manager? || user.regional_review_manager?) && user.jurisdictions.find(record&.jurisdiction_id))
+    create_or_update_jurisdiction_template_version_customization?
+  end
+
+  def promote_jurisdiction_template_version_customization?
+    create_or_update_jurisdiction_template_version_customization?
   end
 
   def compare_requirements?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -443,6 +443,7 @@ en:
       create_or_update_permit_block_status_error:
         title: Error
         message: "There was an error updating permit block status"
+
     permit_collaboration:
       destroy_success:
         title: ""
@@ -500,6 +501,12 @@ en:
       update_error:
         title: Error
         message: "Something went wrong updating Jurisdiction Customization"
+      promote_success:
+        title: ""
+        message: "Jurisdiction Template Customization promoted!"
+      promote_error:
+        title: Error
+        message: "Something went wrong promoting Jurisdiction Customization"
     integration_mapping:
       update_success:
         title: ""

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,8 @@ Rails.application.routes.draw do
               to: "template_versions#show_jurisdiction_template_version_customization"
           post "jurisdiction_template_version_customization",
                to: "template_versions#create_or_update_jurisdiction_template_version_customization"
+          post "jurisdiction_template_version_customization/promote",
+               to: "template_versions#promote_jurisdiction_template_version_customization"
           post "copy_jurisdiction_template_version_customization",
                to: "template_versions#copy_jurisdiction_template_version_customization"
           get "download_customization_csv", to: "template_versions#download_customization_csv"


### PR DESCRIPTION
## Description

- Add endpoint and api call for promote customization to live non-sandbox.
- Add confirmation modals for save and promote buttons
- update use-jurisdiction-template-version-customization.ts to handle sandbox changes
- add temporary sandbox ID selector and sandbox requirement template scoping



## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1848
