### PR TITLE
add page and processing for early access view

### DIFF
--- a/app/blueprints/requirement_template_blueprint.rb
+++ b/app/blueprints/requirement_template_blueprint.rb
@@ -9,7 +9,7 @@ class RequirementTemplateBlueprint < Blueprinter::Base
               name: :deprecated_template_versions
   association :scheduled_template_versions, blueprint: TemplateVersionBlueprint
   association :published_template_version, blueprint: TemplateVersionBlueprint do |rt, options|
-    options[:published_template_version].present? ? options[:published_template_version] : rt.published_template_version
+    defaulted_template_version(rt, options)
   end
 
   association :assignee,
@@ -19,9 +19,17 @@ class RequirementTemplateBlueprint < Blueprinter::Base
 
   view :extended do
     association :requirement_template_sections, blueprint: RequirementTemplateSectionBlueprint
+
+    association :published_template_version, blueprint: TemplateVersionBlueprint, view: :extended do |rt, options|
+      defaulted_template_version(rt, options)
+    end
   end
 
   view :template_snapshot do
     association :requirement_template_sections, blueprint: RequirementTemplateSectionBlueprint
   end
+end
+
+def defaulted_template_version(rt, options)
+  options[:published_template_version].present? ? options[:published_template_version] : rt.published_template_version
 end

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -90,6 +90,7 @@ const EditPermitApplicationScreen = lazy(() =>
     default: module.EditPermitApplicationScreen,
   }))
 )
+
 const NewPermitApplicationScreen = lazy(() =>
   import("../permit-application/new-permit-application-screen").then((module) => ({
     default: module.NewPermitApplicationScreen,
@@ -205,10 +206,18 @@ const EarlyAccessScreen = lazy(() =>
   }))
 )
 
-const EarlyAccessRequirementTemplatesScreen = lazy(() =>
+const EarlyAccessRequirementTemplatesIndexScreen = lazy(() =>
   import("../super-admin/early-access/requirement-templates").then((module) => ({
-    default: module.EarlyAccessRequirementTemplatesScreen,
+    default: module.EarlyAccessRequirementTemplatesIndexScreen,
   }))
+)
+
+const EarlyAccessRequirementTemplateScreen = lazy(() =>
+  import("../super-admin/early-access/requirement-templates/early-access-requirement-template-screen").then(
+    (module) => ({
+      default: module.EarlyAccessRequirementTemplateScreen,
+    })
+  )
 )
 
 const NewEarlyAccessRequirementTemplateScreen = lazy(() =>
@@ -322,7 +331,11 @@ const AppRoutes = observer(() => {
       <Route path="/requirements-library" element={<RequirementsLibraryScreen />} />
       <Route path="/early-access/requirements-library" element={<EarlyAccessRequirementsLibraryScreen />} />
       <Route path="/requirement-templates" element={<RequirementTemplatesScreen />} />
-      <Route path="/early-access/requirement-templates" element={<EarlyAccessRequirementTemplatesScreen />} />
+      <Route path="/early-access/requirement-templates" element={<EarlyAccessRequirementTemplatesIndexScreen />} />
+      <Route
+        path="/early-access/requirement-templates/:requirementTemplateId"
+        element={<EarlyAccessRequirementTemplateScreen />}
+      />
       <Route path="/early-access/requirement-templates/new" element={<NewEarlyAccessRequirementTemplateScreen />} />
       <Route
         path="/early-access/requirement-templates/:requirementTemplateId/edit"

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -39,7 +39,19 @@ import { RegionalRMJurisdictionSelect } from "./regional-rm-jurisdiction-select"
 import { SubNavBar } from "./sub-nav-bar"
 
 function isTemplateEditPath(path: string): boolean {
-  const regex = /^(\/early-access)?\/requirement-templates\/([a-f\d-]+)\/edit$/
+  const regex = /^\/requirement-templates\/([a-f\d-]+)\/edit$/
+
+  return regex.test(path)
+}
+
+function isEarlyAccessTemplateEditPath(path: string): boolean {
+  const regex = /^\/early-access?\/requirement-templates\/([a-f\d-]+)\/edit$/
+
+  return regex.test(path)
+}
+
+function isEarlyAccessTemplateViewPath(path: string): boolean {
+  const regex = /^\/early-access\/requirement-templates\/([a-f\d-]+)$/
 
   return regex.test(path)
 }
@@ -74,6 +86,8 @@ function shouldHideSubNavbarForPath(path: string): boolean {
   const matchers: Array<(path: string) => boolean> = [
     (path) => path === "/",
     isTemplateEditPath,
+    isEarlyAccessTemplateEditPath,
+    isEarlyAccessTemplateViewPath,
     isTemplateVersionPath,
     isPermitApplicationEditPath,
     isPermitApplicationPath,

--- a/app/frontend/components/domains/super-admin/early-access/requirement-templates/early-access-requirement-template-screen.tsx
+++ b/app/frontend/components/domains/super-admin/early-access/requirement-templates/early-access-requirement-template-screen.tsx
@@ -1,0 +1,91 @@
+import { Box, Flex, HStack, Heading, Text } from "@chakra-ui/react"
+import { observer } from "mobx-react-lite"
+import React, { useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { useRequirementTemplate } from "../../../../../hooks/resources/use-requirement-template"
+import { useMst } from "../../../../../setup/root"
+import { ErrorScreen } from "../../../../shared/base/error-screen"
+import { LoadingScreen } from "../../../../shared/base/loading-screen"
+import { BackButton } from "../../../../shared/buttons/back-button"
+import { FloatingHelpDrawer } from "../../../../shared/floating-help-drawer"
+import { BrowserSearchPrompt } from "../../../../shared/permit-applications/browser-search-prompt"
+import { PermitApplicationStatusTag } from "../../../../shared/permit-applications/permit-application-status-tag"
+import { RequirementForm } from "../../../../shared/permit-applications/requirement-form"
+import { ChecklistSideBar } from "../../../permit-application/checklist-sidebar"
+
+interface IEarlyAccessRequirementTemplateScreenProps {}
+
+export const EarlyAccessRequirementTemplateScreen = observer(({}: IEarlyAccessRequirementTemplateScreenProps) => {
+  const { t } = useTranslation()
+
+  const { userStore, permitApplicationStore } = useMst()
+  const { getEphemeralPermitApplication } = permitApplicationStore
+  const currentUser = userStore.currentUser
+
+  const { requirementTemplate, error } = useRequirementTemplate()
+
+  const permitHeaderRef = useRef()
+  const formRef = useRef(null)
+
+  // @ts-ignore
+  const permitHeaderHeight = permitHeaderRef?.current?.offsetHeight ?? 0
+
+  const [completedBlocks, setCompletedBlocks] = useState({})
+
+  if (error) return <ErrorScreen error={error} />
+  if (!currentUser || !requirementTemplate?.isFullyLoaded) return <LoadingScreen />
+
+  const ephemeralPermitApplication = getEphemeralPermitApplication(requirementTemplate)
+
+  return (
+    <Box as="main" id="submitter-view-permit">
+      <Flex id="permitHeader" direction="column" position="sticky" top={0} zIndex={12} ref={permitHeaderRef}>
+        <Flex
+          w="full"
+          px={6}
+          py={3}
+          bg="theme.blue"
+          justify="space-between"
+          color="greys.white"
+          position="sticky"
+          top="0"
+          zIndex={12}
+          flexDirection={{ base: "column", md: "row" }}
+        >
+          <HStack gap={4} flex={1}>
+            <PermitApplicationStatusTag permitApplication={ephemeralPermitApplication} />
+
+            <Flex direction="column" w="full">
+              <Heading fontSize="xl">{requirementTemplate.nickname}</Heading>
+              <Text noOfLines={1}>{requirementTemplate.label}</Text>
+            </Flex>
+          </HStack>
+          <HStack
+            flexDir={{
+              base: "column",
+              md: "row",
+            }}
+            gap={4}
+          >
+            <BrowserSearchPrompt />
+            <BackButton variant="secondaryInverse" />
+          </HStack>
+        </Flex>
+        <FloatingHelpDrawer top={permitHeaderHeight + 20} position="absolute" />
+      </Flex>
+      <Box id="sidebar-and-form-container" sx={{ "&:after": { content: `""`, display: "block", clear: "both" } }}>
+        <ChecklistSideBar permitApplication={ephemeralPermitApplication} completedBlocks={completedBlocks} />
+
+        <Flex flex={1} direction="column" pt={8} position={"relative"} id="permitApplicationFieldsContainer">
+          <RequirementForm
+            formRef={formRef}
+            permitApplication={ephemeralPermitApplication}
+            onCompletedBlocksChange={setCompletedBlocks}
+            showHelpButton
+            isEditing={true}
+          />
+        </Flex>
+      </Box>
+    </Box>
+  )
+})

--- a/app/frontend/components/domains/super-admin/early-access/requirement-templates/index.tsx
+++ b/app/frontend/components/domains/super-admin/early-access/requirement-templates/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Container, Flex, Heading, VStack } from "@chakra-ui/react"
+import { Box, Container, Flex, HStack, Heading, VStack } from "@chakra-ui/react"
+import { ArrowSquareOut } from "@phosphor-icons/react"
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useState } from "react"
@@ -19,7 +20,7 @@ import { YesNoTag } from "../../../../shared/yes-no-tag"
 import { CreateModal } from "./create-modal"
 import { GridHeaders } from "./grid-headers"
 
-export const EarlyAccessRequirementTemplatesScreen = observer(function RequirementTemplate() {
+export const EarlyAccessRequirementTemplatesIndexScreen = observer(function RequirementTemplate() {
   const { requirementTemplateStore, earlyAccessRequirementTemplateStore, userStore } = useMst()
   const {
     tableEarlyAccessRequirementTemplates,
@@ -94,7 +95,12 @@ export const EarlyAccessRequirementTemplatesScreen = observer(function Requireme
                     />
                   </SearchGridItem>
                   <SearchGridItem>
-                    <RouterLinkButton to={`${rt.id}/edit`}>{t("ui.edit")}</RouterLinkButton>
+                    <HStack gap={2}>
+                      <RouterLinkButton to={`${rt.id}/edit`}>{t("ui.edit")}</RouterLinkButton>
+                      <RouterLinkButton rightIcon={<ArrowSquareOut />} variant="secondary" to={`${rt.id}`}>
+                        {t("ui.view")}
+                      </RouterLinkButton>
+                    </HStack>
                   </SearchGridItem>
                 </Box>
               )

--- a/app/frontend/components/shared/permit-applications/permit-application-status-tag.tsx
+++ b/app/frontend/components/shared/permit-applications/permit-application-status-tag.tsx
@@ -16,6 +16,7 @@ export const PermitApplicationStatusTag = ({ permitApplication, ...rest }: IPerm
     [EPermitApplicationStatus.resubmitted]: "theme.yellow",
     [EPermitApplicationStatus.newDraft]: "theme.blueLight",
     [EPermitApplicationStatus.revisionsRequested]: "semantic.errorLight",
+    [EPermitApplicationStatus.ephemeral]: "theme.blueLight",
   }
 
   const colorMap = {
@@ -23,6 +24,7 @@ export const PermitApplicationStatusTag = ({ permitApplication, ...rest }: IPerm
     [EPermitApplicationStatus.resubmitted]: "text.primary",
     [EPermitApplicationStatus.newDraft]: "text.primary",
     [EPermitApplicationStatus.revisionsRequested]: "semantic.error",
+    [EPermitApplicationStatus.ephemeral]: "text.primary",
   }
 
   return (

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -369,7 +369,10 @@ export const RequirementForm = observer(
             />
           ) : (
             <CustomMessageBox
-              title={t("permitApplication.show.submittingTo.title", { jurisdictionName: jurisdiction.qualifiedName })}
+              title={
+                jurisdiction &&
+                t("permitApplication.show.submittingTo.title", { jurisdictionName: jurisdiction?.qualifiedName })
+              }
               description={
                 <Trans
                   t={t}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -502,6 +502,7 @@ const options = {
             newly_submitted: "Submitted",
             resubmitted: "Resubmitted",
             revisions_requested: "Revisions Requested",
+            ephemeral: "Preview",
           },
           statusGroup: {
             draft: "Draft permits",
@@ -1410,6 +1411,7 @@ const options = {
           assignTo: "Assign to...",
         },
         earlyAccessRequirementTemplate: {
+          show: {},
           index: {
             tableHeading: "Previews",
             title: "Early access templates catalogue",

--- a/app/frontend/models/template-version.ts
+++ b/app/frontend/models/template-version.ts
@@ -5,7 +5,7 @@ import { IJurisdictionTemplateVersionCustomizationForm } from "../components/dom
 import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
 import { EDeprecationReason, EExportFormat, ETemplateVersionStatus } from "../types/enums"
-import { IDenormalizedRequirementBlock, IDenormalizedTemplate, ITemplateVersionUpdate } from "../types/types"
+import { IDenormalizedRequirementBlock, IDenormalizedTemplate, IFormJson, ITemplateVersionUpdate } from "../types/types"
 import { startBlobDownload } from "../utils/utility-functions"
 import { IIntegrationMapping, IntegrationMappingModel } from "./integration-mapping"
 import { JurisdictionTemplateVersionCustomizationModel } from "./jurisdiction-template-version-customization"
@@ -25,6 +25,7 @@ export const TemplateVersionModel = types
     templateVersionCustomizationsByJurisdiction: types.map(JurisdictionTemplateVersionCustomizationModel),
     integrationMappingByJurisdiction: types.map(IntegrationMappingModel),
     latestVersionId: types.maybeNull(types.string),
+    formJson: types.maybeNull(types.frozen<IFormJson>()),
     isFullyLoaded: types.optional(types.boolean, false),
   })
   .extend(withEnvironment())

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -30,6 +30,7 @@ export enum EPermitApplicationStatus {
   newlySubmitted = "newly_submitted",
   revisionsRequested = "revisions_requested",
   resubmitted = "resubmitted",
+  ephemeral = "ephemeral",
 }
 
 export enum EPermitApplicationStatusGroup {

--- a/app/frontend/utils/formio-component-traversal.ts
+++ b/app/frontend/utils/formio-component-traversal.ts
@@ -105,6 +105,9 @@ export const combineComplianceHints = (
       }
     }
   })
+
+  if (!formattedComplianceData) return updatedJson
+
   //compliance data logic
   for (const [key, value] of Object.entries(formattedComplianceData)) {
     const section = key.split("|")[0].replace("formSubmissionDataRST", "")
@@ -243,7 +246,7 @@ export const combineChangeMarkers = (formJson: IFormJson, isInReview: boolean, c
     section.components.forEach((block: IFormIOBlock) => {
       for (let i = 0; i < block.components.length; i++) {
         const requirement = block.components[i]
-        requirement.disabled = isInReview
+        requirement.disabled ||= isInReview
         if (section.id === COMPLETTION_SECTION_ID || !changedKeys.includes(requirement.key)) continue
 
         const changeMarker = convertToChangeMarker(requirement)
@@ -267,7 +270,10 @@ export const getRequirementByKey = (formJson: IFormJson, requirementKey: string)
   return foundRequirement
 }
 
-export const traverseFormIORequirements = (formJson: IFormJson, callback: (requirement) => void) => {
+export const traverseFormIORequirements = (
+  formJson: IFormJson,
+  callback: (requirement: IFormIORequirement) => void
+) => {
   formJson.components.forEach((section: IFormIOSection) => {
     section.components.forEach((block: IFormIOBlock) => {
       block.components.forEach((requirement: IFormIORequirement) => {
@@ -275,4 +281,15 @@ export const traverseFormIORequirements = (formJson: IFormJson, callback: (requi
       })
     })
   })
+}
+
+export const processFieldsForEphemeral = (formJson: IFormJson) => {
+  traverseFormIORequirements(formJson, (requirement) => {
+    if (["simplefile"].includes(requirement.type) || ["submit"].includes(requirement.key)) {
+      requirement.disabled = true
+    }
+    requirement.conditional = false
+    requirement.customConditional = null
+  })
+  return formJson
 }

--- a/app/models/template_version.rb
+++ b/app/models/template_version.rb
@@ -13,6 +13,7 @@ class TemplateVersion < ApplicationRecord
   delegate :label, to: :requirement_template
   delegate :published_template_version, to: :requirement_template
   delegate :first_nations, to: :requirement_template
+  delegate :early_access?, to: :requirement_template
 
   enum status: { scheduled: 0, published: 1, deprecated: 2 }, _default: 0
   enum deprecation_reason: { new_publish: 0, unscheduled: 1 }, _prefix: true

--- a/app/services/requirement_template_copy_service.rb
+++ b/app/services/requirement_template_copy_service.rb
@@ -13,12 +13,10 @@ class RequirementTemplateCopyService
           activity_id: requirement_template.activity_id,
           permit_type_id: requirement_template.permit_type_id,
           description: field_overrides[:description] || "Copy of #{requirement_template.description}",
+          nickname: field_overrides[:nickname],
           first_nations: field_overrides[:first_nations] || requirement_template.first_nations,
           copied_from: requirement_template,
         )
-
-      # Save the new template first to get its ID
-      new_template.save
 
       return new_template unless new_template.valid?
 
@@ -34,6 +32,10 @@ class RequirementTemplateCopyService
         # Associate existing requirement blocks with the new section
         section.requirement_blocks.each { |block| new_section.requirement_blocks << block }
       end
+
+      # Save the new template first to get its ID
+      new_template.save
+
       new_template
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -160,15 +160,6 @@ if PermitApplication.first.blank?
   LiveRequirementTemplate.find_or_create_by!(activity: activity2, permit_type: permit_type1)
   LiveRequirementTemplate.find_or_create_by!(activity: activity2, permit_type: permit_type2)
 
-  puts "Seeding early access requirement templates..."
-
-  3.times do |n|
-    EarlyAccessRequirementTemplate.find_or_create_by!(nickname: "Early access #{n}") do |record|
-      record.activity = activity1
-      record.permit_type = permit_type1
-    end
-  end
-
   RequirementTemplate.reindex
 
   PermitTypeRequiredStepSeeder.seed
@@ -252,3 +243,10 @@ EulaUpdater.run
 
 puts "Seeding default revision reasons..."
 RevisionReasonSeeder.seed
+
+puts "Seeding early access requirement templates..."
+
+LiveRequirementTemplate.find_each do |lrt|
+  overrides = { type: EarlyAccessRequirementTemplate.name, nickname: "Early access #{lrt.label}" }
+  RequirementTemplateCopyService.new(lrt).build_requirement_template_from_existing(overrides)
+end


### PR DESCRIPTION
## Description

Adds the "view" page for a single EarlyAccessRequirementTemplate and its automatically published template version.
Makes re-use of existing RequirementForm and PermitApplication model, but generates an "ephemeral" permit application that allows us to use the existing code without a permit application record.

Performs pre-processing for the formJSON including enabling all electives and disabling submit/file uploads

## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-2192

## Steps to QA

Create some previews
go to the list
click view on one with some blocks attached.