### PR TITLE
Add aasm state for managing API enablement with role considerations

### DIFF
--- a/app/blueprints/jurisdiction_blueprint.rb
+++ b/app/blueprints/jurisdiction_blueprint.rb
@@ -19,10 +19,12 @@ class JurisdictionBlueprint < Blueprinter::Base
            :map_zoom,
            :regional_district_name,
            :created_at,
-           :updated_at,
-           :external_api_enabled,
-           :submission_inbox_set_up
+           :submission_inbox_set_up,
+           :updated_at
 
+    field :external_api_enabled do |jurisdiction, options|
+      jurisdiction.external_api_enabled?
+    end
     association :contacts, blueprint: ContactBlueprint
     association :permit_type_submission_contacts, blueprint: PermitTypeSubmissionContactBlueprint
     association :permit_type_required_steps, blueprint: PermitTypeRequiredStepBlueprint
@@ -33,6 +35,9 @@ class JurisdictionBlueprint < Blueprinter::Base
   end
 
   view :minimal do
-    fields :qualified_name, :external_api_enabled, :submission_inbox_set_up
+    fields :qualified_name, :submission_inbox_set_up
+    field :external_api_enabled do |jurisdiction, options|
+      jurisdiction.external_api_enabled?
+    end
   end
 end

--- a/app/frontend/components/domains/external-api-key/grid-header.tsx
+++ b/app/frontend/components/domains/external-api-key/grid-header.tsx
@@ -69,22 +69,18 @@ export const GridHeaders = observer(function GridHeaders() {
 })
 
 const ExternalApiEnabledSwitchWithConfirmation = observer(() => {
-  const { jurisdictionStore, userStore } = useMst()
+  const { jurisdictionStore } = useMst()
   const { currentJurisdiction } = jurisdictionStore
-  const { currentUser } = userStore
   const { t } = useTranslation()
 
-  const isDisabled =
-    (currentUser.isReviewManager || currentUser.isRegionalReviewManager) && !currentJurisdiction.externalApiEnabled
   const shouldUseDisableConfirmationModal =
-    !isDisabled && currentJurisdiction.externalApiEnabled && currentJurisdiction.externalApiKeysMap.size > 0
+    currentJurisdiction.externalApiEnabled && currentJurisdiction.externalApiKeysMap.size > 0
 
   return shouldUseDisableConfirmationModal ? (
     <RemoveConfirmationModal
       renderTriggerButton={({ onClick }) => (
         <ExternalApiEnabledSwitch
           externalApiEnabled={currentJurisdiction.externalApiEnabled}
-          isDisabled={isDisabled}
           // @ts-ignore
           onChange={onClick}
         />
@@ -97,7 +93,6 @@ const ExternalApiEnabledSwitchWithConfirmation = observer(() => {
   ) : (
     <ExternalApiEnabledSwitch
       externalApiEnabled={currentJurisdiction.externalApiEnabled}
-      isDisabled={isDisabled}
       onChange={currentJurisdiction.toggleExternalApiEnabled}
     />
   )

--- a/app/frontend/components/domains/external-api-key/index.tsx
+++ b/app/frontend/components/domains/external-api-key/index.tsx
@@ -145,7 +145,7 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
                   target={"_blank"}
                   rel="noopener noreferrer"
                 >
-                  Access the API Documentation
+                  {t("externalApiKey.index.accessDocs")}
                 </Link>
               ),
             }}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1666,6 +1666,7 @@ const options = {
             createExternalApiKey: "Create new API key",
             enabled: "Enabled",
             disabled: "Disabled",
+            accessDocs: "Access the API Documentation",
             table: {
               heading: "API keys",
             },

--- a/app/models/concerns/jurisdiction_external_api_state.rb
+++ b/app/models/concerns/jurisdiction_external_api_state.rb
@@ -1,0 +1,93 @@
+module JurisdictionExternalApiState
+  extend ActiveSupport::Concern
+  included do
+    enum external_api_state: { g_off: "g_off", j_on: "j_on", j_off: "j_off" }
+
+    # Update the after_save callback
+    after_save :create_integration_mappings_async, if: :external_api_just_enabled?
+
+    # AASM configuration
+    include AASM
+
+    aasm column: "external_api_state", enum: true do
+      state :g_off, initial: true
+      state :j_on
+      state :j_off
+
+      # Transition from g_off to j_on
+      event :_enable_external_api do
+        transitions from: :g_off, to: :j_on
+      end
+
+      # Transition from j_on to j_off
+      event :_disable_external_api do
+        transitions from: :j_on, to: :j_off
+      end
+
+      # Transition from j_off to j_on
+      event :_enable_again_external_api do
+        transitions from: :j_off, to: :j_on
+      end
+
+      # Transition from j_on or j_off to g_off
+      event :_reset_external_api do
+        transitions from: %i[j_on j_off], to: :g_off
+      end
+    end
+
+    # Define methods to check user permissions
+    # These methods will receive the user performing the action
+    # We'll define a context for the user when triggering events
+
+    # Custom methods to handle transitions with user context
+    def enable_external_api!(user)
+      if user.super_admin?
+        _enable_external_api!
+      else
+        raise Pundit::NotAuthorizedError, I18n.t("misc.user_not_authorized_error")
+      end
+    end
+
+    def disable_external_api!(user)
+      if user.manager?
+        _disable_external_api!
+      else
+        raise Pundit::NotAuthorizedError, I18n.t("misc.user_not_authorized_error")
+      end
+    end
+
+    def enable_again_external_api!(user)
+      if user.manager? || user.super_admin?
+        _enable_again_external_api!
+      else
+        raise Pundit::NotAuthorizedError, I18n.t("misc.user_not_authorized_error")
+      end
+    end
+
+    def reset_external_api!(user)
+      if user.super_admin?
+        _reset_external_api!
+      else
+        raise Pundit::NotAuthorizedError, I18n.t("misc.user_not_authorized_error")
+      end
+    end
+
+    def create_integration_mappings_async
+      return unless external_api_enabled?
+
+      if Rails.env.test?
+        ModelCallbackJob.new.perform(self.class.name, id, "create_integration_mappings")
+      else
+        ModelCallbackJob.perform_async(self.class.name, id, "create_integration_mappings")
+      end
+    end
+
+    def external_api_enabled?
+      j_on?
+    end
+
+    def external_api_just_enabled?
+      saved_change_to_external_api_state? && external_api_state == "j_on"
+    end
+  end
+end

--- a/app/models/external_api_key.rb
+++ b/app/models/external_api_key.rb
@@ -8,9 +8,9 @@ class ExternalApiKey < ApplicationRecord
   scope :active,
         -> do
           joins(:jurisdiction).where(
-            "jurisdictions.external_api_enabled = TRUE AND (expired_at IS NULL OR expired_at > ?) AND revoked_at IS
-NULL",
-            Time.now,
+            "jurisdictions.external_api_state = ? AND (expired_at IS NULL OR expired_at > ?) AND revoked_at IS NULL",
+            "j_on",
+            Time.current,
           )
         end
   # Token namespace can be useful for secrets scanning tools, e.g. GitHub secret scanning

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -1,6 +1,7 @@
 class Jurisdiction < ApplicationRecord
   extend FriendlyId
   friendly_id :qualified_name, use: :slugged
+  include JurisdictionExternalApiState
 
   BASE_INCLUDES = %i[permit_type_submission_contacts contacts permit_type_required_steps]
 
@@ -31,9 +32,9 @@ class Jurisdiction < ApplicationRecord
   before_validation :normalize_locality_type
   before_validation :normalize_name
   before_validation :set_type_based_on_locality
+
   before_save :sanitize_html_fields
 
-  after_save :create_integration_mappings_async, if: :saved_change_to_external_api_enabled?
   after_create :create_permit_type_required_steps
 
   accepts_nested_attributes_for :contacts
@@ -190,16 +191,6 @@ class Jurisdiction < ApplicationRecord
   end
 
   private
-
-  def create_integration_mappings_async
-    return unless external_api_enabled?
-
-    if Rails.env.test?
-      ModelCallbackJob.new.perform(self.class.name, id, "create_integration_mappings")
-    else
-      ModelCallbackJob.perform_async(self.class.name, id, "create_integration_mappings")
-    end
-  end
 
   def create_permit_type_required_steps
     PermitType.all.each do |permit_type|

--- a/app/models/template_version.rb
+++ b/app/models/template_version.rb
@@ -87,7 +87,7 @@ class TemplateVersion < ApplicationRecord
   def create_integration_mappings
     return unless !deprecation_reason_unscheduled?
 
-    api_enabled_jurisdictions = Jurisdiction.where(external_api_enabled: true)
+    api_enabled_jurisdictions = Jurisdiction.where(external_api_state: "j_on")
 
     existing_mapping_jurisdiction_ids = integration_mappings.pluck(:jurisdiction_id)
 
@@ -124,7 +124,7 @@ class TemplateVersion < ApplicationRecord
   def notify_users_of_missing_requirements_mappings
     return unless saved_change_to_status? && (published? || scheduled?)
     relevant_integration_mappings =
-      integration_mappings.joins(:jurisdiction).where({ jurisdictions: { external_api_enabled: true } })
+      integration_mappings.joins(:jurisdiction).where({ jurisdictions: { external_api_state: "j_on" } })
 
     relevant_integration_mappings.each { |im| im.send_missing_requirements_mapping_communication }
   end

--- a/app/policies/jurisdiction_policy.rb
+++ b/app/policies/jurisdiction_policy.rb
@@ -24,9 +24,7 @@ class JurisdictionPolicy < ApplicationPolicy
   end
 
   def update_external_api_enabled?
-    return true if user.super_admin?
-
-    (user.review_manager? || user.regional_review_manager?) && record.external_api_enabled?
+    user.super_admin? || (user.manager? && user.jurisdictions.find(record.id))
   end
 
   def search_users?

--- a/db/data/20240605235009_add_integration_mappings_for_jurisdictions.rb
+++ b/db/data/20240605235009_add_integration_mappings_for_jurisdictions.rb
@@ -2,7 +2,7 @@
 
 class AddIntegrationMappingsForJurisdictions < ActiveRecord::Migration[7.1]
   def up
-    jurisdictions_wit_api_enabled = Jurisdiction.where(external_api_enabled: true)
+    jurisdictions_wit_api_enabled = Jurisdiction.where(external_api_state: "j_on")
 
     jurisdictions_wit_api_enabled.each { |jurisdiction| jurisdiction.create_integration_mappings }
   end

--- a/db/migrate/20241002222326_change_external_api_enabled_to_external_api_state_in_jurisdictions.rb
+++ b/db/migrate/20241002222326_change_external_api_enabled_to_external_api_state_in_jurisdictions.rb
@@ -1,4 +1,4 @@
-class ChangeExternalApiEnabledToExternalApiStateInJurisdictions < ActiveRecord::Migration[6.1]
+class ChangeExternalApiEnabledToExternalApiStateInJurisdictions < ActiveRecord::Migration[7.1]
   def up
     # Add the new column with a default value
     add_column :jurisdictions, :external_api_state, :string, default: "g_off", null: false

--- a/db/migrate/20241002222326_change_external_api_enabled_to_external_api_state_in_jurisdictions.rb
+++ b/db/migrate/20241002222326_change_external_api_enabled_to_external_api_state_in_jurisdictions.rb
@@ -1,0 +1,33 @@
+class ChangeExternalApiEnabledToExternalApiStateInJurisdictions < ActiveRecord::Migration[6.1]
+  def up
+    # Add the new column with a default value
+    add_column :jurisdictions, :external_api_state, :string, default: "g_off", null: false
+
+    # Migrate existing data
+    Jurisdiction.reset_column_information
+    Jurisdiction.find_each do |jurisdiction|
+      if jurisdiction.external_api_enabled
+        jurisdiction.update_columns(external_api_state: "j_on")
+      else
+        jurisdiction.update_columns(external_api_state: "g_off")
+      end
+    end
+
+    # Remove the old boolean column
+    remove_column :jurisdictions, :external_api_enabled, :boolean
+  end
+
+  def down
+    # Re-add the old boolean column
+    add_column :jurisdictions, :external_api_enabled, :boolean, default: false, null: false
+
+    # Migrate data back
+    Jurisdiction.reset_column_information
+    Jurisdiction.find_each do |jurisdiction|
+      jurisdiction.update_columns(external_api_enabled: (jurisdiction.external_api_state == "j_on"))
+    end
+
+    # Remove the enum column
+    remove_column :jurisdictions, :external_api_state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -245,7 +245,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_02_222326) do
     t.jsonb "compliance_data", default: {}, null: false
     t.datetime "revisions_requested_at", precision: nil
     t.boolean "first_nations", default: false
-    t.uuid "sandbox_id"
     t.index ["activity_id"], name: "index_permit_applications_on_activity_id"
     t.index ["jurisdiction_id"],
             name: "index_permit_applications_on_jurisdiction_id"
@@ -254,7 +253,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_02_222326) do
             unique: true
     t.index ["permit_type_id"],
             name: "index_permit_applications_on_permit_type_id"
-    t.index ["sandbox_id"], name: "index_permit_applications_on_sandbox_id"
     t.index ["submitter_id"], name: "index_permit_applications_on_submitter_id"
     t.index ["template_version_id"],
             name: "index_permit_applications_on_template_version_id"
@@ -891,7 +889,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_02_222326) do
   add_foreign_key "jurisdiction_memberships", "users"
   add_foreign_key "jurisdiction_template_version_customizations",
                   "jurisdictions"
-  add_foreign_key "jurisdiction_template_version_customizations", "sandboxes"
   add_foreign_key "jurisdiction_template_version_customizations",
                   "template_versions"
   add_foreign_key "jurisdictions",
@@ -904,7 +901,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_02_222326) do
   add_foreign_key "permit_applications",
                   "permit_classifications",
                   column: "permit_type_id"
-  add_foreign_key "permit_applications", "sandboxes"
   add_foreign_key "permit_applications", "template_versions"
   add_foreign_key "permit_applications", "users", column: "submitter_id"
   add_foreign_key "permit_block_statuses", "permit_applications"
@@ -930,7 +926,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_02_222326) do
   add_foreign_key "revision_reasons", "site_configurations"
   add_foreign_key "revision_requests", "submission_versions"
   add_foreign_key "revision_requests", "users"
-  add_foreign_key "sandboxes", "jurisdictions"
   add_foreign_key "step_code_building_characteristics_summaries",
                   "step_code_checklists"
   add_foreign_key "step_code_checklists",

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_20_173324) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_02_222326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -196,7 +196,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_173324) do
     t.string "prefix", null: false
     t.string "slug"
     t.integer "map_zoom"
-    t.boolean "external_api_enabled", default: false
+    t.string "external_api_state", default: "g_off", null: false
     t.index ["prefix"], name: "index_jurisdictions_on_prefix", unique: true
     t.index ["regional_district_id"],
             name: "index_jurisdictions_on_regional_district_id"
@@ -245,6 +245,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_173324) do
     t.jsonb "compliance_data", default: {}, null: false
     t.datetime "revisions_requested_at", precision: nil
     t.boolean "first_nations", default: false
+    t.uuid "sandbox_id"
     t.index ["activity_id"], name: "index_permit_applications_on_activity_id"
     t.index ["jurisdiction_id"],
             name: "index_permit_applications_on_jurisdiction_id"
@@ -253,6 +254,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_173324) do
             unique: true
     t.index ["permit_type_id"],
             name: "index_permit_applications_on_permit_type_id"
+    t.index ["sandbox_id"], name: "index_permit_applications_on_sandbox_id"
     t.index ["submitter_id"], name: "index_permit_applications_on_submitter_id"
     t.index ["template_version_id"],
             name: "index_permit_applications_on_template_version_id"
@@ -889,6 +891,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_173324) do
   add_foreign_key "jurisdiction_memberships", "users"
   add_foreign_key "jurisdiction_template_version_customizations",
                   "jurisdictions"
+  add_foreign_key "jurisdiction_template_version_customizations", "sandboxes"
   add_foreign_key "jurisdiction_template_version_customizations",
                   "template_versions"
   add_foreign_key "jurisdictions",
@@ -901,6 +904,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_173324) do
   add_foreign_key "permit_applications",
                   "permit_classifications",
                   column: "permit_type_id"
+  add_foreign_key "permit_applications", "sandboxes"
   add_foreign_key "permit_applications", "template_versions"
   add_foreign_key "permit_applications", "users", column: "submitter_id"
   add_foreign_key "permit_block_statuses", "permit_applications"
@@ -926,6 +930,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_20_173324) do
   add_foreign_key "revision_reasons", "site_configurations"
   add_foreign_key "revision_requests", "submission_versions"
   add_foreign_key "revision_requests", "users"
+  add_foreign_key "sandboxes", "jurisdictions"
   add_foreign_key "step_code_building_characteristics_summaries",
                   "step_code_checklists"
   add_foreign_key "step_code_checklists",

--- a/spec/controllers/external_api/application_controller_spec.rb
+++ b/spec/controllers/external_api/application_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe MockExternalApiController, type: :controller do
 
     it "returns 401 unauthorized with existing token, if corresponding jurisdiction did not enable api" do
       expired_external_api_key =
-        create(:external_api_key, jurisdiction: create(:sub_district, external_api_enabled: false))
+        create(:external_api_key, jurisdiction: create(:sub_district, external_api_state: "g_off"))
 
       request.headers["Authorization"] = "Bearer #{expired_external_api_key.token}"
 

--- a/spec/factories/external_api_key.rb
+++ b/spec/factories/external_api_key.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :external_api_key do
-    association :jurisdiction, factory: :sub_district, external_api_enabled: true
+    association :jurisdiction, factory: :sub_district, external_api_state: "j_on"
     name { Faker::Lorem.words(number: 4).join(" ") }
     connecting_application { Faker::Lorem.words(number: 2).join(" ") }
     expired_at { Time.now + 1.day }

--- a/spec/factories/sub_districts.rb
+++ b/spec/factories/sub_districts.rb
@@ -7,13 +7,8 @@ FactoryBot.define do
     checklist_html { "<p>Some checklist</p>" }
     look_out_html { "<p>Some lookout</p>" }
     contact_summary_html { "<p>Some lookout</p>" }
-    external_api_enabled { false }
+    external_api_state { "g_off" } # Updated from external_api_enabled
 
-    after(:create) do |jurisdiction|
-      create(:permit_type_submission_contact, jurisdiction: jurisdiction)
-      # This creates a PermitTypeSubmissionContact associated with the jurisdiction.
-      # If your PermitTypeSubmissionContact factory requires a permit_type,
-      # ensure that a permit_type factory is also defined and associated here.
-    end
+    after(:create) { |jurisdiction| create(:permit_type_submission_contact, jurisdiction: jurisdiction) }
   end
 end

--- a/spec/models/external_api_key_spec.rb
+++ b/spec/models/external_api_key_spec.rb
@@ -53,18 +53,10 @@ RSpec.describe ExternalApiKey, type: :model do
         create(:external_api_key, revoked_at: Time.now),
       ]
       jurisdiction_disabled_external_api_keys = [
-        create(:external_api_key, jurisdiction: create(:sub_district, external_api_enabled: false)),
-        create(
-          :external_api_key,
-          jurisdiction: create(:sub_district, external_api_enabled: false),
-          revoked_at: Time.now - 1.day,
-        ),
-        create(
-          :external_api_key,
-          jurisdiction: create(:sub_district, external_api_enabled: false),
-          expired_at: Time.now - 1.day,
-        ),
-        create(:external_api_key, jurisdiction: create(:sub_district, external_api_enabled: false)),
+        create(:external_api_key, jurisdiction: create(:sub_district)),
+        create(:external_api_key, jurisdiction: create(:sub_district), revoked_at: Time.now - 1.day),
+        create(:external_api_key, jurisdiction: create(:sub_district), expired_at: Time.now - 1.day),
+        create(:external_api_key, jurisdiction: create(:sub_district)),
       ]
 
       expect(ExternalApiKey.active).to match_array(active_external_api_keys)

--- a/spec/models/jurisdiction_spec.rb
+++ b/spec/models/jurisdiction_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Jurisdiction, type: :model do
       create(:template_version, status: "deprecated", deprecation_reason: "unscheduled", deprecated_by: create(:user))
     end
 
-    context "when external_api_enabled is true" do
-      let(:jurisdiction) { create(:sub_district, external_api_enabled: true) }
+    context "when external_api_state is j_on" do
+      let(:jurisdiction) { create(:sub_district, external_api_state: "j_on") }
       it "creates mappings for published template versions" do
         expect(jurisdiction.integration_mappings.count).to eq(2)
         expect(jurisdiction.integration_mappings.pluck(:template_version_id)).to match_array(
@@ -48,16 +48,53 @@ RSpec.describe Jurisdiction, type: :model do
       let!(:template_version_deprecated_other) do
         create(:template_version, status: "deprecated", deprecation_reason: "unscheduled", deprecated_by: create(:user))
       end
+      let!(:user) { create(:user, :super_admin) }
 
       it "creates mappings for published template versions" do
         expect(jurisdiction.integration_mappings.count).to eq(0)
 
-        jurisdiction.update(external_api_enabled: true)
+        jurisdiction.enable_external_api!(user)
 
         expect(jurisdiction.integration_mappings.count).to eq(2)
         expect(jurisdiction.integration_mappings.pluck(:template_version_id)).to match_array(
           [template_version_published.id, template_version_deprecated.id],
         )
+      end
+    end
+  end
+
+  describe "callbacks" do
+    let(:super_admin) { create(:user, :super_admin) }
+    let(:manager) { create(:user, :review_manager) }
+    let(:jurisdiction) { create(:sub_district) }
+    let(:enabled_jurisdiction) { create(:sub_district, external_api_state: "j_on") }
+    describe "#create_integration_mappings_async" do
+      context "when transitioning to j_on" do
+        it "enqueues the job" do
+          allow(Rails.env).to receive(:test?).and_return(false)
+          expect(ModelCallbackJob).to receive(:perform_async).with(
+            "SubDistrict",
+            jurisdiction.id,
+            "create_integration_mappings",
+          )
+          jurisdiction.enable_external_api!(super_admin)
+        end
+
+        it "performs the job immediately in test environment" do
+          allow(Rails.env).to receive(:test?).and_return(true)
+          job_instance = double("ModelCallbackJob")
+          expect(ModelCallbackJob).to receive(:new).and_return(job_instance)
+          expect(job_instance).to receive(:perform).with("SubDistrict", jurisdiction.id, "create_integration_mappings")
+          jurisdiction.enable_external_api!(super_admin)
+        end
+      end
+
+      context "when not transitioning to j_on" do
+        it "does not enqueue the job" do
+          allow(Rails.env).to receive(:test?).and_return(false)
+          expect(ModelCallbackJob).to receive(:new).at_most(:once)
+          enabled_jurisdiction.disable_external_api!(manager)
+        end
       end
     end
   end

--- a/spec/models/template_version_spec.rb
+++ b/spec/models/template_version_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe TemplateVersion, type: :model do
   describe "#create_integration_mappings callback" do
     context "when the template version is published and status has changed" do
-      let!(:jurisdiction) { create(:sub_district, external_api_enabled: false) }
-      let!(:disabled_api_jurisdiction) { create(:sub_district, external_api_enabled: false) }
+      let!(:jurisdiction) { create(:sub_district) }
+      let!(:disabled_api_jurisdiction) { create(:sub_district) }
       let!(:template_version) { create(:template_version, status: "scheduled") }
       let!(:existing_mapping) { create(:integration_mapping, template_version: template_version) }
 
       it "creates integration requirements mappings for jurisdictions without mapping and whose api keys are enabled" do
-        expect { jurisdiction.update(external_api_enabled: true) }.to change { IntegrationMapping.count }.by(1)
+        expect { jurisdiction.update(external_api_state: "j_on") }.to change { IntegrationMapping.count }.by(1)
 
         expect(IntegrationMapping.find_by(template_version: template_version, jurisdiction: jurisdiction)).to be_present
 


### PR DESCRIPTION
## Description

Add 3 way aasm statement management for role based API enablement. Changes to frontend are minimized.

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1501

## Steps to QA

Log in as manager, should not be able to enable API (under configuration management)
Log in as super admin in side incognito window, enable API (under jurisdictions -> manage)
Back in manager window, refresh, it should now be enabled. Disable it, and this succeeds. Enable it again, this succeeds.
Back in super admin window, disable again, this succeeds.
Manager should not be able to enable again.