### PR TITLE
Adds Request ID to logging in Openshift

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,10 @@ module HousPermitPortal
     config.hosts.concat(ENV["AUTHORIZED_HOSTS"].split(",")) if ENV["AUTHORIZED_HOSTS"]
     # This sets up keys needed for active record attribute encryption
 
+    # Add request-id to the logging tags
+    config.middleware.insert_before 0, ActionDispatch::RequestId, header: "X-Request-Id"
+    config.log_tags = [:request_id]
+
     # the minimum lengths for the keys should be 12 bytes for the
     # primary key (this will be used to derive the AES 32
     # bytes key) and 20 bytes for the salt.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,15 +50,8 @@ Rails.application.configure do
   # instead this will be redirected on the route level
   # config.force_ssl = true
 
-  # Log to STDOUT by default
-  config.logger =
-    ActiveSupport::Logger
-      .new(STDOUT)
-      .tap { |logger| logger.formatter = ::Logger::Formatter.new }
-      .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
+  # Logger configured in initializer
+  #config.logger = #
 
   # Info include generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you

--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -1,0 +1,15 @@
+# Configure logs so that we get request-id (log tags configured in application.rb)
+Rails.application.config.logger =
+  ActiveSupport::TaggedLogging.new(
+    ActiveSupport::Logger
+      .new(STDOUT)
+      .tap do |logger|
+        logger.formatter =
+          proc do |severity, datetime, progname, msg|
+            tags = (Thread.current[:activesupport_tagged_logging_tags] || []).join(" ")
+            "#{severity} [#{datetime}] #{tags}: #{msg}\n"
+          end
+      end,
+  )
+
+Rails.logger = Rails.application.config.logger


### PR DESCRIPTION
Adds RequestID and custom logger format to logs for better tracing in the Openshift / Kibana environments

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-2216

## Steps to QA

Deploy then look at `oc logs -f <web-pod-id>`
You should see something like this
`INFO [2024-10-16 17:07:40 +0000] : [84bf3831-f099-4bba-9d09-38da88a749a3]   Rendered html template (Duration: 0.0ms | Allocations: 2)`