### PR TITLE
format pid labels with dashes in selector

### DIFF
--- a/app/controllers/api/geocoder_controller.rb
+++ b/app/controllers/api/geocoder_controller.rb
@@ -70,6 +70,8 @@ class Api::GeocoderController < Api::ApplicationController
       raise StandardError unless jurisdiction.present?
       render_success jurisdiction, nil, { blueprint: JurisdictionBlueprint, blueprint_opts: { view: :base } }
     rescue Errors::FeatureAttributesRetrievalError => e
+      render_error "geocoder.ltsa_retrieval_error", {}, e and return
+    rescue Errors::LtsaUnavailableError => e
       render_error "geocoder.ltsa_unavailable_error", {}, e and return
     rescue StandardError => e
       render_error "geocoder.jurisdiction_error", {}, e and return

--- a/app/frontend/components/shared/select/selectors/sites-select.tsx
+++ b/app/frontend/components/shared/select/selectors/sites-select.tsx
@@ -10,7 +10,7 @@ import { ControlProps, InputProps, OptionProps, components } from "react-select"
 import CreatableSelect from "react-select/creatable"
 import { useMst } from "../../../../setup/root"
 import { IOption } from "../../../../types/types"
-import { formatPidValue } from "../../../../utils/utility-functions"
+import { formatPidLabel, formatPidValue } from "../../../../utils/utility-functions"
 import { AsyncSelect, TAsyncSelectProps } from "../async-select"
 
 type TSitesSelectProps = {
@@ -58,7 +58,7 @@ export const SitesSelect = observer(function ({
       //set the label for the address?
       fetchPids(option.value).then((pids: string[]) => {
         if (pids) {
-          setPidOptions(pids.map((pid) => ({ value: pid, label: pid })))
+          setPidOptions(pids.map((pid) => ({ value: pid, label: formatPidLabel(pid) })))
           const selectControl = pidSelectRef?.current?.controlRef
           if (selectControl && !R.isEmpty(pids)) {
             selectControl.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }))
@@ -136,7 +136,7 @@ export const SitesSelect = observer(function ({
                     options={pidOptions}
                     ref={pidSelectRef}
                     value={{
-                      label: value,
+                      label: formatPidLabel(value),
                       value: formatPidValue(value),
                     }}
                     onChange={(option) => {
@@ -146,10 +146,12 @@ export const SitesSelect = observer(function ({
                       onChange(formatPidValue(option?.value))
                     }}
                     onCreateOption={(inputValue: string) => {
-                      const newValue = { label: inputValue, value: formatPidValue(inputValue) }
+                      const newValue = { label: formatPidLabel(inputValue), value: formatPidValue(inputValue) }
                       onChange(newValue.value)
                     }}
-                    formatCreateLabel={(inputValue: string) => t("permitApplication.usePid", { inputValue })}
+                    formatCreateLabel={(inputValue: string) =>
+                      t("permitApplication.usePid", { inputValue: formatPidLabel(inputValue) })
+                    }
                     isClearable
                     isSearchable
                   />

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -570,7 +570,7 @@ const options = {
               "Upon receipt by the local jurisdiction, you will be notified via email or phone of any updates to your application's status or if additional documentation is required.",
             emailed:
               "A confirmation email has also been sent to the applicant and the {{ jurisdictionName }} building permit office",
-            pinRequired: "PID not found for this address. Please select a PIN and jurisdiction below:",
+            pinRequired: "PID not found. Please select a PIN and jurisdiction below:",
             pinVerified: "PIN is verified.",
             pinUnableToVerify: "Unable to verify PIN, please confirm and proceed as applicable.",
           },

--- a/app/frontend/utils/utility-functions.ts
+++ b/app/frontend/utils/utility-functions.ts
@@ -248,3 +248,12 @@ export function formatPidValue(pid?: string) {
 
   return pid.replace(/[^a-zA-Z0-9]/g, "")
 }
+
+export function formatPidLabel(pid?: string) {
+  if (!pid) return null
+  // Remove all non-numeric characters
+  const numericString = pid.replace(/\D/g, "")
+
+  // Add a dash after every third character
+  return numericString.replace(/(\d{3})(?=\d)/g, "$1-")
+}

--- a/app/models/errors/ltsa_unavailable_error.rb
+++ b/app/models/errors/ltsa_unavailable_error.rb
@@ -1,0 +1,5 @@
+class Errors::LtsaUnavailableError < StandardError
+  def initialize(msg = "land title service unavailable")
+    super
+  end
+end

--- a/app/services/wrappers/ltsa_parcel_map_bc.rb
+++ b/app/services/wrappers/ltsa_parcel_map_bc.rb
@@ -91,7 +91,7 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
       raise Errors::FeatureAttributesRetrievalError unless attributes.present?
       return attributes
     else
-      raise Errors::FeatureAttributesRetrievalError
+      raise Errors::LtsaUnavailableError
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -170,6 +170,9 @@ en:
       jurisdiction_error:
         title: Error
         message: Jurisdiction could not be determined. Please manually enter your jurisdiction.
+      ltsa_retrieval_error:
+        title: Error
+        message: The land title could not be found
       ltsa_unavailable_error:
         title: Error
         message: The land title service is currently unavailable


### PR DESCRIPTION
## Description

Rework the pid selector to always display pids with dashes, leaving them dashless under the hood and in the backend

## What type of PR is this? (check all applicable)

- [x ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-1739