### PR TITLE
Chore/fix lint staged

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-# Ignore auto-generated files
-db/schema.rb

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,12 +1,7 @@
 export default {
-  plugins: ["prettier-plugin-organize-imports", "@prettier/plugin-ruby"],
+  plugins: ["prettier-plugin-organize-imports"],
   printWidth: 120,
   requirePragma: false,
-  rubyArrayLiteral: true,
-  rubyHashLabel: true,
-  rubyModifier: true,
-  rubySingleQuote: false,
-  rubyToProc: true,
   tabWidth: 2,
   trailingComma: "es5",
   semi: false,

--- a/.streeignore
+++ b/.streeignore
@@ -1,0 +1,2 @@
+# Ignore auto-generated files
+db/schema.rb

--- a/app/blueprints/collaborator_blueprint.rb
+++ b/app/blueprints/collaborator_blueprint.rb
@@ -2,7 +2,11 @@
 
 class CollaboratorBlueprint < Blueprinter::Base
   identifier :id
-  association :collaboratorable, blueprint: ->(c) { c.blueprint }, default: {}, view: :minimal
+  association :collaboratorable,
+              blueprint: ->(c) { c.blueprint },
+              default: {
+              },
+              view: :minimal
   association :user, blueprint: UserBlueprint, view: :minimal
   fields :collaboratorable_type, :collaboratorable_id
 end

--- a/app/blueprints/integration_mapping_blueprint.rb
+++ b/app/blueprints/integration_mapping_blueprint.rb
@@ -14,6 +14,9 @@ class IntegrationMappingBlueprint < Blueprinter::Base
   view :external_api do
     field :elective_filtered_requirements_mapping, name: :requirements_mapping
 
-    association :template_version, blueprint: TemplateVersionBlueprint, view: :external_api, name: :permit_version
+    association :template_version,
+                blueprint: TemplateVersionBlueprint,
+                view: :external_api,
+                name: :permit_version
   end
 end

--- a/app/blueprints/jurisdiction_blueprint.rb
+++ b/app/blueprints/jurisdiction_blueprint.rb
@@ -24,11 +24,15 @@ class JurisdictionBlueprint < Blueprinter::Base
            :submission_inbox_set_up
 
     association :contacts, blueprint: ContactBlueprint
-    association :permit_type_submission_contacts, blueprint: PermitTypeSubmissionContactBlueprint
+    association :permit_type_submission_contacts,
+                blueprint: PermitTypeSubmissionContactBlueprint
     association :sandboxes, blueprint: SandboxBlueprint
-    association :permit_type_required_steps, blueprint: PermitTypeRequiredStepBlueprint
+    association :permit_type_required_steps,
+                blueprint: PermitTypeRequiredStepBlueprint
 
-    association :permit_type_required_steps, blueprint: PermitTypeRequiredStepBlueprint do |jurisdiction, _options|
+    association :permit_type_required_steps,
+                blueprint:
+                  PermitTypeRequiredStepBlueprint do |jurisdiction, _options|
       jurisdiction.enabled_permit_type_required_steps
     end
   end

--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -20,7 +20,9 @@ class PermitApplicationBlueprint < Blueprinter::Base
            :missing_pdfs
     association :permit_type, blueprint: PermitClassificationBlueprint
     association :activity, blueprint: PermitClassificationBlueprint
-    association :submission_versions, blueprint: SubmissionVersionBlueprint, view: :base
+    association :submission_versions,
+                blueprint: SubmissionVersionBlueprint,
+                view: :base
     association :submitter, blueprint: UserBlueprint, view: :minimal
 
     field :indexed_using_current_template_version do |pa, options|
@@ -34,15 +36,22 @@ class PermitApplicationBlueprint < Blueprinter::Base
 
     association :supporting_documents, blueprint: SupportingDocumentBlueprint
     # only the delegatee is needed for the inbox screen
-    association :permit_collaborations, blueprint: PermitCollaborationBlueprint, view: :base do |pa, _options|
-      pa.permit_collaborations.where(collaboration_type: :review, collaborator_type: :delegatee)
+    association :permit_collaborations,
+                blueprint: PermitCollaborationBlueprint,
+                view: :base do |pa, _options|
+      pa.permit_collaborations.where(
+        collaboration_type: :review,
+        collaborator_type: :delegatee
+      )
     end
     association :submitter, blueprint: UserBlueprint, view: :minimal
   end
 
   view :extended do
     include_view :base
-    fields :formatted_compliance_data, :front_end_form_update, :form_customizations
+    fields :formatted_compliance_data,
+           :front_end_form_update,
+           :form_customizations
 
     association :submitter, blueprint: UserBlueprint, view: :minimal
 
@@ -61,24 +70,29 @@ class PermitApplicationBlueprint < Blueprinter::Base
     association :template_version, blueprint: TemplateVersionBlueprint
     association :published_template_version, blueprint: TemplateVersionBlueprint
 
-    association :supporting_documents, blueprint: SupportingDocumentBlueprint do |pa, options|
+    association :supporting_documents,
+                blueprint: SupportingDocumentBlueprint do |pa, options|
       pa.supporting_documents_for_submitter_based_on_user_permissions(
         pa.supporting_documents,
-        user: options[:current_user],
+        user: options[:current_user]
       )
     end
     association :all_submission_version_completed_supporting_documents,
                 blueprint: SupportingDocumentBlueprint do |pa, options|
       pa.supporting_documents_for_submitter_based_on_user_permissions(
         pa.all_submission_version_completed_supporting_documents,
-        user: options[:current_user],
+        user: options[:current_user]
       )
     end
     association :jurisdiction, blueprint: JurisdictionBlueprint, view: :base
     association :step_code, blueprint: StepCodeBlueprint
-    association :permit_collaborations, blueprint: PermitCollaborationBlueprint, view: :base
+    association :permit_collaborations,
+                blueprint: PermitCollaborationBlueprint,
+                view: :base
     association :permit_block_statuses, blueprint: PermitBlockStatusBlueprint
-    association :submission_versions, blueprint: SubmissionVersionBlueprint, view: :extended
+    association :submission_versions,
+                blueprint: SubmissionVersionBlueprint,
+                view: :extended
   end
 
   view :pdf_generation do
@@ -93,7 +107,11 @@ class PermitApplicationBlueprint < Blueprinter::Base
     end
 
     field :submission_data do |pa, options|
-      options[:submission_data].present? ? options[:submission_data] : pa.formatted_submission_data
+      if options[:submission_data].present?
+        options[:submission_data]
+      else
+        pa.formatted_submission_data
+      end
     end
   end
 
@@ -104,8 +122,11 @@ class PermitApplicationBlueprint < Blueprinter::Base
     field :submission_data do |pa, options|
       pa.formatted_submission_data
     end
-    association :all_submission_version_completed_supporting_documents, blueprint: SupportingDocumentBlueprint
-    association :submission_versions, blueprint: SubmissionVersionBlueprint, view: :review_extended
+    association :all_submission_version_completed_supporting_documents,
+                blueprint: SupportingDocumentBlueprint
+    association :submission_versions,
+                blueprint: SubmissionVersionBlueprint,
+                view: :review_extended
   end
 
   view :compliance_update do
@@ -115,7 +136,14 @@ class PermitApplicationBlueprint < Blueprinter::Base
 
   view :external_api do
     identifier :id
-    fields :status, :number, :full_address, :pid, :pin, :reference_number, :submitted_at, :resubmitted_at
+    fields :status,
+           :number,
+           :full_address,
+           :pid,
+           :pin,
+           :reference_number,
+           :submitted_at,
+           :resubmitted_at
 
     field :submission_data do |pa, _options|
       pa.formatted_submission_data_for_external_use
@@ -129,10 +157,18 @@ class PermitApplicationBlueprint < Blueprinter::Base
       pa.formatted_raw_h2k_files_for_external_use
     end
 
-    association :template_version, blueprint: TemplateVersionBlueprint, view: :external_api, name: :permit_version
-    association :submitter, blueprint: UserBlueprint, view: :external_api, name: :account_holder
+    association :template_version,
+                blueprint: TemplateVersionBlueprint,
+                view: :external_api,
+                name: :permit_version
+    association :submitter,
+                blueprint: UserBlueprint,
+                view: :external_api,
+                name: :account_holder
     association :permit_type, blueprint: PermitClassificationBlueprint
-    association :activity, blueprint: PermitClassificationBlueprint, name: :activity_type
+    association :activity,
+                blueprint: PermitClassificationBlueprint,
+                name: :activity_type
   end
 
   view :supporting_docs_update do

--- a/app/blueprints/permit_block_status_blueprint.rb
+++ b/app/blueprints/permit_block_status_blueprint.rb
@@ -2,5 +2,10 @@
 
 class PermitBlockStatusBlueprint < Blueprinter::Base
   identifier :id
-  fields :collaboration_type, :requirement_block_id, :permit_application_id, :status, :created_at, :updated_at
+  fields :collaboration_type,
+         :requirement_block_id,
+         :permit_application_id,
+         :status,
+         :created_at,
+         :updated_at
 end

--- a/app/blueprints/permit_collaboration_blueprint.rb
+++ b/app/blueprints/permit_collaboration_blueprint.rb
@@ -2,7 +2,11 @@
 
 class PermitCollaborationBlueprint < Blueprinter::Base
   identifier :id
-  fields :collaboration_type, :collaborator_type, :assigned_requirement_block_id, :created_at, :updated_at
+  fields :collaboration_type,
+         :collaborator_type,
+         :assigned_requirement_block_id,
+         :created_at,
+         :updated_at
 
   view :base do
     fields :assigned_requirement_block_name
@@ -11,6 +15,8 @@ class PermitCollaborationBlueprint < Blueprinter::Base
 
   view :extended do
     include_view :base
-    association :permit_application, blueprint: PermitApplicationBlueprint, view: :base
+    association :permit_application,
+                blueprint: PermitApplicationBlueprint,
+                view: :base
   end
 end

--- a/app/blueprints/permit_type_required_step_blueprint.rb
+++ b/app/blueprints/permit_type_required_step_blueprint.rb
@@ -1,7 +1,10 @@
 class PermitTypeRequiredStepBlueprint < Blueprinter::Base
   identifier :id
 
-  fields :permit_type_id, :energy_step_required, :zero_carbon_step_required, :default
+  fields :permit_type_id,
+         :energy_step_required,
+         :zero_carbon_step_required,
+         :default
 
   field :permit_type_name do |ptr_step, _options|
     ptr_step.permit_type_name

--- a/app/blueprints/requirement_blueprint.rb
+++ b/app/blueprints/requirement_blueprint.rb
@@ -19,14 +19,19 @@ class RequirementBlueprint < Blueprinter::Base
   end
 
   field :input_options do |requirement|
-    unless requirement.input_options.dig("computed_compliance", "options_map").is_a?(Hash)
+    unless requirement
+             .input_options
+             .dig("computed_compliance", "options_map")
+             .is_a?(Hash)
       requirement.input_options
     else
       input_options_dup = requirement.input_options.deep_dup
 
       # this needs to be done to prevent camelizing the computed compliance options map keys
       # as conversion results in unexpected behaviour
-      input_options_dup["computed_compliance"]["options_map"] = input_options_dup["computed_compliance"][
+      input_options_dup["computed_compliance"][
+        "options_map"
+      ] = input_options_dup["computed_compliance"][
         "options_map"
       ].transform_keys { |key| "compliance-options-map-prefix-#{key.to_s}" }
 

--- a/app/blueprints/requirement_template_blueprint.rb
+++ b/app/blueprints/requirement_template_blueprint.rb
@@ -1,6 +1,14 @@
 class RequirementTemplateBlueprint < Blueprinter::Base
   identifier :id
-  fields :nickname, :type, :description, :first_nations, :label, :discarded_at, :fetched_at, :created_at, :updated_at
+  fields :nickname,
+         :type,
+         :description,
+         :first_nations,
+         :label,
+         :discarded_at,
+         :fetched_at,
+         :created_at,
+         :updated_at
 
   association :permit_type, blueprint: PermitClassificationBlueprint
   association :activity, blueprint: PermitClassificationBlueprint
@@ -8,28 +16,39 @@ class RequirementTemplateBlueprint < Blueprinter::Base
               blueprint: TemplateVersionBlueprint,
               name: :deprecated_template_versions
   association :scheduled_template_versions, blueprint: TemplateVersionBlueprint
-  association :published_template_version, blueprint: TemplateVersionBlueprint do |rt, options|
+  association :published_template_version,
+              blueprint: TemplateVersionBlueprint do |rt, options|
     defaulted_template_version(rt, options)
   end
 
   association :assignee,
               blueprint: UserBlueprint,
               view: :minimal,
-              if: ->(_field_name, rt, options) { options[:current_user]&.super_admin? }
+              if: ->(_field_name, rt, options) do
+                options[:current_user]&.super_admin?
+              end
 
   view :extended do
-    association :requirement_template_sections, blueprint: RequirementTemplateSectionBlueprint
+    association :requirement_template_sections,
+                blueprint: RequirementTemplateSectionBlueprint
 
-    association :published_template_version, blueprint: TemplateVersionBlueprint, view: :extended do |rt, options|
+    association :published_template_version,
+                blueprint: TemplateVersionBlueprint,
+                view: :extended do |rt, options|
       defaulted_template_version(rt, options)
     end
   end
 
   view :template_snapshot do
-    association :requirement_template_sections, blueprint: RequirementTemplateSectionBlueprint
+    association :requirement_template_sections,
+                blueprint: RequirementTemplateSectionBlueprint
   end
 end
 
 def defaulted_template_version(rt, options)
-  options[:published_template_version].present? ? options[:published_template_version] : rt.published_template_version
+  if options[:published_template_version].present?
+    options[:published_template_version]
+  else
+    rt.published_template_version
+  end
 end

--- a/app/blueprints/revision_request_blueprint.rb
+++ b/app/blueprints/revision_request_blueprint.rb
@@ -2,7 +2,11 @@ class RevisionRequestBlueprint < Blueprinter::Base
   identifier :id
 
   view :base do
-    fields :comment, :reason_code, :requirement_json, :submission_json, :created_at
+    fields :comment,
+           :reason_code,
+           :requirement_json,
+           :submission_json,
+           :created_at
   end
 
   view :extended do

--- a/app/blueprints/round_decimals_transformer.rb
+++ b/app/blueprints/round_decimals_transformer.rb
@@ -1,5 +1,7 @@
 class RoundDecimalsTransformer < Blueprinter::Transformer
   def transform(hash, _object, _options)
-    hash.transform_values! { |value| value.respond_to?(:round) ? value.round(2).to_s : value }
+    hash.transform_values! do |value|
+      value.respond_to?(:round) ? value.round(2).to_s : value
+    end
   end
 end

--- a/app/blueprints/step_code/building_characteristics_transformer.rb
+++ b/app/blueprints/step_code/building_characteristics_transformer.rb
@@ -17,15 +17,15 @@ class StepCode::BuildingCharacteristicsTransformer < Blueprinter::Transformer
         ].inject({}) do |h, key|
           h[key] = lines_attrs(object.send(key))
           h
-        end,
+        end
       )
       .merge!(
         {
           windows_glazed_doors: {
             performance_type: object.windows_glazed_doors.performance_type,
-            lines: object.windows_glazed_doors.lines.map(&:attributes),
-          },
-        },
+            lines: object.windows_glazed_doors.lines.map(&:attributes)
+          }
+        }
       )
       .merge!({ fossil_fuels: object.fossil_fuels.attributes })
       .merge!({ airtightness: object.airtightness.attributes })

--- a/app/blueprints/step_code/compliance_report_blueprint.rb
+++ b/app/blueprints/step_code/compliance_report_blueprint.rb
@@ -5,6 +5,8 @@ class StepCode::ComplianceReportBlueprint < Blueprinter::Base
   end
 
   field :zero_carbon do |report, _options|
-    StepCode::ZeroCarbon::ComplianceBlueprint.render_as_hash(report[:zero_carbon])
+    StepCode::ZeroCarbon::ComplianceBlueprint.render_as_hash(
+      report[:zero_carbon]
+    )
   end
 end

--- a/app/blueprints/step_code/compliance_reports_transformer.rb
+++ b/app/blueprints/step_code/compliance_reports_transformer.rb
@@ -3,8 +3,10 @@ class StepCode::ComplianceReportsTransformer < Blueprinter::Transformer
     hash.merge!(
       {
         compliance_reports:
-          object.compliance_reports.map { |report| StepCode::ComplianceReportBlueprint.render_as_hash(report) },
-      },
+          object.compliance_reports.map do |report|
+            StepCode::ComplianceReportBlueprint.render_as_hash(report)
+          end
+      }
     )
   end
 end

--- a/app/blueprints/step_code/energy/airtightness_transformer.rb
+++ b/app/blueprints/step_code/energy/airtightness_transformer.rb
@@ -1,5 +1,9 @@
 class StepCode::Energy::AirtightnessTransformer < Blueprinter::Transformer
   def transform(hash, object, options)
-    hash.merge!(StepCode::Energy::AirtightnessBlueprint.render_as_hash(object.airtightness_checker))
+    hash.merge!(
+      StepCode::Energy::AirtightnessBlueprint.render_as_hash(
+        object.airtightness_checker
+      )
+    )
   end
 end

--- a/app/blueprints/step_code/energy/meui_transformer.rb
+++ b/app/blueprints/step_code/energy/meui_transformer.rb
@@ -1,5 +1,7 @@
 class StepCode::Energy::MEUITransformer < Blueprinter::Transformer
   def transform(hash, object, options)
-    hash.merge!(StepCode::Energy::MEUIBlueprint.render_as_hash(object.meui_checker))
+    hash.merge!(
+      StepCode::Energy::MEUIBlueprint.render_as_hash(object.meui_checker)
+    )
   end
 end

--- a/app/blueprints/step_code/energy/tedi_blueprint.rb
+++ b/app/blueprints/step_code/energy/tedi_blueprint.rb
@@ -1,5 +1,8 @@
 class StepCode::Energy::TEDIBlueprint < Blueprinter::Base
-  fields :tedi, :tedi_requirement, :tedi_hlr_percent, :tedi_hlr_percent_requirement
+  fields :tedi,
+         :tedi_requirement,
+         :tedi_hlr_percent,
+         :tedi_hlr_percent_requirement
 
   field :tedi_passed do |checker, _options|
     checker.requirements_met?

--- a/app/blueprints/step_code/energy/tedi_transformer.rb
+++ b/app/blueprints/step_code/energy/tedi_transformer.rb
@@ -1,5 +1,7 @@
 class StepCode::Energy::TEDITransformer < Blueprinter::Transformer
   def transform(hash, object, options)
-    hash.merge!(StepCode::Energy::TEDIBlueprint.render_as_hash(object.tedi_checker))
+    hash.merge!(
+      StepCode::Energy::TEDIBlueprint.render_as_hash(object.tedi_checker)
+    )
   end
 end

--- a/app/blueprints/step_code/zero_carbon/co2_transformer.rb
+++ b/app/blueprints/step_code/zero_carbon/co2_transformer.rb
@@ -1,5 +1,7 @@
 class StepCode::ZeroCarbon::CO2Transformer < Blueprinter::Transformer
   def transform(hash, object, options)
-    hash.merge!(StepCode::ZeroCarbon::CO2Blueprint.render_as_hash(object.co2_checker))
+    hash.merge!(
+      StepCode::ZeroCarbon::CO2Blueprint.render_as_hash(object.co2_checker)
+    )
   end
 end

--- a/app/blueprints/step_code/zero_carbon/ghg_transformer.rb
+++ b/app/blueprints/step_code/zero_carbon/ghg_transformer.rb
@@ -1,5 +1,7 @@
 class StepCode::ZeroCarbon::GHGTransformer < Blueprinter::Transformer
   def transform(hash, object, options)
-    hash.merge!(StepCode::ZeroCarbon::GHGBlueprint.render_as_hash(object.ghg_checker))
+    hash.merge!(
+      StepCode::ZeroCarbon::GHGBlueprint.render_as_hash(object.ghg_checker)
+    )
   end
 end

--- a/app/blueprints/step_code/zero_carbon/prescriptive_transformer.rb
+++ b/app/blueprints/step_code/zero_carbon/prescriptive_transformer.rb
@@ -1,5 +1,9 @@
 class StepCode::ZeroCarbon::PrescriptiveTransformer < Blueprinter::Transformer
   def transform(hash, object, options)
-    hash.merge!(StepCode::ZeroCarbon::PrescriptiveBlueprint.render_as_hash(object.prescriptive_checker))
+    hash.merge!(
+      StepCode::ZeroCarbon::PrescriptiveBlueprint.render_as_hash(
+        object.prescriptive_checker
+      )
+    )
   end
 end

--- a/app/blueprints/step_code_checklist_blueprint.rb
+++ b/app/blueprints/step_code_checklist_blueprint.rb
@@ -13,7 +13,11 @@ class StepCodeChecklistBlueprint < Blueprinter::Base
   end
 
   view :project_info do
-    fields :building_permit_number, :jurisdiction_name, :pid, :building_type, :builder
+    fields :building_permit_number,
+           :jurisdiction_name,
+           :pid,
+           :building_type,
+           :builder
     field :full_address, name: :address
 
     field :dwelling_units_count do |checklist, _options|
@@ -44,7 +48,8 @@ class StepCodeChecklistBlueprint < Blueprinter::Base
   end
 
   view :building_characteristics_summary do
-    association :building_characteristics_summary, blueprint: StepCodeBuildingCharacteristicsSummaryBlueprint
+    association :building_characteristics_summary,
+                blueprint: StepCodeBuildingCharacteristicsSummaryBlueprint
   end
 
   view :mid_construction_testing_results do
@@ -75,7 +80,9 @@ class StepCodeChecklistBlueprint < Blueprinter::Base
            :epc_calculation_compliance
 
     field :selected_report do |checklist, _options|
-      report = checklist.selected_report || checklist.passing_compliance_reports[0] || checklist.compliance_reports[0]
+      report =
+        checklist.selected_report || checklist.passing_compliance_reports[0] ||
+          checklist.compliance_reports[0]
       StepCode::ComplianceReportBlueprint.render_as_hash(report)
     end
   end

--- a/app/blueprints/submission_version_blueprint.rb
+++ b/app/blueprints/submission_version_blueprint.rb
@@ -8,15 +8,23 @@ class SubmissionVersionBlueprint < Blueprinter::Base
     include_view :base
     fields :form_json
     field :submission_data do |submission_version, options|
-      submission_version.formatted_submission_data(current_user: options[:current_user])
+      submission_version.formatted_submission_data(
+        current_user: options[:current_user]
+      )
     end
-    association :revision_requests, blueprint: RevisionRequestBlueprint, view: :base do |submission_version, options|
-      submission_version.revision_requests_for_submitter_based_on_user_permissions(user: options[:current_user])
+    association :revision_requests,
+                blueprint: RevisionRequestBlueprint,
+                view: :base do |submission_version, options|
+      submission_version.revision_requests_for_submitter_based_on_user_permissions(
+        user: options[:current_user]
+      )
     end
   end
 
   view :review_extended do
     include_view :extended
-    association :revision_requests, blueprint: RevisionRequestBlueprint, view: :extended
+    association :revision_requests,
+                blueprint: RevisionRequestBlueprint,
+                view: :extended
   end
 end

--- a/app/blueprints/template_version_blueprint.rb
+++ b/app/blueprints/template_version_blueprint.rb
@@ -1,6 +1,12 @@
 class TemplateVersionBlueprint < Blueprinter::Base
   identifier :id
-  fields :status, :deprecation_reason, :created_at, :updated_at, :version_date, :label, :first_nations
+  fields :status,
+         :deprecation_reason,
+         :created_at,
+         :updated_at,
+         :version_date,
+         :label,
+         :first_nations
 
   field :version_date do |template_version|
     # Parse version date in BC time

--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -2,7 +2,14 @@ class UserBlueprint < Blueprinter::Base
   identifier :id
 
   view :minimal do
-    fields :email, :role, :first_name, :last_name, :organization, :certified, :confirmed_at, :discarded_at
+    fields :email,
+           :role,
+           :first_name,
+           :last_name,
+           :organization,
+           :certified,
+           :confirmed_at,
+           :discarded_at
   end
 
   view :accepted_license_agreements do
@@ -29,7 +36,8 @@ class UserBlueprint < Blueprinter::Base
   view :current_user do
     include_view :base
     field :eula_accepted do |user, _options|
-      user.eula_variant.present? && user.license_agreements.active_agreement(user.eula_variant).present?
+      user.eula_variant.present? &&
+        user.license_agreements.active_agreement(user.eula_variant).present?
     end
   end
 
@@ -48,8 +56,14 @@ class UserBlueprint < Blueprinter::Base
       user.invited_by&.email
     end
 
-    association :invited_to_jurisdiction, blueprint: JurisdictionBlueprint, view: :minimal do |user, _options|
-      user.jurisdiction_memberships&.order(updated_at: :desc)&.first&.jurisdiction
+    association :invited_to_jurisdiction,
+                blueprint: JurisdictionBlueprint,
+                view: :minimal do |user, _options|
+      user
+        .jurisdiction_memberships
+        &.order(updated_at: :desc)
+        &.first
+        &.jurisdiction
     end
   end
 end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -21,7 +21,9 @@ class Api::ApplicationController < ActionController::API
   protected
 
   def check_for_archived_user
-    render_error("misc.user_not_authorized_error", {}, nil) and return if current_user&.discarded?
+    if current_user&.discarded?
+      render_error("misc.user_not_authorized_error", {}, nil) and return
+    end
   end
 
   def apply_search_authorization(results, policy_action = action_name)
@@ -36,7 +38,7 @@ class Api::ApplicationController < ActionController::API
     render_error(
       "misc.user_not_authorized_error",
       { message_opts: { error_message: exception.message }, status: 403 },
-      exception,
+      exception
     ) and return
   end
 

--- a/app/controllers/api/collaborators_controller.rb
+++ b/app/controllers/api/collaborators_controller.rb
@@ -6,22 +6,29 @@ class Api::CollaboratorsController < Api::ApplicationController
 
   def collaborator_search
     perform_collaborator_search
-    authorized_results = apply_search_authorization(@collaborator_search.results, "collaborator_search")
+    authorized_results =
+      apply_search_authorization(
+        @collaborator_search.results,
+        "collaborator_search"
+      )
     render_success authorized_results,
                    nil,
                    {
                      meta: {
                        total_pages: @collaborator_search.total_pages,
                        total_count: @collaborator_search.total_count,
-                       current_page: @collaborator_search.current_page,
+                       current_page: @collaborator_search.current_page
                      },
-                     blueprint: CollaboratorBlueprint,
+                     blueprint: CollaboratorBlueprint
                    }
   end
 
   private
 
   def set_collaboratorable
-    @collaboratorable = Collaborator.find_by!(collaboratorable_id: params[:collaboratorable_id]).collaboratorable
+    @collaboratorable =
+      Collaborator.find_by!(
+        collaboratorable_id: params[:collaboratorable_id]
+      ).collaboratorable
   end
 end

--- a/app/controllers/api/concerns/search/admin_users.rb
+++ b/app/controllers/api/concerns/search/admin_users.rb
@@ -14,7 +14,7 @@ module Api::Concerns::Search::AdminUsers
               else
                 nil
               end
-            ),
+            )
         },
         order: user_order,
         match: :word_start,
@@ -22,18 +22,27 @@ module Api::Concerns::Search::AdminUsers
         per_page:
           (
             if user_search_params[:page]
-              (user_search_params[:per_page] || Kaminari.config.default_per_page)
+              (
+                user_search_params[:per_page] ||
+                  Kaminari.config.default_per_page
+              )
             else
               nil
             end
-          ),
+          )
       )
   end
 
   private
 
   def user_search_params
-    params.permit(:query, :show_archived, :page, :per_page, sort: %i[field direction])
+    params.permit(
+      :query,
+      :show_archived,
+      :page,
+      :per_page,
+      sort: %i[field direction]
+    )
   end
 
   def user_query

--- a/app/controllers/api/concerns/search/collaborators.rb
+++ b/app/controllers/api/concerns/search/collaborators.rb
@@ -10,14 +10,18 @@ module Api::Concerns::Search::Collaborators
       per_page:
         (
           if collaborator_search_params[:page]
-            (collaborator_search_params[:per_page] || Kaminari.config.default_per_page)
+            (
+              collaborator_search_params[:per_page] ||
+                Kaminari.config.default_per_page
+            )
           else
             nil
           end
-        ),
+        )
     }
 
-    @collaborator_search = Collaborator.search(collaborator_query, **search_conditions)
+    @collaborator_search =
+      Collaborator.search(collaborator_query, **search_conditions)
   end
 
   private
@@ -27,7 +31,11 @@ module Api::Concerns::Search::Collaborators
   end
 
   def collaborator_query
-    collaborator_search_params[:query].present? ? collaborator_search_params[:query] : "*"
+    if collaborator_search_params[:query].present?
+      collaborator_search_params[:query]
+    else
+      "*"
+    end
   end
 
   def collaborator_order
@@ -39,7 +47,9 @@ module Api::Concerns::Search::Collaborators
   end
 
   def collaborator_where_clause
-    raise ArgumentError, "Missing collaboratorable" unless @collaboratorable.present?
+    unless @collaboratorable.present?
+      raise ArgumentError, "Missing collaboratorable"
+    end
 
     { collaboratorable_id: @collaboratorable.id }
   end

--- a/app/controllers/api/concerns/search/jurisdiction_users.rb
+++ b/app/controllers/api/concerns/search/jurisdiction_users.rb
@@ -13,12 +13,13 @@ module Api::Concerns::Search::JurisdictionUsers
             (
               if current_user.super_admin?
                 %w[review_manager regional_review_manager]
-              elsif current_user.review_manager? || current_user.regional_review_manager?
+              elsif current_user.review_manager? ||
+                    current_user.regional_review_manager?
                 %w[regional_review_manager review_manager reviewer]
               else
                 nil
               end
-            ),
+            )
         },
         order: user_order,
         match: :word_start,
@@ -26,18 +27,27 @@ module Api::Concerns::Search::JurisdictionUsers
         per_page:
           (
             if user_search_params[:page]
-              (user_search_params[:per_page] || Kaminari.config.default_per_page)
+              (
+                user_search_params[:per_page] ||
+                  Kaminari.config.default_per_page
+              )
             else
               nil
             end
-          ),
+          )
       )
   end
 
   private
 
   def user_search_params
-    params.permit(:query, :show_archived, :page, :per_page, sort: %i[field direction])
+    params.permit(
+      :query,
+      :show_archived,
+      :page,
+      :per_page,
+      sort: %i[field direction]
+    )
   end
 
   def user_query

--- a/app/controllers/api/concerns/search/jurisdictions.rb
+++ b/app/controllers/api/concerns/search/jurisdictions.rb
@@ -9,26 +9,46 @@ module Api::Concerns::Search::Jurisdictions
       per_page:
         (
           if jurisdiction_search_params[:page]
-            (jurisdiction_search_params[:per_page] || Kaminari.config.default_per_page)
+            (
+              jurisdiction_search_params[:per_page] ||
+                Kaminari.config.default_per_page
+            )
           else
             nil
           end
-        ),
+        )
     }
 
     # Conditionally add the `where` clause
-    search_params[:where] = jurisdiction_where_clause unless jurisdiction_where_clause.nil?
-    @search = Jurisdiction.search(jurisdiction_query, **search_params, includes: Jurisdiction::BASE_INCLUDES)
+    search_params[
+      :where
+    ] = jurisdiction_where_clause unless jurisdiction_where_clause.nil?
+    @search =
+      Jurisdiction.search(
+        jurisdiction_query,
+        **search_params,
+        includes: Jurisdiction::BASE_INCLUDES
+      )
   end
 
   private
 
   def jurisdiction_search_params
-    params.permit(:query, :page, :per_page, filters: [:submission_inbox_set_up], sort: %i[field direction])
+    params.permit(
+      :query,
+      :page,
+      :per_page,
+      filters: [:submission_inbox_set_up],
+      sort: %i[field direction]
+    )
   end
 
   def jurisdiction_query
-    jurisdiction_search_params[:query].present? ? jurisdiction_search_params[:query] : "*"
+    if jurisdiction_search_params[:query].present?
+      jurisdiction_search_params[:query]
+    else
+      "*"
+    end
   end
 
   def jurisdiction_order

--- a/app/controllers/api/concerns/search/permit_applications.rb
+++ b/app/controllers/api/concerns/search/permit_applications.rb
@@ -12,21 +12,25 @@ module Api::Concerns::Search::PermitApplications
         { permit_classifications: :word_middle },
         { submitter: :word_middle },
         { status: :word_middle },
-        { review_delegatee_name: :word_middle },
+        { review_delegatee_name: :word_middle }
       ],
       where: permit_application_where_clause,
       page: permit_application_search_params[:page],
       per_page:
         (
           if permit_application_search_params[:page]
-            (permit_application_search_params[:per_page] || Kaminari.config.default_per_page)
+            (
+              permit_application_search_params[:per_page] ||
+                Kaminari.config.default_per_page
+            )
           else
             nil
           end
         ),
-      includes: PermitApplication::SEARCH_INCLUDES,
+      includes: PermitApplication::SEARCH_INCLUDES
     }
-    @permit_application_search = PermitApplication.search(permit_application_query, **search_conditions)
+    @permit_application_search =
+      PermitApplication.search(permit_application_query, **search_conditions)
   end
 
   private
@@ -37,12 +41,16 @@ module Api::Concerns::Search::PermitApplications
       :page,
       :per_page,
       filters: [:requirement_template_id, :template_version_id, { status: [] }],
-      sort: %i[field direction],
+      sort: %i[field direction]
     )
   end
 
   def permit_application_query
-    permit_application_search_params[:query].present? ? permit_application_search_params[:query] : "*"
+    if permit_application_search_params[:query].present?
+      permit_application_search_params[:query]
+    else
+      "*"
+    end
   end
 
   def permit_application_order
@@ -66,10 +74,13 @@ module Api::Concerns::Search::PermitApplications
         jurisdiction_id: @jurisdiction.id,
         sandbox_id: current_sandbox&.id,
         # Overrides status filter, reorder the code if necessary
-        status: %i[newly_submitted resubmitted],
+        status: %i[newly_submitted resubmitted]
       }
     else
-      where = { user_ids_with_submission_edit_permissions: current_user.id, sandbox_id: nil }
+      where = {
+        user_ids_with_submission_edit_permissions: current_user.id,
+        sandbox_id: nil
+      }
     end
     ret = (filters&.to_h || {}).deep_symbolize_keys.compact.merge!(where)
 

--- a/app/controllers/api/concerns/search/requirement_blocks.rb
+++ b/app/controllers/api/concerns/search/requirement_blocks.rb
@@ -9,7 +9,7 @@ module Api::Concerns::Search::RequirementBlocks
         match: :word_start,
         where: {
           discarded: discarded,
-          early_access: early_access,
+          early_access: early_access
         },
         page: search_params[:page],
         per_page:
@@ -20,14 +20,20 @@ module Api::Concerns::Search::RequirementBlocks
               nil
             end
           ),
-        includes: %i[taggings requirements],
+        includes: %i[taggings requirements]
       )
   end
 
   private
 
   def search_params
-    params.permit(:query, :page, :show_archived, :per_page, sort: %i[field direction])
+    params.permit(
+      :query,
+      :page,
+      :show_archived,
+      :per_page,
+      sort: %i[field direction]
+    )
   end
 
   def query

--- a/app/controllers/api/concerns/search/requirement_templates.rb
+++ b/app/controllers/api/concerns/search/requirement_templates.rb
@@ -15,7 +15,7 @@ module Api::Concerns::Search::RequirementTemplates
         order: order,
         where: {
           discarded: discarded,
-          early_access: early_access,
+          early_access: early_access
         },
         match: :word_start,
         page: search_params[:page],
@@ -27,14 +27,21 @@ module Api::Concerns::Search::RequirementTemplates
               nil
             end
           ),
-        includes: RequirementTemplate::SEARCH_INCLUDES,
+        includes: RequirementTemplate::SEARCH_INCLUDES
       )
   end
 
   private
 
   def search_params
-    params.permit(:query, :show_archived, :early_access, :page, :per_page, sort: %i[field direction])
+    params.permit(
+      :query,
+      :show_archived,
+      :early_access,
+      :page,
+      :per_page,
+      sort: %i[field direction]
+    )
   end
 
   def query

--- a/app/controllers/api/confirmations_controller.rb
+++ b/app/controllers/api/confirmations_controller.rb
@@ -10,16 +10,21 @@ class Api::ConfirmationsController < Devise::ConfirmationsController
 
     if resource.errors.empty?
       PermitHubMailer.welcome(@user).deliver_later
-      redirect_to confirmed_url(frontend_flash_message("user.confirmation_success", "success"))
+      redirect_to confirmed_url(
+                    frontend_flash_message(
+                      "user.confirmation_success",
+                      "success"
+                    )
+                  )
     else
       redirect_to root_url(
                     frontend_flash_message(
                       "user.confirmation_error",
                       "error",
                       message_opts: {
-                        error_message: resource.errors.full_messages.join(","),
-                      },
-                    ),
+                        error_message: resource.errors.full_messages.join(",")
+                      }
+                    )
                   )
     end
   end

--- a/app/controllers/api/contacts_controller.rb
+++ b/app/controllers/api/contacts_controller.rb
@@ -8,13 +8,15 @@ class Api::ContactsController < Api::ApplicationController
         contact_search_params[:query] || "*",
         match: :word_start,
         where: {
-          contactable_id: current_user.id,
+          contactable_id: current_user.id
         },
-        limit: 10,
+        limit: 10
       ) || []
 
     apply_search_authorization(contacts)
-    render_success contacts.map { |c| { label: c.name, value: c } }, nil, { blueprint: ContactOptionBlueprint }
+    render_success contacts.map { |c| { label: c.name, value: c } },
+                   nil,
+                   { blueprint: ContactOptionBlueprint }
   rescue StandardError => e
     render_error "contact.options_error", {}, e and return
   end
@@ -26,9 +28,14 @@ class Api::ContactsController < Api::ApplicationController
     authorize @contact
 
     if @contact.save
-      render_success @contact, "contact.create_success", { blueprint: ContactBlueprint }
+      render_success @contact,
+                     "contact.create_success",
+                     { blueprint: ContactBlueprint }
     else
-      render_error "contact.create_error", message_opts: { error_message: @contact.errors.full_messages.join(", ") }
+      render_error "contact.create_error",
+                   message_opts: {
+                     error_message: @contact.errors.full_messages.join(", ")
+                   }
     end
   end
 
@@ -36,9 +43,14 @@ class Api::ContactsController < Api::ApplicationController
     authorize @contact
 
     if @contact.update(contact_params)
-      render_success @contact, "contact.update_success", { blueprint: ContactBlueprint }
+      render_success @contact,
+                     "contact.update_success",
+                     { blueprint: ContactBlueprint }
     else
-      render_error "contact.update_error", message_opts: { error_message: @contact.errors.full_messages.join(", ") }
+      render_error "contact.update_error",
+                   message_opts: {
+                     error_message: @contact.errors.full_messages.join(", ")
+                   }
     end
   end
 
@@ -46,9 +58,14 @@ class Api::ContactsController < Api::ApplicationController
     authorize @contact
 
     if @contact.destroy
-      render_success @contact, "contact.destroy_success", { blueprint: ContactBlueprint }
+      render_success @contact,
+                     "contact.destroy_success",
+                     { blueprint: ContactBlueprint }
     else
-      render_error "contact.destroy_error", message_opts: { error_message: @contact.errors.full_messages.join(", ") }
+      render_error "contact.destroy_error",
+                   message_opts: {
+                     error_message: @contact.errors.full_messages.join(", ")
+                   }
     end
   end
 
@@ -72,7 +89,7 @@ class Api::ContactsController < Api::ApplicationController
       :address,
       :business_name,
       :professional_association,
-      :professional_number,
+      :professional_number
     )
   end
 

--- a/app/controllers/api/end_user_license_agreement_controller.rb
+++ b/app/controllers/api/end_user_license_agreement_controller.rb
@@ -4,6 +4,8 @@ class Api::EndUserLicenseAgreementController < Api::ApplicationController
 
   def index
     authorize :end_user_license_agreement, :index?
-    render_success EndUserLicenseAgreement.active_agreement(current_user.eula_variant)
+    render_success EndUserLicenseAgreement.active_agreement(
+                     current_user.eula_variant
+                   )
   end
 end

--- a/app/controllers/api/external_api_keys_controller.rb
+++ b/app/controllers/api/external_api_keys_controller.rb
@@ -3,7 +3,9 @@ class Api::ExternalApiKeysController < Api::ApplicationController
 
   def index
     # Only authorized to query own jurisdiction for review managers
-    if (current_user.review_manager? || current_user.regional_review_manager?) && params[:jurisdiction_id].present? &&
+    if (
+         current_user.review_manager? || current_user.regional_review_manager?
+       ) && params[:jurisdiction_id].present? &&
          !current_user.jurisdictions.find(params[:jurisdiction_id])
       raise Pundit::NotAuthorizedError
     end
@@ -11,19 +13,30 @@ class Api::ExternalApiKeysController < Api::ApplicationController
     @external_api_key =
       (
         if params[:jurisdiction_id].present?
-          policy_scope(ExternalApiKey).where(jurisdiction_id: params[:jurisdiction_id])
+          policy_scope(ExternalApiKey).where(
+            jurisdiction_id: params[:jurisdiction_id]
+          )
         else
           policy_scope(ExternalApiKey)
         end
       )
 
-    render_success @external_api_key, nil, { blueprint: ExternalApiKeyBlueprint }
+    render_success @external_api_key,
+                   nil,
+                   { blueprint: ExternalApiKeyBlueprint }
   end
 
   def show
     authorize @external_api_key
 
-    render_success @external_api_key, nil, { blueprint: ExternalApiKeyBlueprint, blueprint_opts: { view: :with_token } }
+    render_success @external_api_key,
+                   nil,
+                   {
+                     blueprint: ExternalApiKeyBlueprint,
+                     blueprint_opts: {
+                       view: :with_token
+                     }
+                   }
   end
 
   def create
@@ -34,11 +47,17 @@ class Api::ExternalApiKeysController < Api::ApplicationController
     if @external_api_key.save
       render_success @external_api_key,
                      "external_api_key.create_success",
-                     { blueprint: ExternalApiKeyBlueprint, blueprint_opts: { view: :with_token } }
+                     {
+                       blueprint: ExternalApiKeyBlueprint,
+                       blueprint_opts: {
+                         view: :with_token
+                       }
+                     }
     else
       render_error "external_api_key.create_error",
                    message_opts: {
-                     error_message: @external_api_key.errors.full_messages.join(", "),
+                     error_message:
+                       @external_api_key.errors.full_messages.join(", ")
                    }
     end
   end
@@ -49,11 +68,17 @@ class Api::ExternalApiKeysController < Api::ApplicationController
     if @external_api_key.update(external_api_key_params)
       render_success @external_api_key,
                      "external_api_key.update_success",
-                     { blueprint: ExternalApiKeyBlueprint, blueprint_opts: { view: :with_token } }
+                     {
+                       blueprint: ExternalApiKeyBlueprint,
+                       blueprint_opts: {
+                         view: :with_token
+                       }
+                     }
     else
       render_error "external_api_key.update_error",
                    message_opts: {
-                     error_message: @external_api_key.errors.full_messages.join(", "),
+                     error_message:
+                       @external_api_key.errors.full_messages.join(", ")
                    }
     end
   end
@@ -66,7 +91,8 @@ class Api::ExternalApiKeysController < Api::ApplicationController
     else
       render_error "external_api_key.delete_error",
                    message_opts: {
-                     error_message: @external_api_key.errors.full_messages.join(", "),
+                     error_message:
+                       @external_api_key.errors.full_messages.join(", ")
                    }
     end
   end
@@ -77,11 +103,17 @@ class Api::ExternalApiKeysController < Api::ApplicationController
     if @external_api_key.revoke
       render_success @external_api_key,
                      "external_api_key.revoke_success",
-                     { blueprint: ExternalApiKeyBlueprint, blueprint_opts: { view: :with_token } }
+                     {
+                       blueprint: ExternalApiKeyBlueprint,
+                       blueprint_opts: {
+                         view: :with_token
+                       }
+                     }
     else
       render_error "external_api_key.revoke_error",
                    message_opts: {
-                     error_message: @external_api_key.errors.full_messages.join(", "),
+                     error_message:
+                       @external_api_key.errors.full_messages.join(", ")
                    }
     end
   end
@@ -99,7 +131,7 @@ class Api::ExternalApiKeysController < Api::ApplicationController
       :connecting_application,
       :notification_email,
       :jurisdiction_id,
-      :webhook_url,
+      :webhook_url
     )
   end
 end

--- a/app/controllers/api/geocoder_controller.rb
+++ b/app/controllers/api/geocoder_controller.rb
@@ -3,7 +3,8 @@ class Api::GeocoderController < Api::ApplicationController
   after_action :verify_authorized
   skip_before_action :authenticate_user!, only: %i[site_options jurisdiction]
 
-  rescue_from Errors::FeatureAttributesRetrievalError, with: :handle_ltsa_unavailable
+  rescue_from Errors::FeatureAttributesRetrievalError,
+              with: :handle_ltsa_unavailable
 
   def site_options
     authorize :geocoder, :site_options?
@@ -23,7 +24,10 @@ class Api::GeocoderController < Api::ApplicationController
   def pid_details #get site details if a pid is supplied instead
     authorize :geocoder, :pid_details?
     begin
-      coordinates = Wrappers::LtsaParcelMapBc.new.get_coordinates_by_pid(geocoder_params[:pid])
+      coordinates =
+        Wrappers::LtsaParcelMapBc.new.get_coordinates_by_pid(
+          geocoder_params[:pid]
+        )
       if coordinates
         wrapper = Wrappers::Geocoder.new
 
@@ -66,11 +70,22 @@ class Api::GeocoderController < Api::ApplicationController
         pid = geocoder_params[:pid]
       end
       raise StandardError unless pid.present?
-      attributes = Wrappers::LtsaParcelMapBc.new.get_feature_attributes_by_pid(pid: pid)
-      render_error "geocoder.jurisdiction_ltsa_error", {}, e and return unless attributes.present?
-      jurisdiction = Jurisdiction.fuzzy_find_by_ltsa_feature_attributes(attributes)
+      attributes =
+        Wrappers::LtsaParcelMapBc.new.get_feature_attributes_by_pid(pid: pid)
+      unless attributes.present?
+        render_error "geocoder.jurisdiction_ltsa_error", {}, e and return
+      end
+      jurisdiction =
+        Jurisdiction.fuzzy_find_by_ltsa_feature_attributes(attributes)
       raise StandardError unless jurisdiction.present?
-      render_success jurisdiction, nil, { blueprint: JurisdictionBlueprint, blueprint_opts: { view: :base } }
+      render_success jurisdiction,
+                     nil,
+                     {
+                       blueprint: JurisdictionBlueprint,
+                       blueprint_opts: {
+                         view: :base
+                       }
+                     }
     rescue StandardError => e
       render_error "geocoder.jurisdiction_error", {}, e and return
     end
@@ -79,7 +94,11 @@ class Api::GeocoderController < Api::ApplicationController
   def pin
     authorize :geocoder, :pin?
     begin
-      attributes = Wrappers::LtsaParcelMapBc.new.get_feature_attributes_by_pid_or_pin(pin: pin_params[:pin], pid: nil)
+      attributes =
+        Wrappers::LtsaParcelMapBc.new.get_feature_attributes_by_pid_or_pin(
+          pin: pin_params[:pin],
+          pid: nil
+        )
       render json: { pin: attributes }, status: :ok
     rescue StandardError => e
       render_error "geocoder.ltsa_unavailable_error", {}, e and return

--- a/app/controllers/api/integration_mappings_controller.rb
+++ b/app/controllers/api/integration_mappings_controller.rb
@@ -6,10 +6,17 @@ class Api::IntegrationMappingsController < Api::ApplicationController
   def update
     authorize @integration_mapping
 
-    if @integration_mapping.update_requirements_mapping(integration_mapping_params.to_h[:simplified_map])
+    if @integration_mapping.update_requirements_mapping(
+         integration_mapping_params.to_h[:simplified_map]
+       )
       render_success @integration_mapping,
                      "integration_mapping.update_success",
-                     { blueprint: IntegrationMappingBlueprint, blueprint_opts: { view: :base } }
+                     {
+                       blueprint: IntegrationMappingBlueprint,
+                       blueprint_opts: {
+                         view: :base
+                       }
+                     }
     else
       render_error "integration_mapping.update_error"
     end

--- a/app/controllers/api/invitations_controller.rb
+++ b/app/controllers/api/invitations_controller.rb
@@ -6,8 +6,15 @@ class Api::InvitationsController < Devise::InvitationsController
   skip_before_action :authenticate_user!, only: %i[show]
 
   def create
-    inviter = Jurisdiction::UserInviter.new(inviter: current_user, users_params: users_params).call
-    if (inviter.results[:invited] + inviter.results[:reinvited] + inviter.results[:email_taken]).any?
+    inviter =
+      Jurisdiction::UserInviter.new(
+        inviter: current_user,
+        users_params: users_params
+      ).call
+    if (
+         inviter.results[:invited] + inviter.results[:reinvited] +
+           inviter.results[:email_taken]
+       ).any?
       render_success(inviter.results, nil, { blueprint: InvitationBlueprint })
     else
       render_error "user.create_invite_error" and return
@@ -16,7 +23,14 @@ class Api::InvitationsController < Devise::InvitationsController
 
   def show
     if @invited_user
-      render_success @invited_user, nil, { blueprint: UserBlueprint, blueprint_opts: { view: :invited_user } }
+      render_success @invited_user,
+                     nil,
+                     {
+                       blueprint: UserBlueprint,
+                       blueprint_opts: {
+                         view: :invited_user
+                       }
+                     }
     else
       render json: { error: :invalid_token }, status: :not_found
     end
@@ -27,7 +41,15 @@ class Api::InvitationsController < Devise::InvitationsController
   def users_params
     params
       .require(:users)
-      .map { |user_param| user_param.permit(:email, :role, :first_name, :last_name, :jurisdiction_id) }
+      .map do |user_param|
+        user_param.permit(
+          :email,
+          :role,
+          :first_name,
+          :last_name,
+          :jurisdiction_id
+        )
+      end
   end
 
   def user_params
@@ -36,10 +58,15 @@ class Api::InvitationsController < Devise::InvitationsController
 
   def render_accept_invite_error(resource)
     render_error "user.accept_invite_error",
-                 { message_opts: { error_message: resource.errors.full_messages.join(", ") } }
+                 {
+                   message_opts: {
+                     error_message: resource.errors.full_messages.join(", ")
+                   }
+                 }
   end
 
   def find_invited_user
-    @invited_user = User.find_by_invitation_token(params[:invitation_token], true)
+    @invited_user =
+      User.find_by_invitation_token(params[:invitation_token], true)
   end
 end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -4,7 +4,8 @@ class Api::NotificationsController < Api::ApplicationController
   def index
     authorize :notification, :index?
 
-    @notification_feed = NotificationService.user_feed_for(current_user.id, params[:page])
+    @notification_feed =
+      NotificationService.user_feed_for(current_user.id, params[:page])
     nf = @notification_feed[:feed_object]
     render_success @notification_feed[:feed_items],
                    nil,
@@ -13,8 +14,8 @@ class Api::NotificationsController < Api::ApplicationController
                      meta: {
                        total_pages: @notification_feed[:total_pages],
                        unread_count: nf.unread_count,
-                       last_read_at: nf.last_read,
-                     },
+                       last_read_at: nf.last_read
+                     }
                    }
   end
 

--- a/app/controllers/api/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/omniauth_callbacks_controller.rb
@@ -2,11 +2,12 @@ class Api::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include BaseControllerMethods
 
   def keycloak
-    origin_query = Rack::Utils.parse_nested_query(URI(request.env["omniauth.origin"]).query)
+    origin_query =
+      Rack::Utils.parse_nested_query(URI(request.env["omniauth.origin"]).query)
     result =
       OmniauthUserResolver.new(
         auth: request.env["omniauth.auth"],
-        invitation_token: origin_query["invitation_token"],
+        invitation_token: origin_query["invitation_token"]
       ).call
     @user = result.user
 
@@ -20,9 +21,9 @@ class Api::OmniauthCallbacksController < Devise::OmniauthCallbacksController
                       result.error_key,
                       "error",
                       message_opts: {
-                        error_message: @user&.errors&.full_messages&.join(","),
-                      },
-                    ),
+                        error_message: @user&.errors&.full_messages&.join(",")
+                      }
+                    )
                   )
     end
   end

--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -21,26 +21,29 @@ class Api::PermitApplicationsController < Api::ApplicationController
 
   def index
     perform_permit_application_search
-    authorized_results = apply_search_authorization(@permit_application_search.results)
+    authorized_results =
+      apply_search_authorization(@permit_application_search.results)
     render_success authorized_results,
                    nil,
                    {
                      meta: {
                        total_pages: @permit_application_search.total_pages,
                        total_count: @permit_application_search.total_count,
-                       current_page: @permit_application_search.current_page,
+                       current_page: @permit_application_search.current_page
                      },
                      blueprint: PermitApplicationBlueprint,
                      blueprint_opts: {
-                       view: :base,
-                     },
+                       view: :base
+                     }
                    }
   end
 
   def mark_as_viewed
     authorize @permit_application
     @permit_application.update_viewed_at
-    render_success @permit_application, nil, { blueprint_opts: { view: :jurisdiction_review_extended } }
+    render_success @permit_application,
+                   nil,
+                   { blueprint_opts: { view: :jurisdiction_review_extended } }
   end
 
   def show
@@ -51,8 +54,8 @@ class Api::PermitApplicationsController < Api::ApplicationController
                      blueprint: PermitApplicationBlueprint,
                      blueprint_opts: {
                        view: show_blueprint_view_for(current_user),
-                       current_user: current_user,
-                     },
+                       current_user: current_user
+                     }
                    }
   end
 
@@ -60,10 +63,16 @@ class Api::PermitApplicationsController < Api::ApplicationController
     authorize @permit_application
 
     # always reset the submission section keys until actual submission
-    submission_section = permit_application_params.dig("submission_data", "data", "section-completion-key")
+    submission_section =
+      permit_application_params.dig(
+        "submission_data",
+        "data",
+        "section-completion-key"
+      )
     submission_section&.each { |key, value| submission_section[key] = nil }
 
-    is_current_user_submitter = current_user.id == @permit_application.submitter_id
+    is_current_user_submitter =
+      current_user.id == @permit_application.submitter_id
 
     if @permit_application.draft? &&
          @permit_application.update_with_submission_data_merge(
@@ -75,10 +84,12 @@ class Api::PermitApplicationsController < Api::ApplicationController
                  submission_collaborator_permit_application_params
                end
              ),
-           current_user: current_user,
+           current_user: current_user
          )
       if !Rails.env.development? || ENV["RUN_COMPLIANCE_ON_SAVE"] == "true"
-        AutomatedCompliance::AutopopulateJob.perform_async(@permit_application.id)
+        AutomatedCompliance::AutopopulateJob.perform_async(
+          @permit_application.id
+        )
       end
       render_success @permit_application,
                      ("permit_application.save_draft_success"),
@@ -86,37 +97,48 @@ class Api::PermitApplicationsController < Api::ApplicationController
                        blueprint: PermitApplicationBlueprint,
                        blueprint_opts: {
                          view: :extended,
-                         current_user: current_user,
-                       },
+                         current_user: current_user
+                       }
                      }
-    elsif @permit_application.submitted? && @permit_application.update(submitted_permit_application_params)
+    elsif @permit_application.submitted? &&
+          @permit_application.update(submitted_permit_application_params)
       render_success @permit_application,
                      ("permit_application.save_success"),
                      {
                        blueprint: PermitApplicationBlueprint,
                        blueprint_opts: {
                          view: show_blueprint_view_for(current_user),
-                         current_user: current_user,
-                       },
+                         current_user: current_user
+                       }
                      }
     else
       render_error "permit_application.update_error",
                    message_opts: {
-                     error_message: @permit_application.errors.full_messages.join(", "),
+                     error_message:
+                       @permit_application.errors.full_messages.join(", ")
                    }
     end
   end
 
   def update_revision_requests
     authorize @permit_application
-    if @permit_application.submitted? && @permit_application.latest_submission_version&.update(revision_request_params)
+    if @permit_application.submitted? &&
+         @permit_application.latest_submission_version&.update(
+           revision_request_params
+         )
       render_success @permit_application,
                      ("permit_application.save_success"),
-                     { blueprint: PermitApplicationBlueprint, blueprint_opts: { view: :jurisdiction_review_extended } }
+                     {
+                       blueprint: PermitApplicationBlueprint,
+                       blueprint_opts: {
+                         view: :jurisdiction_review_extended
+                       }
+                     }
     else
       render_error "permit_application.update_error",
                    message_opts: {
-                     error_message: @permit_application.errors.full_messages.join(", "),
+                     error_message:
+                       @permit_application.errors.full_messages.join(", ")
                    }
     end
   end
@@ -124,20 +146,23 @@ class Api::PermitApplicationsController < Api::ApplicationController
   def update_version
     authorize @permit_application
 
-    if TemplateVersioningService.update_draft_permit_with_new_template_version(@permit_application)
+    if TemplateVersioningService.update_draft_permit_with_new_template_version(
+         @permit_application
+       )
       render_success @permit_application,
                      ("permit_application.update_version_succes"),
                      {
                        blueprint: PermitApplicationBlueprint,
                        blueprint_opts: {
                          view: :extended,
-                         current_user: current_user,
-                       },
+                         current_user: current_user
+                       }
                      }
     else
       render_error "permit_application.update_error",
                    message_opts: {
-                     error_message: @permit_application.errors.full_messages.join(", "),
+                     error_message:
+                       @permit_application.errors.full_messages.join(", ")
                    }
     end
   end
@@ -148,13 +173,21 @@ class Api::PermitApplicationsController < Api::ApplicationController
     if success
       regex_pattern =
         "(#{supporting_document_params["supporting_documents_attributes"].map { |spd| spd.dig("file", "id") }.compact.join("|")})$"
-      render_success @permit_application.supporting_documents.file_ids_with_regex(regex_pattern),
+      render_success @permit_application.supporting_documents.file_ids_with_regex(
+                       regex_pattern
+                     ),
                      nil,
-                     { blueprint: SupportingDocumentBlueprint, blueprint_opts: { view: :form_io_details } }
+                     {
+                       blueprint: SupportingDocumentBlueprint,
+                       blueprint_opts: {
+                         view: :form_io_details
+                       }
+                     }
     else
       render_error "permit_application.update_error",
                    message_opts: {
-                     error_message: @permit_application.errors.full_messages.join(", "),
+                     error_message:
+                       @permit_application.errors.full_messages.join(", ")
                    }
     end
   end
@@ -164,10 +197,12 @@ class Api::PermitApplicationsController < Api::ApplicationController
     # for submissions, we do not run the automated compliance as that should have already been complete
     #
     if !@permit_application.using_current_template_version
-      render_error "permit_application.outdated_error", message_opts: {} and return
+      render_error "permit_application.outdated_error", message_opts: {} and
+        return
     end
 
-    is_current_user_submitter = current_user.id == @permit_application.submitter_id
+    is_current_user_submitter =
+      current_user.id == @permit_application.submitter_id
 
     if @permit_application.update(
          (
@@ -176,7 +211,7 @@ class Api::PermitApplicationsController < Api::ApplicationController
            else
              submission_collaborator_permit_application_params
            end
-         ),
+         )
        ) && @permit_application.submit
       render_success @permit_application,
                      nil,
@@ -184,24 +219,32 @@ class Api::PermitApplicationsController < Api::ApplicationController
                        blueprint: PermitApplicationBlueprint,
                        blueprint_opts: {
                          view: :extended,
-                         current_user: current_user,
-                       },
+                         current_user: current_user
+                       }
                      }
     else
       render_error "permit_application.submit_error",
                    message_opts: {
-                     error_message: @permit_application.errors.full_messages.join(", "),
+                     error_message:
+                       @permit_application.errors.full_messages.join(", ")
                    }
     end
   end
 
   def create
     @permit_application =
-      PermitApplication.build(permit_application_params.to_h.merge(submitter: current_user, sandbox: current_sandbox))
+      PermitApplication.build(
+        permit_application_params.to_h.merge(
+          submitter: current_user,
+          sandbox: current_sandbox
+        )
+      )
     authorize @permit_application
     if @permit_application.save
       if !Rails.env.development? || ENV["RUN_COMPLIANCE_ON_SAVE"] == "true"
-        AutomatedCompliance::AutopopulateJob.perform_async(@permit_application.id)
+        AutomatedCompliance::AutopopulateJob.perform_async(
+          @permit_application.id
+        )
       end
       render_success @permit_application,
                      "permit_application.create_success",
@@ -209,13 +252,14 @@ class Api::PermitApplicationsController < Api::ApplicationController
                        blueprint: PermitApplicationBlueprint,
                        blueprint_opts: {
                          view: :extended,
-                         current_user: current_user,
-                       },
+                         current_user: current_user
+                       }
                      }
     else
       render_error "permit_application.create_error",
                    message_opts: {
-                     error_message: @permit_application.errors.full_messages.join(", "),
+                     error_message:
+                       @permit_application.errors.full_messages.join(", ")
                    }
     end
   end
@@ -223,20 +267,32 @@ class Api::PermitApplicationsController < Api::ApplicationController
   def create_permit_collaboration
     begin
       @permit_collaboration =
-        PermitCollaboration::CollaborationManagementService.new(@permit_application).assign_collaborator!(
+        PermitCollaboration::CollaborationManagementService.new(
+          @permit_application
+        ).assign_collaborator!(
           authorize_collaboration: ->(permit_collaboration) do
-            authorize permit_collaboration, policy_class: PermitApplicationPolicy
+            authorize permit_collaboration,
+                      policy_class: PermitApplicationPolicy
           end,
           collaborator_id: permit_collaboration_params[:collaborator_id],
           collaborator_type: permit_collaboration_params[:collaborator_type],
-          assigned_requirement_block_id: permit_collaboration_params[:assigned_requirement_block_id],
+          assigned_requirement_block_id:
+            permit_collaboration_params[:assigned_requirement_block_id]
         )
 
       render_success @permit_collaboration,
                      "permit_application.assign_collaborator_success",
-                     { blueprint: PermitCollaborationBlueprint, blueprint_opts: { view: :base } }
+                     {
+                       blueprint: PermitCollaborationBlueprint,
+                       blueprint_opts: {
+                         view: :base
+                       }
+                     }
     rescue PermitCollaborationError => e
-      render_error "permit_application.assign_collaborator_error", message_opts: { error_message: e.message }
+      render_error "permit_application.assign_collaborator_error",
+                   message_opts: {
+                     error_message: e.message
+                   }
     end
   end
 
@@ -244,26 +300,36 @@ class Api::PermitApplicationsController < Api::ApplicationController
     begin
       @permit_collaboration =
         PermitCollaboration::CollaborationManagementService.new(
-          @permit_application,
+          @permit_application
         ).invite_new_submission_collaborator!(
           authorize_collaboration: ->(permit_collaboration) do
-            authorize permit_collaboration, policy_class: PermitApplicationPolicy
+            authorize permit_collaboration,
+                      policy_class: PermitApplicationPolicy
           end,
           user_params: collaborator_invite_params[:user],
           inviter: current_user,
           collaborator_type: collaborator_invite_params[:collaborator_type],
-          assigned_requirement_block_id: collaborator_invite_params[:assigned_requirement_block_id],
+          assigned_requirement_block_id:
+            collaborator_invite_params[:assigned_requirement_block_id]
         )
 
       render_success @permit_collaboration,
                      "permit_application.assign_collaborator_success",
-                     { blueprint: PermitCollaborationBlueprint, blueprint_opts: { view: :base } }
+                     {
+                       blueprint: PermitCollaborationBlueprint,
+                       blueprint_opts: {
+                         view: :base
+                       }
+                     }
     rescue PermitCollaborationError => e
       # The skip_authorization is necessary here as if there are any errors
       # in the invite_new_submission_collaborator! method, before the permit_collaboration
       # is created, the policy will not be able to authorize the permit_collaboration
       skip_authorization
-      render_error "permit_application.assign_collaborator_error", message_opts: { error_message: e.message }
+      render_error "permit_application.assign_collaborator_error",
+                   message_opts: {
+                     error_message: e.message
+                   }
     end
   end
 
@@ -284,8 +350,8 @@ class Api::PermitApplicationsController < Api::ApplicationController
                        blueprint: PermitApplicationBlueprint,
                        blueprint_opts: {
                          view: :extended,
-                         current_user: current_user,
-                       },
+                         current_user: current_user
+                       }
                      }
     else
       render_error "permit_application.revision_request_finalize_error"
@@ -299,13 +365,18 @@ class Api::PermitApplicationsController < Api::ApplicationController
       @permit_application.permit_collaborations.where(
         collaborator_id: params.require(:collaborator_id),
         collaborator_type: params.require(:collaborator_type),
-        collaboration_type: params.require(:collaboration_type),
+        collaboration_type: params.require(:collaboration_type)
       )
 
     if collaborations_to_remove.destroy_all
       render_success nil,
                      "permit_application.remove_collaborator_collaborations_success",
-                     { blueprint: PermitApplicationBlueprint, blueprint_opts: { view: :extended } }
+                     {
+                       blueprint: PermitApplicationBlueprint,
+                       blueprint_opts: {
+                         view: :extended
+                       }
+                     }
     else
       render_error "permit_application.remove_collaborator_collaborations_error"
     end
@@ -315,7 +386,7 @@ class Api::PermitApplicationsController < Api::ApplicationController
     @permit_block_status =
       @permit_application.permit_block_statuses.find_or_initialize_by(
         requirement_block_id: params.require(:requirement_block_id),
-        collaboration_type: params.require(:collaboration_type),
+        collaboration_type: params.require(:collaboration_type)
       )
 
     authorize @permit_block_status, policy_class: PermitApplicationPolicy
@@ -330,7 +401,8 @@ class Api::PermitApplicationsController < Api::ApplicationController
       else
         render_error "permit_application.create_or_update_permit_block_status_error",
                      message_opts: {
-                       error_message: @permit_block_status.errors.full_messages.join(", "),
+                       error_message:
+                         @permit_block_status.errors.full_messages.join(", ")
                      }
       end
     end
@@ -361,7 +433,7 @@ class Api::PermitApplicationsController < Api::ApplicationController
       :pid,
       :first_nations,
       submission_data: {
-      },
+      }
     )
   end
 
@@ -369,7 +441,7 @@ class Api::PermitApplicationsController < Api::ApplicationController
     designated_submitter =
       @permit_application.users_by_collaboration_options(
         collaboration_type: :submission,
-        collaborator_type: :delegatee,
+        collaborator_type: :delegatee
       ).first
     if designated_submitter&.id == current_user.id
       params.require(:permit_application).permit(:nickname, submission_data: {})
@@ -379,20 +451,27 @@ class Api::PermitApplicationsController < Api::ApplicationController
   end
 
   def permit_collaboration_params
-    params.require(:permit_collaboration).permit(:collaborator_id, :collaborator_type, :assigned_requirement_block_id)
+    params.require(:permit_collaboration).permit(
+      :collaborator_id,
+      :collaborator_type,
+      :assigned_requirement_block_id
+    )
   end
 
   def collaborator_invite_params
     params.require(:collaborator_invite).permit(
       :collaborator_type,
       :assigned_requirement_block_id,
-      user: %i[email first_name last_name],
+      user: %i[email first_name last_name]
     )
   end
 
   def supporting_document_params
     params.require(:permit_application).permit(
-      supporting_documents_attributes: [:data_key, file: [:id, :storage, metadata: {}]],
+      supporting_documents_attributes: [
+        :data_key,
+        file: [:id, :storage, metadata: {}]
+      ]
     )
   end
 
@@ -411,8 +490,8 @@ class Api::PermitApplicationsController < Api::ApplicationController
         requirement_json: {
         },
         submission_json: {
-        },
-      ],
+        }
+      ]
     )
   end
 end

--- a/app/controllers/api/permit_classifications_controller.rb
+++ b/app/controllers/api/permit_classifications_controller.rb
@@ -1,7 +1,9 @@
 class Api::PermitClassificationsController < Api::ApplicationController
   def index
     @permit_classifications = policy_scope(PermitClassification)
-    render_success @permit_classifications, nil, { blueprint: PermitClassificationBlueprint }
+    render_success @permit_classifications,
+                   nil,
+                   { blueprint: PermitClassificationBlueprint }
   end
 
   def permit_classification_options
@@ -17,34 +19,45 @@ class Api::PermitClassificationsController < Api::ApplicationController
               .where(permit_classifications: { enabled: true })
 
           if classification_option_params[:jurisdiction_id].present?
-            jurisdiction = Jurisdiction.find(classification_option_params[:jurisdiction_id])
-            permit_type_ids = jurisdiction.permit_type_submission_contacts.pluck(:permit_type_id)
+            jurisdiction =
+              Jurisdiction.find(classification_option_params[:jurisdiction_id])
+            permit_type_ids =
+              jurisdiction.permit_type_submission_contacts.pluck(
+                :permit_type_id
+              )
             query = query.where(permit_type_id: permit_type_ids)
           end
 
           query =
-            query.where(permit_type_id: classification_option_params[:permit_type_id]) if classification_option_params[
-            :permit_type_id
-          ].present?
-
-          query = query.where(activity_id: classification_option_params[:activity_id]) if classification_option_params[
-            :activity_id
-          ].present?
+            query.where(
+              permit_type_id: classification_option_params[:permit_type_id]
+            ) if classification_option_params[:permit_type_id].present?
 
           query =
-            query.where(first_nations: classification_option_params[:first_nations]) if !classification_option_params[
-            :first_nations
-          ].nil?
+            query.where(
+              activity_id: classification_option_params[:activity_id]
+            ) if classification_option_params[:activity_id].present?
+
+          query =
+            query.where(
+              first_nations: classification_option_params[:first_nations]
+            ) if !classification_option_params[:first_nations].nil?
 
           # &:activities or &:permit_types
           query.map(&classification_option_params[:type].underscore.to_sym).uniq
         else
-          PermitClassification.where(type: classification_option_params[:type], enabled: true)
+          PermitClassification.where(
+            type: classification_option_params[:type],
+            enabled: true
+          )
         end
 
-      options = permit_classifications.map { |pc| { label: pc.name, value: pc } }
+      options =
+        permit_classifications.map { |pc| { label: pc.name, value: pc } }
 
-      render_success options, nil, { blueprint: PermitClassificationOptionBlueprint }
+      render_success options,
+                     nil,
+                     { blueprint: PermitClassificationOptionBlueprint }
     rescue StandardError => e
       render_error "permit_classification.options_error", {}, e and return
     end
@@ -53,6 +66,16 @@ class Api::PermitClassificationsController < Api::ApplicationController
   private
 
   def classification_option_params
-    params.permit(%i[type pid published permit_type_id activity_id jurisdiction_id first_nations])
+    params.permit(
+      %i[
+        type
+        pid
+        published
+        permit_type_id
+        activity_id
+        jurisdiction_id
+        first_nations
+      ]
+    )
   end
 end

--- a/app/controllers/api/permit_collaborations_controller.rb
+++ b/app/controllers/api/permit_collaborations_controller.rb
@@ -11,7 +11,8 @@ class Api::PermitCollaborationsController < Api::ApplicationController
     else
       render_error "permit_collaboration.destroy_error",
                    message_opts: {
-                     error_message: @permit_collaboration.errors.full_messages.join(", "),
+                     error_message:
+                       @permit_collaboration.errors.full_messages.join(", ")
                    }
     end
   end
@@ -19,15 +20,23 @@ class Api::PermitCollaborationsController < Api::ApplicationController
   def reinvite
     authorize @permit_collaboration
     begin
-      PermitCollaboration::CollaborationManagementService.new(@permit_application).send_submission_collaboration_email!(
-        @permit_collaboration,
-      )
+      PermitCollaboration::CollaborationManagementService.new(
+        @permit_application
+      ).send_submission_collaboration_email!(@permit_collaboration)
 
       render_success @permit_collaboration,
                      "permit_collaboration.re_invite_success",
-                     { blueprint: PermitCollaborationBlueprint, blueprint_opts: { view: :base } }
+                     {
+                       blueprint: PermitCollaborationBlueprint,
+                       blueprint_opts: {
+                         view: :base
+                       }
+                     }
     rescue PermitCollaborationError => e
-      render_error "permit_collaboration.re_invite_error", message_opts: { error_message: e.message }
+      render_error "permit_collaboration.re_invite_error",
+                   message_opts: {
+                     error_message: e.message
+                   }
     end
   end
 

--- a/app/controllers/api/permit_type_submission_contacts_controller.rb
+++ b/app/controllers/api/permit_type_submission_contacts_controller.rb
@@ -2,7 +2,8 @@ class Api::PermitTypeSubmissionContactsController < ActionController::API
   # GET /permit_type_submission_contacts/confirm?confirmation_token=abcdef
   # use a special redirect with a frontend flash message here
   def confirm
-    @contact = PermitTypeSubmissionContact.confirm_by_token!(params[:confirmation_token])
+    @contact =
+      PermitTypeSubmissionContact.confirm_by_token!(params[:confirmation_token])
     redirect_to confirmed_url
   end
 end

--- a/app/controllers/api/requirement_blocks_controller.rb
+++ b/app/controllers/api/requirement_blocks_controller.rb
@@ -15,16 +15,18 @@ class Api::RequirementBlocksController < Api::ApplicationController
                      meta: {
                        total_pages: @search.total_pages,
                        total_count: @search.total_count,
-                       current_page: @search.current_page,
+                       current_page: @search.current_page
                      },
-                     blueprint: RequirementBlockBlueprint,
+                     blueprint: RequirementBlockBlueprint
                    }
   end
 
   def show
     authorize @requirement_block
 
-    render_success @requirement_block, nil, { blueprint: RequirementBlockBlueprint }
+    render_success @requirement_block,
+                   nil,
+                   { blueprint: RequirementBlockBlueprint }
   end
 
   def create
@@ -33,11 +35,14 @@ class Api::RequirementBlocksController < Api::ApplicationController
 
     if @requirement_block.save
       RequirementBlock.search_index.refresh
-      render_success @requirement_block, nil, { blueprint: RequirementBlockBlueprint }
+      render_success @requirement_block,
+                     nil,
+                     { blueprint: RequirementBlockBlueprint }
     else
       render_error "requirement_block.create_error",
                    message_opts: {
-                     error_message: @requirement_block.errors.full_messages.join(", "),
+                     error_message:
+                       @requirement_block.errors.full_messages.join(", ")
                    }
     end
   end
@@ -46,11 +51,14 @@ class Api::RequirementBlocksController < Api::ApplicationController
     authorize @requirement_block
 
     if @requirement_block.update(requirement_block_params)
-      render_success @requirement_block, nil, { blueprint: RequirementBlockBlueprint }
+      render_success @requirement_block,
+                     nil,
+                     { blueprint: RequirementBlockBlueprint }
     else
       render_error "requirement_block.update_error",
                    message_opts: {
-                     error_message: @requirement_block.errors.full_messages.join(", "),
+                     error_message:
+                       @requirement_block.errors.full_messages.join(", ")
                    }
     end
   end
@@ -59,11 +67,14 @@ class Api::RequirementBlocksController < Api::ApplicationController
     authorize @requirement_block
 
     if @requirement_block.discard
-      render_success @requirement_block, "requirement_block.destroy_success", { blueprint: RequirementBlockBlueprint }
+      render_success @requirement_block,
+                     "requirement_block.destroy_success",
+                     { blueprint: RequirementBlockBlueprint }
     else
       render_error "requirement_block.destroy_error",
                    message_opts: {
-                     error_message: @requirement_block.errors.full_messages.join(", "),
+                     error_message:
+                       @requirement_block.errors.full_messages.join(", ")
                    }
     end
   end
@@ -72,18 +83,23 @@ class Api::RequirementBlocksController < Api::ApplicationController
     authorize @requirement_block
 
     if @requirement_block.undiscard
-      render_success @requirement_block, "requirement_block.restore_success", { blueprint: RequirementBlockBlueprint }
+      render_success @requirement_block,
+                     "requirement_block.restore_success",
+                     { blueprint: RequirementBlockBlueprint }
     else
       render_error "requirement_block.restore_error",
                    message_opts: {
-                     error_message: @requirement_block.errors.full_messages.join(", "),
+                     error_message:
+                       @requirement_block.errors.full_messages.join(", ")
                    }
     end
   end
 
   def auto_compliance_module_configurations
-    available_module_configurations = AutomatedComplianceConfigurationService.available_module_configurations
-    authorize available_module_configurations, policy_class: RequirementBlockPolicy
+    available_module_configurations =
+      AutomatedComplianceConfigurationService.available_module_configurations
+    authorize available_module_configurations,
+              policy_class: RequirementBlockPolicy
     render json: { data: available_module_configurations }
   end
 
@@ -119,9 +135,9 @@ class Api::RequirementBlocksController < Api::ApplicationController
           value_options: [%i[value label]],
           conditional: {
           },
-          computed_compliance: [:value, :module, options_map: {}],
-        ],
-      ],
+          computed_compliance: [:value, :module, options_map: {}]
+        ]
+      ]
     )
   end
 

--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -1,6 +1,7 @@
 class Api::RequirementTemplatesController < Api::ApplicationController
   include Api::Concerns::Search::RequirementTemplates
-  before_action :set_requirement_template, only: %i[show destroy restore update schedule force_publish_now]
+  before_action :set_requirement_template,
+                only: %i[show destroy restore update schedule force_publish_now]
   before_action :set_template_version, only: %i[unschedule_template_version]
   skip_after_action :verify_policy_scoped, only: [:index]
 
@@ -13,12 +14,12 @@ class Api::RequirementTemplatesController < Api::ApplicationController
                      meta: {
                        total_pages: @search.total_pages,
                        total_count: @search.total_count,
-                       current_page: @search.current_page,
+                       current_page: @search.current_page
                      },
                      blueprint: RequirementTemplateBlueprint,
                      blueprint_opts: {
-                       current_user: current_user,
-                     },
+                       current_user: current_user
+                     }
                    }
   end
 
@@ -31,8 +32,8 @@ class Api::RequirementTemplatesController < Api::ApplicationController
                      blueprint: RequirementTemplateBlueprint,
                      blueprint_opts: {
                        view: :extended,
-                       current_user: current_user,
-                     },
+                       current_user: current_user
+                     }
                    }
   end
 
@@ -46,7 +47,8 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     else
       render_error "requirement_template.create_error",
                    message_opts: {
-                     error_message: @requirement_template.errors.full_messages.join(", "),
+                     error_message:
+                       @requirement_template.errors.full_messages.join(", ")
                    }
     end
   end
@@ -55,10 +57,11 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     found_template =
       if requirement_template_params[:id].present?
         RequirementTemplate.find_by(id: requirement_template_params[:id])
-      elsif requirement_template_params[:permit_type_id].present? && requirement_template_params[:activity_id].present?
+      elsif requirement_template_params[:permit_type_id].present? &&
+            requirement_template_params[:activity_id].present?
         LiveRequirementTemplate.find_by(
           permit_type_id: requirement_template_params[:permit_type_id],
-          activity_id: requirement_template_params[:activity_id],
+          activity_id: requirement_template_params[:activity_id]
         )
       end
 
@@ -68,9 +71,9 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     end
 
     @requirement_template =
-      RequirementTemplateCopyService.new(found_template).build_requirement_template_from_existing(
-        requirement_template_params,
-      )
+      RequirementTemplateCopyService.new(
+        found_template
+      ).build_requirement_template_from_existing(requirement_template_params)
     authorize @requirement_template
 
     if @requirement_template.save
@@ -80,7 +83,8 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     else
       render_error "requirement_template.copy_error",
                    message_opts: {
-                     error_message: @requirement_template.errors.full_messages.join(", "),
+                     error_message:
+                       @requirement_template.errors.full_messages.join(", ")
                    }
     end
   end
@@ -95,13 +99,14 @@ class Api::RequirementTemplatesController < Api::ApplicationController
                        blueprint: RequirementTemplateBlueprint,
                        blueprint_opts: {
                          view: :extended,
-                         current_user: current_user,
-                       },
+                         current_user: current_user
+                       }
                      }
     else
       render_error "requirement_template.update_error",
                    message_opts: {
-                     error_message: @requirement_template.errors.full_messages.join(", "),
+                     error_message:
+                       @requirement_template.errors.full_messages.join(", ")
                    }
     end
   end
@@ -113,16 +118,23 @@ class Api::RequirementTemplatesController < Api::ApplicationController
       unless @requirement_template.update(requirement_template_params)
         render_error "requirement_template.schedule_error",
                      message_opts: {
-                       error_message: @requirement_template.errors.full_messages.join(", "),
+                       error_message:
+                         @requirement_template.errors.full_messages.join(", ")
                      }
       end
 
       begin
         scheduled_template_version =
-          TemplateVersioningService.schedule!(@requirement_template, Date.parse(schedule_params))
+          TemplateVersioningService.schedule!(
+            @requirement_template,
+            Date.parse(schedule_params)
+          )
       rescue StandardError => e
         # If there is an error in TemplateVersioningService.schedule!, rollback the transaction
-        render_error "requirement_template.schedule_error", message_opts: { error_message: e.message }
+        render_error "requirement_template.schedule_error",
+                     message_opts: {
+                       error_message: e.message
+                     }
         raise ActiveRecord::Rollback
       end
 
@@ -131,7 +143,12 @@ class Api::RequirementTemplatesController < Api::ApplicationController
 
       render_success @requirement_template,
                      "requirement_template.schedule_success",
-                     { blueprint: RequirementTemplateBlueprint, blueprint_opts: { view: :extended } }
+                     {
+                       blueprint: RequirementTemplateBlueprint,
+                       blueprint_opts: {
+                         view: :extended
+                       }
+                     }
     end
   end
 
@@ -150,7 +167,8 @@ class Api::RequirementTemplatesController < Api::ApplicationController
       end
 
       begin
-        published_template_version = TemplateVersioningService.force_publish_now!(@requirement_template)
+        published_template_version =
+          TemplateVersioningService.force_publish_now!(@requirement_template)
       rescue StandardError => e
         # If there is an error in TemplateVersioningService.schedule!, rollback the transaction
         error_message = e.message
@@ -169,11 +187,14 @@ class Api::RequirementTemplatesController < Api::ApplicationController
                        blueprint: RequirementTemplateBlueprint,
                        blueprint_opts: {
                          view: :extended,
-                         published_template_version: published_template_version,
-                       },
+                         published_template_version: published_template_version
+                       }
                      }
     else
-      render_error "requirement_template.force_publish_now_error", message_opts: { error_message: error_message }
+      render_error "requirement_template.force_publish_now_error",
+                   message_opts: {
+                     error_message: error_message
+                   }
     end
   end
 
@@ -181,9 +202,13 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     authorize @template_version, policy_class: RequirementTemplatePolicy
 
     begin
-      template_version = TemplateVersioningService.unschedule!(@template_version, current_user)
+      template_version =
+        TemplateVersioningService.unschedule!(@template_version, current_user)
     rescue StandardError => e
-      render_error "requirement_template.template_unschedule_error", message_opts: { error_message: e.message }
+      render_error "requirement_template.template_unschedule_error",
+                   message_opts: {
+                     error_message: e.message
+                   }
     end
 
     render_success @template_version,
@@ -194,7 +219,10 @@ class Api::RequirementTemplatesController < Api::ApplicationController
   def destroy
     authorize @requirement_template
     if @requirement_template.discard
-      render_success(@requirement_template, "requirement_template.destroy_success")
+      render_success(
+        @requirement_template,
+        "requirement_template.destroy_success"
+      )
     else
       render_error "requirement_template.destroy_error"
     end
@@ -203,7 +231,10 @@ class Api::RequirementTemplatesController < Api::ApplicationController
   def restore
     authorize @requirement_template
     if @requirement_template.update(discarded_at: nil)
-      render_success(@requirement_template, "requirement_template.restore_success")
+      render_success(
+        @requirement_template,
+        "requirement_template.restore_success"
+      )
     else
       render_error "requirement_template.restore_error", {}
     end
@@ -220,7 +251,9 @@ class Api::RequirementTemplatesController < Api::ApplicationController
         :published_template_version,
         :last_three_deprecated_template_versions,
         :scheduled_template_versions,
-        requirement_template_sections: [template_section_blocks: [requirement_block: :requirements]],
+        requirement_template_sections: [
+          template_section_blocks: [requirement_block: :requirements]
+        ]
       ).find(params[:id])
   end
 
@@ -244,13 +277,20 @@ class Api::RequirementTemplatesController < Api::ApplicationController
           :name,
           :position,
           :_destroy,
-          template_section_blocks_attributes: %i[id requirement_block_id position _destroy],
-        ],
+          template_section_blocks_attributes: %i[
+            id
+            requirement_block_id
+            position
+            _destroy
+          ]
+        ]
       )
 
     # This is a workaround needed to validate step code related errors
     if permitted_params[:requirement_template_sections_attributes].present?
-      permitted_params[:requirement_template_sections_attributes_copy] = permitted_params[
+      permitted_params[
+        :requirement_template_sections_attributes_copy
+      ] = permitted_params[
         requirement_template_sections_attributes: :requirements
       ].deep_dup
     end

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -5,7 +5,8 @@ class Api::SessionsController < Devise::SessionsController
   skip_before_action :verify_signed_out_user
 
   def destroy
-    signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
+    signed_out =
+      (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
     render_success nil, "user.logout_success"
   end
 

--- a/app/controllers/api/site_configuration_controller.rb
+++ b/app/controllers/api/site_configuration_controller.rb
@@ -22,8 +22,8 @@ class Api::SiteConfigurationController < Api::ApplicationController
         render_error(
           "site_configuration.update_error",
           message_opts: {
-            error_message: @site_configuration.errors.full_messages.join(", "),
-          },
+            error_message: @site_configuration.errors.full_messages.join(", ")
+          }
         )
       )
     end
@@ -43,9 +43,9 @@ class Api::SiteConfigurationController < Api::ApplicationController
         get_started_link_item: %i[href title description show],
         best_practices_link_item: %i[href title description show],
         dictionary_link_item: %i[href title description show],
-        user_guide_link_item: %i[href title description show],
+        user_guide_link_item: %i[href title description show]
       ],
-      revision_reasons_attributes: %i[id description reason_code _discard],
+      revision_reasons_attributes: %i[id description reason_code _discard]
     )
   end
 end

--- a/app/controllers/api/step_code_checklists_controller.rb
+++ b/app/controllers/api/step_code_checklists_controller.rb
@@ -2,14 +2,20 @@ class Api::StepCodeChecklistsController < Api::ApplicationController
   before_action :set_and_authorize_checklist, only: %i[show update]
 
   def index
-    @step_code_checklists = policy_scope(StepCodeChecklist).where(step_code_id: params[:step_code_id])
+    @step_code_checklists =
+      policy_scope(StepCodeChecklist).where(step_code_id: params[:step_code_id])
     render_success @step_code_checklists
   end
 
   def show
     render_success @step_code_checklist,
                    nil,
-                   { blueprint: StepCodeChecklistBlueprint, blueprint_opts: { view: :extended } }
+                   {
+                     blueprint: StepCodeChecklistBlueprint,
+                     blueprint_opts: {
+                       view: :extended
+                     }
+                   }
   end
 
   # PATCH /api/step_code_checklists
@@ -17,11 +23,17 @@ class Api::StepCodeChecklistsController < Api::ApplicationController
     if @step_code_checklist.update(step_code_checklist_params)
       render_success @step_code_checklist,
                      "step_code_checklist.update_success",
-                     { blueprint: StepCodeChecklistBlueprint, blueprint_opts: { view: :extended } }
+                     {
+                       blueprint: StepCodeChecklistBlueprint,
+                       blueprint_opts: {
+                         view: :extended
+                       }
+                     }
     else
       render_error "step_code_checklist.update_error",
                    message_opts: {
-                     error_message: @step_code_checklist.errors.full_messages.join(", "),
+                     error_message:
+                       @step_code_checklist.errors.full_messages.join(", ")
                    }
     end
   end
@@ -61,15 +73,23 @@ class Api::StepCodeChecklistsController < Api::ApplicationController
         unheated_floors_lines: %i[details rsi],
         below_grade_walls_lines: %i[details rsi],
         slabs_lines: %i[details rsi],
-        windows_glazed_doors: [:performance_type, lines: %i[details performance_value shgc]],
+        windows_glazed_doors: [
+          :performance_type,
+          lines: %i[details performance_value shgc]
+        ],
         doors_lines: %i[details performance_type performance_value],
         airtightness: [:details],
-        space_heating_cooling_lines: %i[details variant performance_value performance_type],
+        space_heating_cooling_lines: %i[
+          details
+          variant
+          performance_value
+          performance_type
+        ],
         hot_water_lines: %i[details performance_type performance_value],
         ventilation_lines: %i[details percent_eff liters_per_sec],
         other_lines: [:details],
-        fossil_fuels: %i[details presence],
-      ],
+        fossil_fuels: %i[details presence]
+      ]
     )
   end
 

--- a/app/controllers/api/step_codes_controller.rb
+++ b/app/controllers/api/step_codes_controller.rb
@@ -3,7 +3,12 @@ class Api::StepCodesController < Api::ApplicationController
     @step_codes = policy_scope(StepCode)
     render_success @step_codes,
                    nil,
-                   { blueprint: StepCodeBlueprint, meta: { select_options: StepCodeChecklist.select_options } }
+                   {
+                     blueprint: StepCodeBlueprint,
+                     meta: {
+                       select_options: StepCodeChecklist.select_options
+                     }
+                   }
   end
 
   # POST /api/step_codes
@@ -14,12 +19,22 @@ class Api::StepCodesController < Api::ApplicationController
       @step_code = StepCode.create(step_code_params)
       if @step_code.valid?
         @step_code.data_entries.each do |de|
-          StepCode::DataEntryFromHot2000.new(xml: Nokogiri.XML(de.h2k_file.read), data_entry: de).call if de.h2k_file
+          if de.h2k_file
+            StepCode::DataEntryFromHot2000.new(
+              xml: Nokogiri.XML(de.h2k_file.read),
+              data_entry: de
+            ).call
+          end
         end
-        render_success @step_code, "step_code.h2k_imported", { blueprint: StepCodeBlueprint } and return
+        render_success @step_code,
+                       "step_code.h2k_imported",
+                       { blueprint: StepCodeBlueprint } and return
       end
     end
-    render_error "step_code.create_error", message_opts: { error_message: @step_code.errors.full_messages.join(", ") }
+    render_error "step_code.create_error",
+                 message_opts: {
+                   error_message: @step_code.errors.full_messages.join(", ")
+                 }
   end
 
   # DELETE /api/step_codes/:id
@@ -50,8 +65,8 @@ class Api::StepCodesController < Api::ApplicationController
         :other_ghg_ef,
         :other_ghg_consumption,
         h2k_file: {
-        },
-      ],
+        }
+      ]
     )
   end
 end

--- a/app/controllers/api/storage_controller.rb
+++ b/app/controllers/api/storage_controller.rb
@@ -7,11 +7,19 @@ class Api::StorageController < Api::ApplicationController
     set_rack_response FileUploader.presign_response(:cache, request.env)
   end
 
-  AUTHORIZED_S3_MODELS = { "SupportingDocument" => SupportingDocument, "StepCode" => StepCode }.freeze
+  AUTHORIZED_S3_MODELS = {
+    "SupportingDocument" => SupportingDocument,
+    "StepCode" => StepCode
+  }.freeze
 
   def download
     if params[:id].start_with?("cache/")
-      url = Shrine.storages[:cache].url(params[:id].slice(6..-1), public: false, expires_in: 3600)
+      url =
+        Shrine.storages[:cache].url(
+          params[:id].slice(6..-1),
+          public: false,
+          expires_in: 3600
+        )
       render json: { url: }, status: :ok
     elsif params[:model_id] && AUTHORIZED_S3_MODELS[params[:model]]
       record_class = AUTHORIZED_S3_MODELS[params[:model]]

--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -1,10 +1,16 @@
 class Api::TagsController < Api::ApplicationController
   def index
     render json:
-             policy_scope(ActsAsTaggableOn::Tag, policy_scope_class: TagPolicy::Scope)
+             policy_scope(
+               ActsAsTaggableOn::Tag,
+               policy_scope_class: TagPolicy::Scope
+             )
                .where(
                  "taggings.taggable_type IN (:taggable_types) AND tags.name ILIKE :query",
-                 { taggable_types: tag_params[:taggable_types], query: "#{tag_params[:query]}%" },
+                 {
+                   taggable_types: tag_params[:taggable_types],
+                   query: "#{tag_params[:query]}%"
+                 }
                )
                .uniq
                .pluck(:name)

--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -23,21 +23,38 @@ class Api::TemplateVersionsController < Api::ApplicationController
         policy_scope(TemplateVersion).order(updated_at: :desc).where(status:)
       end
 
-    render_success @template_versions, nil, { blueprint: TemplateVersionBlueprint, blueprint_opts: { view: :extended } }
+    render_success @template_versions,
+                   nil,
+                   {
+                     blueprint: TemplateVersionBlueprint,
+                     blueprint_opts: {
+                       view: :extended
+                     }
+                   }
   end
 
   def show
     authorize @template_version
 
-    render_success @template_version, nil, { blueprint: TemplateVersionBlueprint, blueprint_opts: { view: :extended } }
+    render_success @template_version,
+                   nil,
+                   {
+                     blueprint: TemplateVersionBlueprint,
+                     blueprint_opts: {
+                       view: :extended
+                     }
+                   }
   end
 
   def show_jurisdiction_template_version_customization
     authorize @template_version, :show?
 
-    return head :not_found if @jurisdiction_template_version_customization.blank?
+    if @jurisdiction_template_version_customization.blank?
+      return head :not_found
+    end
 
-    authorize @jurisdiction_template_version_customization, policy_class: TemplateVersionPolicy
+    authorize @jurisdiction_template_version_customization,
+              policy_class: TemplateVersionPolicy
 
     render_success @jurisdiction_template_version_customization
   end
@@ -45,18 +62,28 @@ class Api::TemplateVersionsController < Api::ApplicationController
   def create_or_update_jurisdiction_template_version_customization
     authorize @template_version, :show?
 
-    authorize @jurisdiction_template_version_customization, policy_class: TemplateVersionPolicy
+    authorize @jurisdiction_template_version_customization,
+              policy_class: TemplateVersionPolicy
 
     # add a db lock in case multiple reviewers are updating this db row
     @jurisdiction_template_version_customization.with_lock do
-      if @jurisdiction_template_version_customization.update(jurisdiction_template_version_customization_params)
+      if @jurisdiction_template_version_customization.update(
+           jurisdiction_template_version_customization_params
+         )
         render_success @jurisdiction_template_version_customization,
                        "jurisdiction_template_version_customization.update_success",
-                       { blueprint: JurisdictionTemplateVersionCustomizationBlueprint }
+                       {
+                         blueprint:
+                           JurisdictionTemplateVersionCustomizationBlueprint
+                       }
       else
         render_error "jurisdiction_template_version_customization.update_error",
                      message_opts: {
-                       error_message: @jurisdiction_template_version_customization.errors.full_messages.join(", "),
+                       error_message:
+                         @jurisdiction_template_version_customization
+                           .errors
+                           .full_messages
+                           .join(", ")
                      }
       end
     end
@@ -65,18 +92,26 @@ class Api::TemplateVersionsController < Api::ApplicationController
   def promote_jurisdiction_template_version_customization
     authorize @template_version, :show?
 
-    authorize @jurisdiction_template_version_customization, policy_class: TemplateVersionPolicy
+    authorize @jurisdiction_template_version_customization,
+              policy_class: TemplateVersionPolicy
 
     # add a db lock in case multiple reviewers are updating this db row
     @jurisdiction_template_version_customization.with_lock do
       if @jurisdiction_template_version_customization.promote
         render_success @jurisdiction_template_version_customization,
                        "jurisdiction_template_version_customization.promote_success",
-                       { blueprint: JurisdictionTemplateVersionCustomizationBlueprint }
+                       {
+                         blueprint:
+                           JurisdictionTemplateVersionCustomizationBlueprint
+                       }
       else
         render_error "jurisdiction_template_version_customization.promote_error",
                      message_opts: {
-                       error_message: @jurisdiction_template_version_customization.errors.full_messages.join(", "),
+                       error_message:
+                         @jurisdiction_template_version_customization
+                           .errors
+                           .full_messages
+                           .join(", ")
                      }
       end
     end
@@ -85,18 +120,24 @@ class Api::TemplateVersionsController < Api::ApplicationController
   def copy_jurisdiction_template_version_customization
     authorize @template_version
     if copy_customization_params[:from_template_version_id]
-      from_template_version = TemplateVersion.find(copy_customization_params[:from_template_version_id])
-    elsif copy_customization_params[:from_non_first_nations] && @template_version.first_nations
+      from_template_version =
+        TemplateVersion.find(
+          copy_customization_params[:from_template_version_id]
+        )
+    elsif copy_customization_params[:from_non_first_nations] &&
+          @template_version.first_nations
       requirement_template =
         RequirementTemplate.find_by(
           activity: @template_version.activity,
           permit_type: @template_version.permit_type,
-          first_nations: false,
+          first_nations: false
         )
       from_template_version = requirement_template.published_template_version
     end
 
-    render_error("misc.not_found_error", status: :not_found) and return if from_template_version.nil?
+    if from_template_version.nil?
+      render_error("misc.not_found_error", status: :not_found) and return
+    end
 
     if @jurisdiction_template_version_customization =
          # TODO: TEST COPY SERVICE
@@ -104,18 +145,25 @@ class Api::TemplateVersionsController < Api::ApplicationController
            from_template_version,
            @template_version,
            Jurisdiction.find(copy_customization_params[:jurisdiction_id]),
-           current_sandbox,
+           current_sandbox
          ).merge_copy_customizations(
            copy_customization_params[:include_electives],
-           copy_customization_params[:include_tips],
+           copy_customization_params[:include_tips]
          )
       render_success @jurisdiction_template_version_customization,
                      "jurisdiction_template_version_customization.update_success",
-                     { blueprint: JurisdictionTemplateVersionCustomizationBlueprint }
+                     {
+                       blueprint:
+                         JurisdictionTemplateVersionCustomizationBlueprint
+                     }
     else
       render_error "jurisdiction_template_version_customization.update_error",
                    message_opts: {
-                     error_message: @jurisdiction_template_version_customization.errors.full_messages.join(", "),
+                     error_message:
+                       @jurisdiction_template_version_customization
+                         .errors
+                         .full_messages
+                         .join(", ")
                    }
     end
   rescue ActiveRecord::RecordNotFound
@@ -125,14 +173,22 @@ class Api::TemplateVersionsController < Api::ApplicationController
   def show_integration_mapping
     authorize @template_version, :show?
 
-    @integration_mapping = @template_version.integration_mappings.find_by(jurisdiction_id: params[:jurisdiction_id])
+    @integration_mapping =
+      @template_version.integration_mappings.find_by(
+        jurisdiction_id: params[:jurisdiction_id]
+      )
 
     authorize @integration_mapping, policy_class: TemplateVersionPolicy
 
     if @integration_mapping.present?
       render_success @integration_mapping,
                      nil,
-                     { blueprint: IntegrationMappingBlueprint, blueprint_opts: { view: :base } }
+                     {
+                       blueprint: IntegrationMappingBlueprint,
+                       blueprint_opts: {
+                         view: :base
+                       }
+                     }
     else
       render_error "integration_mapping.not_found_error", status: 404
     end
@@ -141,9 +197,9 @@ class Api::TemplateVersionsController < Api::ApplicationController
   def compare_requirements
     authorize @template_version
     before_version =
-      TemplateVersion.find(compare_requirements_params[:previous_version_id]) if compare_requirements_params[
-      :previous_version_id
-    ].present?
+      TemplateVersion.find(
+        compare_requirements_params[:previous_version_id]
+      ) if compare_requirements_params[:previous_version_id].present?
 
     render_success @template_version.compare_requirements(before_version),
                    nil,
@@ -160,14 +216,22 @@ class Api::TemplateVersionsController < Api::ApplicationController
   def download_customization_csv
     authorize @template_version
 
-    csv_data = TemplateExportService.new(@template_version, @jurisdiction_template_version_customization).to_csv
+    csv_data =
+      TemplateExportService.new(
+        @template_version,
+        @jurisdiction_template_version_customization
+      ).to_csv
     send_data csv_data, type: "text/csv"
   end
 
   def download_customization_json
     authorize @template_version
 
-    json_data = TemplateExportService.new(@template_version, @jurisdiction_template_version_customization).to_json
+    json_data =
+      TemplateExportService.new(
+        @template_version,
+        @jurisdiction_template_version_customization
+      ).to_json
     send_data json_data, type: "text/plain"
   end
 
@@ -196,7 +260,7 @@ class Api::TemplateVersionsController < Api::ApplicationController
         from_non_first_nations
         include_tips
         include_electives
-      ],
+      ]
     )
   end
 
@@ -212,7 +276,7 @@ class Api::TemplateVersionsController < Api::ApplicationController
     @jurisdiction_template_version_customization =
       @template_version.jurisdiction_template_version_customizations.find_or_create_by(
         jurisdiction_id: params[:jurisdiction_id],
-        sandbox: current_sandbox,
+        sandbox: current_sandbox
       )
   end
 
@@ -220,8 +284,8 @@ class Api::TemplateVersionsController < Api::ApplicationController
     params.require(:jurisdiction_template_version_customization).permit(
       customizations: {
         requirement_block_changes: {
-        },
-      },
+        }
+      }
     )
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,15 +1,25 @@
 class Api::UsersController < Api::ApplicationController
   include Api::Concerns::Search::AdminUsers
 
-  before_action :find_user, only: %i[destroy restore accept_eula update reinvite accept_invitation]
+  before_action :find_user,
+                only: %i[
+                  destroy
+                  restore
+                  accept_eula
+                  update
+                  reinvite
+                  accept_invitation
+                ]
   skip_after_action :verify_policy_scoped, only: %i[index]
   skip_before_action :require_confirmation, only: %i[profile]
-  skip_before_action :require_confirmation, only: %i[accept_eula resend_confirmation]
+  skip_before_action :require_confirmation,
+                     only: %i[accept_eula resend_confirmation]
 
   def index
     authorize :user, :index?
     perform_user_search
-    authorized_results = apply_search_authorization(@user_search.results, "search_admin_users")
+    authorized_results =
+      apply_search_authorization(@user_search.results, "search_admin_users")
 
     render_success authorized_results,
                    nil,
@@ -17,12 +27,12 @@ class Api::UsersController < Api::ApplicationController
                      meta: {
                        total_pages: @user_search.total_pages,
                        total_count: @user_search.total_count,
-                       current_page: @user_search.current_page,
+                       current_page: @user_search.current_page
                      },
                      blueprint: UserBlueprint,
                      blueprint_opts: {
-                       view: :base,
-                     },
+                       view: :base
+                     }
                    }
   end
 
@@ -30,7 +40,14 @@ class Api::UsersController < Api::ApplicationController
     authorize :user, :super_admins?
     begin
       super_admins = User.super_admin
-      render_success super_admins, nil, { blueprint: UserBlueprint, blueprint_opts: { view: :minimal } }
+      render_success super_admins,
+                     nil,
+                     {
+                       blueprint: UserBlueprint,
+                       blueprint_opts: {
+                         view: :minimal
+                       }
+                     }
     rescue StandardError => e
       render_error "user.get_super_admins_error", {}, e and return
     end
@@ -38,10 +55,16 @@ class Api::UsersController < Api::ApplicationController
 
   def update
     authorize @user
-    return render_error "misc.user_not_authorized_error" unless %w[reviewer review_manager].include?(user_params[:role])
+    unless %w[reviewer review_manager].include?(user_params[:role])
+      return render_error "misc.user_not_authorized_error"
+    end
 
     if @user.update(user_params)
-      render_success @user, "user.update_success", blueprint_opts: { view: :base }
+      render_success @user,
+                     "user.update_success",
+                     blueprint_opts: {
+                       view: :base
+                     }
     else
       render_error "user.update_error"
     end
@@ -54,9 +77,11 @@ class Api::UsersController < Api::ApplicationController
 
     # allow user to change back to original confirmed email
     # https://github.com/heartcombo/devise/issues/5470
-    current_user.unconfirmed_email = nil if current_user.email && profile_params[:email] == current_user.email
+    current_user.unconfirmed_email = nil if current_user.email &&
+      profile_params[:email] == current_user.email
     if current_user.update(profile_params)
-      should_send_confirmation = @user.confirmed_at.blank? && @user.confirmation_sent_at.blank?
+      should_send_confirmation =
+        @user.confirmed_at.blank? && @user.confirmation_sent_at.blank?
       current_user.send_confirmation_instructions if should_send_confirmation
       render_success(
         current_user,
@@ -68,12 +93,17 @@ class Api::UsersController < Api::ApplicationController
           end
         ),
         blueprint_opts: {
-          view: :base,
-        },
+          view: :base
+        }
       )
     else
       render_error "user.update_error",
-                   { message_opts: { error_message: current_user.errors.full_messages.join(", ") } }
+                   {
+                     message_opts: {
+                       error_message:
+                         current_user.errors.full_messages.join(", ")
+                     }
+                   }
     end
   end
 
@@ -81,13 +111,24 @@ class Api::UsersController < Api::ApplicationController
     @user = current_user
     authorize current_user
 
-    render_success @user, nil, { blueprint: UserBlueprint, blueprint_opts: { view: :accepted_license_agreements } }
+    render_success @user,
+                   nil,
+                   {
+                     blueprint: UserBlueprint,
+                     blueprint_opts: {
+                       view: :accepted_license_agreements
+                     }
+                   }
   end
 
   def destroy
     authorize @user
     if @user.discard
-      render_success(@user, "user.destroy_success", { blueprint_opts: { view: :base } })
+      render_success(
+        @user,
+        "user.destroy_success",
+        { blueprint_opts: { view: :base } }
+      )
     else
       render_error "user.destroy_error", {}
     end
@@ -96,7 +137,13 @@ class Api::UsersController < Api::ApplicationController
   def restore
     authorize @user
     if @user.update(discarded_at: nil)
-      render_success(@user, "user.restore_success", blueprint_opts: { view: :base })
+      render_success(
+        @user,
+        "user.restore_success",
+        blueprint_opts: {
+          view: :base
+        }
+      )
     else
       render_error "user.restore_error", {}
     end
@@ -106,37 +153,54 @@ class Api::UsersController < Api::ApplicationController
     authorize @user
     @user.license_agreements.create!(
       accepted_at: Time.current,
-      agreement: EndUserLicenseAgreement.active_agreement(@user.eula_variant),
+      agreement: EndUserLicenseAgreement.active_agreement(@user.eula_variant)
     )
-    render_success @user, "user.eula_accepted", { blueprint_opts: { view: :current_user } }
+    render_success @user,
+                   "user.eula_accepted",
+                   { blueprint_opts: { view: :current_user } }
   end
 
   def accept_invitation
     authorize @user
-    invited_user = User.find_by_invitation_token(params[:invitation_token], true)
+    invited_user =
+      User.find_by_invitation_token(params[:invitation_token], true)
     if @user.id != invited_user.id
       PromoteUser.new(existing_user: @user, invited_user:).call
       if !@user.valid?
         render_error "user.accept_invite_error",
-                     { message_opts: { error_message: @user.errors.full_messages.join(", ") } } and return
+                     {
+                       message_opts: {
+                         error_message: @user.errors.full_messages.join(", ")
+                       }
+                     } and return
       end
     else
       @user.accept_invitation!
     end
 
-    render_success @user, "user.invitation_accepted", { blueprint_opts: { view: :extended } }
+    render_success @user,
+                   "user.invitation_accepted",
+                   { blueprint_opts: { view: :extended } }
   end
 
   def resend_confirmation
     authorize current_user
     current_user.resend_confirmation_instructions
-    render_success(current_user, "user.reconfirmation_sent", { blueprint_opts: { view: :current_user } })
+    render_success(
+      current_user,
+      "user.reconfirmation_sent",
+      { blueprint_opts: { view: :current_user } }
+    )
   end
 
   def reinvite
     authorize @user
     @user.invite!(current_user)
-    render_success(@user, "user.reinvited", { blueprint_opts: { view: :invited_user } })
+    render_success(
+      @user,
+      "user.reinvited",
+      { blueprint_opts: { view: :invited_user } }
+    )
   end
 
   private
@@ -178,7 +242,7 @@ class Api::UsersController < Api::ApplicationController
         enable_email_collaboration_notification
         enable_in_app_integration_mapping_notification
         enable_email_integration_mapping_notification
-      ],
+      ]
     )
   end
 end

--- a/app/controllers/concerns/base_controller_methods.rb
+++ b/app/controllers/concerns/base_controller_methods.rb
@@ -10,12 +10,19 @@ module BaseControllerMethods
   end
 
   def frontend_flash_message(message_key, message_type, opts = {})
-    msg = ArbitraryMessageConstruct.message(key: message_key, type: message_type, options: opts[:message_opts]).to_json
+    msg =
+      ArbitraryMessageConstruct.message(
+        key: message_key,
+        type: message_type,
+        options: opts[:message_opts]
+      ).to_json
     { flash: msg }
   end
 
   def render_success(resource, message_key = nil, opts = {})
-    opts.reverse_merge!({ blueprint: nil, blueprint_opts: {}, status: 200, meta: {} })
+    opts.reverse_merge!(
+      { blueprint: nil, blueprint_opts: {}, status: 200, meta: {} }
+    )
     message =
       (
         if message_key
@@ -32,7 +39,8 @@ module BaseControllerMethods
     else
       if opts[:blueprint].blank?
         begin
-          single_resource = resource.respond_to?(:first) ? resource.first : resource
+          single_resource =
+            resource.respond_to?(:first) ? resource.first : resource
           model_instance =
             (
               if single_resource.respond_to?(:__getobj__)
@@ -47,13 +55,16 @@ module BaseControllerMethods
         end
       end
       blueprint_opts = opts[:blueprint_opts].merge({ root: "data", meta: meta })
-      render json: opts[:blueprint].render(resource, blueprint_opts), status: opts[:status]
+      render json: opts[:blueprint].render(resource, blueprint_opts),
+             status: opts[:status]
     end
   end
 
   # error_key maps to a translation key in en.yml
   def render_error(error_key = nil, opts = {}, exception = nil)
-    Rails.logger.error "#{exception.message}\n#{exception.backtrace}" if exception.present?
+    if exception.present?
+      Rails.logger.error "#{exception.message}\n#{exception.backtrace}"
+    end
     opts.reverse_merge!({ status: 400, meta: {} })
     message =
       (
@@ -68,7 +79,12 @@ module BaseControllerMethods
   end
 
   def render_flash_message(message_key, message_type, opts = {})
-    msg = ArbitraryMessageConstruct.message(key: message_key, type: message_type, options: opts[:message_opts]).to_json
+    msg =
+      ArbitraryMessageConstruct.message(
+        key: message_key,
+        type: message_type,
+        options: opts[:message_opts]
+      ).to_json
     { flash: msg }
   end
 
@@ -83,7 +99,7 @@ module BaseControllerMethods
       value: form_authenticity_token,
       secure: Rails.env.production?,
       httponly: false, # Allow frontend to read the cookie
-      same_site: :lax,
+      same_site: :lax
     }
   end
 

--- a/app/controllers/external_api/application_controller.rb
+++ b/app/controllers/external_api/application_controller.rb
@@ -20,7 +20,9 @@ class ExternalApi::ApplicationController < ActionController::API
   protected
 
   def apply_search_authorization(results, policy_action = action_name)
-    results.select { |result| policy([:external_api, result]).send("#{policy_action}?".to_sym) }
+    results.select do |result|
+      policy([:external_api, result]).send("#{policy_action}?".to_sym)
+    end
   end
 
   def store_currents
@@ -31,7 +33,7 @@ class ExternalApi::ApplicationController < ActionController::API
     render_error(
       "misc.external_api_key_unauthorized_error",
       { message_opts: { error_message: exception.message }, status: 403 },
-      exception,
+      exception
     ) and return
   end
 
@@ -49,7 +51,12 @@ class ExternalApi::ApplicationController < ActionController::API
 
     render_error(
       "misc.external_api_key_forbidden_error",
-      { message_opts: { error_message: message || "Access denied" }, status: 401 },
+      {
+        message_opts: {
+          error_message: message || "Access denied"
+        },
+        status: 401
+      }
     ) and return
   end
 end

--- a/app/controllers/external_api/concerns/search/permit_applications.rb
+++ b/app/controllers/external_api/concerns/search/permit_applications.rb
@@ -5,7 +5,8 @@ module ExternalApi::Concerns::Search::PermitApplications
     # This search should always be scoped to a jurisdiction via the api key.
     # The following condition should never be true, but is an added reduncy
     # for security purposes.
-    if current_external_api_key.blank? || current_external_api_key.jurisdiction_id.blank?
+    if current_external_api_key.blank? ||
+         current_external_api_key.jurisdiction_id.blank?
       raise Pundit::NotAuthorizedError
     end
 
@@ -17,15 +18,19 @@ module ExternalApi::Concerns::Search::PermitApplications
       per_page:
         (
           if permit_application_search_params[:page]
-            (permit_application_search_params[:per_page] || Kaminari.config.default_per_page)
+            (
+              permit_application_search_params[:per_page] ||
+                Kaminari.config.default_per_page
+            )
           else
             nil
           end
         ),
-      includes: PermitApplication::SEARCH_INCLUDES,
+      includes: PermitApplication::SEARCH_INCLUDES
     }
 
-    @permit_application_search = PermitApplication.search(permit_application_query, **search_conditions)
+    @permit_application_search =
+      PermitApplication.search(permit_application_query, **search_conditions)
   end
 
   private
@@ -38,9 +43,9 @@ module ExternalApi::Concerns::Search::PermitApplications
         :permit_classifications,
         :status,
         submitted_at: %i[gt lt gte lte],
-        resubmitted_at: %i[gt lt gte lte],
+        resubmitted_at: %i[gt lt gte lte]
       ],
-      sort: %i[field direction],
+      sort: %i[field direction]
     )
   end
 
@@ -63,10 +68,11 @@ module ExternalApi::Concerns::Search::PermitApplications
     where = {
       jurisdiction_id: current_external_api_key.jurisdiction_id,
       # TODO: Support sandboxes in external API
-      sandbox_id: nil,
+      sandbox_id: nil
     }
 
-    where[:status] = %i[newly_submitted resubmitted] if constraints.blank? || constraints[:status].blank?
+    where[:status] = %i[newly_submitted resubmitted] if constraints.blank? ||
+      constraints[:status].blank?
 
     where.merge!(constraints.to_h.deep_symbolize_keys) if constraints.present?
 

--- a/app/controllers/external_api/v1/permit_applications_controller.rb
+++ b/app/controllers/external_api/v1/permit_applications_controller.rb
@@ -6,19 +6,20 @@ class ExternalApi::V1::PermitApplicationsController < ExternalApi::ApplicationCo
 
   def index
     perform_permit_application_search
-    authorized_results = apply_search_authorization(@permit_application_search.results)
+    authorized_results =
+      apply_search_authorization(@permit_application_search.results)
     render_success authorized_results,
                    nil,
                    {
                      meta: {
                        total_pages: @permit_application_search.total_pages,
                        total_count: @permit_application_search.total_count,
-                       current_page: @permit_application_search.current_page,
+                       current_page: @permit_application_search.current_page
                      },
                      blueprint: PermitApplicationBlueprint,
                      blueprint_opts: {
-                       view: :external_api,
-                     },
+                       view: :external_api
+                     }
                    }
   end
 
@@ -27,19 +28,32 @@ class ExternalApi::V1::PermitApplicationsController < ExternalApi::ApplicationCo
 
     render_success @permit_application,
                    nil,
-                   { blueprint: PermitApplicationBlueprint, blueprint_opts: { view: :external_api } }
+                   {
+                     blueprint: PermitApplicationBlueprint,
+                     blueprint_opts: {
+                       view: :external_api
+                     }
+                   }
   end
 
   def show_integration_mapping
     @integration_mapping =
-      @template_version.integration_mappings.find_by(jurisdiction: current_external_api_key.jurisdiction)
+      @template_version.integration_mappings.find_by(
+        jurisdiction: current_external_api_key.jurisdiction
+      )
 
-    authorize @integration_mapping, policy_class: ExternalApi::PermitApplicationPolicy
+    authorize @integration_mapping,
+              policy_class: ExternalApi::PermitApplicationPolicy
 
     if @integration_mapping.present?
       render_success @integration_mapping,
                      nil,
-                     { blueprint: IntegrationMappingBlueprint, blueprint_opts: { view: :external_api } }
+                     {
+                       blueprint: IntegrationMappingBlueprint,
+                       blueprint_opts: {
+                         view: :external_api
+                       }
+                     }
     else
       render_error "integration_mapping.not_found_error", status: 404
     end

--- a/app/errors/template_versions_publish_error.rb
+++ b/app/errors/template_versions_publish_error.rb
@@ -3,6 +3,8 @@ class TemplateVersionsPublishError < StandardError
 
   def initialize(errors)
     @errors = errors
-    super("Failed to publish some versions. See the errors attribute for details.")
+    super(
+      "Failed to publish some versions. See the errors attribute for details."
+    )
   end
 end

--- a/app/helpers/frontend_url_helper.rb
+++ b/app/helpers/frontend_url_helper.rb
@@ -4,6 +4,9 @@ module FrontendUrlHelper
   end
 
   def self.frontend_url(path)
-    Addressable::URI.join(Rails.application.routes.url_helpers.root_url, path).to_s
+    Addressable::URI.join(
+      Rails.application.routes.url_helpers.root_url,
+      path
+    ).to_s
   end
 end

--- a/app/jobs/automated_compliance/autopopulate_job.rb
+++ b/app/jobs/automated_compliance/autopopulate_job.rb
@@ -13,28 +13,49 @@ class AutomatedCompliance::AutopopulateJob
 
       # set front end form updates, force these to get picked up for processing
       # these are for forms already loaded and rendered
-      permit_application.assign_attributes(front_end_form_update: permit_application.formatted_compliance_data)
+      permit_application.assign_attributes(
+        front_end_form_update: permit_application.formatted_compliance_data
+      )
 
       WebsocketBroadcaster.push_update_to_relevant_users(
         permit_application.notifiable_users.pluck(:id),
         Constants::Websockets::Events::PermitApplication::DOMAIN,
-        Constants::Websockets::Events::PermitApplication::TYPES[:update_compliance],
-        PermitApplicationBlueprint.render_as_hash(permit_application, { view: :compliance_update }),
+        Constants::Websockets::Events::PermitApplication::TYPES[
+          :update_compliance
+        ],
+        PermitApplicationBlueprint.render_as_hash(
+          permit_application,
+          { view: :compliance_update }
+        )
       )
     end
   end
 
   def match(compliance_module_name, permit_application)
-    unless (%w[DigitalSealValidator ParcelInfoExtractor HistoricSite PermitApplication]).include? compliance_module_name
+    unless (
+             %w[
+               DigitalSealValidator
+               ParcelInfoExtractor
+               HistoricSite
+               PermitApplication
+             ]
+           ).include? compliance_module_name
       # AlrValidator
       Rails.logger.error "unsafe compliance module called #{compliance_module_name}"
       return
     end
     # looks for a matching job, if not, runs the module directly
-    if Object.const_defined?("AutomatedCompliance::#{compliance_module_name}Job")
-      "AutomatedCompliance::#{compliance_module_name}Job".safe_constantize.perform_async(permit_application.id)
+    if Object.const_defined?(
+         "AutomatedCompliance::#{compliance_module_name}Job"
+       )
+      "AutomatedCompliance::#{compliance_module_name}Job".safe_constantize.perform_async(
+        permit_application.id
+      )
     else
-      "AutomatedCompliance::#{compliance_module_name}".safe_constantize.new.call(permit_application)
+      "AutomatedCompliance::#{compliance_module_name}"
+        .safe_constantize
+        .new
+        .call(permit_application)
     end
   end
 end

--- a/app/jobs/automated_compliance/digital_seal_validator_job.rb
+++ b/app/jobs/automated_compliance/digital_seal_validator_job.rb
@@ -7,13 +7,20 @@ class AutomatedCompliance::DigitalSealValidatorJob
     return if permit_application.blank?
     AutomatedCompliance::DigitalSealValidator.new.call(permit_application)
 
-    permit_application.assign_attributes(front_end_form_update: permit_application.formatted_compliance_data)
+    permit_application.assign_attributes(
+      front_end_form_update: permit_application.formatted_compliance_data
+    )
 
     WebsocketBroadcaster.push_update_to_relevant_users(
       permit_application.notifiable_users.pluck(:id),
       Constants::Websockets::Events::PermitApplication::DOMAIN,
-      Constants::Websockets::Events::PermitApplication::TYPES[:update_compliance],
-      PermitApplicationBlueprint.render_as_hash(permit_application, { view: :compliance_update }),
+      Constants::Websockets::Events::PermitApplication::TYPES[
+        :update_compliance
+      ],
+      PermitApplicationBlueprint.render_as_hash(
+        permit_application,
+        { view: :compliance_update }
+      )
     )
   end
 end

--- a/app/jobs/derivatives_job.rb
+++ b/app/jobs/derivatives_job.rb
@@ -6,7 +6,8 @@ class DerivativesJob
     attacher_class = Object.const_get(attacher_class)
     record = Object.const_get(record_class).find(record_id) # if using Active Record
 
-    attacher = attacher_class.retrieve(model: record, name: name, file: file_data)
+    attacher =
+      attacher_class.retrieve(model: record, name: name, file: file_data)
     attacher.create_derivatives # perform processing
     attacher.atomic_promote
   rescue Shrine::AttachmentChanged, ActiveRecord::RecordNotFound

--- a/app/jobs/model_callback_job.rb
+++ b/app/jobs/model_callback_job.rb
@@ -4,7 +4,7 @@ class ModelCallbackJob
                   queue: :model_callbacks,
                   on_conflict: {
                     client: :log,
-                    server: :reject,
+                    server: :reject
                   }
 
   def perform(model_name, model_id, callback_name)

--- a/app/jobs/permit_webhook_job.rb
+++ b/app/jobs/permit_webhook_job.rb
@@ -7,8 +7,10 @@ class PermitWebhookJob
 
     service = PermitWebhookService.new(external_api_key)
 
-    if event_type == Constants::Webhooks::Events::PermitApplication::PERMIT_SUBMITTED ||
-         event_type == Constants::Webhooks::Events::PermitApplication::PERMIT_RESUBMITTED
+    if event_type ==
+         Constants::Webhooks::Events::PermitApplication::PERMIT_SUBMITTED ||
+         event_type ==
+           Constants::Webhooks::Events::PermitApplication::PERMIT_RESUBMITTED
       service.send_submitted_event(permit_application_id)
     end
   end

--- a/app/jobs/send_batched_integration_mapping_notifications_job.rb
+++ b/app/jobs/send_batched_integration_mapping_notifications_job.rb
@@ -18,13 +18,17 @@ class SendBatchedIntegrationMappingNotificationsJob
       .distinct
       .find_each do |notifiable|
         # Get all unprocessed notifications for the notifiable (either User or ExternalApiKey)
-        notifications = notifiable.integration_mapping_notifications.where(processed_at: nil)
+        notifications =
+          notifiable.integration_mapping_notifications.where(processed_at: nil)
 
         notification_ids = notifications.pluck(:id)
 
         # Bundle notifications into an email
         if notifications.any?
-          PermitHubMailer.send_batched_integration_mapping_notifications(notifiable, notification_ids)&.deliver_later
+          PermitHubMailer.send_batched_integration_mapping_notifications(
+            notifiable,
+            notification_ids
+          )&.deliver_later
 
           # Mark notifications as processed
           notifications.update_all(processed_at: Time.current)

--- a/app/jobs/zipfile_job.rb
+++ b/app/jobs/zipfile_job.rb
@@ -4,7 +4,7 @@ class ZipfileJob
                   queue: :file_processing,
                   on_conflict: {
                     client: :log,
-                    server: :reject,
+                    server: :reject
                   }
 
   def self.lock_args(args)
@@ -23,8 +23,13 @@ class ZipfileJob
       WebsocketBroadcaster.push_update_to_relevant_users(
         permit_application.notifiable_users.pluck(:id),
         Constants::Websockets::Events::PermitApplication::DOMAIN,
-        Constants::Websockets::Events::PermitApplication::TYPES[:update_supporting_documents],
-        PermitApplicationBlueprint.render_as_hash(permit_application.reload, { view: :supporting_docs_update }),
+        Constants::Websockets::Events::PermitApplication::TYPES[
+          :update_supporting_documents
+        ],
+        PermitApplicationBlueprint.render_as_hash(
+          permit_application.reload,
+          { view: :supporting_docs_update }
+        )
       )
     end
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -12,7 +12,7 @@ class ApplicationMailer < ActionMailer::Base
       to: email,
       subject:
         "#{I18n.t("application_mailer.subject_start")} - #{I18n.t("application_mailer.subjects.#{template_key}", **subject_i18n_params)}",
-      template_name: template_key, # this isn't fully necessary since rails introspects it anyway, but here for clarity (template_path is also auto introspected by rails)
+      template_name: template_key # this isn't fully necessary since rails introspects it anyway, but here for clarity (template_path is also auto introspected by rails)
     )
   end
 end

--- a/app/mailers/custom_devise_mailer.rb
+++ b/app/mailers/custom_devise_mailer.rb
@@ -17,9 +17,10 @@ class CustomDeviseMailer < Devise::Mailer
     mail(
       to: mail_headers[:to],
       from: mail_headers[:from],
-      subject: "#{I18n.t("application_mailer.subject_start")} - #{mail_headers[:subject]}",
+      subject:
+        "#{I18n.t("application_mailer.subject_start")} - #{mail_headers[:subject]}",
       template_path: "devise/mailer",
-      template_name: mail_headers[:template_name],
+      template_name: mail_headers[:template_name]
     )
   end
 end

--- a/app/mailers/permit_hub_mailer.rb
+++ b/app/mailers/permit_hub_mailer.rb
@@ -13,14 +13,20 @@ class PermitHubMailer < ApplicationMailer
   def new_jurisdiction_membership(user, jurisdiction_id)
     @user = user
     @jurisdiction = Jurisdiction.find(jurisdiction_id)
-    send_user_mail(email: user.email, template_key: "new_jurisdiction_membership")
+    send_user_mail(
+      email: user.email,
+      template_key: "new_jurisdiction_membership"
+    )
   end
 
   def notify_submitter_application_submitted(permit_application, user)
     @user = user
     @permit_application = permit_application
 
-    send_user_mail(email: @user.email, template_key: "notify_submitter_application_submitted")
+    send_user_mail(
+      email: @user.email,
+      template_key: "notify_submitter_application_submitted"
+    )
   end
 
   def notify_permit_collaboration(permit_collaboration:)
@@ -29,7 +35,10 @@ class PermitHubMailer < ApplicationMailer
 
     return unless permit_collaboration.permit_application
 
-    send_user_mail(email: @user.email, template_key: :notify_permit_collaboration)
+    send_user_mail(
+      email: @user.email,
+      template_key: :notify_permit_collaboration
+    )
   end
 
   def notify_block_status_ready(permit_block_status:, user:, status_set_by: nil)
@@ -37,12 +46,18 @@ class PermitHubMailer < ApplicationMailer
     @user = user
     @status_set_by = status_set_by
 
-    return unless permit_block_status.block_exists? && @user.preference&.enable_email_collaboration_notification
+    unless permit_block_status.block_exists? &&
+             @user.preference&.enable_email_collaboration_notification
+      return
+    end
 
     send_user_mail(email: @user.email, template_key: :notify_block_status_ready)
   end
 
-  def notify_new_or_unconfirmed_permit_collaboration(permit_collaboration:, user:)
+  def notify_new_or_unconfirmed_permit_collaboration(
+    permit_collaboration:,
+    user:
+  )
     @permit_collaboration = permit_collaboration
     @user = user
 
@@ -57,10 +72,16 @@ class PermitHubMailer < ApplicationMailer
       @user.save!
     end
 
-    send_mail(email: @user.email, template_key: :notify_new_or_unconfirmed_permit_collaboration)
+    send_mail(
+      email: @user.email,
+      template_key: :notify_new_or_unconfirmed_permit_collaboration
+    )
   end
 
-  def send_batched_integration_mapping_notifications(notifiable, notification_ids)
+  def send_batched_integration_mapping_notifications(
+    notifiable,
+    notification_ids
+  )
     # This should be called by the SendBatchedIntegrationMappingNotificationsJob
 
     @notifications = IntegrationMappingNotification.where(id: notification_ids)
@@ -69,22 +90,31 @@ class PermitHubMailer < ApplicationMailer
 
     if notifiable.is_a?(User)
       @user = notifiable
-      send_user_mail(email: notifiable.email, template_key: "notify_batched_integration_mapping")
+      send_user_mail(
+        email: notifiable.email,
+        template_key: "notify_batched_integration_mapping"
+      )
     elsif notifiable.is_a?(ExternalApiKey)
       @external_api_key = notifiable
       @jurisdiction_name = @external_api_key&.jurisdiction.qualified_name
-      send_mail(email: notifiable.notification_email, template_key: "notify_batched_integration_mapping")
+      send_mail(
+        email: notifiable.notification_email,
+        template_key: "notify_batched_integration_mapping"
+      )
     end
   end
 
-  def notify_reviewer_application_received(permit_type_submission_contact, permit_application)
+  def notify_reviewer_application_received(
+    permit_type_submission_contact,
+    permit_application
+  )
     @permit_application = permit_application
     send_mail(
       email: permit_type_submission_contact.email,
       template_key: "notify_reviewer_application_received",
       subject_i18n_params: {
-        permit_application_number: permit_application.number,
-      },
+        permit_application_number: permit_application.number
+      }
     )
   end
 
@@ -95,8 +125,8 @@ class PermitHubMailer < ApplicationMailer
       email: @user.email,
       template_key: "notify_application_viewed",
       subject_i18n_params: {
-        permit_application_number: permit_application.number,
-      },
+        permit_application_number: permit_application.number
+      }
     )
   end
 
@@ -107,20 +137,26 @@ class PermitHubMailer < ApplicationMailer
       email: @user.email,
       template_key: "notify_application_revisions_requested",
       subject_i18n_params: {
-        permit_application_number: permit_application.number,
-      },
+        permit_application_number: permit_application.number
+      }
     )
   end
 
   def remind_reviewer(permit_type_submission_contact, permit_applications)
     @permit_applications = permit_applications
-    send_mail(email: permit_type_submission_contact.email, template_key: "remind_reviewer")
+    send_mail(
+      email: permit_type_submission_contact.email,
+      template_key: "remind_reviewer"
+    )
   end
 
   #### PermitTypeSubmission Contact Mailer
   def permit_type_submission_contact_confirm(permit_type_submission_contact)
     @permit_type_submission_contact = permit_type_submission_contact
-    send_mail(email: permit_type_submission_contact.email, template_key: "permit_type_submission_contact_confirm")
+    send_mail(
+      email: permit_type_submission_contact.email,
+      template_key: "permit_type_submission_contact_confirm"
+    )
   end
 
   def send_user_mail(*args, **kwargs)

--- a/app/models/collaborator.rb
+++ b/app/models/collaborator.rb
@@ -1,5 +1,6 @@
 class Collaborator < ApplicationRecord
-  searchkick searchable: %i[first_name last_name email], word_start: %i[first_name last_name email]
+  searchkick searchable: %i[first_name last_name email],
+             word_start: %i[first_name last_name email]
 
   belongs_to :user
   belongs_to :collaboratorable, polymorphic: true
@@ -7,7 +8,10 @@ class Collaborator < ApplicationRecord
   has_many :permit_collaborations, dependent: :destroy
 
   validates :collaboratorable_type, inclusion: { in: %w[User Jurisdiction] }
-  validates :user, uniqueness: { scope: %i[collaboratorable_id collaboratorable_type] }
+  validates :user,
+            uniqueness: {
+              scope: %i[collaboratorable_id collaboratorable_type]
+            }
 
   validate :validate_user, on: :create
 
@@ -23,7 +27,7 @@ class Collaborator < ApplicationRecord
       last_name: user.last_name,
       email: user.email,
       jurisdiction_ids: user.jurisdictions.pluck(:id),
-      discarded: user.discarded_at.present?,
+      discarded: user.discarded_at.present?
     }
   end
 
@@ -32,7 +36,11 @@ class Collaborator < ApplicationRecord
   def reindex_permit_applications
     return unless saved_change_to_user_id
 
-    permit_applications = permit_collaborations.includes(:permit_application).map(&:permit_application).uniq
+    permit_applications =
+      permit_collaborations
+        .includes(:permit_application)
+        .map(&:permit_application)
+        .uniq
 
     permit_applications.each(&:reindex)
   end

--- a/app/models/concerns/automated_compliance_utils.rb
+++ b/app/models/concerns/automated_compliance_utils.rb
@@ -13,11 +13,15 @@ module AutomatedComplianceUtils
 
   def automated_compliance_requirements
     #check which fields in requirement have custom compliance components
-    requirements_lookups.select { |field_id, req| req["computedCompliance"].present? }
+    requirements_lookups.select do |field_id, req|
+      req["computedCompliance"].present?
+    end
   end
 
   def automated_compliance_unfilled_requirements
-    automated_compliance_requirements.select { |field_id, req| submission_field_is_empty?(field_id, req) }
+    automated_compliance_requirements.select do |field_id, req|
+      submission_field_is_empty?(field_id, req)
+    end
   end
 
   def submission_field_is_empty?(field_id, requirement)
@@ -38,7 +42,10 @@ module AutomatedComplianceUtils
   end
 
   def automated_compliance_unique_unfilled_modules
-    automated_compliance_unfilled_requirements.values.map { |req| req.dig("computedCompliance", "module") }.uniq
+    automated_compliance_unfilled_requirements
+      .values
+      .map { |req| req.dig("computedCompliance", "module") }
+      .uniq
   end
 
   def automated_compliance_requirements_for_module(compliance_module_name)

--- a/app/models/concerns/form_supporting_documents.rb
+++ b/app/models/concerns/form_supporting_documents.rb
@@ -5,7 +5,11 @@ module FormSupportingDocuments
   included do
     has_many :supporting_documents, dependent: :destroy
     has_many :active_supporting_documents,
-             ->(permit_application) { where(id: permit_application.supporting_doc_ids_from_submission_data) },
+             ->(permit_application) do
+               where(
+                 id: permit_application.supporting_doc_ids_from_submission_data
+               )
+             end,
              class_name: "SupportingDocument"
 
     CHECKLIST_PDF_DATA_KEY = SupportingDocument::CHECKLIST_PDF_DATA_KEY
@@ -15,31 +19,38 @@ module FormSupportingDocuments
     has_many :inactive_supporting_documents,
              ->(permit_application) do
                where
-                 .not(id: permit_application.supporting_doc_ids_from_submission_data)
+                 .not(
+                   id:
+                     permit_application.supporting_doc_ids_from_submission_data
+                 )
                  .where.not(data_key: STATIC_DOCUMENT_DATA_KEYS)
              end,
              class_name: "SupportingDocument"
     has_many :completed_supporting_documents,
              ->(permit_application) do
-               where(id: permit_application.supporting_doc_ids_from_submission_data).or(
-                 where(data_key: STATIC_DOCUMENT_DATA_KEYS),
-               )
+               where(
+                 id: permit_application.supporting_doc_ids_from_submission_data
+               ).or(where(data_key: STATIC_DOCUMENT_DATA_KEYS))
              end,
              class_name: "SupportingDocument"
     has_many :all_submission_version_completed_supporting_documents,
              ->(permit_application) do
-               where(id: permit_application.supporting_doc_ids_from_all_versions_submission_data).or(
-                 where(data_key: STATIC_DOCUMENT_DATA_KEYS),
-               ).order(created_at: :desc)
+               where(
+                 id:
+                   permit_application.supporting_doc_ids_from_all_versions_submission_data
+               ).or(where(data_key: STATIC_DOCUMENT_DATA_KEYS)).order(
+                 created_at: :desc
+               )
              end,
              class_name: "SupportingDocument"
     accepts_nested_attributes_for :supporting_documents, allow_destroy: true
   end
 
   def supporting_doc_ids_from_submission_data
-    find_file_fields_and_transform!(submission_data, []) do |file_field_key, file_array|
-      file_array.map { |fa| fa["model_id"] }
-    end
+    find_file_fields_and_transform!(
+      submission_data,
+      []
+    ) { |file_field_key, file_array| file_array.map { |fa| fa["model_id"] } }
   end
 
   def supporting_doc_ids_from_all_versions_submission_data
@@ -47,7 +58,10 @@ module FormSupportingDocuments
 
     submission_versions.map do |sv|
       version_doc_ids =
-        find_file_fields_and_transform!(sv.formatted_submission_data, []) do |_file_field_key, file_array|
+        find_file_fields_and_transform!(
+          sv.formatted_submission_data,
+          []
+        ) do |_file_field_key, file_array|
           file_array.map { |fa| fa["model_id"] }
         end
 
@@ -65,7 +79,9 @@ module FormSupportingDocuments
     # fetch the energy step_code from json
     if requirement_energy_step_code_key_value && step_code
       if step_code.plan_out_of_date
-        joined[requirement_energy_step_code_key_value[0]] = "warningFileOutOfDate"
+        joined[
+          requirement_energy_step_code_key_value[0]
+        ] = "warningFileOutOfDate"
       else
         joined[requirement_energy_step_code_key_value[0]] = "infoInProgress"
       end
@@ -73,17 +89,29 @@ module FormSupportingDocuments
 
     # data from individual documents
     grouped_compliance_data =
-      active_supporting_documents.where.not(compliance_data: {}).map { |sd| sd.compliance_message_view }
-    grouped_compliance_data.group_by { |sd| sd["data_key"] }.each { |key, value| joined[key] = value }
+      active_supporting_documents
+        .where.not(compliance_data: {})
+        .map { |sd| sd.compliance_message_view }
+    grouped_compliance_data
+      .group_by { |sd| sd["data_key"] }
+      .each { |key, value| joined[key] = value }
 
     joined
   end
 
   # for automated compliance fields
-  def fetch_file_ids_from_submission_data_matching_requirements(fields_and_requirements_array)
+  def fetch_file_ids_from_submission_data_matching_requirements(
+    fields_and_requirements_array
+  )
     fields_and_requirements_array
       .map do |field_id, req|
-        self.submission_data.dig("data", PermitApplication.section_from_key(field_id), field_id, 0, "id")
+        self.submission_data.dig(
+          "data",
+          PermitApplication.section_from_key(field_id),
+          field_id,
+          0,
+          "id"
+        )
       end
       .compact
       .map { |id| id.start_with?("cache/") ? id.slice(6..-1) : id }
@@ -105,7 +133,8 @@ module FormSupportingDocuments
     zipfile&.url(
       public: false,
       expires_in: 3600,
-      response_content_disposition: "attachment; filename=\"#{zipfile.original_filename}\"",
+      response_content_disposition:
+        "attachment; filename=\"#{zipfile.original_filename}\""
     )
   end
 

--- a/app/models/concerns/html_sanitize_attributes.rb
+++ b/app/models/concerns/html_sanitize_attributes.rb
@@ -20,7 +20,8 @@ module HtmlSanitizeAttributes
     ActionController::Base.helpers.sanitize(
       html,
       tags: Rails::Html::WhiteListSanitizer.allowed_tags,
-      attributes: Rails::Html::WhiteListSanitizer.allowed_attributes + %w[target rel],
+      attributes:
+        Rails::Html::WhiteListSanitizer.allowed_attributes + %w[target rel]
     )
   end
 

--- a/app/models/concerns/permit_application_status.rb
+++ b/app/models/concerns/permit_application_status.rb
@@ -2,7 +2,13 @@ module PermitApplicationStatus
   extend ActiveSupport::Concern
   included do
     include AASM
-    enum status: { new_draft: 0, newly_submitted: 1, revisions_requested: 3, resubmitted: 4 }, _default: 0
+    enum status: {
+           new_draft: 0,
+           newly_submitted: 1,
+           revisions_requested: 3,
+           resubmitted: 4
+         },
+         _default: 0
 
     def self.draft_statuses
       %w[new_draft revisions_requested]
@@ -19,8 +25,14 @@ module PermitApplicationStatus
       state :resubmitted
 
       event :submit do
-        transitions from: :new_draft, to: :newly_submitted, guard: :can_submit?, after: :handle_submission
-        transitions from: :revisions_requested, to: :resubmitted, guard: :can_submit?, after: :handle_submission
+        transitions from: :new_draft,
+                    to: :newly_submitted,
+                    guard: :can_submit?,
+                    after: :handle_submission
+        transitions from: :revisions_requested,
+                    to: :resubmitted,
+                    guard: :can_submit?,
+                    after: :handle_submission
       end
 
       event :finalize_revision_requests do
@@ -40,7 +52,8 @@ module PermitApplicationStatus
     end
 
     def can_submit?
-      signed = submission_data.dig("data", "section-completion-key", "signed").present?
+      signed =
+        submission_data.dig("data", "section-completion-key", "signed").present?
       signed && using_current_template_version
     end
 
@@ -64,11 +77,14 @@ module PermitApplicationStatus
         step_code_checklist_json:
           (
             if checklist.present?
-              StepCodeChecklistBlueprint.render_as_hash(checklist, view: :extended)
+              StepCodeChecklistBlueprint.render_as_hash(
+                checklist,
+                view: :extended
+              )
             else
               nil
             end
-          ),
+          )
       )
 
       zip_and_upload_supporting_documents

--- a/app/models/concerns/step_code_field_extraction.rb
+++ b/app/models/concerns/step_code_field_extraction.rb
@@ -33,7 +33,9 @@ module StepCodeFieldExtraction
 
   def step_code_plan_field
     # can be overridden by config settings requirement_energy_step_code["plan_file_field"]
-    requirements_lookups.keys.find { |k| k.ends_with?("|#{Requirement::STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE}") }
+    requirements_lookups.keys.find do |k|
+      k.ends_with?("|#{Requirement::STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE}")
+    end
   end
 
   def step_code_plan_document # looks for the first instance that matches the plan field
@@ -42,6 +44,8 @@ module StepCodeFieldExtraction
 
   def requirement_energy_step_code_key_value
     # energy stepcode is a unique field, look at the published form_json to find item with lookup_type: "energy_step_code"
-    requirements_lookups.find { |k, v| v["requirementInputType"] == "energy_step_code" }
+    requirements_lookups.find do |k, v|
+      v["requirementInputType"] == "energy_step_code"
+    end
   end
 end

--- a/app/models/concerns/traverse_data_json.rb
+++ b/app/models/concerns/traverse_data_json.rb
@@ -16,7 +16,11 @@ module TraverseDataJson
           find_file_fields_and_transform!(value, files, &block)
         when Array
           # If the value is an array, iterate through its elements
-          value.each { |item| find_file_fields_and_transform!(item, files, &block) if item.is_a?(Hash) }
+          value.each do |item|
+            if item.is_a?(Hash)
+              find_file_fields_and_transform!(item, files, &block)
+            end
+          end
         else
           # do nothing for remaining
         end
@@ -31,8 +35,14 @@ module TraverseDataJson
     #requirements may have nesting (like general contact, etc),  but in our purpose we skip this
     #TODO: explore performanc edifference to move this straight into jsonb functions
     data_hash["components"]
-      .map { |section_json| section_json["components"].map { |blocks_json| blocks_json["components"].flatten }.flatten }
+      .map do |section_json|
+        section_json["components"]
+          .map { |blocks_json| blocks_json["components"].flatten }
+          .flatten
+      end
       .flatten
-      .reduce({}) { |obj, requirement| obj.merge({ requirement["key"] => requirement }) }
+      .reduce({}) do |obj, requirement|
+        obj.merge({ requirement["key"] => requirement })
+      end
   end
 end

--- a/app/models/concerns/validate_url_attributes.rb
+++ b/app/models/concerns/validate_url_attributes.rb
@@ -13,7 +13,9 @@ module ValidateUrlAttributes
 
       begin
         uri = URI.parse(value)
-        errors.add(attr_name, "must be a valid URL") unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+        unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+          errors.add(attr_name, "must be a valid URL")
+        end
       rescue URI::InvalidURIError
         errors.add(attr_name, "must be a valid URL")
       end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,8 +1,26 @@
 class Contact < ApplicationRecord
-  searchkick searchable: %i[first_name last_name email organization department professional_association],
-             word_start: %i[first_name last_name email organization department professional_association]
+  searchkick searchable: %i[
+               first_name
+               last_name
+               email
+               organization
+               department
+               professional_association
+             ],
+             word_start: %i[
+               first_name
+               last_name
+               email
+               organization
+               department
+               professional_association
+             ]
 
-  validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
+  validates :email,
+            format: {
+              with: URI::MailTo::EMAIL_REGEXP
+            },
+            allow_blank: true
   validates :phone, phone: true, allow_blank: true
   validates :cell, phone: true, allow_blank: true
   before_validation :normalize_phone
@@ -25,7 +43,7 @@ class Contact < ApplicationRecord
       organization: organization,
       department: department,
       professional_association: professional_association,
-      contactable_id: contactable_id,
+      contactable_id: contactable_id
     }
   end
 end

--- a/app/models/early_access_requirement_template.rb
+++ b/app/models/early_access_requirement_template.rb
@@ -1,5 +1,7 @@
 class EarlyAccessRequirementTemplate < RequirementTemplate
-  has_one :template_version, dependent: :destroy, foreign_key: :requirement_template_id
+  has_one :template_version,
+          dependent: :destroy,
+          foreign_key: :requirement_template_id
 
   belongs_to :assignee, class_name: "User", optional: true
 
@@ -19,8 +21,8 @@ class EarlyAccessRequirementTemplate < RequirementTemplate
       errors.add(
         :template_versions,
         I18n.t(
-          "activerecord.errors.models.requirement_template.attributes.template_versions.published_required_for_early_access",
-        ),
+          "activerecord.errors.models.requirement_template.attributes.template_versions.published_required_for_early_access"
+        )
       )
     end
   end

--- a/app/models/end_user_license_agreement.rb
+++ b/app/models/end_user_license_agreement.rb
@@ -18,6 +18,9 @@ class EndUserLicenseAgreement < ApplicationRecord
   private
 
   def replace_active_agreement
-    EndUserLicenseAgreement.where(active: true, variant: variant).where.not(id: id).update_all(active: false)
+    EndUserLicenseAgreement
+      .where(active: true, variant: variant)
+      .where.not(id: id)
+      .update_all(active: false)
   end
 end

--- a/app/models/external_api_key.rb
+++ b/app/models/external_api_key.rb
@@ -1,7 +1,9 @@
 class ExternalApiKey < ApplicationRecord
   include ValidateUrlAttributes
 
-  has_many :integration_mapping_notifications, as: :notifiable, dependent: :destroy
+  has_many :integration_mapping_notifications,
+           as: :notifiable,
+           dependent: :destroy
 
   url_validatable :webhook_url
 
@@ -10,7 +12,7 @@ class ExternalApiKey < ApplicationRecord
           joins(:jurisdiction).where(
             "jurisdictions.external_api_enabled = TRUE AND (expired_at IS NULL OR expired_at > ?) AND revoked_at IS
 NULL",
-            Time.now,
+            Time.now
           )
         end
   # Token namespace can be useful for secrets scanning tools, e.g. GitHub secret scanning
@@ -23,7 +25,11 @@ NULL",
   validates :name, presence: true, uniqueness: { scope: :jurisdiction_id }
   validates :connecting_application, presence: true
   validates :expired_at, presence: true
-  validates :notification_email, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_blank: true
+  validates :notification_email,
+            format: {
+              with: URI::MailTo::EMAIL_REGEXP
+            },
+            allow_blank: true
 
   before_create :generate_token
 
@@ -54,7 +60,10 @@ NULL",
   private
 
   def valid_url_format
-    return if url.blank? || URI.parse(url).is_a?(URI::HTTP) || URI.parse(url).is_a?(URI::HTTPS)
+    if url.blank? || URI.parse(url).is_a?(URI::HTTP) ||
+         URI.parse(url).is_a?(URI::HTTPS)
+      return
+    end
     errors.add(:url, "must be a valid URL")
   rescue URI::InvalidURIError
     errors.add(:url, "must be a valid URL")

--- a/app/models/integration_mapping.rb
+++ b/app/models/integration_mapping.rb
@@ -24,7 +24,10 @@ class IntegrationMapping < ApplicationRecord
   attr_accessor :simplified_map_to_sync
 
   def jurisdiction_template_version_customization
-    JurisdictionTemplateVersionCustomization.find_by(jurisdiction:, template_version:)
+    JurisdictionTemplateVersionCustomization.find_by(
+      jurisdiction:,
+      template_version:
+    )
   end
 
   def missing_requirements_mapping
@@ -34,15 +37,28 @@ class IntegrationMapping < ApplicationRecord
     requirements_mapping.each do |requirement_block_sku, requirement_block|
       requirement_block["requirements"]&.each do |requirement_code, requirement|
         is_elective =
-          !!template_version.get_requirement_json(requirement_block["id"], requirement["id"])&.dig("elective")
-        enabled = !!template_version_customization&.elective_enabled?(requirement_block["id"], requirement["id"])
+          !!template_version.get_requirement_json(
+            requirement_block["id"],
+            requirement["id"]
+          )&.dig("elective")
+        enabled =
+          !!template_version_customization&.elective_enabled?(
+            requirement_block["id"],
+            requirement["id"]
+          )
 
         next if is_elective && !enabled
 
         next unless requirement["local_system_mapping"].blank?
 
-        missing_mapping[requirement_block_sku] ||= { "id" => requirement_block["id"], "requirements" => {} }
-        missing_mapping[requirement_block_sku]["requirements"][requirement_code] = requirement
+        missing_mapping[requirement_block_sku] ||= {
+          "id" => requirement_block["id"],
+          "requirements" => {
+          }
+        }
+        missing_mapping[requirement_block_sku]["requirements"][
+          requirement_code
+        ] = requirement
       end
     end
 
@@ -62,8 +78,8 @@ class IntegrationMapping < ApplicationRecord
       "action_text" =>
         "#{I18n.t("notification.integration_mapping.#{template_version.published? ? "published" : "scheduled"}_template_missing_requirements_mapping", template_label: template_version.label, version_date: template_version.version_date)}",
       "object_data" => {
-        "template_version_id" => template_version_id,
-      },
+        "template_version_id" => template_version_id
+      }
     }
   end
 
@@ -81,7 +97,10 @@ class IntegrationMapping < ApplicationRecord
   # @return [Boolean] true if the update was successful, false otherwise
   def update_requirements_mapping(simplified_map, skip_sync = false)
     self.with_lock do
-      new_requirements_mapping = IntegrationMappingService.new(self).get_updated_requirements_mapping(simplified_map)
+      new_requirements_mapping =
+        IntegrationMappingService.new(self).get_updated_requirements_mapping(
+          simplified_map
+        )
 
       # nothing to update, so returns true
       return true if self.requirements_mapping == new_requirements_mapping
@@ -106,8 +125,14 @@ class IntegrationMapping < ApplicationRecord
   # @param requirement_code [String] the code of the requirement
   #
   # @return [IntegrationMapping] the copyable record with existing mapping
-  def copyable_record_with_existing_mapping(requirement_block_sku, requirement_code)
-    IntegrationMappingService.new(self).copyable_record_with_existing_mapping(requirement_block_sku, requirement_code)
+  def copyable_record_with_existing_mapping(
+    requirement_block_sku,
+    requirement_code
+  )
+    IntegrationMappingService.new(self).copyable_record_with_existing_mapping(
+      requirement_block_sku,
+      requirement_code
+    )
   end
 
   def send_missing_requirements_mapping_communication
@@ -144,11 +169,12 @@ class IntegrationMapping < ApplicationRecord
         .where(
           role: %w[review_manager regional_review_manager],
           preferences: {
-            enable_email_integration_mapping_notification: true,
-          },
+            enable_email_integration_mapping_notification: true
+          }
         )
     users_to_notify.uniq.each do |user|
-      unless user.preference&.enable_email_integration_mapping_notification && jurisdiction.external_api_enabled? &&
+      unless user.preference&.enable_email_integration_mapping_notification &&
+               jurisdiction.external_api_enabled? &&
                (user.review_manager? || user.regional_review_manager?) &&
                (template_version.published? || template_version.scheduled?)
         return
@@ -157,7 +183,7 @@ class IntegrationMapping < ApplicationRecord
       IntegrationMappingNotification.create(
         notifiable: user,
         front_end_path: front_end_edit_path,
-        template_version: template_version, # Associate the template version
+        template_version: template_version # Associate the template version
       )
     end
 
@@ -167,7 +193,8 @@ class IntegrationMapping < ApplicationRecord
     external_api_keys.uniq.each do |external_api_key|
       next unless external_api_key.notification_email.present?
 
-      unless external_api_key.notification_email.present? && external_api_key.jurisdiction.external_api_enabled? &&
+      unless external_api_key.notification_email.present? &&
+               external_api_key.jurisdiction.external_api_enabled? &&
                (template_version.published? || template_version.scheduled?)
         return
       end
@@ -175,7 +202,7 @@ class IntegrationMapping < ApplicationRecord
       # Create a notification record instead of sending the email immediately
       IntegrationMappingNotification.create(
         notifiable: external_api_key,
-        template_version: template_version, # Associate the template version
+        template_version: template_version # Associate the template version
       )
     end
   end
@@ -197,13 +224,26 @@ class IntegrationMapping < ApplicationRecord
     requirements_mapping.each do |requirement_block_sku, requirement_block|
       requirement_block["requirements"]&.each do |requirement_code, requirement|
         is_elective =
-          !!template_version.get_requirement_json(requirement_block["id"], requirement["id"])&.dig("elective")
-        enabled = !!template_version_customization&.elective_enabled?(requirement_block["id"], requirement["id"])
+          !!template_version.get_requirement_json(
+            requirement_block["id"],
+            requirement["id"]
+          )&.dig("elective")
+        enabled =
+          !!template_version_customization&.elective_enabled?(
+            requirement_block["id"],
+            requirement["id"]
+          )
 
         next if is_elective && !enabled
 
-        elective_filtered_mapping[requirement_block_sku] ||= { "id" => requirement_block["id"], "requirements" => {} }
-        elective_filtered_mapping[requirement_block_sku]["requirements"][requirement_code] = requirement
+        elective_filtered_mapping[requirement_block_sku] ||= {
+          "id" => requirement_block["id"],
+          "requirements" => {
+          }
+        }
+        elective_filtered_mapping[requirement_block_sku]["requirements"][
+          requirement_code
+        ] = requirement
       end
     end
 
@@ -228,7 +268,8 @@ class IntegrationMapping < ApplicationRecord
   # @return [void]
 
   def sync_changes_with_other_currently_active_mappings
-    unless simplified_map_to_sync.present? && simplified_map_to_sync.is_a?(Hash) &&
+    unless simplified_map_to_sync.present? &&
+             simplified_map_to_sync.is_a?(Hash) &&
              (template_version.published? || template_version.scheduled?)
       return
     end
@@ -239,12 +280,15 @@ class IntegrationMapping < ApplicationRecord
         .where(
           jurisdiction_id: jurisdiction_id,
           template_versions: {
-            status: template_version.published? ? %i[published scheduled] : :scheduled,
-          },
+            status:
+              template_version.published? ? %i[published scheduled] : :scheduled
+          }
         )
         .where.not(id: id)
 
-    active_mappings.each { |mapping| mapping.update_requirements_mapping(simplified_map_to_sync, true) }
+    active_mappings.each do |mapping|
+      mapping.update_requirements_mapping(simplified_map_to_sync, true)
+    end
   end
 
   def template_missing_requirements_event_type

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -2,7 +2,11 @@ class Jurisdiction < ApplicationRecord
   extend FriendlyId
   friendly_id :qualified_name, use: :slugged
 
-  BASE_INCLUDES = %i[permit_type_submission_contacts contacts permit_type_required_steps]
+  BASE_INCLUDES = %i[
+    permit_type_submission_contacts
+    contacts
+    permit_type_required_steps
+  ]
 
   include ActionView::Helpers::SanitizeHelper
   searchkick searchable: %i[name reverse_qualified_name qualified_name],
@@ -17,7 +21,8 @@ class Jurisdiction < ApplicationRecord
   has_many :users, through: :jurisdiction_memberships
   has_many :submitters, through: :permit_applications, source: :submitter
   has_many :jurisdiction_template_version_customizations
-  has_many :template_versions, through: :jurisdiction_template_version_customizations
+  has_many :template_versions,
+           through: :jurisdiction_template_version_customizations
   has_many :requirement_templates, through: :template_versions
   has_many :permit_type_submission_contacts
   has_many :external_api_keys, dependent: :destroy
@@ -40,13 +45,17 @@ class Jurisdiction < ApplicationRecord
   before_validation :set_type_based_on_locality
   before_save :sanitize_html_fields
 
-  after_save :create_integration_mappings_async, if: :saved_change_to_external_api_enabled?
+  after_save :create_integration_mappings_async,
+             if: :saved_change_to_external_api_enabled?
   after_create :create_permit_type_required_steps
 
   accepts_nested_attributes_for :contacts
   accepts_nested_attributes_for :permit_type_submission_contacts,
                                 allow_destroy: true,
-                                reject_if: proc { |attributes| attributes["email"].blank? }
+                                reject_if:
+                                  proc { |attributes|
+                                    attributes["email"].blank?
+                                  }
 
   accepts_nested_attributes_for :permit_type_required_steps, allow_destroy: true
 
@@ -87,14 +96,21 @@ class Jurisdiction < ApplicationRecord
   end
 
   def self.locality_types
-    find_by_sql("SELECT DISTINCT locality_type FROM jurisdictions").pluck(:locality_type)
+    find_by_sql("SELECT DISTINCT locality_type FROM jurisdictions").pluck(
+      :locality_type
+    )
   end
 
   def self.fuzzy_find_by_ltsa_feature_attributes(attributes)
     name = attributes["MUNICIPALITY"]
     regional_district_name = attributes["REGIONAL_DISTRICT"]
 
-    named_params = { fields: %w[reverse_qualified_name qualified_name], misspellings: { edit_distance: 1 } }
+    named_params = {
+      fields: %w[reverse_qualified_name qualified_name],
+      misspellings: {
+        edit_distance: 1
+      }
+    }
     return(
       SubDistrict.search(name, **named_params).first ||
         RegionalDistrict.search(regional_district_name, **named_params).first
@@ -113,12 +129,17 @@ class Jurisdiction < ApplicationRecord
       reviewers_size: reviewers_size,
       permit_applications_size: permit_applications_size,
       user_ids: users.pluck(:id),
-      submission_inbox_set_up: submission_inbox_set_up,
+      submission_inbox_set_up: submission_inbox_set_up
     }
   end
 
   def self.custom_titleize_locality_type(locality_type)
-    locality_type.split.map { |word| %w[the of].include?(word.downcase) ? word.downcase : word.capitalize }.join(" ")
+    locality_type
+      .split
+      .map do |word|
+        %w[the of].include?(word.downcase) ? word.downcase : word.capitalize
+      end
+      .join(" ")
   end
 
   def qualifier
@@ -152,9 +173,15 @@ class Jurisdiction < ApplicationRecord
   def submission_inbox_set_up
     # preload all of the permit_types and contacts for efficiency
     permit_types = PermitType.enabled.to_a
-    contacts = permit_type_submission_contacts.where.not(email: nil).where.not(confirmed_at: nil).to_a
+    contacts =
+      permit_type_submission_contacts
+        .where.not(email: nil)
+        .where.not(confirmed_at: nil)
+        .to_a
 
-    permit_types.all? { |permit_type| contacts.any? { |contact| contact.permit_type_id == permit_type.id } }
+    permit_types.all? do |permit_type|
+      contacts.any? { |contact| contact.permit_type_id == permit_type.id }
+    end
   end
 
   def self.class_for_locality_type(locality_type)
@@ -170,7 +197,11 @@ class Jurisdiction < ApplicationRecord
   end
 
   def enabled_permit_type_required_steps()
-    permit_type_required_steps.joins(:permit_type).where(permit_classifications: { enabled: true })
+    permit_type_required_steps.joins(:permit_type).where(
+      permit_classifications: {
+        enabled: true
+      }
+    )
   end
 
   def permit_type_required_steps_by_classification(permit_type = nil)
@@ -182,7 +213,8 @@ class Jurisdiction < ApplicationRecord
   def create_integration_mappings
     return unless external_api_enabled?
 
-    existing_mapping_template_ids = integration_mappings.pluck(:template_version_id)
+    existing_mapping_template_ids =
+      integration_mappings.pluck(:template_version_id)
 
     relevant_template_versions =
       TemplateVersion
@@ -202,7 +234,10 @@ class Jurisdiction < ApplicationRecord
   end
 
   def template_version_customization(template_version, sandbox = nil)
-    jurisdiction_template_version_customizations.find_by!(template_version_id: template_version.id, sandbox: sandbox)
+    jurisdiction_template_version_customizations.find_by!(
+      template_version_id: template_version.id,
+      sandbox: sandbox
+    )
   end
 
   private
@@ -211,9 +246,17 @@ class Jurisdiction < ApplicationRecord
     return unless external_api_enabled?
 
     if Rails.env.test?
-      ModelCallbackJob.new.perform(self.class.name, id, "create_integration_mappings")
+      ModelCallbackJob.new.perform(
+        self.class.name,
+        id,
+        "create_integration_mappings"
+      )
     else
-      ModelCallbackJob.perform_async(self.class.name, id, "create_integration_mappings")
+      ModelCallbackJob.perform_async(
+        self.class.name,
+        id,
+        "create_integration_mappings"
+      )
     end
   end
 
@@ -223,14 +266,15 @@ class Jurisdiction < ApplicationRecord
         permit_type:,
         energy_step_required: ENV["MIN_ENERGY_STEP"],
         zero_carbon_step_required: ENV["MIN_ZERO_CARBON_STEP"],
-        default: true,
+        default: true
       )
     end
   end
 
   def sanitize_html_fields
     attributes.each do |name, value|
-      self[name] = sanitize(value) if name.ends_with?("_html") && will_save_change_to_attribute?(name)
+      self[name] = sanitize(value) if name.ends_with?("_html") &&
+        will_save_change_to_attribute?(name)
     end
   end
 
@@ -280,12 +324,27 @@ class Jurisdiction < ApplicationRecord
 
   # Callback method to ensure a default sandbox is created
   def ensure_default_sandboxes
-    sandboxes.build(name: "Published Sandbox", template_version_status_scope: :published) if sandboxes.published.empty?
-    sandboxes.build(name: "Scheduled Sandbox", template_version_status_scope: :scheduled) if sandboxes.scheduled.empty?
+    if sandboxes.published.empty?
+      sandboxes.build(
+        name: "Published Sandbox",
+        template_version_status_scope: :published
+      )
+    end
+    if sandboxes.scheduled.empty?
+      sandboxes.build(
+        name: "Scheduled Sandbox",
+        template_version_status_scope: :scheduled
+      )
+    end
   end
 
   # Custom validation method
   def must_have_one_sandbox
-    errors.add(:base, I18n.t("activerecord.errors.models.jurisdiction.no_sandboxes")) if sandboxes.empty?
+    if sandboxes.empty?
+      errors.add(
+        :base,
+        I18n.t("activerecord.errors.models.jurisdiction.no_sandboxes")
+      )
+    end
   end
 end

--- a/app/models/live_requirement_template.rb
+++ b/app/models/live_requirement_template.rb
@@ -11,10 +11,15 @@ class LiveRequirementTemplate < RequirementTemplate
         permit_type_id: permit_type_id,
         activity_id: activity_id,
         first_nations: first_nations,
-        discarded_at: nil,
+        discarded_at: nil
       )
     if existing_record.present?
-      errors.add(:base, I18n.t("activerecord.errors.models.requirement_template.nonunique_classification"))
+      errors.add(
+        :base,
+        I18n.t(
+          "activerecord.errors.models.requirement_template.nonunique_classification"
+        )
+      )
     end
   end
 end

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -5,9 +5,24 @@ class PermitApplication < ApplicationRecord
   include ZipfileUploader.Attachment(:zipfile)
   include PermitApplicationStatus
 
-  SEARCH_INCLUDES = %i[permit_type submission_versions step_code activity jurisdiction submitter permit_collaborations]
+  SEARCH_INCLUDES = %i[
+    permit_type
+    submission_versions
+    step_code
+    activity
+    jurisdiction
+    submitter
+    permit_collaborations
+  ]
 
-  searchkick word_middle: %i[nickname full_address permit_classifications submitter status review_delegatee_name],
+  searchkick word_middle: %i[
+               nickname
+               full_address
+               permit_classifications
+               submitter
+               status
+               review_delegatee_name
+             ],
              text_end: %i[number]
 
   belongs_to :submitter, class_name: "User"
@@ -52,18 +67,27 @@ class PermitApplication < ApplicationRecord
 
   after_commit :reindex_jurisdiction_permit_application_size
   after_commit :send_submitted_webhook, if: :saved_change_to_status?
-  after_commit :notify_user_reference_number_updated, if: :saved_change_to_reference_number?
+  after_commit :notify_user_reference_number_updated,
+               if: :saved_change_to_reference_number?
 
-  scope :with_submitter_role, -> { joins(:submitter).where(users: { role: "submitter" }) }
+  scope :with_submitter_role,
+        -> { joins(:submitter).where(users: { role: "submitter" }) }
 
-  scope :unviewed, -> { where(status: :submitted, viewed_at: nil).order(submitted_at: :asc) }
+  scope :unviewed,
+        -> do
+          where(status: :submitted, viewed_at: nil).order(submitted_at: :asc)
+        end
 
   COMPLETION_SECTION_KEY = "section-completion-key"
 
-  def supporting_documents_for_submitter_based_on_user_permissions(supporting_documents, user: nil)
+  def supporting_documents_for_submitter_based_on_user_permissions(
+    supporting_documents,
+    user: nil
+  )
     return supporting_documents if user.blank?
 
-    permissions = submission_requirement_block_edit_permissions(user_id: user.id)
+    permissions =
+      submission_requirement_block_edit_permissions(user_id: user.id)
 
     return supporting_documents if permissions == :all
 
@@ -79,17 +103,23 @@ class PermitApplication < ApplicationRecord
   end
 
   def formatted_submission_data(current_user: nil)
-    PermitApplication::SubmissionDataService.new(self).formatted_submission_data(current_user: current_user)
+    PermitApplication::SubmissionDataService.new(
+      self
+    ).formatted_submission_data(current_user: current_user)
   end
 
-  def users_by_collaboration_options(collaboration_type:, collaborator_type: nil, assigned_requirement_block_id: nil)
+  def users_by_collaboration_options(
+    collaboration_type:,
+    collaborator_type: nil,
+    assigned_requirement_block_id: nil
+  )
     base_where_clause = {
       collaborations: {
         permit_collaborations: {
           collaboration_type: collaboration_type,
-          permit_application_id: id,
-        },
-      },
+          permit_application_id: id
+        }
+      }
     }
 
     base_where_clause[:collaborations][:permit_collaborations][
@@ -100,7 +130,10 @@ class PermitApplication < ApplicationRecord
       :assigned_requirement_block_id
     ] = assigned_requirement_block_id if assigned_requirement_block_id.present?
 
-    User.joins(collaborations: :permit_collaborations).where(base_where_clause).distinct
+    User
+      .joins(collaborations: :permit_collaborations)
+      .where(base_where_clause)
+      .distinct
   end
 
   # Helper method to get the latest SubmissionVersion
@@ -118,7 +151,11 @@ class PermitApplication < ApplicationRecord
   end
 
   def form_json(current_user: nil)
-    result = PermitApplication::FormJsonService.new(permit_application: self, current_user:).call
+    result =
+      PermitApplication::FormJsonService.new(
+        permit_application: self,
+        current_user:
+      ).call
     result.form_json
   end
 
@@ -127,14 +164,20 @@ class PermitApplication < ApplicationRecord
     # for development purposes only
 
     current_published_template_version.update(
-      form_json: current_published_template_version.requirement_template.to_form_json,
+      form_json:
+        current_published_template_version.requirement_template.to_form_json
     )
   end
 
-  def update_with_submission_data_merge(permit_application_params:, current_user: nil)
-    PermitApplication::SubmissionDataService.new(self).update_with_submission_data_merge(
+  def update_with_submission_data_merge(
+    permit_application_params:,
+    current_user: nil
+  )
+    PermitApplication::SubmissionDataService.new(
+      self
+    ).update_with_submission_data_merge(
       permit_application_params:,
-      current_user:,
+      current_user:
     )
   end
 
@@ -155,22 +198,38 @@ class PermitApplication < ApplicationRecord
       created_at: created_at,
       using_current_template_version: using_current_template_version,
       user_ids_with_submission_edit_permissions:
-        [submitter.id] + users_by_collaboration_options(collaboration_type: :submission).pluck(:id),
+        [submitter.id] +
+          users_by_collaboration_options(collaboration_type: :submission).pluck(
+            :id
+          ),
       review_delegatee_name:
-        users_by_collaboration_options(collaboration_type: :review, collaborator_type: :delegatee).first&.name,
-      sandbox_id: sandbox_id,
+        users_by_collaboration_options(
+          collaboration_type: :review,
+          collaborator_type: :delegatee
+        ).first&.name,
+      sandbox_id: sandbox_id
     }
   end
 
   def collaborator?(user_id:, collaboration_type:, collaborator_type: nil)
-    users_by_collaboration_options(collaboration_type:, collaborator_type:).exists?(id: user_id)
+    users_by_collaboration_options(
+      collaboration_type:,
+      collaborator_type:
+    ).exists?(id: user_id)
   end
 
   def submission_requirement_block_edit_permissions(user_id:)
-    return nil if submitter_id != user_id && !collaborator?(user_id:, collaboration_type: :submission)
+    if submitter_id != user_id &&
+         !collaborator?(user_id:, collaboration_type: :submission)
+      return nil
+    end
 
     if submitter_id == user_id ||
-         collaborator?(user_id:, collaboration_type: :submission, collaborator_type: :delegatee)
+         collaborator?(
+           user_id:,
+           collaboration_type: :submission,
+           collaborator_type: :delegatee
+         )
       return :all
     end
 
@@ -195,7 +254,11 @@ class PermitApplication < ApplicationRecord
 
   def current_published_template_version
     # this will eventually be different, if there is a new version it should notify the user
-    RequirementTemplate.published_requirement_template_version(activity, permit_type, first_nations)
+    RequirementTemplate.published_requirement_template_version(
+      activity,
+      permit_type,
+      first_nations
+    )
   end
 
   def form_customizations
@@ -221,16 +284,25 @@ class PermitApplication < ApplicationRecord
   def notifiable_users
     relevant_collaborators = [submitter]
     designated_submitter =
-      users_by_collaboration_options(collaboration_type: :submission, collaborator_type: :delegatee).first
+      users_by_collaboration_options(
+        collaboration_type: :submission,
+        collaborator_type: :delegatee
+      ).first
 
-    relevant_collaborators << designated_submitter if designated_submitter.present?
+    if designated_submitter.present?
+      relevant_collaborators << designated_submitter
+    end
 
     if submitted?
       relevant_collaborators =
-        relevant_collaborators + jurisdiction.review_managers if jurisdiction.review_managers.present?
+        relevant_collaborators +
+          jurisdiction.review_managers if jurisdiction.review_managers.present?
       relevant_collaborators =
-        relevant_collaborators + jurisdiction.regional_review_managers if jurisdiction.regional_review_managers.present?
-      relevant_collaborators = relevant_collaborators + jurisdiction.reviewers if jurisdiction.reviewers.present?
+        relevant_collaborators +
+          jurisdiction.regional_review_managers if jurisdiction.regional_review_managers.present?
+      relevant_collaborators =
+        relevant_collaborators +
+          jurisdiction.reviewers if jurisdiction.reviewers.present?
     end
 
     relevant_collaborators
@@ -280,19 +352,27 @@ class PermitApplication < ApplicationRecord
   end
 
   def confirmed_permit_type_submission_contacts
-    jurisdiction.permit_type_submission_contacts.where(permit_type: permit_type).where.not(confirmed_at: nil)
+    jurisdiction
+      .permit_type_submission_contacts
+      .where(permit_type: permit_type)
+      .where.not(confirmed_at: nil)
   end
 
   def send_submit_notifications
     # All submission related emails and in-app notifications are handled by this method
     NotificationService.publish_application_submission_event(self)
     confirmed_permit_type_submission_contacts.each do |permit_type_submission_contact|
-      PermitHubMailer.notify_reviewer_application_received(permit_type_submission_contact, self).deliver_later
+      PermitHubMailer.notify_reviewer_application_received(
+        permit_type_submission_contact,
+        self
+      ).deliver_later
     end
   end
 
   def formatted_submission_data_for_external_use
-    ExternalPermitApplicationService.new(self).formatted_submission_data_for_external_use
+    ExternalPermitApplicationService.new(
+      self
+    ).formatted_submission_data_for_external_use
   end
 
   def formatted_raw_h2k_files_for_external_use
@@ -304,7 +384,9 @@ class PermitApplication < ApplicationRecord
 
     jurisdiction
       .active_external_api_keys
-      .where.not(webhook_url: [nil, ""]) # Only send webhooks to keys with a webhook URL
+      .where.not(
+        webhook_url: [nil, ""]
+      ) # Only send webhooks to keys with a webhook URL
       .each do |external_api_key|
         PermitWebhookJob.perform_async(
           external_api_key.id,
@@ -315,7 +397,7 @@ class PermitApplication < ApplicationRecord
               Constants::Webhooks::Events::PermitApplication::PERMIT_RESUBMITTED
             end
           ),
-          id,
+          id
         )
       end
   end
@@ -362,24 +444,27 @@ class PermitApplication < ApplicationRecord
 
     {
       "id" => SecureRandom.uuid,
-      "action_type" => Constants::NotificationActionTypes::APPLICATION_SUBMISSION,
-      "action_text" => "#{I18n.t(i18n_key, number: number, jurisdiction_name: jurisdiction_name)}",
+      "action_type" =>
+        Constants::NotificationActionTypes::APPLICATION_SUBMISSION,
+      "action_text" =>
+        "#{I18n.t(i18n_key, number: number, jurisdiction_name: jurisdiction_name)}",
       "object_data" => {
-        "permit_application_id" => id,
-      },
+        "permit_application_id" => id
+      }
     }
   end
 
   def revisions_request_event_notification_data
     {
       "id" => SecureRandom.uuid,
-      "action_type" => Constants::NotificationActionTypes::APPLICATION_REVISIONS_REQUEST,
+      "action_type" =>
+        Constants::NotificationActionTypes::APPLICATION_REVISIONS_REQUEST,
       "action_text" =>
         "#{I18n.t("notification.permit_application.revisions_request_notification", number: number, jurisdiction_name: jurisdiction_name)}",
       "object_data" => {
         "permit_application_id" => id,
-        "permit_application_number" => number,
-      },
+        "permit_application_number" => number
+      }
     }
   end
 
@@ -390,20 +475,21 @@ class PermitApplication < ApplicationRecord
       "action_text" =>
         "#{I18n.t("notification.permit_application.view_notification", number: number, jurisdiction_name: jurisdiction_name)}",
       "object_data" => {
-        "permit_application_id" => id,
-      },
+        "permit_application_id" => id
+      }
     }
   end
 
   def application_reference_updated_event_notification_data
     {
       "id" => SecureRandom.uuid,
-      "action_type" => Constants::NotificationActionTypes::APPLICATION_REFERENCE_UPDATED,
+      "action_type" =>
+        Constants::NotificationActionTypes::APPLICATION_REFERENCE_UPDATED,
       "action_text" =>
         "#{I18n.t("notification.permit_application.reference_updated_notification", number: number, jurisdiction_name: jurisdiction_name)}",
       "object_data" => {
-        "permit_application_id" => id,
-      },
+        "permit_application_id" => id
+      }
     }
   end
 
@@ -414,16 +500,24 @@ class PermitApplication < ApplicationRecord
   def energy_step_code_required?
     custom_requirements = step_code_requirements.customizations
 
-    custom_requirements.empty? || custom_requirements.any? { |r| r.energy_step_required || r.zero_carbon_step_required }
+    custom_requirements.empty? ||
+      custom_requirements.any? do |r|
+        r.energy_step_required || r.zero_carbon_step_required
+      end
   end
 
   def self.count_by_jurisdiction_and_status
     Jurisdiction.all.map do |j|
-      row = PermitApplication.with_submitter_role.where(jurisdiction: j).group(:status).count
+      row =
+        PermitApplication
+          .with_submitter_role
+          .where(jurisdiction: j)
+          .group(:status)
+          .count
 
       {
         "draft" => (row["new_draft"] || 0) + (row["revisions_requested"] || 0), # nil defaults to 0
-        "submitted" => (row["newly_submitted"] || 0) + (row["resubmitted"] || 0),
+        "submitted" => (row["newly_submitted"] || 0) + (row["resubmitted"] || 0)
       }.merge({ name: j.qualified_name })
     end
   end
@@ -431,11 +525,15 @@ class PermitApplication < ApplicationRecord
   def self.count_by_jurisdiction_and_status
     Jurisdiction.all.map do |j|
       row =
-        PermitApplication.joins(:submitter).where(jurisdiction: j, users: { role: "submitter" }).group(:status).count
+        PermitApplication
+          .joins(:submitter)
+          .where(jurisdiction: j, users: { role: "submitter" })
+          .group(:status)
+          .count
 
       {
         "draft" => (row["new_draft"] || 0) + (row["revisions_requested"] || 0), # nil defaults to 0
-        "submitted" => (row["newly_submitted"] || 0) + (row["resubmitted"] || 0),
+        "submitted" => (row["newly_submitted"] || 0) + (row["resubmitted"] || 0)
       }.merge({ name: j.qualified_name })
     end
   end
@@ -447,7 +545,8 @@ class PermitApplication < ApplicationRecord
   end
 
   def assign_default_nickname
-    self.nickname = "#{jurisdiction_qualified_name}: #{full_address || pid || pin || id}" if self.nickname.blank?
+    self.nickname =
+      "#{jurisdiction_qualified_name}: #{full_address || pid || pin || id}" if self.nickname.blank?
   end
 
   def assign_unique_number
@@ -486,7 +585,7 @@ class PermitApplication < ApplicationRecord
           number_prefix,
           new_integer / 1_000_000 % 1000,
           new_integer / 1000 % 1000,
-          new_integer % 1000,
+          new_integer % 1000
         )
     else
       # Start with the initial number if there are no previous numbers
@@ -528,24 +627,37 @@ class PermitApplication < ApplicationRecord
     unless submitter&.submitter?
       errors.add(
         :submitter,
-        I18n.t("activerecord.errors.models.permit_application.attributes.submitter.incorrect_role"),
+        I18n.t(
+          "activerecord.errors.models.permit_application.attributes.submitter.incorrect_role"
+        )
       )
     end
   end
 
   def jurisdiction_has_matching_submission_contact
-    matching_contacts = PermitTypeSubmissionContact.where(jurisdiction: jurisdiction, permit_type: permit_type)
+    matching_contacts =
+      PermitTypeSubmissionContact.where(
+        jurisdiction: jurisdiction,
+        permit_type: permit_type
+      )
     if matching_contacts.empty?
       errors.add(
         :jurisdiction,
-        I18n.t("activerecord.errors.models.permit_application.attributes.jurisdiction.no_contact"),
+        I18n.t(
+          "activerecord.errors.models.permit_application.attributes.jurisdiction.no_contact"
+        )
       )
     end
   end
 
   def pid_or_pin_presence
     if pin.blank? && pid.blank?
-      errors.add(:base, I18n.t("activerecord.errors.models.permit_application.attributes.pid_or_pin"))
+      errors.add(
+        :base,
+        I18n.t(
+          "activerecord.errors.models.permit_application.attributes.pid_or_pin"
+        )
+      )
     end
   end
 end

--- a/app/models/permit_classification.rb
+++ b/app/models/permit_classification.rb
@@ -17,6 +17,8 @@ class PermitClassification < ApplicationRecord
        ]
 
   def image_url
-    ActionController::Base.helpers.asset_path("images/permit_classifications/#{self.code}.png")
+    ActionController::Base.helpers.asset_path(
+      "images/permit_classifications/#{self.code}.png"
+    )
   end
 end

--- a/app/models/permit_type_required_step.rb
+++ b/app/models/permit_type_required_step.rb
@@ -3,12 +3,17 @@ class PermitTypeRequiredStep < ApplicationRecord
   belongs_to :permit_type
   delegate :name, to: :permit_type, prefix: true
 
-  has_many :step_code_checklists, foreign_key: "step_requirement_id", dependent: :nullify
+  has_many :step_code_checklists,
+           foreign_key: "step_requirement_id",
+           dependent: :nullify
 
   before_create :nullify_invalid_checklists, if: :overriding_default?
 
   def nullify_invalid_checklists
-    other_requirements.find_by(default: true).step_code_checklists.update_all(step_requirement_id: nil)
+    other_requirements
+      .find_by(default: true)
+      .step_code_checklists
+      .update_all(step_requirement_id: nil)
   end
 
   def overriding_default?

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -26,7 +26,7 @@ class Requirement < ApplicationRecord
          energy_step_code: 16,
          general_contact: 17,
          professional_contact: 18,
-         pid_info: 19,
+         pid_info: 19
        },
        _prefix: true
 
@@ -35,12 +35,21 @@ class Requirement < ApplicationRecord
   before_validation :merge_computed_compliance_default_settings
 
   before_validation :convert_value_options,
-                    if: Proc.new { |req| TYPES_WITH_VALUE_OPTIONS.include?(req.input_type.to_s) }
+                    if:
+                      Proc.new { |req|
+                        TYPES_WITH_VALUE_OPTIONS.include?(req.input_type.to_s)
+                      }
   before_save :set_digital_seal_validator_to_step_code_package_file
-  validate :validate_value_options, if: Proc.new { |req| TYPES_WITH_VALUE_OPTIONS.include?(req.input_type.to_s) }
+  validate :validate_value_options,
+           if:
+             Proc.new { |req|
+               TYPES_WITH_VALUE_OPTIONS.include?(req.input_type.to_s)
+             }
   validate :validate_unit_for_number_inputs
   validate :validate_can_add_multiple_contacts
-  validates_format_of :requirement_code, without: /\||\.|\=|\>/, message: "must not contain | or . or = or >"
+  validates_format_of :requirement_code,
+                      without: /\||\.|\=|\>/,
+                      message: "must not contain | or . or = or >"
   validates_format_of :requirement_code,
                       with: /_file\z/,
                       if: Proc.new { |req| req.input_type == "file" },
@@ -50,12 +59,12 @@ class Requirement < ApplicationRecord
   validates :label,
             uniqueness: {
               scope: :requirement_block_id,
-              message: "should be unique within the same requirement block",
+              message: "should be unique within the same requirement block"
             }
   validates :requirement_code,
             uniqueness: {
               scope: :requirement_block_id,
-              message: "should be unique within the same requirement block",
+              message: "should be unique within the same requirement block"
             }
   validate :validate_energy_step_code_requirement_code
   validate :validate_energy_step_code_related_requirements_schema
@@ -74,10 +83,13 @@ class Requirement < ApplicationRecord
       "input_type" => "select",
       "input_options" => {
         "value_options" => [
-          { "label" => "Utilizing the digital step code tool", "value" => "tool" },
-          { "label" => "By file upload", "value" => "file" },
-        ],
-      },
+          {
+            "label" => "Utilizing the digital step code tool",
+            "value" => "tool"
+          },
+          { "label" => "By file upload", "value" => "file" }
+        ]
+      }
     },
     energy_step_code_tool_part_9: {
       "requirement_code" => "energy_step_code_tool_part_9",
@@ -86,10 +98,10 @@ class Requirement < ApplicationRecord
         "conditional" => {
           "eq" => "tool",
           "show" => true,
-          "when" => "energy_step_code_method",
+          "when" => "energy_step_code_method"
         },
-        "energy_step_code" => "part_9",
-      },
+        "energy_step_code" => "part_9"
+      }
     },
     energy_step_code_report_file: {
       "requirement_code" => "energy_step_code_report_file",
@@ -98,9 +110,9 @@ class Requirement < ApplicationRecord
         "conditional" => {
           "eq" => "file",
           "show" => true,
-          "when" => "energy_step_code_method",
-        },
-      },
+          "when" => "energy_step_code_method"
+        }
+      }
     },
     energy_step_code_h2000_file: {
       "requirement_code" => "energy_step_code_h2000_file",
@@ -109,12 +121,13 @@ class Requirement < ApplicationRecord
         "conditional" => {
           "eq" => "file",
           "show" => true,
-          "when" => "energy_step_code_method",
-        },
-      },
-    },
+          "when" => "energy_step_code_method"
+        }
+      }
+    }
   }
-  ENERGY_STEP_CODE_REQUIRED_DEPENDENCY_CODES = ENERGY_STEP_CODE_DEPENDENCY_REQUIRED_SCHEMA.keys.map(&:to_s).freeze
+  ENERGY_STEP_CODE_REQUIRED_DEPENDENCY_CODES =
+    ENERGY_STEP_CODE_DEPENDENCY_REQUIRED_SCHEMA.keys.map(&:to_s).freeze
 
   def value_options
     return nil if input_options.blank? || input_options["value_options"].blank?
@@ -129,7 +142,9 @@ class Requirement < ApplicationRecord
   end
 
   def computed_compliance
-    return nil if input_options.blank? || input_options["computed_compliance"].blank?
+    if input_options.blank? || input_options["computed_compliance"].blank?
+      return nil
+    end
 
     input_options["computed_compliance"]
   end
@@ -191,16 +206,19 @@ class Requirement < ApplicationRecord
     required_computed_compliance = {
       "module" => "DigitalSealValidator",
       "trigger" => "on_save",
-      "value_on" => "compliance_data",
+      "value_on" => "compliance_data"
     }
 
-    return unless required_computed_compliance != input_options["computed_compliance"]
+    unless required_computed_compliance != input_options["computed_compliance"]
+      return
+    end
 
     self.input_options["computed_compliance"] = required_computed_compliance
   end
 
   def using_dummied_requirement_code(code = self.requirement_code)
-    uuid_regex = /^dummy-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    uuid_regex =
+      /^dummy-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     uuid_regex.match?(code)
   end
 
@@ -208,15 +226,22 @@ class Requirement < ApplicationRecord
   def set_requirement_code
     using_dummy = self.using_dummied_requirement_code
     blank = self.requirement_code.blank?
-    needs_file_suffix = input_type_file? && !requirement_code&.end_with?("_file")
+    needs_file_suffix =
+      input_type_file? && !requirement_code&.end_with?("_file")
     return unless using_dummy || blank || needs_file_suffix
 
     new_requirement_code =
       (
         if (using_dummy || blank)
-          return ENERGY_STEP_CODE_REQUIREMENT_CODE if input_type_energy_step_code?
+          if input_type_energy_step_code?
+            return ENERGY_STEP_CODE_REQUIREMENT_CODE
+          end
 
-          label.blank? ? ENERGY_STEP_CODE_REQUIREMENT_CODE : label.parameterize(separator: "_")
+          if label.blank?
+            ENERGY_STEP_CODE_REQUIREMENT_CODE
+          else
+            label.parameterize(separator: "_")
+          end
         else
           requirement_code
         end
@@ -227,16 +252,21 @@ class Requirement < ApplicationRecord
     # when the requirement code is generated from the label, because if it was intended to be used
     # as a step code package file requirement code, it would have been set as such from the front-end.
     new_code_clashes_with_step_code_package =
-      using_dummy && new_requirement_code == STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE
+      using_dummy &&
+        new_requirement_code == STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE
 
     # new_requirement_code =
-    new_requirement_code = new_requirement_code + "_not_step_code_package" if new_code_clashes_with_step_code_package
+    new_requirement_code =
+      new_requirement_code +
+        "_not_step_code_package" if new_code_clashes_with_step_code_package
     new_requirement_code = new_requirement_code + "_file" if needs_file_suffix
 
     # remove file suffix if it is not a file input, as we use the suffix to differentiate between file and non-file inputs
     # in formio
-    new_requirement_code = new_requirement_code + "_label" if new_requirement_code.end_with?("_file") &&
-      !input_type_file?
+    new_requirement_code =
+      new_requirement_code + "_label" if new_requirement_code.end_with?(
+      "_file"
+    ) && !input_type_file?
 
     if using_dummy
       self.requirement_block.requirements.each do |req|
@@ -255,9 +285,11 @@ class Requirement < ApplicationRecord
   end
 
   def validate_value_options
-    if input_options.blank? || input_options["value_options"].blank? || !input_options["value_options"].is_a?(Array) ||
+    if input_options.blank? || input_options["value_options"].blank? ||
+         !input_options["value_options"].is_a?(Array) ||
          !input_options["value_options"].all? { |option|
-           option.is_a?(Hash) && (option.key?("label") && option["label"].is_a?(String)) &&
+           option.is_a?(Hash) &&
+             (option.key?("label") && option["label"].is_a?(String)) &&
              (option.key?("value") && option["value"].is_a?(String))
          }
       errors.add(:input_options, "must have value options defined")
@@ -265,12 +297,24 @@ class Requirement < ApplicationRecord
   end
 
   def validate_unit_for_number_inputs
-    return unless (input_options.present? && input_options["number_unit"].present?)
+    unless (input_options.present? && input_options["number_unit"].present?)
+      return
+    end
 
-    return(errors.add(:input_options, "number_unit is only allowed for number inputs")) if !input_type_number?
+    if !input_type_number?
+      return(
+        errors.add(
+          :input_options,
+          "number_unit is only allowed for number inputs"
+        )
+      )
+    end
 
     if !NUMBER_UNITS.include?(input_options["number_unit"])
-      errors.add(:input_options, "the number_unit must be one of #{NUMBER_UNITS.join(", ")}")
+      errors.add(
+        :input_options,
+        "the number_unit must be one of #{NUMBER_UNITS.join(", ")}"
+      )
     end
   end
 
@@ -278,15 +322,22 @@ class Requirement < ApplicationRecord
     return unless attribute_changed?(:input_options)
 
     inverted_computed_compliance_options_map =
-      computed_compliance["options_map"].invert if computed_compliance.present? &&
-      computed_compliance["options_map"].present? && computed_compliance["options_map"].is_a?(Hash)
+      computed_compliance[
+        "options_map"
+      ].invert if computed_compliance.present? &&
+      computed_compliance["options_map"].present? &&
+      computed_compliance["options_map"].is_a?(Hash)
     # all values MUST be converted to camelCase and stripped of white space to be compatible with rehyration on front
     # end
-    input_options["value_options"] = input_options["value_options"].map do |option_json|
+    input_options["value_options"] = input_options[
+      "value_options"
+    ].map do |option_json|
       # camelize the value
       # this is a two step process as camelize only camelizes individual words and ignores spaces
 
-      return option_json unless option_json.is_a?(Hash) && option_json["value"].is_a?(String)
+      unless option_json.is_a?(Hash) && option_json["value"].is_a?(String)
+        return option_json
+      end
 
       # remove spaces to make one word and capitalize each word
       value = option_json["value"]
@@ -296,8 +347,11 @@ class Requirement < ApplicationRecord
       formatted_value = words.join("").strip.camelize(:lower)
 
       # update the option in computed compliance options map
-      if inverted_computed_compliance_options_map.present? && inverted_computed_compliance_options_map[value].present?
-        self.computed_compliance["options_map"][inverted_computed_compliance_options_map[value]] = formatted_value
+      if inverted_computed_compliance_options_map.present? &&
+           inverted_computed_compliance_options_map[value].present?
+        self.computed_compliance["options_map"][
+          inverted_computed_compliance_options_map[value]
+        ] = formatted_value
       end
 
       option_json.merge("value" => formatted_value)
@@ -316,10 +370,20 @@ class Requirement < ApplicationRecord
   end
 
   def validate_can_add_multiple_contacts
-    return unless (input_options.present? && input_options["can_add_multiple_contacts"].present?)
+    unless (
+             input_options.present? &&
+               input_options["can_add_multiple_contacts"].present?
+           )
+      return
+    end
 
     unless CONTACT_TYPES.include?(input_type.to_s)
-      return(errors.add(:input_options, "can_add_multiple_contacts is only allowed for contact inputs"))
+      return(
+        errors.add(
+          :input_options,
+          "can_add_multiple_contacts is only allowed for contact inputs"
+        )
+      )
     end
 
     if !(
@@ -331,7 +395,8 @@ class Requirement < ApplicationRecord
   end
 
   def validate_energy_step_code_requirement_code
-    unless input_type_energy_step_code? && requirement_code != ENERGY_STEP_CODE_REQUIREMENT_CODE &&
+    unless input_type_energy_step_code? &&
+             requirement_code != ENERGY_STEP_CODE_REQUIREMENT_CODE &&
              !using_dummied_requirement_code
       return
     end
@@ -340,14 +405,20 @@ class Requirement < ApplicationRecord
       :requirement_code,
       :incorrect_energy_requirement_code,
       correct_requirement_code: ENERGY_STEP_CODE_REQUIREMENT_CODE,
-      incorrect_requirement_code: requirement_code,
+      incorrect_requirement_code: requirement_code
     )
   end
 
   def validate_energy_step_code_related_requirements_schema
-    return unless ENERGY_STEP_CODE_REQUIRED_DEPENDENCY_CODES.include?(requirement_code)
+    unless ENERGY_STEP_CODE_REQUIRED_DEPENDENCY_CODES.include?(requirement_code)
+      return
+    end
 
-    current_attributes_of_interest = self.attributes.slice("requirement_code", "input_type", "input_options").deep_dup
+    current_attributes_of_interest =
+      self
+        .attributes
+        .slice("requirement_code", "input_type", "input_options")
+        .deep_dup
 
     # The front-end sends the conditional as an empty object due to the form setup when conditionals are not added.
     # Since the energy_step_code_method does not have any conditionals, the schema wouldn't match.
@@ -355,16 +426,31 @@ class Requirement < ApplicationRecord
     # if it is an empty hash as we don't care about it. if it as it will have no effect to conditionals.
     # Note we don't want to remove the key if it has other conditionals, as we want the validation below
     # to catch that, as it is an invalid schema. Also the key is only removed from the duplicated attributes.
-    if requirement_code == ENERGY_STEP_CODE_DEPENDENCY_REQUIRED_SCHEMA[:energy_step_code_method]["requirement_code"] &&
+    if requirement_code ==
+         ENERGY_STEP_CODE_DEPENDENCY_REQUIRED_SCHEMA[:energy_step_code_method][
+           "requirement_code"
+         ] &&
          (
-           current_attributes_of_interest.dig("input_options", "conditional").present? &&
-             current_attributes_of_interest.dig("input_options", "conditional").empty?
+           current_attributes_of_interest.dig(
+             "input_options",
+             "conditional"
+           ).present? &&
+             current_attributes_of_interest.dig(
+               "input_options",
+               "conditional"
+             ).empty?
          )
       current_attributes_of_interest["input_options"].delete("conditional")
     end
 
-    unless ENERGY_STEP_CODE_DEPENDENCY_REQUIRED_SCHEMA[requirement_code.to_sym] == current_attributes_of_interest
-      errors.add(:base, :incorrect_energy_requirement_schema, requirement_code: requirement_code)
+    unless ENERGY_STEP_CODE_DEPENDENCY_REQUIRED_SCHEMA[
+             requirement_code.to_sym
+           ] == current_attributes_of_interest
+      errors.add(
+        :base,
+        :incorrect_energy_requirement_schema,
+        requirement_code: requirement_code
+      )
     end
   end
 end

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -3,7 +3,12 @@ class RequirementBlock < ApplicationRecord
   include Discard::Model
 
   sanitizable :display_description
-  searchkick searchable: %i[name requirement_labels associations configurations],
+  searchkick searchable: %i[
+               name
+               requirement_labels
+               associations
+               configurations
+             ],
              word_start: %i[name requirement_labels associations configurations]
 
   has_many :requirements, -> { order(position: :asc) }, dependent: :destroy
@@ -45,7 +50,7 @@ class RequirementBlock < ApplicationRecord
       associations: association_list,
       configurations: configurations_search_list,
       discarded: discarded_at.present?,
-      early_access: early_access?,
+      early_access: early_access?
     }
   end
 
@@ -62,7 +67,7 @@ class RequirementBlock < ApplicationRecord
       description: display_description,
       collapsible: true,
       collapsed: false,
-      components: components_form_json(section_key),
+      components: components_form_json(section_key)
     }
   end
 
@@ -70,7 +75,9 @@ class RequirementBlock < ApplicationRecord
     optional_block = requirements.all? { |req| !req.required }
     requirement_map = requirements.map { |r| r.to_form_json(key(section_key)) }
 
-    requirement_map.push(optional_block_confirmation_requirement(section_key)) if optional_block
+    if optional_block
+      requirement_map.push(optional_block_confirmation_requirement(section_key))
+    end
 
     requirement_map
   end
@@ -82,13 +89,16 @@ class RequirementBlock < ApplicationRecord
       type: "checkbox",
       custom_class: "optional-block-confirmation-checkbox",
       validate: {
-        required: true,
+        required: true
       },
       input: true,
-      label: I18n.t("formio.requirement_block.optional_block_confirmation_requirement_label"),
+      label:
+        I18n.t(
+          "formio.requirement_block.optional_block_confirmation_requirement_label"
+        ),
       widget: {
-        type: "input",
-      },
+        type: "input"
+      }
     }
   end
 
@@ -97,13 +107,16 @@ class RequirementBlock < ApplicationRecord
   def early_access_on_appropriate_template
     return unless early_access?
     # Fetch associated requirement templates through requirement_template_sections
-    associated_templates = requirement_template_sections.map(&:requirement_template)
+    associated_templates =
+      requirement_template_sections.map(&:requirement_template)
 
     # Check if all associated templates satisfy early_access? check
     unless associated_templates.all?(&:early_access?)
       errors.add(
         :visibility,
-        I18n.t("activerecord.errors.models.requirement_block.attributes.visibility.wrong_requirement_template_type"),
+        I18n.t(
+          "activerecord.errors.models.requirement_block.attributes.visibility.wrong_requirement_template_type"
+        )
       )
     end
   end
@@ -118,26 +131,35 @@ class RequirementBlock < ApplicationRecord
 
       next unless conditional.present?
 
-      if [conditional["when"], conditional["eq"], conditional["show"]].any?(&:blank?)
+      if [conditional["when"], conditional["eq"], conditional["show"]].any?(
+           &:blank?
+         )
         errors.add(:input_options, "conditional must have when, eq, and show")
         break
       end
 
-      if requirements.find { |r| r.requirement_code == conditional["when"] }.blank?
-        errors.add(:input_options, "conditional 'when' field must be a requirement code in the same requirement block")
+      if requirements
+           .find { |r| r.requirement_code == conditional["when"] }
+           .blank?
+        errors.add(
+          :input_options,
+          "conditional 'when' field must be a requirement code in the same requirement block"
+        )
         break
       end
     end
   end
 
   def validate_step_code_dependencies
-    has_energy_step_code = requirements.any? { |req| req.input_type_energy_step_code? }
+    has_energy_step_code =
+      requirements.any? { |req| req.input_type_energy_step_code? }
 
     return unless has_energy_step_code
 
     has_all_dependencies =
       Requirement::ENERGY_STEP_CODE_REQUIRED_DEPENDENCY_CODES.all? do |dependency_code|
-        requirements.count { |req| req.requirement_code == dependency_code } == 1
+        requirements.count { |req| req.requirement_code == dependency_code } ==
+          1
       end
 
     return if has_all_dependencies
@@ -176,7 +198,8 @@ class RequirementBlock < ApplicationRecord
     # With UUIDs it shouldn't be needed, but have a max retry count
     # to be safe. This is to prevent infinite loops in case of a bug.
     while RequirementBlock.exists?(sku: self.sku) && retry_count < 5
-      self.sku = "#{parameterized_name}_#{retry_count > 3 ? SecureRandom.uuid : SecureRandom.hex(3)}"
+      self.sku =
+        "#{parameterized_name}_#{retry_count > 3 ? SecureRandom.uuid : SecureRandom.hex(3)}"
 
       retry_count += 1
     end

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -16,27 +16,41 @@ class RequirementTemplate < ApplicationRecord
   belongs_to :permit_type
   belongs_to :copied_from, class_name: "RequirementTemplate", optional: true
 
-  has_many :requirement_template_sections, -> { order(position: :asc) }, dependent: :destroy
+  has_many :requirement_template_sections,
+           -> { order(position: :asc) },
+           dependent: :destroy
   has_many :requirement_blocks, through: :requirement_template_sections
   has_many :requirements, through: :requirement_blocks
-  has_many :template_versions, -> { order(version_date: :desc) }, dependent: :destroy
+  has_many :template_versions,
+           -> { order(version_date: :desc) },
+           dependent: :destroy
   has_many :scheduled_template_versions,
-           -> { where(template_versions: { status: "scheduled" }).order(version_date: :desc) },
+           -> do
+             where(template_versions: { status: "scheduled" }).order(
+               version_date: :desc
+             )
+           end,
            class_name: "TemplateVersion"
   has_many :last_three_deprecated_template_versions,
-           -> { where(template_versions: { status: "deprecated" }).order(version_date: :desc).limit(3) },
+           -> do
+             where(template_versions: { status: "deprecated" }).order(
+               version_date: :desc
+             ).limit(3)
+           end,
            class_name: "TemplateVersion"
   has_many :jurisdiction_template_version_customizations
 
-  has_one :published_template_version, -> { where(status: "published") }, class_name: "TemplateVersion"
+  has_one :published_template_version,
+          -> { where(status: "published") },
+          class_name: "TemplateVersion"
 
   # Scope to get RequirementTemplates with a published template version
   scope :for_sandbox,
         ->(sandbox) do
           joins(:template_versions).where(
             template_versions: {
-              status: sandbox&.template_version_status_scope || :published,
-            },
+              status: sandbox&.template_version_status_scope || :published
+            }
           )
         end
 
@@ -44,7 +58,8 @@ class RequirementTemplate < ApplicationRecord
 
   include Discard::Model
 
-  accepts_nested_attributes_for :requirement_template_sections, allow_destroy: true
+  accepts_nested_attributes_for :requirement_template_sections,
+                                allow_destroy: true
 
   # This is a workaround needed to validate step code related errors
   attr_accessor :requirement_template_sections_attributes_copy
@@ -101,21 +116,28 @@ class RequirementTemplate < ApplicationRecord
                   id: "section-signoff-id",
                   key: "section-signoff-key",
                   type: "panel",
-                  title: I18n.t("formio.requirement_template.signoff_panel_title"),
+                  title:
+                    I18n.t("formio.requirement_template.signoff_panel_title"),
                   collapsible: true,
                   collapsed: false,
                   components: [
                     {
                       type: "checkbox",
                       key: "signed",
-                      title: I18n.t("formio.requirement_template.signoff_checkbox_title"),
-                      label: I18n.t("formio.requirement_template.signoff_checkbox_label"),
+                      title:
+                        I18n.t(
+                          "formio.requirement_template.signoff_checkbox_title"
+                        ),
+                      label:
+                        I18n.t(
+                          "formio.requirement_template.signoff_checkbox_label"
+                        ),
                       inputType: "checkbox",
                       validate: {
-                        required: true,
+                        required: true
                       },
                       input: true,
-                      defaultValue: false,
+                      defaultValue: false
                     },
                     {
                       key: "submit",
@@ -123,32 +145,46 @@ class RequirementTemplate < ApplicationRecord
                       type: "button",
                       block: false,
                       input: true,
-                      title: I18n.t("formio.requirement_template.signoff_submit_title"),
-                      label: I18n.t("formio.requirement_template.signoff_submit_title"),
+                      title:
+                        I18n.t(
+                          "formio.requirement_template.signoff_submit_title"
+                        ),
+                      label:
+                        I18n.t(
+                          "formio.requirement_template.signoff_submit_title"
+                        ),
                       theme: "primary",
                       action: "submit",
                       widget: {
-                        type: "input",
+                        type: "input"
                       },
                       disabled: false,
                       show: false,
                       conditional: {
                         show: true,
                         when: "signed",
-                        eq: "true",
-                      },
-                    },
-                  ],
-                ],
-              },
-            ],
-          ),
-      }.to_json,
+                        eq: "true"
+                      }
+                    }
+                  ]
+                ]
+              }
+            ]
+          )
+      }.to_json
     )
   end
 
-  def self.published_requirement_template_version(activity, permit_type, first_nations)
-    find_by(activity: activity, permit_type: permit_type, first_nations: first_nations).published_template_version
+  def self.published_requirement_template_version(
+    activity,
+    permit_type,
+    first_nations
+  )
+    find_by(
+      activity: activity,
+      permit_type: permit_type,
+      first_nations: first_nations
+    ).published_template_version
   rescue NoMethodError => e
     rails.logger.error e.message
   end
@@ -163,7 +199,7 @@ class RequirementTemplate < ApplicationRecord
       activity: activity.name,
       discarded: discarded_at.present?,
       assignee: assignee&.name,
-      early_access: early_access?,
+      early_access: early_access?
     }
   end
 
@@ -171,7 +207,12 @@ class RequirementTemplate < ApplicationRecord
 
   def validate_uniqueness_of_blocks
     # Track duplicates across all sections within the same template
-    duplicates = requirement_blocks.unscope(:order).group(:id).having("COUNT(*) > 1").pluck(:name)
+    duplicates =
+      requirement_blocks
+        .unscope(:order)
+        .group(:id)
+        .having("COUNT(*) > 1")
+        .pluck(:name)
   end
 
   def requirement_block_ids_from_nested_attributes_copy
@@ -206,7 +247,7 @@ class RequirementTemplate < ApplicationRecord
 
     Requirement.where(
       requirement_block_id: requirement_block_ids,
-      input_type: Requirement.input_types[:energy_step_code],
+      input_type: Requirement.input_types[:energy_step_code]
     )
   end
 
@@ -217,7 +258,7 @@ class RequirementTemplate < ApplicationRecord
 
     Requirement.where(
       requirement_block_id: requirement_block_ids,
-      requirement_code: Requirement::STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE,
+      requirement_code: Requirement::STEP_CODE_PACKAGE_FILE_REQUIREMENT_CODE
     )
   end
 
@@ -232,26 +273,37 @@ class RequirementTemplate < ApplicationRecord
         :base,
         I18n.t(
           "model_validation.requirement_template.duplicate_block_in_template",
-          requirement_block_name: duplicate_block_name,
-        ),
+          requirement_block_name: duplicate_block_name
+        )
       )
     end
   end
 
   def validate_step_code_related_dependencies
-    energy_step_code_requirements_count = energy_step_code_requirements_from_nest_attributes_copy.count
-    step_code_package_file_requirements_count = step_code_package_file_requirements_from_nest_attributes_copy.count
+    energy_step_code_requirements_count =
+      energy_step_code_requirements_from_nest_attributes_copy.count
+    step_code_package_file_requirements_count =
+      step_code_package_file_requirements_from_nest_attributes_copy.count
 
     has_any_step_code_requirements = energy_step_code_requirements_count > 0
-    has_any_step_code_package_file_requirements = step_code_package_file_requirements_count > 0
-    has_duplicate_step_code_requirements = energy_step_code_requirements_count > 1
-    has_duplicate_step_code_package_file_requirements = step_code_package_file_requirements_count > 1
+    has_any_step_code_package_file_requirements =
+      step_code_package_file_requirements_count > 0
+    has_duplicate_step_code_requirements =
+      energy_step_code_requirements_count > 1
+    has_duplicate_step_code_package_file_requirements =
+      step_code_package_file_requirements_count > 1
 
     return unless has_any_step_code_requirements
 
-    errors.add(:base, :step_code_package_required) if !has_any_step_code_package_file_requirements
-    errors.add(:base, :duplicate_energy_step_code) if has_duplicate_step_code_requirements
-    errors.add(:base, :duplicate_step_code_package) if has_duplicate_step_code_package_file_requirements
+    if !has_any_step_code_package_file_requirements
+      errors.add(:base, :step_code_package_required)
+    end
+    if has_duplicate_step_code_requirements
+      errors.add(:base, :duplicate_energy_step_code)
+    end
+    if has_duplicate_step_code_package_file_requirements
+      errors.add(:base, :duplicate_step_code_package)
+    end
   end
 
   def refresh_search_index

--- a/app/models/requirement_template_section.rb
+++ b/app/models/requirement_template_section.rb
@@ -1,8 +1,12 @@
 class RequirementTemplateSection < ApplicationRecord
   belongs_to :requirement_template
-  belongs_to :copied_from, class_name: "RequirementTemplateSection", optional: true
+  belongs_to :copied_from,
+             class_name: "RequirementTemplateSection",
+             optional: true
 
-  has_many :template_section_blocks, -> { order(position: :asc) }, dependent: :destroy
+  has_many :template_section_blocks,
+           -> { order(position: :asc) },
+           dependent: :destroy
   has_many :requirement_blocks, through: :template_section_blocks
 
   accepts_nested_attributes_for :template_section_blocks, allow_destroy: true
@@ -22,7 +26,7 @@ class RequirementTemplateSection < ApplicationRecord
       hide_label: false,
       collapsible: false,
       initially_collapsed: false,
-      components: requirement_blocks.map { |rb| rb.to_form_json(key) },
+      components: requirement_blocks.map { |rb| rb.to_form_json(key) }
     }
   end
 end

--- a/app/models/revision_reason.rb
+++ b/app/models/revision_reason.rb
@@ -2,7 +2,9 @@ class RevisionReason < ApplicationRecord
   include Discard::Model
   belongs_to :site_configuration
 
-  has_many :revision_requests, foreign_key: :reason_code, primary_key: :reason_code
+  has_many :revision_requests,
+           foreign_key: :reason_code,
+           primary_key: :reason_code
 
   validates :description, presence: true
   validates :reason_code, presence: true, uniqueness: true
@@ -15,7 +17,8 @@ class RevisionReason < ApplicationRecord
   private
 
   def normalize_reason_code
-    self.reason_code = reason_code.parameterize(separator: "_") if reason_code.present?
+    self.reason_code =
+      reason_code.parameterize(separator: "_") if reason_code.present?
   end
 
   def discard_if_marked

--- a/app/models/revision_request.rb
+++ b/app/models/revision_request.rb
@@ -1,7 +1,10 @@
 class RevisionRequest < ApplicationRecord
   belongs_to :submission_version
   belongs_to :user
-  belongs_to :revision_reason, foreign_key: :reason_code, primary_key: :reason_code, optional: true
+  belongs_to :revision_reason,
+             foreign_key: :reason_code,
+             primary_key: :reason_code,
+             optional: true
 
   validate :user_must_be_review_staff
 
@@ -9,7 +12,12 @@ class RevisionRequest < ApplicationRecord
 
   def user_must_be_review_staff
     unless user&.review_staff?
-      errors.add(:user, I18n.t("activerecord.errors.models.revision_request.attributes.user.incorrect_role"))
+      errors.add(
+        :user,
+        I18n.t(
+          "activerecord.errors.models.revision_request.attributes.user.incorrect_role"
+        )
+      )
     end
   end
 end

--- a/app/models/sandbox.rb
+++ b/app/models/sandbox.rb
@@ -4,7 +4,11 @@ class Sandbox < ApplicationRecord
   has_many :permit_applications, dependent: :destroy
   has_many :jurisdiction_template_version_customizations, dependent: :destroy
 
-  enum template_version_status_scope: { published: 0, scheduled: 1 }, _default: 0
+  enum template_version_status_scope: {
+         published: 0,
+         scheduled: 1
+       },
+       _default: 0
 
   validates :name, presence: true, uniqueness: { scope: :jurisdiction_id }
 

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -9,7 +9,12 @@ class SiteConfiguration < ApplicationRecord
   validate :max_undiscarded_revision_reasons
   validate :max_revision_reasons
 
-  HELP_LINK_KEYS = %w[get_started_link_item best_practices_link_item dictionary_link_item user_guide_link_item]
+  HELP_LINK_KEYS = %w[
+    get_started_link_item
+    best_practices_link_item
+    dictionary_link_item
+    user_guide_link_item
+  ]
 
   def self.instance
     first_or_create
@@ -21,7 +26,10 @@ class SiteConfiguration < ApplicationRecord
     attributes.each do |attribute, _|
       next unless attribute["id"].blank? && attribute["reason_code"].present?
 
-      existing_reason = self.revision_reasons.with_discarded.find_by(reason_code: attribute["reason_code"])
+      existing_reason =
+        self.revision_reasons.with_discarded.find_by(
+          reason_code: attribute["reason_code"]
+        )
 
       next unless existing_reason.present?
 
@@ -39,7 +47,9 @@ class SiteConfiguration < ApplicationRecord
     if revision_reasons.count > 200
       errors.add(
         :revision_reasons,
-        I18n.t("activerecord.errors.models.site_configuration.attributes.revision_reasons.max_records"),
+        I18n.t(
+          "activerecord.errors.models.site_configuration.attributes.revision_reasons.max_records"
+        )
       )
     end
   end
@@ -48,7 +58,9 @@ class SiteConfiguration < ApplicationRecord
     if revision_reasons.kept.count > 20
       errors.add(
         :revision_reasons,
-        I18n.t("activerecord.errors.models.site_configuration.attributes.revision_reasons.max_undiscarded_records"),
+        I18n.t(
+          "activerecord.errors.models.site_configuration.attributes.revision_reasons.max_undiscarded_records"
+        )
       )
     end
   end
@@ -56,7 +68,10 @@ class SiteConfiguration < ApplicationRecord
   # A private method to ensure only one record exists
   def ensure_single_record
     if SiteConfiguration.count > 0
-      errors.add(:base, I18n.t("activerecord.errors.models.site_configuration.single_record"))
+      errors.add(
+        :base,
+        I18n.t("activerecord.errors.models.site_configuration.single_record")
+      )
     end
   end
 
@@ -66,10 +81,14 @@ class SiteConfiguration < ApplicationRecord
     help_link_items.each do |key, item|
       # Check if item should show
       if item["show"]
-        unless item["href"].present? && item["title"].present? && item["description"].present?
+        unless item["href"].present? && item["title"].present? &&
+                 item["description"].present?
           errors.add(
             :base,
-            I18n.t("activerecord.errors.models.site_configuration.attributes.help_link_items.incomplete", link: key),
+            I18n.t(
+              "activerecord.errors.models.site_configuration.attributes.help_link_items.incomplete",
+              link: key
+            )
           )
         end
       end
@@ -81,13 +100,19 @@ class SiteConfiguration < ApplicationRecord
           unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
             errors.add(
               :base,
-              I18n.t("activerecord.errors.models.site_configuration.attributes.help_link_items.invalid_url", link: key),
+              I18n.t(
+                "activerecord.errors.models.site_configuration.attributes.help_link_items.invalid_url",
+                link: key
+              )
             )
           end
         rescue URI::InvalidURIError
           errors.add(
             :base,
-            I18n.t("activerecord.errors.models.site_configuration.attributes.help_link_items.invalid_url", link: key),
+            I18n.t(
+              "activerecord.errors.models.site_configuration.attributes.help_link_items.invalid_url",
+              link: key
+            )
           )
         end
       end

--- a/app/models/step_code.rb
+++ b/app/models/step_code.rb
@@ -2,11 +2,17 @@ class StepCode < ApplicationRecord
   belongs_to :permit_application, optional: Rails.env.test?
 
   delegate :number, to: :permit_application, prefix: :building_permit
-  delegate :submitter, :jurisdiction_name, :full_address, :pid, to: :permit_application
+  delegate :submitter,
+           :jurisdiction_name,
+           :full_address,
+           :pid,
+           to: :permit_application
 
   has_many :data_entries, class_name: "StepCodeDataEntry", dependent: :destroy
   has_many :checklists, class_name: "StepCodeChecklist", dependent: :destroy
-  has_one :pre_construction_checklist, -> { where(stage: :pre_construction) }, class_name: "StepCodeChecklist"
+  has_one :pre_construction_checklist,
+          -> { where(stage: :pre_construction) },
+          class_name: "StepCodeChecklist"
 
   accepts_nested_attributes_for :data_entries
   accepts_nested_attributes_for :pre_construction_checklist
@@ -17,7 +23,10 @@ class StepCode < ApplicationRecord
   def requires_plan_document
     return if permit_application.blank? #do not enforce if there is no permit application
     if permit_application.step_code_plan_document.blank?
-      errors.add(:plan_version, "file is missing.  Please upload on the permit application first.")
+      errors.add(
+        :plan_version,
+        "file is missing.  Please upload on the permit application first."
+      )
       # EVENTUALLY BRING THIS LOGIC BACK ONCE WE DECIDE BEST WAY TO CONFIGURE IF A STEP CODE REQUIRES A SIGNED DOCUMENT.
       # elsif permit_application.step_code_plan_document.compliance_data.blank? ||
       #       permit_application.step_code_plan_document.compliance_data.empty?
@@ -32,13 +41,14 @@ class StepCode < ApplicationRecord
     assign_attributes(
       plan_author: permit_application.step_code_plan_author,
       plan_version: permit_application.step_code_plan_version,
-      plan_date: permit_application.step_code_plan_date,
+      plan_date: permit_application.step_code_plan_date
     )
   end
 
   def plan_out_of_date
     permit_application.step_code_plan_author != plan_author ||
-      permit_application.step_code_plan_version != plan_version || permit_application.step_code_plan_date != plan_date
+      permit_application.step_code_plan_version != plan_version ||
+      permit_application.step_code_plan_date != plan_date
   end
 
   def builder
@@ -46,7 +56,10 @@ class StepCode < ApplicationRecord
   end
 
   def step_requirements
-    all = permit_application.jurisdiction.permit_type_required_steps.where(permit_type: permit_application.permit_type)
+    all =
+      permit_application.jurisdiction.permit_type_required_steps.where(
+        permit_type: permit_application.permit_type
+      )
     all.customizations.any? ? all.customizations : all
   end
 end

--- a/app/models/step_code_building_characteristics_summary.rb
+++ b/app/models/step_code_building_characteristics_summary.rb
@@ -1,20 +1,30 @@
 class StepCodeBuildingCharacteristicsSummary < ApplicationRecord
   belongs_to :step_code_checklist
 
-  serialize :above_grade_walls_lines, coder: StepCode::BuildingCharacteristics::Line::AboveGradeWalls
-  serialize :airtightness, coder: StepCode::BuildingCharacteristics::Airtightness
-  serialize :below_grade_walls_lines, coder: StepCode::BuildingCharacteristics::Line::BelowGradeWalls
+  serialize :above_grade_walls_lines,
+            coder: StepCode::BuildingCharacteristics::Line::AboveGradeWalls
+  serialize :airtightness,
+            coder: StepCode::BuildingCharacteristics::Airtightness
+  serialize :below_grade_walls_lines,
+            coder: StepCode::BuildingCharacteristics::Line::BelowGradeWalls
   serialize :doors_lines, coder: StepCode::BuildingCharacteristics::Line::Doors
   serialize :fossil_fuels, coder: StepCode::BuildingCharacteristics::FossilFuels
-  serialize :framings_lines, coder: StepCode::BuildingCharacteristics::Line::Framings
-  serialize :hot_water_lines, coder: StepCode::BuildingCharacteristics::Line::HotWater
+  serialize :framings_lines,
+            coder: StepCode::BuildingCharacteristics::Line::Framings
+  serialize :hot_water_lines,
+            coder: StepCode::BuildingCharacteristics::Line::HotWater
   serialize :other_lines, coder: StepCode::BuildingCharacteristics::Line::Other
-  serialize :roof_ceilings_lines, coder: StepCode::BuildingCharacteristics::Line::RoofCeilings
+  serialize :roof_ceilings_lines,
+            coder: StepCode::BuildingCharacteristics::Line::RoofCeilings
   serialize :slabs_lines, coder: StepCode::BuildingCharacteristics::Line::Slabs
-  serialize :space_heating_cooling_lines, coder: StepCode::BuildingCharacteristics::Line::SpaceHeatingCooling
-  serialize :unheated_floors_lines, coder: StepCode::BuildingCharacteristics::Line::UnheatedFloors
-  serialize :ventilation_lines, coder: StepCode::BuildingCharacteristics::Line::Ventilation
-  serialize :windows_glazed_doors, coder: StepCode::BuildingCharacteristics::WindowsGlazedDoors
+  serialize :space_heating_cooling_lines,
+            coder: StepCode::BuildingCharacteristics::Line::SpaceHeatingCooling
+  serialize :unheated_floors_lines,
+            coder: StepCode::BuildingCharacteristics::Line::UnheatedFloors
+  serialize :ventilation_lines,
+            coder: StepCode::BuildingCharacteristics::Line::Ventilation
+  serialize :windows_glazed_doors,
+            coder: StepCode::BuildingCharacteristics::WindowsGlazedDoors
 
   validates_with StepCode::BuildingCharacteristics::Validator
 end

--- a/app/models/step_code_checklist.rb
+++ b/app/models/step_code_checklist.rb
@@ -1,12 +1,21 @@
 class StepCodeChecklist < ApplicationRecord
   belongs_to :step_code, optional: Rails.env.test?
-  belongs_to :step_requirement, class_name: "PermitTypeRequiredStep", optional: true
+  belongs_to :step_requirement,
+             class_name: "PermitTypeRequiredStep",
+             optional: true
 
-  has_one :building_characteristics_summary, class_name: "StepCodeBuildingCharacteristicsSummary", dependent: :destroy
+  has_one :building_characteristics_summary,
+          class_name: "StepCodeBuildingCharacteristicsSummary",
+          dependent: :destroy
   accepts_nested_attributes_for :building_characteristics_summary
   after_create :create_building_characteristics_summary
 
-  delegate :data_entries, :building_permit_number, :jurisdiction_name, :full_address, :pid, to: :step_code
+  delegate :data_entries,
+           :building_permit_number,
+           :jurisdiction_name,
+           :full_address,
+           :pid,
+           to: :step_code
   delegate :plan_author, :plan_version, :plan_date, to: :step_code
 
   enum stage: %i[pre_construction mid_construction as_built]
@@ -34,22 +43,34 @@ class StepCodeChecklist < ApplicationRecord
       airtightness_values: epc_calculation_airtightnesses.keys,
       epc_testing_target_types: epc_calculation_testing_target_types.keys,
       building_types: building_types.keys,
-      energy_steps: (ENV["MIN_ENERGY_STEP"].to_i..ENV["MAX_ENERGY_STEP"].to_i).to_a,
-      zero_carbon_steps: (ENV["MIN_ZERO_CARBON_STEP"].to_i..ENV["MAX_ZERO_CARBON_STEP"].to_i).to_a,
+      energy_steps:
+        (ENV["MIN_ENERGY_STEP"].to_i..ENV["MAX_ENERGY_STEP"].to_i).to_a,
+      zero_carbon_steps:
+        (
+          ENV["MIN_ZERO_CARBON_STEP"].to_i..ENV["MAX_ZERO_CARBON_STEP"].to_i
+        ).to_a,
       building_characteristics_summary: {
         performance_types: {
-          windows_glazed_doors: StepCode::BuildingCharacteristics::WindowsGlazedDoors::PERFORMANCE_TYPES.keys,
-          doors: StepCode::BuildingCharacteristics::Line::Doors::PERFORMANCE_TYPES.keys,
-          space_heating_cooling: StepCode::BuildingCharacteristics::Line::SpaceHeatingCooling::PERFORMANCE_TYPES.keys,
-          hot_water: StepCode::BuildingCharacteristics::Line::HotWater::PERFORMANCE_TYPES.keys,
+          windows_glazed_doors:
+            StepCode::BuildingCharacteristics::WindowsGlazedDoors::PERFORMANCE_TYPES.keys,
+          doors:
+            StepCode::BuildingCharacteristics::Line::Doors::PERFORMANCE_TYPES.keys,
+          space_heating_cooling:
+            StepCode::BuildingCharacteristics::Line::SpaceHeatingCooling::PERFORMANCE_TYPES.keys,
+          hot_water:
+            StepCode::BuildingCharacteristics::Line::HotWater::PERFORMANCE_TYPES.keys
         },
-        fossil_fuels_presence: StepCode::BuildingCharacteristics::FossilFuels::PRESENCE.keys,
-      },
+        fossil_fuels_presence:
+          StepCode::BuildingCharacteristics::FossilFuels::PRESENCE.keys
+      }
     }
   end
 
   def compliance_reports
-    StepCode::Compliance::GenerateReports.new(checklist: self, requirements: step_code.step_requirements).call.reports
+    StepCode::Compliance::GenerateReports
+      .new(checklist: self, requirements: step_code.step_requirements)
+      .call
+      .reports
   end
 
   def passing_compliance_reports

--- a/app/models/step_code_data_entry.rb
+++ b/app/models/step_code_data_entry.rb
@@ -31,7 +31,8 @@ class StepCodeDataEntry < ApplicationRecord
     h2k_file&.url(
       public: false,
       expires_in: 3600,
-      response_content_disposition: "attachment; filename=\"#{h2k_file.original_filename}\"",
+      response_content_disposition:
+        "attachment; filename=\"#{h2k_file.original_filename}\""
     )
   end
 end

--- a/app/models/submission_version.rb
+++ b/app/models/submission_version.rb
@@ -9,22 +9,43 @@ class SubmissionVersion < ApplicationRecord
 
   delegate :sandbox, to: :permit_application
 
-  scope :sandboxed, -> { joins(:permit_application).where.not(permit_applications: { sandbox_id: nil }) }
+  scope :sandboxed,
+        -> do
+          joins(:permit_application).where.not(
+            permit_applications: {
+              sandbox_id: nil
+            }
+          )
+        end
 
-  scope :live, -> { joins(:permit_application).where(permit_applications: { sandbox_id: nil }) }
+  scope :live,
+        -> do
+          joins(:permit_application).where(
+            permit_applications: {
+              sandbox_id: nil
+            }
+          )
+        end
 
   def missing_pdfs
     missing_data_keys = []
 
-    existing_application_pdf = supporting_documents.find_by(data_key: SupportingDocument::APPLICATION_PDF_DATA_KEY)
+    existing_application_pdf =
+      supporting_documents.find_by(
+        data_key: SupportingDocument::APPLICATION_PDF_DATA_KEY
+      )
 
     if existing_application_pdf.blank? || existing_application_pdf.file.blank?
       missing_data_keys << "#{SupportingDocument::APPLICATION_PDF_DATA_KEY}_#{id}"
     end
 
-    existing_checklist_pdf = supporting_documents.find_by(data_key: SupportingDocument::CHECKLIST_PDF_DATA_KEY)
+    existing_checklist_pdf =
+      supporting_documents.find_by(
+        data_key: SupportingDocument::CHECKLIST_PDF_DATA_KEY
+      )
 
-    if has_step_code_checklist? && (existing_checklist_pdf.blank? || existing_checklist_pdf.file.blank?)
+    if has_step_code_checklist? &&
+         (existing_checklist_pdf.blank? || existing_checklist_pdf.file.blank?)
       missing_data_keys << "#{SupportingDocument::CHECKLIST_PDF_DATA_KEY}_#{id}"
     end
 
@@ -32,7 +53,10 @@ class SubmissionVersion < ApplicationRecord
   end
 
   def missing_permit_application_pdf?
-    existing_document = supporting_documents.find_by(data_key: SupportingDocument::APPLICATION_PDF_DATA_KEY)
+    existing_document =
+      supporting_documents.find_by(
+        data_key: SupportingDocument::APPLICATION_PDF_DATA_KEY
+      )
 
     existing_document.blank? || existing_document.file.blank?
   end
@@ -40,7 +64,10 @@ class SubmissionVersion < ApplicationRecord
   def missing_step_code_checklist_pdf?
     return false unless has_step_code_checklist?
 
-    existing_document = supporting_documents.find_by(data_key: SupportingDocument::CHECKLIST_PDF_DATA_KEY).present?
+    existing_document =
+      supporting_documents.find_by(
+        data_key: SupportingDocument::CHECKLIST_PDF_DATA_KEY
+      ).present?
 
     existing_document.blank? || existing_document.file.blank?
   end
@@ -54,20 +81,29 @@ class SubmissionVersion < ApplicationRecord
   end
 
   def formatted_submission_data(current_user: nil)
-    PermitApplication::SubmissionDataService.new(permit_application).formatted_submission_data(
+    PermitApplication::SubmissionDataService.new(
+      permit_application
+    ).formatted_submission_data(
       current_user: current_user,
-      submission_data: submission_data,
+      submission_data: submission_data
     )
   end
 
   def version_number
-    permit_application.submission_versions.order(:created_at).pluck(:id).index(id) + 1
+    permit_application
+      .submission_versions
+      .order(:created_at)
+      .pluck(:id)
+      .index(id) + 1
   end
 
   def revision_requests_for_submitter_based_on_user_permissions(user: nil)
     return revision_requests if user.blank?
 
-    permissions = permit_application.submission_requirement_block_edit_permissions(user_id: user.id)
+    permissions =
+      permit_application.submission_requirement_block_edit_permissions(
+        user_id: user.id
+      )
 
     return revision_requests if permissions == :all
 

--- a/app/models/supporting_document.rb
+++ b/app/models/supporting_document.rb
@@ -6,16 +6,25 @@ class SupportingDocument < ApplicationRecord
 
   validate :validate_submission_version_data_key
 
-  scope :file_ids_with_regex, ->(regex_pattern) { where("file_data ->> 'id' ~ ?", regex_pattern) }
-  scope :without_compliance, -> { where("compliance_data = '{}' OR compliance_data IS NULL") }
-  validates :submission_version_id, uniqueness: { scope: %i[permit_application_id data_key], allow_nil: true }
+  scope :file_ids_with_regex,
+        ->(regex_pattern) { where("file_data ->> 'id' ~ ?", regex_pattern) }
+  scope :without_compliance,
+        -> { where("compliance_data = '{}' OR compliance_data IS NULL") }
+  validates :submission_version_id,
+            uniqueness: {
+              scope: %i[permit_application_id data_key],
+              allow_nil: true
+            }
 
   APPLICATION_PDF_DATA_KEY = "permit_application_pdf"
   CHECKLIST_PDF_DATA_KEY = "step_code_checklist_pdf"
 
   def last_signer
     if compliance_data["result"] &&
-         signer = compliance_data["result"].sort_by { |signer| signer.dig("signatureTimestamp", "date") }&.last
+         signer =
+           compliance_data["result"]
+             .sort_by { |signer| signer.dig("signatureTimestamp", "date") }
+             &.last
       parse_signature(signer)
     else
       { name: nil, date: nil }
@@ -28,20 +37,33 @@ class SupportingDocument < ApplicationRecord
         compliance_data["result"]
           .map { |signer| parse_signature(signer) }
           .group_by { |signer| signer[:subjectName] }
-          .map { |subjectName, signaturesArray| signaturesArray.sort_by { |signer| signer[:date] }&.last }
+          .map do |subjectName, signaturesArray|
+            signaturesArray.sort_by { |signer| signer[:date] }&.last
+          end
           .sort_by { |signer| signer[:date] }
           .reverse
           .map { |signer| summarizeString(signer) }
 
-      { "id" => file_id, "data_key" => data_key, "message" => "Signers validated: #{signers.join(",")}" }
+      {
+        "id" => file_id,
+        "data_key" => data_key,
+        "message" => "Signers validated: #{signers.join(",")}"
+      }
     else
-      { "id" => file_id, "data_key" => data_key, "message" => compliance_data["error"], "error" => true }
+      {
+        "id" => file_id,
+        "data_key" => data_key,
+        "message" => compliance_data["error"],
+        "error" => true
+      }
     end
   end
 
   def parse_signature(signer)
     {
-      name: signer.dig("signerStatus", "certificateInfo", "commonName") || signer["signatureFieldName"],
+      name:
+        signer.dig("signerStatus", "certificateInfo", "commonName") ||
+          signer["signatureFieldName"],
       subjectName: signer.dig("signerStatus", "certificateInfo", "subjectName"),
       subject:
         signer
@@ -54,12 +76,13 @@ class SupportingDocument < ApplicationRecord
         Time
           .parse(signer.dig("signatureTimestamp", "date"))
           .in_time_zone(Rails.application.config.time_zone)
-          .strftime("%Y-%m-%d %H:%M:%S %Z"),
+          .strftime("%Y-%m-%d %H:%M:%S %Z")
     }
   end
 
   def standardized_filename
-    name = "#{permit_application.number}_#{data_key.split("|").last.gsub("_file", "")}"
+    name =
+      "#{permit_application.number}_#{data_key.split("|").last.gsub("_file", "")}"
 
     extension = file_data["id"].split(".").last
 
@@ -100,18 +123,27 @@ class SupportingDocument < ApplicationRecord
     file&.url(
       public: false,
       expires_in: 3600,
-      response_content_disposition: "attachment; filename=\"#{file.original_filename}\"",
+      response_content_disposition:
+        "attachment; filename=\"#{file.original_filename}\""
     )
   end
 
-  STATIC_DOCUMENT_DATA_KEYS = [APPLICATION_PDF_DATA_KEY, CHECKLIST_PDF_DATA_KEY].freeze
+  STATIC_DOCUMENT_DATA_KEYS = [
+    APPLICATION_PDF_DATA_KEY,
+    CHECKLIST_PDF_DATA_KEY
+  ].freeze
 
   def validate_submission_version_data_key
-    return unless submission_version.present? && !STATIC_DOCUMENT_DATA_KEYS.include?(data_key)
+    unless submission_version.present? &&
+             !STATIC_DOCUMENT_DATA_KEYS.include?(data_key)
+      return
+    end
 
     self.errors.add(
       :data_key,
-      I18n.t("activerecord.errors.models.supporting_document.attributes.data_key.submission_version_data_key"),
+      I18n.t(
+        "activerecord.errors.models.supporting_document.attributes.data_key.submission_version_data_key"
+      )
     )
   end
 end

--- a/app/models/template_version.rb
+++ b/app/models/template_version.rb
@@ -27,7 +27,8 @@ class TemplateVersion < ApplicationRecord
   after_save :create_integration_mappings
   after_save :notify_users_of_missing_requirements_mappings
 
-  scope :for_sandbox, ->(sandbox) { where(status: sandbox.template_version_status_scope) }
+  scope :for_sandbox,
+        ->(sandbox) { where(status: sandbox.template_version_status_scope) }
 
   def customizations
     # Convenience method to prevent carpal tunnel syndrome
@@ -65,14 +66,16 @@ class TemplateVersion < ApplicationRecord
   def publish_event_notification_data(recent_permit_application = nil)
     {
       "id" => SecureRandom.uuid,
-      "action_type" => Constants::NotificationActionTypes::NEW_TEMPLATE_VERSION_PUBLISH,
-      "action_text" => "#{I18n.t("notification.template_version.new_version_notification", template_label: label)}",
+      "action_type" =>
+        Constants::NotificationActionTypes::NEW_TEMPLATE_VERSION_PUBLISH,
+      "action_text" =>
+        "#{I18n.t("notification.template_version.new_version_notification", template_label: label)}",
       "object_data" => {
         "template_version_id" => id,
         "previous_template_version_id" => previous_version.id,
         "requirement_template_id" => requirement_template_id,
-        "permit_application_id" => recent_permit_application&.id,
-      },
+        "permit_application_id" => recent_permit_application&.id
+      }
     }
   end
 
@@ -89,7 +92,9 @@ class TemplateVersion < ApplicationRecord
   end
 
   def get_requirement_json(requirement_block_id, requirement_id)
-    requirement_blocks_json.dig(requirement_block_id, "requirements")&.find { |req| req["id"] == requirement_id }
+    requirement_blocks_json
+      .dig(requirement_block_id, "requirements")
+      &.find { |req| req["id"] == requirement_id }
   end
 
   def create_integration_mappings
@@ -97,23 +102,28 @@ class TemplateVersion < ApplicationRecord
 
     api_enabled_jurisdictions = Jurisdiction.where(external_api_enabled: true)
 
-    existing_mapping_jurisdiction_ids = integration_mappings.pluck(:jurisdiction_id)
+    existing_mapping_jurisdiction_ids =
+      integration_mappings.pluck(:jurisdiction_id)
 
-    jurisdictions_without_mappings = api_enabled_jurisdictions.where.not(id: existing_mapping_jurisdiction_ids)
+    jurisdictions_without_mappings =
+      api_enabled_jurisdictions.where.not(id: existing_mapping_jurisdiction_ids)
 
-    jurisdictions_without_mappings.each { |jurisdiction| integration_mappings.create(jurisdiction: jurisdiction) }
+    jurisdictions_without_mappings.each do |jurisdiction|
+      integration_mappings.create(jurisdiction: jurisdiction)
+    end
   end
 
   def force_publish_now!
     return unless scheduled?
 
-    updated_template_version = TemplateVersioningService.publish_version!(self, true)
+    updated_template_version =
+      TemplateVersioningService.publish_version!(self, true)
 
     WebsocketBroadcaster.push_update_to_relevant_users(
       User.super_admin.kept.all.pluck(:id), # only super admins can force publish
       Constants::Websockets::Events::TemplateVersion::DOMAIN,
       Constants::Websockets::Events::TemplateVersion::TYPES[:update],
-      TemplateVersionBlueprint.render_as_hash(updated_template_version),
+      TemplateVersionBlueprint.render_as_hash(updated_template_version)
     )
   end
 
@@ -123,18 +133,30 @@ class TemplateVersion < ApplicationRecord
     return unless !deprecation_reason_unscheduled? && saved_change_to_status?
 
     if Rails.env.test?
-      ModelCallbackJob.new.perform(self.class.name, id, "create_integration_mappings")
+      ModelCallbackJob.new.perform(
+        self.class.name,
+        id,
+        "create_integration_mappings"
+      )
     else
-      ModelCallbackJob.perform_async(self.class.name, id, "create_integration_mappings")
+      ModelCallbackJob.perform_async(
+        self.class.name,
+        id,
+        "create_integration_mappings"
+      )
     end
   end
 
   def notify_users_of_missing_requirements_mappings
     return unless saved_change_to_status? && (published? || scheduled?)
     relevant_integration_mappings =
-      integration_mappings.joins(:jurisdiction).where({ jurisdictions: { external_api_enabled: true } })
+      integration_mappings.joins(:jurisdiction).where(
+        { jurisdictions: { external_api_enabled: true } }
+      )
 
-    relevant_integration_mappings.each { |im| im.send_missing_requirements_mapping_communication }
+    relevant_integration_mappings.each do |im|
+      im.send_missing_requirements_mapping_communication
+    end
   end
 
   def set_default_deprecation_reason

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   PASSWORD_REGEX = /\A(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{8,64}\z/
-  searchkick searchable: %i[first_name last_name email], word_start: %i[first_name last_name email]
+  searchkick searchable: %i[first_name last_name email],
+             word_start: %i[first_name last_name email]
 
   include Devise::JWT::RevocationStrategies::Allowlist
   include Discard::Model
@@ -17,7 +18,14 @@ class User < ApplicationRecord
          omniauth_providers: %i[keycloak],
          jwt_revocation_strategy: self
 
-  enum role: { submitter: 0, review_manager: 1, reviewer: 2, super_admin: 3, regional_review_manager: 4 }, _default: 0
+  enum role: {
+         submitter: 0,
+         review_manager: 1,
+         reviewer: 2,
+         super_admin: 3,
+         regional_review_manager: 4
+       },
+       _default: 0
 
   # https://github.com/waiting-for-dev/devise-jwt
   self.skip_session_storage = %i[http_auth params_auth]
@@ -25,14 +33,25 @@ class User < ApplicationRecord
   # Associations
   has_many :jurisdiction_memberships, dependent: :destroy
   has_many :jurisdictions, through: :jurisdiction_memberships
-  has_many :integration_mapping_notifications, as: :notifiable, dependent: :destroy
+  has_many :integration_mapping_notifications,
+           as: :notifiable,
+           dependent: :destroy
 
-  has_many :permit_applications, foreign_key: "submitter_id", dependent: :destroy
-  has_many :applied_jurisdictions, through: :permit_applications, source: :jurisdiction
-  has_many :license_agreements, class_name: "UserLicenseAgreement", dependent: :destroy
+  has_many :permit_applications,
+           foreign_key: "submitter_id",
+           dependent: :destroy
+  has_many :applied_jurisdictions,
+           through: :permit_applications,
+           source: :jurisdiction
+  has_many :license_agreements,
+           class_name: "UserLicenseAgreement",
+           dependent: :destroy
   has_many :contacts, as: :contactable, dependent: :destroy
   has_many :collaborators, as: :collaboratorable, dependent: :destroy
-  has_many :collaborations, foreign_key: "user_id", class_name: "Collaborator", dependent: :destroy
+  has_many :collaborations,
+           foreign_key: "user_id",
+           class_name: "Collaborator",
+           dependent: :destroy
   has_one :preference, dependent: :destroy
   accepts_nested_attributes_for :preference
 
@@ -52,7 +71,8 @@ class User < ApplicationRecord
   attr_accessor :collaboration_invitation # this is needed to signal that a registration invitation is for collaboration when sending the email
 
   after_discard { destroy_jurisdiction_collaborator }
-  after_save :create_jurisdiction_collaborator, if: :saved_change_to_discarded_at
+  after_save :create_jurisdiction_collaborator,
+             if: :saved_change_to_discarded_at
 
   delegate :sandboxes, to: :jurisdiction
 
@@ -66,7 +86,7 @@ class User < ApplicationRecord
       reviewer: "employee",
       review_manager: "employee",
       regional_review_manager: "employee",
-      super_admin: nil,
+      super_admin: nil
     }[
       role.to_sym
     ]
@@ -87,7 +107,7 @@ class User < ApplicationRecord
       email: email,
       jurisdiction_ids: jurisdictions.pluck(:id),
       discarded: discarded_at.present?,
-      last_sign_in_at: last_sign_in_at,
+      last_sign_in_at: last_sign_in_at
     }
   end
 
@@ -123,7 +143,9 @@ class User < ApplicationRecord
   end
 
   def set_collaboration_invitation(permit_collaboration)
-    self.collaboration_invitation = { permit_collaboration: permit_collaboration }
+    self.collaboration_invitation = {
+      permit_collaboration: permit_collaboration
+    }
   end
 
   def create_jurisdiction_collaborator
@@ -159,7 +181,7 @@ class User < ApplicationRecord
       enable_in_app_new_template_version_publish_notification: true,
       enable_email_new_template_version_publish_notification: true,
       enable_in_app_customization_update_notification: true,
-      enable_email_customization_update_notification: true,
+      enable_email_customization_update_notification: true
     ).save
   end
 
@@ -175,21 +197,36 @@ class User < ApplicationRecord
   end
 
   def confirmed_user_has_fields
-    errors.add(:user, "Confirmed user must have first_name") unless !confirmed? || first_name.present?
-    errors.add(:user, "Confirmed user must have last_name") unless !confirmed? || last_name.present?
-    errors.add(:user, "Confirmed user must have email") unless !confirmed? || email.present?
+    unless !confirmed? || first_name.present?
+      errors.add(:user, "Confirmed user must have first_name")
+    end
+    unless !confirmed? || last_name.present?
+      errors.add(:user, "Confirmed user must have last_name")
+    end
+    unless !confirmed? || email.present?
+      errors.add(:user, "Confirmed user must have email")
+    end
   end
 
   def jurisdiction_must_belong_to_correct_roles
-    errors.add(:jurisdictions, :reviewers_only) if jurisdictions.any? && !review_staff?
+    if jurisdictions.any? && !review_staff?
+      errors.add(:jurisdictions, :reviewers_only)
+    end
   end
 
   def unique_omniauth_uid
     return unless omniauth_uid.present?
-    existing_user = User.where.not(omniauth_uid: nil).find_by(omniauth_uid:, omniauth_provider:)
+    existing_user =
+      User
+        .where.not(omniauth_uid: nil)
+        .find_by(omniauth_uid:, omniauth_provider:)
     return unless existing_user && existing_user != self
     if !super_admin?
-      errors.add(:base, :bceid_taken, jurisdiction: existing_user.jurisdictions.first&.name)
+      errors.add(
+        :base,
+        :bceid_taken,
+        jurisdiction: existing_user.jurisdictions.first&.name
+      )
     elsif super_admin?
       errors.add(:base, :idir_taken)
     end

--- a/app/models/user_license_agreement.rb
+++ b/app/models/user_license_agreement.rb
@@ -14,6 +14,8 @@ class UserLicenseAgreement < ApplicationRecord
   def user_eula_variant_matches_agreement_variant
     return if user.blank? || agreement.blank?
 
-    errors.add(:agreement, "variant must match user's eula_variant") unless user.eula_variant == agreement.variant
+    unless user.eula_variant == agreement.variant
+      errors.add(:agreement, "variant must match user's eula_variant")
+    end
   end
 end

--- a/app/policies/external_api_key_policy.rb
+++ b/app/policies/external_api_key_policy.rb
@@ -5,7 +5,8 @@ class ExternalApiKeyPolicy < ApplicationPolicy
 
   def show?
     return true if user.super_admin?
-    (user.review_manager? || user.regional_review_manager?) && record.jurisdiction.external_api_enabled? &&
+    (user.review_manager? || user.regional_review_manager?) &&
+      record.jurisdiction.external_api_enabled? &&
       user.jurisdictions.find(record.jurisdiction_id).present?
   end
 
@@ -27,9 +28,16 @@ class ExternalApiKeyPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      raise Pundit::NotAuthorizedError unless user.super_admin? || user.review_manager? || user.regional_review_manager?
+      unless user.super_admin? || user.review_manager? ||
+               user.regional_review_manager?
+        raise Pundit::NotAuthorizedError
+      end
 
-      user.super_admin? ? ExternalApiKey.all : ExternalApiKey.where(jurisdiction_id: user.jurisdictions.pluck(:id))
+      if user.super_admin?
+        ExternalApiKey.all
+      else
+        ExternalApiKey.where(jurisdiction_id: user.jurisdictions.pluck(:id))
+      end
     end
   end
 end

--- a/app/policies/integration_mapping_policy.rb
+++ b/app/policies/integration_mapping_policy.rb
@@ -1,7 +1,8 @@
 class IntegrationMappingPolicy < ApplicationPolicy
   def update?
     (
-      (user.review_manager? || user.regional_review_manager?) && record.jurisdiction.external_api_enabled? &&
+      (user.review_manager? || user.regional_review_manager?) &&
+        record.jurisdiction.external_api_enabled? &&
         user.jurisdictions.find(record.jurisdiction_id)
     )
   end

--- a/app/policies/jurisdiction_policy.rb
+++ b/app/policies/jurisdiction_policy.rb
@@ -26,7 +26,8 @@ class JurisdictionPolicy < ApplicationPolicy
   def update_external_api_enabled?
     return true if user.super_admin?
 
-    (user.review_manager? || user.regional_review_manager?) && record.external_api_enabled?
+    (user.review_manager? || user.regional_review_manager?) &&
+      record.external_api_enabled?
   end
 
   def search_users?

--- a/app/policies/permit_application_policy.rb
+++ b/app/policies/permit_application_policy.rb
@@ -23,7 +23,9 @@ class PermitApplicationPolicy < ApplicationPolicy
 
   def update?
     if record.draft?
-      record.submission_requirement_block_edit_permissions(user_id: user.id).present?
+      record.submission_requirement_block_edit_permissions(
+        user_id: user.id
+      ).present?
     else
       user.review_staff? && user.jurisdictions.find(record.jurisdiction_id)
     end
@@ -34,7 +36,7 @@ class PermitApplicationPolicy < ApplicationPolicy
     designated_submitter =
       permit_application.users_by_collaboration_options(
         collaboration_type: :submission,
-        collaborator_type: :delegatee,
+        collaborator_type: :delegatee
       ).first
 
     record.draft? && (record.submitter == user || designated_submitter == user)
@@ -51,7 +53,8 @@ class PermitApplicationPolicy < ApplicationPolicy
   def submit?
     record.draft? ? record.submitter == user : user.review_staff?
     if record.draft?
-      record.submission_requirement_block_edit_permissions(user_id: user.id) == :all
+      record.submission_requirement_block_edit_permissions(user_id: user.id) ==
+        :all
     else
       user.review_staff? && user.jurisdictions.find(record.jurisdiction_id)
     end
@@ -70,11 +73,14 @@ class PermitApplicationPolicy < ApplicationPolicy
     permit_collaboration = record
 
     if permit_collaboration.submission?
-      permit_collaboration.permit_application.submitter == user && permit_collaboration.permit_application.draft?
+      permit_collaboration.permit_application.submitter == user &&
+        permit_collaboration.permit_application.draft?
     elsif permit_collaboration.review?
       (user.review_staff?) &&
-        user.jurisdictions.find_by(id: permit_collaboration.permit_application.jurisdiction_id).present? &&
-        permit_collaboration.permit_application.submitted?
+        user
+          .jurisdictions
+          .find_by(id: permit_collaboration.permit_application.jurisdiction_id)
+          .present? && permit_collaboration.permit_application.submitted?
     else
       false
     end
@@ -86,7 +92,8 @@ class PermitApplicationPolicy < ApplicationPolicy
     if permit_application.draft?
       permit_application.submitter_id == user.id
     else
-      user.review_staff? && user.jurisdictions.find(permit_application.jurisdiction_id)
+      user.review_staff? &&
+        user.jurisdictions.find(permit_application.jurisdiction_id)
     end
   end
 
@@ -96,7 +103,8 @@ class PermitApplicationPolicy < ApplicationPolicy
     # New collaborators (i.e new user in the system) can only be invited for submission collaborations
     return false if permit_collaboration.review?
 
-    permit_collaboration.permit_application.submitter == user && permit_collaboration.permit_application.draft?
+    permit_collaboration.permit_application.submitter == user &&
+      permit_collaboration.permit_application.draft?
   end
 
   def create_or_update_permit_block_status?
@@ -104,14 +112,22 @@ class PermitApplicationPolicy < ApplicationPolicy
 
     if permit_block_status.submission?
       block_permissions =
-        permit_block_status.permit_application.submission_requirement_block_edit_permissions(user_id: user.id)
+        permit_block_status.permit_application.submission_requirement_block_edit_permissions(
+          user_id: user.id
+        )
 
-      permit_block_status.permit_application.draft? && block_permissions.present? &&
-        (block_permissions == :all || block_permissions.include?(permit_block_status.requirement_block_id))
+      permit_block_status.permit_application.draft? &&
+        block_permissions.present? &&
+        (
+          block_permissions == :all ||
+            block_permissions.include?(permit_block_status.requirement_block_id)
+        )
     elsif permit_block_status.review?
       (user.review_staff?) &&
-        user.jurisdictions.find_by(id: permit_block_status.permit_application.jurisdiction_id).present? &&
-        permit_block_status.permit_application.submitted?
+        user
+          .jurisdictions
+          .find_by(id: permit_block_status.permit_application.jurisdiction_id)
+          .present? && permit_block_status.permit_application.submitted?
     else
       false
     end

--- a/app/policies/permit_collaboration_policy.rb
+++ b/app/policies/permit_collaboration_policy.rb
@@ -5,13 +5,18 @@ class PermitCollaborationPolicy < ApplicationPolicy
     if record.submission?
       user == record.permit_application.submitter
     elsif record.review?
-      user.review_staff? && user.jurisdictions.find_by(id: record.permit_application.jurisdiction_id).present?
+      user.review_staff? &&
+        user
+          .jurisdictions
+          .find_by(id: record.permit_application.jurisdiction_id)
+          .present?
     else
       false
     end
   end
 
   def reinvite?
-    record.submission? && record.collaborator.user.submitter? && user == record.permit_application.submitter
+    record.submission? && record.collaborator.user.submitter? &&
+      user == record.permit_application.submitter
   end
 end

--- a/app/policies/step_code_policy.rb
+++ b/app/policies/step_code_policy.rb
@@ -22,7 +22,11 @@ class StepCodePolicy < ApplicationPolicy
   class Scope < Scope
     # NOTE: Be explicit about which records you allow access to!
     def resolve
-      scope.includes(:permit_application).where(permit_applications: { submitter: user })
+      scope.includes(:permit_application).where(
+        permit_applications: {
+          submitter: user
+        }
+      )
     end
   end
 end

--- a/app/policies/supporting_document_policy.rb
+++ b/app/policies/supporting_document_policy.rb
@@ -1,7 +1,11 @@
 class SupportingDocumentPolicy < ApplicationPolicy
   def download?
     return true if record.permit_application.submitter_id == user.id
-    user.review_staff? ? user.jurisdictions.find(record.permit_application.jurisdiction.id) : false
+    if user.review_staff?
+      user.jurisdictions.find(record.permit_application.jurisdiction.id)
+    else
+      false
+    end
   end
 
   def destroy?

--- a/app/policies/template_version_policy.rb
+++ b/app/policies/template_version_policy.rb
@@ -28,7 +28,8 @@ class TemplateVersionPolicy < ApplicationPolicy
   end
 
   def create_or_update_jurisdiction_template_version_customization?
-    (user.review_manager? || user.regional_review_manager?) && user.jurisdictions.find(record&.jurisdiction_id)
+    (user.review_manager? || user.regional_review_manager?) &&
+      user.jurisdictions.find(record&.jurisdiction_id)
   end
 
   def show_integration_mapping?
@@ -56,7 +57,8 @@ class TemplateVersionPolicy < ApplicationPolicy
           .where.not(status: "deprecated")
       if sandbox.present?
         template_versions.for_sandbox(sandbox)
-      elsif user.super_admin? || user.review_manager? || user.regional_review_manager?
+      elsif user.super_admin? || user.review_manager? ||
+            user.regional_review_manager?
         template_versions
       else
         template_versions.where(status: "published")

--- a/app/services/automated_compliance/digital_seal_validator.rb
+++ b/app/services/automated_compliance/digital_seal_validator.rb
@@ -1,15 +1,25 @@
 class AutomatedCompliance::DigitalSealValidator < AutomatedCompliance::Base
   def call(permit_application)
     #if supporting document has compliance run validation on it
-    fields_for_digital_check = permit_application.automated_compliance_requirements_for_module("DigitalSealValidator")
+    fields_for_digital_check =
+      permit_application.automated_compliance_requirements_for_module(
+        "DigitalSealValidator"
+      )
     supporting_doc_ids =
-      permit_application.fetch_file_ids_from_submission_data_matching_requirements(fields_for_digital_check)
+      permit_application.fetch_file_ids_from_submission_data_matching_requirements(
+        fields_for_digital_check
+      )
     regex_pattern = "(#{supporting_doc_ids.join("|")})$"
-    supporting_docs_to_check = permit_application.supporting_documents_without_compliance_matching(regex_pattern)
+    supporting_docs_to_check =
+      permit_application.supporting_documents_without_compliance_matching(
+        regex_pattern
+      )
 
     #return list of field ids that were checked
     supporting_docs_to_check.map do |supporting_document|
-      AutomatedCompliance::SubProcess::DocDigitalSealValidator.new.call(supporting_document)
+      AutomatedCompliance::SubProcess::DocDigitalSealValidator.new.call(
+        supporting_document
+      )
     end
   end
 end

--- a/app/services/automated_compliance/historic_site.rb
+++ b/app/services/automated_compliance/historic_site.rb
@@ -4,7 +4,10 @@ class AutomatedCompliance::HistoricSite < AutomatedCompliance::Base
       raise Errors::GeometryError if permit_application.pid.blank?
 
       # extraction of parcel data can be done via LTSA base
-      attributes = Wrappers::LtsaParcelMapBc.new.historic_site_by_pid(pid: permit_application.pid)
+      attributes =
+        Wrappers::LtsaParcelMapBc.new.historic_site_by_pid(
+          pid: permit_application.pid
+        )
 
       raise Errors::GeometryError if attributes.nil?
 

--- a/app/services/automated_compliance/parcel_info_extractor.rb
+++ b/app/services/automated_compliance/parcel_info_extractor.rb
@@ -1,13 +1,15 @@
 class AutomatedCompliance::ParcelInfoExtractor < AutomatedCompliance::Base
   def call(permit_application)
     begin
-      raise Errors::ParcelError if permit_application.pid.blank? && permit_application.pin.blank?
+      if permit_application.pid.blank? && permit_application.pin.blank?
+        raise Errors::ParcelError
+      end
 
       # extraction of parcel data can be done via LTSA base
       attributes =
         Wrappers::LtsaParcelMapBc.new.get_feature_attributes_by_pid_or_pin(
           pid: permit_application.pid,
-          pin: permit_application.pin,
+          pin: permit_application.pin
         )
 
       raise Errors::ParcelError if attributes.nil?

--- a/app/services/automated_compliance/permit_application.rb
+++ b/app/services/automated_compliance/permit_application.rb
@@ -1,8 +1,10 @@
 class AutomatedCompliance::PermitApplication < AutomatedCompliance::Base
   WHITELISTED_ATTRIBUTES =
-    AutomatedComplianceConfigurationService.available_module_configurations[:PermitApplication][:available_fields]
-      .map { |field| field[:value] }
-      .freeze
+    AutomatedComplianceConfigurationService.available_module_configurations[
+      :PermitApplication
+    ][
+      :available_fields
+    ].map { |field| field[:value] }.freeze
 
   def call(permit_application)
     return if permit_application.full_address.blank?
@@ -12,8 +14,11 @@ class AutomatedCompliance::PermitApplication < AutomatedCompliance::Base
       permit_application
         .automated_compliance_requirements_for_module("PermitApplication")
         .each do |field_id, req|
-          if WHITELISTED_ATTRIBUTES.include?(req.dig("computedCompliance", "value"))
-            value = permit_application.try(req.dig("computedCompliance", "value"))
+          if WHITELISTED_ATTRIBUTES.include?(
+               req.dig("computedCompliance", "value")
+             )
+            value =
+              permit_application.try(req.dig("computedCompliance", "value"))
             if value != permit_application.compliance_data[field_id]
               updated = true
               permit_application.compliance_data[field_id] = value

--- a/app/services/automated_compliance/sub_process/doc_digital_seal_validator.rb
+++ b/app/services/automated_compliance/sub_process/doc_digital_seal_validator.rb
@@ -5,16 +5,28 @@ class AutomatedCompliance::SubProcess::DocDigitalSealValidator < AutomatedCompli
     #stream down the supporting document
     uploaded_file = supporting_document.file
     uploaded_file.open do
-      response = Wrappers::DigitalSealValidator.new.call(uploaded_file.download, uploaded_file.mime_type)
+      response =
+        Wrappers::DigitalSealValidator.new.call(
+          uploaded_file.download,
+          uploaded_file.mime_type
+        )
       if response.success
-        return(supporting_document.update(compliance_data: { status: "success", result: response.signatures }))
+        return(
+          supporting_document.update(
+            compliance_data: {
+              status: "success",
+              result: response.signatures
+            }
+          )
+        )
       else
         return(
           supporting_document.update(
             compliance_data: {
               status: "failed",
-              error: "Unable to run digital seal validator integration - #{response.error}",
-            },
+              error:
+                "Unable to run digital seal validator integration - #{response.error}"
+            }
           )
         )
       end
@@ -22,8 +34,8 @@ class AutomatedCompliance::SubProcess::DocDigitalSealValidator < AutomatedCompli
     supporting_document.update(
       compliance_data: {
         status: "failed",
-        error: "Unable to run digital seal validator integration",
-      },
+        error: "Unable to run digital seal validator integration"
+      }
     )
     #special case
   end

--- a/app/services/automated_compliance_configuration_service.rb
+++ b/app/services/automated_compliance_configuration_service.rb
@@ -4,87 +4,121 @@ class AutomatedComplianceConfigurationService
   AVAILABLE_MODULE_CONFIGURATIONS = {
     DigitalSealValidator: {
       module: "DigitalSealValidator",
-      label: I18n.t("services.auto_compliance_configuration.digital_seal_validator.label"),
+      label:
+        I18n.t(
+          "services.auto_compliance_configuration.digital_seal_validator.label"
+        ),
       default_settings: {
         "trigger" => "on_save",
-        "value_on" => "compliance_data",
+        "value_on" => "compliance_data"
       },
       available_on_input_types: ["file"],
-      type: :file_validator,
+      type: :file_validator
     },
     ParcelInfoExtractor: {
       module: "ParcelInfoExtractor",
-      label: I18n.t("services.auto_compliance_configuration.parcel_info_extractor.label"),
+      label:
+        I18n.t(
+          "services.auto_compliance_configuration.parcel_info_extractor.label"
+        ),
       type: :external_value_extractor,
       available_fields: [
         {
           value: "FEATURE_AREA_SQM",
           label:
-            I18n.t("services.auto_compliance_configuration.parcel_info_extractor.available_field_labels.feature_area"),
-          available_on_input_types: %w[text number],
+            I18n.t(
+              "services.auto_compliance_configuration.parcel_info_extractor.available_field_labels.feature_area"
+            ),
+          available_on_input_types: %w[text number]
         },
         {
           value: "PID",
-          label: I18n.t("services.auto_compliance_configuration.parcel_info_extractor.available_field_labels.pid"),
-          available_on_input_types: %w[text],
+          label:
+            I18n.t(
+              "services.auto_compliance_configuration.parcel_info_extractor.available_field_labels.pid"
+            ),
+          available_on_input_types: %w[text]
         },
         {
           value: "PIN",
-          label: I18n.t("services.auto_compliance_configuration.parcel_info_extractor.available_field_labels.pin"),
-          available_on_input_types: %w[text],
+          label:
+            I18n.t(
+              "services.auto_compliance_configuration.parcel_info_extractor.available_field_labels.pin"
+            ),
+          available_on_input_types: %w[text]
         },
         {
           value: "PLAN_NUMBER",
           label:
-            I18n.t("services.auto_compliance_configuration.parcel_info_extractor.available_field_labels.plan_number"),
-          available_on_input_types: %w[text],
-        },
+            I18n.t(
+              "services.auto_compliance_configuration.parcel_info_extractor.available_field_labels.plan_number"
+            ),
+          available_on_input_types: %w[text]
+        }
       ],
-      available_on_input_types: %w[text number],
+      available_on_input_types: %w[text number]
     },
     PermitApplication: {
       module: "PermitApplication",
-      label: I18n.t("services.auto_compliance_configuration.permit_application.label"),
+      label:
+        I18n.t(
+          "services.auto_compliance_configuration.permit_application.label"
+        ),
       type: :internal_value_extractor,
       available_fields: [
         {
           value: "full_address",
           label:
-            I18n.t("services.auto_compliance_configuration.permit_application.available_field_labels.full_address"),
-          available_on_input_types: %w[text],
+            I18n.t(
+              "services.auto_compliance_configuration.permit_application.available_field_labels.full_address"
+            ),
+          available_on_input_types: %w[text]
         },
         {
           value: "pid",
-          label: I18n.t("services.auto_compliance_configuration.permit_application.available_field_labels.pid"),
-          available_on_input_types: %w[text],
+          label:
+            I18n.t(
+              "services.auto_compliance_configuration.permit_application.available_field_labels.pid"
+            ),
+          available_on_input_types: %w[text]
         },
         {
           value: "pin",
-          label: I18n.t("services.auto_compliance_configuration.permit_application.available_field_labels.pin"),
-          available_on_input_types: %w[text],
-        },
+          label:
+            I18n.t(
+              "services.auto_compliance_configuration.permit_application.available_field_labels.pin"
+            ),
+          available_on_input_types: %w[text]
+        }
       ],
-      available_on_input_types: %w[text],
+      available_on_input_types: %w[text]
     },
     HistoricSite: {
       module: "HistoricSite",
-      label: I18n.t("services.auto_compliance_configuration.historic_site.label"),
+      label:
+        I18n.t("services.auto_compliance_configuration.historic_site.label"),
       type: :external_options_mapper,
       default_settings: {
-        "value" => "HISTORIC_SITE_IND",
+        "value" => "HISTORIC_SITE_IND"
       },
       mappable_external_options: [
         {
           value: "Y",
-          label: I18n.t("services.auto_compliance_configuration.historic_site.mappable_external_option_labels.y"),
+          label:
+            I18n.t(
+              "services.auto_compliance_configuration.historic_site.mappable_external_option_labels.y"
+            )
         },
         {
           value: "N",
-          label: I18n.t("services.auto_compliance_configuration.historic_site.mappable_external_option_labels.n"),
-        },
+          label:
+            I18n.t(
+              "services.auto_compliance_configuration.historic_site.mappable_external_option_labels.n"
+            )
+        }
       ],
-      available_on_input_types: %w[select],
-    },
+      available_on_input_types: %w[select]
+    }
   }
   VALUE_EXTRACTION_TYPES = %i[external_value_extractor internal_value_extractor]
   OPTIONS_MAPPER_TYPES = %i[external_options_mapper]
@@ -102,7 +136,8 @@ class AutomatedComplianceConfigurationService
 
     return unless module_name.present?
 
-    available_module_configuration = available_module_configurations[module_name.to_sym]
+    available_module_configuration =
+      available_module_configurations[module_name.to_sym]
 
     return unless available_module_configuration.present?
 
@@ -121,10 +156,11 @@ class AutomatedComplianceConfigurationService
 
     module_name = computed_compliance["module"]
 
-    unless module_name.present? && available_module_configurations[module_name.to_sym].present?
+    unless module_name.present? &&
+             available_module_configurations[module_name.to_sym].present?
       validation_result[:error] = I18n.t(
         "services.auto_compliance_configuration.validation_errors.incorrect_computed_compliance_module",
-        accepted_values: self.class.available_module_names.join(", "),
+        accepted_values: self.class.available_module_names.join(", ")
       )
       return validation_result
     end
@@ -135,7 +171,7 @@ class AutomatedComplianceConfigurationService
       validation_result[:error] = I18n.t(
         "services.auto_compliance_configuration.validation_errors.incompatible_input_type_for_module",
         module_name: module_name,
-        input_type: requirement.input_type,
+        input_type: requirement.input_type
       )
       return validation_result
     end
@@ -144,15 +180,16 @@ class AutomatedComplianceConfigurationService
          !valid_extraction_field_value?(module_config, computed_compliance)
       validation_result[:error] = I18n.t(
         "services.auto_compliance_configuration.validation_errors.incorrect_value_extraction_field",
-        module_name: module_name,
+        module_name: module_name
       )
       return validation_result
     end
 
-    if is_options_mapper_module_config?(module_config) && !valid_options_map?(module_config, computed_compliance)
+    if is_options_mapper_module_config?(module_config) &&
+         !valid_options_map?(module_config, computed_compliance)
       validation_result[:error] = I18n.t(
         "services.auto_compliance_configuration.validation_errors.incorrect_options_map",
-        module_name: module_name,
+        module_name: module_name
       )
       return validation_result
     end
@@ -162,7 +199,7 @@ class AutomatedComplianceConfigurationService
     unless valid_default_settings?(module_config, computed_compliance)
       validation_result[:error] = I18n.t(
         "services.auto_compliance_configuration.validation_errors.default_settings_not_valid",
-        module_name: module_name,
+        module_name: module_name
       )
     end
 
@@ -215,14 +252,26 @@ class AutomatedComplianceConfigurationService
     options_map = computed_compliance["options_map"]
     value_options = requirement.value_options
 
-    return false unless value_options.present? && value_options.is_a?(Array) && !value_options.empty?
+    unless value_options.present? && value_options.is_a?(Array) &&
+             !value_options.empty?
+      return false
+    end
 
-    return false unless options_map.present? && options_map.is_a?(Hash) && !options_map.empty?
+    unless options_map.present? && options_map.is_a?(Hash) &&
+             !options_map.empty?
+      return false
+    end
 
     is_valid_options_map =
       options_map.all? do |external_option_value, requirement_option_value|
-        external_option_valid = mappable_external_options.any? { |option| option[:value] == external_option_value }
-        requirement_option_valid = value_options.any? { |option| option["value"] == requirement_option_value }
+        external_option_valid =
+          mappable_external_options.any? do |option|
+            option[:value] == external_option_value
+          end
+        requirement_option_valid =
+          value_options.any? do |option|
+            option["value"] == requirement_option_value
+          end
 
         external_option_valid && requirement_option_valid
       end

--- a/app/services/constants/notification_action_types.rb
+++ b/app/services/constants/notification_action_types.rb
@@ -3,14 +3,17 @@ module Constants
     NEW_TEMPLATE_VERSION_PUBLISH = "new_template_version_publish"
     CUSTOMIZATION_UPDATE = "customization_update"
     SUBMISSION_COLLABORATION_ASSIGNMENT = "submission_collaboration_assignment"
-    SUBMISSION_COLLABORATION_UNASSIGNMENT = "submission_collaboration_unassignment"
+    SUBMISSION_COLLABORATION_UNASSIGNMENT =
+      "submission_collaboration_unassignment"
     REVIEW_COLLABORATION_ASSIGNMENT = "review_collaboration_assignment"
     REVIEW_COLLABORATION_UNASSIGNMENT = "review_collaboration_unassignment"
     PERMIT_BLOCK_STATUS_READY = "permit_block_status_ready"
     APPLICATION_SUBMISSION = "application_submission"
     APPLICATION_REVISIONS_REQUEST = "application_revisions_request"
     APPLICATION_VIEW = "application_view"
-    PUBLISHED_TEMPLATE_MISSING_REQUIREMENTS_MAPPING = "published_template_missing_requirements_mapping"
-    SCHEDULED_TEMPLATE_MISSING_REQUIREMENTS_MAPPING = "scheduled_template_missing_requirements_mapping"
+    PUBLISHED_TEMPLATE_MISSING_REQUIREMENTS_MAPPING =
+      "published_template_missing_requirements_mapping"
+    SCHEDULED_TEMPLATE_MISSING_REQUIREMENTS_MAPPING =
+      "scheduled_template_missing_requirements_mapping"
   end
 end

--- a/app/services/constants/websockets.rb
+++ b/app/services/constants/websockets.rb
@@ -10,7 +10,7 @@ module Constants
         TYPES = {
           update_compliance: :update_compliance,
           update_supporting_documents: :update_supporting_documents,
-          update_permit_block_status: :update_permit_block_status,
+          update_permit_block_status: :update_permit_block_status
         }.freeze
       end
 

--- a/app/services/customization_copy_service.rb
+++ b/app/services/customization_copy_service.rb
@@ -1,7 +1,15 @@
 class CustomizationCopyService
-  attr_accessor :from_template_version, :to_template_version, :jurisdiction, :sandbox
+  attr_accessor :from_template_version,
+                :to_template_version,
+                :jurisdiction,
+                :sandbox
 
-  def initialize(from_template_version, to_template_version, jurisdiction, sandbox)
+  def initialize(
+    from_template_version,
+    to_template_version,
+    jurisdiction,
+    sandbox
+  )
     @from_template_version = from_template_version
     @to_template_version = to_template_version
     @jurisdiction = jurisdiction
@@ -17,10 +25,14 @@ class CustomizationCopyService
         from_customization.customizations["requirement_block_changes"],
         to_customization.customizations["requirement_block_changes"] || {},
         include_electives,
-        include_tips,
+        include_tips
       )
 
-    to_customization.update!(customizations: { "requirement_block_changes" => merged_customizations })
+    to_customization.update!(
+      customizations: {
+        "requirement_block_changes" => merged_customizations
+      }
+    )
     to_customization
   end
 
@@ -30,7 +42,7 @@ class CustomizationCopyService
     JurisdictionTemplateVersionCustomization.find_by!(
       template_version_id: template_version.id,
       jurisdiction_id: @jurisdiction.id,
-      sandbox: @sandbox,
+      sandbox: @sandbox
     )
   end
 
@@ -38,11 +50,18 @@ class CustomizationCopyService
     JurisdictionTemplateVersionCustomization.find_or_create_by!(
       template_version_id: template_version.id,
       jurisdiction_id: @jurisdiction.id,
-      sandbox: @sandbox,
-    ) { |customization| customization.customizations = { "requirement_block_changes" => {} } }
+      sandbox: @sandbox
+    ) do |customization|
+      customization.customizations = { "requirement_block_changes" => {} }
+    end
   end
 
-  def merge_customizations(from_blocks, to_blocks, include_electives, include_tips)
+  def merge_customizations(
+    from_blocks,
+    to_blocks,
+    include_electives,
+    include_tips
+  )
     merged_blocks = to_blocks.deep_dup
 
     from_blocks.each do |block_id, changes|
@@ -51,8 +70,12 @@ class CustomizationCopyService
       merged_blocks[block_id]["tip"] = changes["tip"] if include_tips
 
       if include_electives
-        merged_blocks[block_id]["enabled_elective_field_ids"] = changes["enabled_elective_field_ids"] || []
-        merged_blocks[block_id]["enabled_elective_field_reasons"] = changes["enabled_elective_field_reasons"] || {}
+        merged_blocks[block_id]["enabled_elective_field_ids"] = changes[
+          "enabled_elective_field_ids"
+        ] || []
+        merged_blocks[block_id]["enabled_elective_field_reasons"] = changes[
+          "enabled_elective_field_reasons"
+        ] || {}
       end
     end
 

--- a/app/services/eula_updater.rb
+++ b/app/services/eula_updater.rb
@@ -19,7 +19,10 @@ class EulaUpdater
         eula =
           (
             if should_override_existing
-              EndUserLicenseAgreement.find_or_initialize_by(active: true, variant: variant)
+              EndUserLicenseAgreement.find_or_initialize_by(
+                active: true,
+                variant: variant
+              )
             else
               EndUserLicenseAgreement.build(active: true, variant: variant)
             end

--- a/app/services/external_permit_application_service.rb
+++ b/app/services/external_permit_application_service.rb
@@ -21,14 +21,18 @@ class ExternalPermitApplicationService
   #                 }>>
   #   }>
   def formatted_submission_data_for_external_use
-    unless self.permit_application.submission_data.present? && self.permit_application.submission_data["data"].present?
+    unless self.permit_application.submission_data.present? &&
+             self.permit_application.submission_data["data"].present?
       return {}
     end
 
-    cloned_submission_data = self.permit_application.submission_data["data"].deep_dup
+    cloned_submission_data =
+      self.permit_application.submission_data["data"].deep_dup
 
     # formats single_contact submissions into array of contact objects, similar to the multi_contact submissions
-    process_single_contact_submission_data_to_common_format!(cloned_submission_data)
+    process_single_contact_submission_data_to_common_format!(
+      cloned_submission_data
+    )
 
     formatted_submission_data = {}
 
@@ -57,7 +61,7 @@ class ExternalPermitApplicationService
             requirement_block_code: requirement_block["sku"],
             name: requirement_block["name"],
             description: requirement_block["description"],
-            requirements: [],
+            requirements: []
           }
         end
 
@@ -94,12 +98,13 @@ class ExternalPermitApplicationService
           name: requirement["label"],
           requirement_code: requirement["requirement_code"],
           type: requirement["input_type"],
-          value: formatted_value,
+          value: formatted_value
         }
       end
     end
 
-    remaining_energy_step_code_submission = form_remaining_energy_step_code_submission_data
+    remaining_energy_step_code_submission =
+      form_remaining_energy_step_code_submission_data
 
     if remaining_energy_step_code_submission.present?
       formatted_submission_data.merge!(remaining_energy_step_code_submission)
@@ -109,11 +114,16 @@ class ExternalPermitApplicationService
   end
 
   def get_requirement_block_json(requirement_block_id)
-    self.permit_application.template_version.requirement_blocks_json[requirement_block_id]
+    self.permit_application.template_version.requirement_blocks_json[
+      requirement_block_id
+    ]
   end
 
   def get_raw_h2k_files
-    return nil unless permit_application.step_code.present? && !permit_application.step_code.data_entries.empty?
+    unless permit_application.step_code.present? &&
+             !permit_application.step_code.data_entries.empty?
+      return nil
+    end
 
     permit_application
       .step_code
@@ -127,7 +137,7 @@ class ExternalPermitApplicationService
           name: data_entry.h2k_file_name,
           type: data_entry.h2k_file_type,
           size: data_entry.h2k_file_size,
-          url: data_entry.h2k_file_url,
+          url: data_entry.h2k_file_url
         }
       end
       .compact
@@ -171,11 +181,15 @@ class ExternalPermitApplicationService
         # create a new key and value pair, to collect the fragmented single_contact field values into a single array,
         # with one contact object.
 
-        contact_submissions_to_merge[formatted_requirement_key] = [{}] unless contact_submissions_to_merge[
+        contact_submissions_to_merge[formatted_requirement_key] = [
+          {}
+        ] unless contact_submissions_to_merge[
           formatted_requirement_key
         ].present?
 
-        contact_submissions_to_merge[formatted_requirement_key].first[contact_property_key] = submitted_value
+        contact_submissions_to_merge[formatted_requirement_key].first[
+          contact_property_key
+        ] = submitted_value
 
         # delete the original single_contact key value pair from the submission data
         submission_data[section_key].delete(submitted_field_key)
@@ -229,7 +243,7 @@ class ExternalPermitApplicationService
           name: file_data&.dig("metadata", "filename"),
           type: file_data["type"],
           size: file_data["size"],
-          url: file_model.file_url,
+          url: file_model.file_url
         }
       end
       .compact
@@ -243,7 +257,9 @@ class ExternalPermitApplicationService
     return nil unless latest_submission_version.present?
 
     checklist_document =
-      latest_submission_version.supporting_documents.find_by(data_key: PermitApplication::CHECKLIST_PDF_DATA_KEY)
+      latest_submission_version.supporting_documents.find_by(
+        data_key: PermitApplication::CHECKLIST_PDF_DATA_KEY
+      )
 
     return nil unless checklist_document.present?
 
@@ -258,8 +274,8 @@ class ExternalPermitApplicationService
         name: checklist_document.file_name,
         type: checklist_document.file_type,
         size: checklist_document.file_size,
-        url: checklist_document.file_url,
-      },
+        url: checklist_document.file_url
+      }
     ]
 
     {
@@ -273,9 +289,9 @@ class ExternalPermitApplicationService
           name: "Energy step code documents",
           requirement_code: "energy_step_code_documents",
           type: :file,
-          value: file_values,
-        },
-      ],
+          value: file_values
+        }
+      ]
     }
   end
 end

--- a/app/services/jurisdiction/user_inviter.rb
+++ b/app/services/jurisdiction/user_inviter.rb
@@ -17,19 +17,33 @@ class Jurisdiction::UserInviter
 
   def invite_users
     users_params.each do |user_params|
-      user = User.where.not(role: :submitter).find_by(email: user_params[:email].strip)
-      is_regional_rm = user&.regional_review_manager? || (user && user_params[:role].to_sym == :regional_review_manager)
+      user =
+        User
+          .where.not(role: :submitter)
+          .find_by(email: user_params[:email].strip)
+      is_regional_rm =
+        user&.regional_review_manager? ||
+          (user && user_params[:role].to_sym == :regional_review_manager)
 
-      if user.present? && !user.discarded? && user.confirmed? && (!is_regional_rm || user.super_admin?)
+      if user.present? && !user.discarded? && user.confirmed? &&
+           (!is_regional_rm || user.super_admin?)
         self.results[:email_taken] << user
-      elsif user && is_regional_rm && jurisdiction_id = user_params[:jurisdiction_id]
-        user.update(role: :regional_review_manager) if !user.regional_review_manager?
+      elsif user && is_regional_rm &&
+            jurisdiction_id = user_params[:jurisdiction_id]
+        if !user.regional_review_manager?
+          user.update(role: :regional_review_manager)
+        end
         membership =
           user
             .jurisdiction_memberships
             .where(jurisdiction_id:)
             .first_or_create do |m|
-              PermitHubMailer.new_jurisdiction_membership(user, jurisdiction_id).deliver_later if user.confirmed?
+              if user.confirmed?
+                PermitHubMailer.new_jurisdiction_membership(
+                  user,
+                  jurisdiction_id
+                ).deliver_later
+              end
             end
         # The purpose of touch is to allow the jurisdiction to be obtained in the user blueprint invited_user view
         membership.touch
@@ -42,8 +56,18 @@ class Jurisdiction::UserInviter
           user.invite!(inviter)
           self.results[:reinvited] << user
         elsif inviter.invitable_roles.include?(user_params[:role].to_s)
-          jurisdiction_id = user_params.delete(:jurisdiction_id) || inviter.jurisdictions.pluck(:id)
-          user = User.new(user_params.merge({ discarded_at: nil, jurisdiction_ids: [jurisdiction_id].flatten }))
+          jurisdiction_id =
+            user_params.delete(:jurisdiction_id) ||
+              inviter.jurisdictions.pluck(:id)
+          user =
+            User.new(
+              user_params.merge(
+                {
+                  discarded_at: nil,
+                  jurisdiction_ids: [jurisdiction_id].flatten
+                }
+              )
+            )
           user.skip_confirmation_notification!
           user.save!
           user.invite!(inviter)

--- a/app/services/jurisdiction_seeder.rb
+++ b/app/services/jurisdiction_seeder.rb
@@ -3,17 +3,30 @@ require "csv"
 class JurisdictionSeeder
   def self.seed
     @current_regional_district = nil
-    CSV.foreach("docs/csv/jurisdictions.csv", headers: true, header_converters: :symbol) do |row|
+    CSV.foreach(
+      "docs/csv/jurisdictions.csv",
+      headers: true,
+      header_converters: :symbol
+    ) do |row|
       next unless row[:name].present?
 
       is_rd = row[:locality_type] == "regional district"
       type = is_rd ? "RegionalDistrict" : "SubDistrict"
 
-      raise ActiveRecord::RecordInvalid if row[:regional_district].present? && is_rd
-      j = Jurisdiction.find_or_create_by!(name: row[:name], locality_type: row[:locality_type], type: type)
+      if row[:regional_district].present? && is_rd
+        raise ActiveRecord::RecordInvalid
+      end
+      j =
+        Jurisdiction.find_or_create_by!(
+          name: row[:name],
+          locality_type: row[:locality_type],
+          type: type
+        )
       j.incorporation_date = row[:incorporation_date]
       j.postal_address = row[:postal_address]
-      j.regional_district = @current_regional_district if row[:regional_district] == @current_regional_district&.name &&
+      j.regional_district = @current_regional_district if row[
+        :regional_district
+      ] == @current_regional_district&.name &&
         @current_regional_district.present?
       j.save
 

--- a/app/services/omniauth_user_resolver.rb
+++ b/app/services/omniauth_user_resolver.rb
@@ -16,7 +16,12 @@ class OmniauthUserResolver
 
   private
 
-  OMNIAUTH_PROVIDERS = { idir: "idir", bceid: "bceidboth", bceid_business: "bceidbusiness", bceid_basic: "bceidbasic" }
+  OMNIAUTH_PROVIDERS = {
+    idir: "idir",
+    bceid: "bceidboth",
+    bceid_business: "bceidbusiness",
+    bceid_basic: "bceidbasic"
+  }
 
   def resolve_user
     if should_promote_user?
@@ -48,7 +53,7 @@ class OmniauthUserResolver
         omniauth_provider:,
         omniauth_uid:,
         omniauth_email:,
-        omniauth_username:,
+        omniauth_username:
       )
     # skip confirmation until user has a chance to add/verify their notification email
     u.skip_confirmation_notification!
@@ -64,7 +69,7 @@ class OmniauthUserResolver
       omniauth_provider:,
       omniauth_uid:,
       omniauth_email:,
-      omniauth_username:,
+      omniauth_username:
     )
     invited_user.accept_invitation! if invited_user.valid?
   end
@@ -83,7 +88,11 @@ class OmniauthUserResolver
     @provider ||=
       case raw_info.identity_provider
       when OMNIAUTH_PROVIDERS[:bceid]
-        raw_info.bceid_business_guid ? OMNIAUTH_PROVIDERS[:bceid_business] : OMNIAUTH_PROVIDERS[:bceid_basic]
+        if raw_info.bceid_business_guid
+          OMNIAUTH_PROVIDERS[:bceid_business]
+        else
+          OMNIAUTH_PROVIDERS[:bceid_basic]
+        end
       else
         raw_info.identity_provider
       end

--- a/app/services/permit_application/form_json_service.rb
+++ b/app/services/permit_application/form_json_service.rb
@@ -23,12 +23,16 @@ class PermitApplication::FormJsonService
     form_json["components"].each do |component|
       next unless component["components"].present?
 
-      component["components"].delete_if { |sub_component| empty_block_ids.include?(sub_component["id"]) }
+      component["components"].delete_if do |sub_component|
+        empty_block_ids.include?(sub_component["id"])
+      end
     end
   end
 
   def remove_empty_sections
-    form_json["components"].delete_if { |component| component["components"].blank? || component["components"].empty? }
+    form_json["components"].delete_if do |component|
+      component["components"].blank? || component["components"].empty?
+    end
 
     form_json
   end
@@ -36,11 +40,17 @@ class PermitApplication::FormJsonService
   def set_step_code_requirement(hash = form_json)
     if hash.is_a?(Hash)
       if energy_step_keys.any? { |key| hash["key"]&.end_with?(key) }
-        hash["validate"] = { "required" => permit_application.energy_step_code_required? }
+        hash["validate"] = {
+          "required" => permit_application.energy_step_code_required?
+        }
       end
     end
 
-    hash["components"].each { |component| set_step_code_requirement(component) } if hash["components"].is_a?(Array)
+    if hash["components"].is_a?(Array)
+      hash["components"].each do |component|
+        set_step_code_requirement(component)
+      end
+    end
   end
 
   def energy_step_keys
@@ -60,7 +70,10 @@ class PermitApplication::FormJsonService
         .map do |rb_id, requirement_block|
           next if requirement_block["requirements"].blank?
 
-          has_only_elective_fields = requirement_block["requirements"].all? { |requirement| requirement["elective"] }
+          has_only_elective_fields =
+            requirement_block["requirements"].all? do |requirement|
+              requirement["elective"]
+            end
 
           next unless has_only_elective_fields
 
@@ -68,7 +81,7 @@ class PermitApplication::FormJsonService
             permit_application.form_customizations&.dig(
               "requirement_block_changes",
               rb_id,
-              "enabled_elective_field_ids",
+              "enabled_elective_field_ids"
             ) || []
 
           # remove the block if no elective fields are enabled
@@ -77,7 +90,9 @@ class PermitApplication::FormJsonService
           # This check is to ensure that the enabled elective fields are valid, i.e. they exist in the requirement block
           any_enabled_elective_field_valid =
             enabled_elective_field_ids.any? do |elective_field_id|
-              requirement_block["requirements"].any? { |requirement| elective_field_id == requirement["id"] }
+              requirement_block["requirements"].any? do |requirement|
+                elective_field_id == requirement["id"]
+              end
             end
 
           # remove the block if no enabled elective fields are valid
@@ -88,13 +103,18 @@ class PermitApplication::FormJsonService
     # If the user is not passed in then we don't remove requirement blocks based on further collaboration permissions.
     return @empty_block_ids if current_user.blank?
 
-    permissions = permit_application.submission_requirement_block_edit_permissions(user_id: current_user.id) || []
+    permissions =
+      permit_application.submission_requirement_block_edit_permissions(
+        user_id: current_user.id
+      ) || []
 
     return @empty_block_ids if permissions == :all
 
-    requirement_block_ids = permit_application&.template_version&.requirement_blocks_json&.keys || []
+    requirement_block_ids =
+      permit_application&.template_version&.requirement_blocks_json&.keys || []
 
-    @empty_block_ids = (@empty_block_ids + (requirement_block_ids - permissions)).uniq
+    @empty_block_ids =
+      (@empty_block_ids + (requirement_block_ids - permissions)).uniq
 
     @empty_block_ids
   end

--- a/app/services/permit_application/submission_data_service.rb
+++ b/app/services/permit_application/submission_data_service.rb
@@ -9,41 +9,53 @@ class PermitApplication::SubmissionDataService
     submission_data ||= permit_application.submission_data
 
     filtered_submission =
-      filter_submission_data_based_on_user_permissions(submission_data: submission_data, user: current_user)
+      filter_submission_data_based_on_user_permissions(
+        submission_data: submission_data,
+        user: current_user
+      )
 
-    completion_section_value = submission_data.dig("data", PermitApplication::COMPLETION_SECTION_KEY)
+    completion_section_value =
+      submission_data.dig("data", PermitApplication::COMPLETION_SECTION_KEY)
 
     # If the completion section is present, we want to include it in the submission data
     # as collaborators are able to view this. They aren't able to update it. So that's
     # why it is removed in the filtered submission_data
     if completion_section_value.present?
-      filtered_submission["data"][PermitApplication::COMPLETION_SECTION_KEY] = submission_data.dig(
-        "data",
-        PermitApplication::COMPLETION_SECTION_KEY,
-      )
+      filtered_submission["data"][
+        PermitApplication::COMPLETION_SECTION_KEY
+      ] = submission_data.dig("data", PermitApplication::COMPLETION_SECTION_KEY)
     end
 
     filtered_submission
   end
 
-  def update_with_submission_data_merge(permit_application_params:, current_user: nil)
-    return permit_application.update(permit_application_params) if current_user.blank?
+  def update_with_submission_data_merge(
+    permit_application_params:,
+    current_user: nil
+  )
+    if current_user.blank?
+      return permit_application.update(permit_application_params)
+    end
 
     permit_application.with_lock do
       permissions_filtered_submission_data =
         filter_submission_data_based_on_user_permissions(
           submission_data: permit_application_params[:submission_data],
-          user: current_user,
+          user: current_user
         )
 
       merged_submission_data = permit_application.submission_data.deep_dup
 
       merged_submission_data["data"] ||= {}
 
-      permissions_filtered_submission_data["data"]&.each do |section_key, section_values|
+      permissions_filtered_submission_data[
+        "data"
+      ]&.each do |section_key, section_values|
         merged_submission_data["data"][section_key] ||= {}
 
-        section_values.each { |key, value| merged_submission_data["data"][section_key][key] = value }
+        section_values.each do |key, value|
+          merged_submission_data["data"][section_key][key] = value
+        end
       end
 
       permit_application_params[:submission_data] = merged_submission_data
@@ -60,7 +72,10 @@ class PermitApplication::SubmissionDataService
 
     return formatted_data unless user.present?
 
-    permissions = permit_application.submission_requirement_block_edit_permissions(user_id: user.id)
+    permissions =
+      permit_application.submission_requirement_block_edit_permissions(
+        user_id: user.id
+      )
 
     return formatted_data if permissions == :all
 

--- a/app/services/permit_classification_seeder.rb
+++ b/app/services/permit_classification_seeder.rb
@@ -8,21 +8,21 @@ class PermitClassificationSeeder
         description:
           "Single detached, duplex, triplex / fourplex / townhouse, secondary suite, accessory dwelling unit (ADU) e.g. garden suite",
         enabled: true,
-        type: "PermitType",
+        type: "PermitType"
       },
       {
         name: "4+ Unit housing",
         code: "medium_residential",
         description: "Part 9 townhouses, small apartment buildings",
         enabled: false,
-        type: "PermitType",
+        type: "PermitType"
       },
       {
         name: "High density apartment buildings",
         code: "high_residential",
         description: "Highest density residential structures",
         enabled: true,
-        type: "PermitType",
+        type: "PermitType"
       },
       {
         name: "New Construction",
@@ -30,7 +30,7 @@ class PermitClassificationSeeder
         description:
           "Includes the addition to an existing building (infill development) but not the renovation of an existing home to include a secondary suite.",
         enabled: true,
-        type: "Activity",
+        type: "Activity"
       },
       {
         name: "Addition, Alteration, or Renovation",
@@ -38,7 +38,7 @@ class PermitClassificationSeeder
         description:
           "Modification of an existing residential dwelling to include a (secondary) suite (within the existing building footprint).",
         enabled: true,
-        type: "Activity",
+        type: "Activity"
       },
       {
         name: "Site Alteration",
@@ -46,7 +46,7 @@ class PermitClassificationSeeder
         description:
           "Modifies land contours through grading, excavation, or preparation for construction projects. This process involves adjusting the earth to support new structures or landscaping.",
         enabled: true,
-        type: "Activity",
+        type: "Activity"
       },
       {
         name: "Demolition",
@@ -54,14 +54,15 @@ class PermitClassificationSeeder
         description:
           "Involves the systematic tearing down of buildings and other structures, including clearing debris and preparing the site for future construction or restoration activities.",
         enabled: true,
-        type: "Activity",
-      },
+        type: "Activity"
+      }
     ]
 
     # Create Classifications
     classifications.each do |classification_attrs|
       # Attempt to find the Activity by code
-      classification = PermitClassification.find_by(code: classification_attrs[:code])
+      classification =
+        PermitClassification.find_by(code: classification_attrs[:code])
       if classification
         # If found, update the attributes
         classification.update(classification_attrs)

--- a/app/services/permit_type_required_step_seeder.rb
+++ b/app/services/permit_type_required_step_seeder.rb
@@ -2,7 +2,10 @@ class PermitTypeRequiredStepSeeder
   def self.seed
     Jurisdiction.find_each do |jurisdiction|
       PermitType.find_each do |permit_type|
-        PermitTypeRequiredStep.find_or_create_by!(jurisdiction: jurisdiction, permit_type: permit_type) do |ptr_step|
+        PermitTypeRequiredStep.find_or_create_by!(
+          jurisdiction: jurisdiction,
+          permit_type: permit_type
+        ) do |ptr_step|
           ptr_step.default = true
           ptr_step.energy_step_required =
             (

--- a/app/services/permit_webhook_service.rb
+++ b/app/services/permit_webhook_service.rb
@@ -7,13 +7,13 @@ class PermitWebhookService
     unless external_api_key.webhook_url.present?
       raise PermitWebhookError.new(
               "Webhook URL is not present for external API key with ID: #{external_api_key.id}
-and name: #{external_api_key.name}",
+and name: #{external_api_key.name}"
             )
     end
 
     unless external_api_key.enabled?
       raise PermitWebhookError.new(
-              "External API key with ID: #{external_api_key.id} and name: #{external_api_key.name} is not enabled.",
+              "External API key with ID: #{external_api_key.id} and name: #{external_api_key.name} is not enabled."
             )
     end
 
@@ -30,7 +30,9 @@ and name: #{external_api_key.name}",
     permit_application = PermitApplication.find(permit_id)
 
     unless permit_application.submitted?
-      raise PermitWebhookError.new("Permit application with ID #{permit_id} is not submitted.")
+      raise PermitWebhookError.new(
+              "Permit application with ID #{permit_id} is not submitted."
+            )
     end
 
     payload = {
@@ -44,8 +46,8 @@ and name: #{external_api_key.name}",
         ),
       payload: {
         permit_id: permit_id,
-        submitted_at: permit_application.submitted_at,
-      },
+        submitted_at: permit_application.submitted_at
+      }
     }
 
     send_webhook(payload)
@@ -59,7 +61,7 @@ and name: #{external_api_key.name}",
       response.success?
     rescue Faraday::Error => e
       raise PermitWebhookError.new(
-              "Failed to send #{payload[:event]} webhook to #{external_api_key.webhook_url}: #{e.message}",
+              "Failed to send #{payload[:event]} webhook to #{external_api_key.webhook_url}: #{e.message}"
             )
     end
   end

--- a/app/services/promote_user.rb
+++ b/app/services/promote_user.rb
@@ -30,7 +30,8 @@ class PromoteUser
 
     invited_user_params = invited_user.slice(accepted_params)
 
-    jurisdiction_ids = existing_user.jurisdiction_ids + invited_user.jurisdiction_ids
+    jurisdiction_ids =
+      existing_user.jurisdiction_ids + invited_user.jurisdiction_ids
     existing_user.assign_attributes(invited_user_params)
     if existing_user.valid?
       ActiveRecord::Base.transaction do
@@ -45,7 +46,9 @@ class PromoteUser
   def merge_collaborations
     invited_user.collaborations.each do |invited_user_collaborator|
       existing_user_collaborator =
-        existing_user.collaborations.find_by(collaboratorable: invited_user_collaborator.collaboratorable)
+        existing_user.collaborations.find_by(
+          collaboratorable: invited_user_collaborator.collaboratorable
+        )
 
       # if the existing_user is not already a collaborator on the same record
       # then update the invited_user's collaborator record to use the existing_user
@@ -56,20 +59,28 @@ class PromoteUser
 
       # if the existing_user is already a collaborator on the same record
       # then update the invited_users permit collaborations with this existing_user
-      invited_user_collaborator.permit_collaborations.each do |invited_user_permit_collaboration|
+      invited_user_collaborator
+        .permit_collaborations
+        .each do |invited_user_permit_collaboration|
         existing_user_permit_collaboration =
           existing_user_collaborator.permit_collaborations.find_by(
-            permit_application: invited_user_permit_collaboration.permit_application,
-            collaboration_type: invited_user_permit_collaboration.collaboration_type,
-            collaborator_type: invited_user_permit_collaboration.collaborator_type,
-            assigned_requirement_block_id: invited_user_permit_collaboration.assigned_requirement_block_id,
+            permit_application:
+              invited_user_permit_collaboration.permit_application,
+            collaboration_type:
+              invited_user_permit_collaboration.collaboration_type,
+            collaborator_type:
+              invited_user_permit_collaboration.collaborator_type,
+            assigned_requirement_block_id:
+              invited_user_permit_collaboration.assigned_requirement_block_id
           )
 
         # if the existing_user is already a collaborator on the same permit application record, collaboration type, and collaborator type and assigned requirement block
         # then skip this record as it is already being managed by the existing_user
         next if existing_user_permit_collaboration.present?
 
-        invited_user_permit_collaboration.update(collaborator: existing_user_collaborator)
+        invited_user_permit_collaboration.update(
+          collaborator: existing_user_collaborator
+        )
       end
     end
 

--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -3,39 +3,39 @@ class RequirementFormJsonService
 
   DEFAULT_FORMIO_TYPE_TO_OPTIONS = {
     text: {
-      type: "simpletextfield",
+      type: "simpletextfield"
     },
     phone: {
-      type: "simplephonenumber",
+      type: "simplephonenumber"
     },
     email: {
-      type: "simpleemail",
+      type: "simpleemail"
     },
     # TODO: figure out why these address fields don't work
     # address: {
     #   type: "simpleaddressadvanced",
     # },
     address: {
-      type: "simpletextfield",
+      type: "simpletextfield"
     },
     bcaddress: {
-      type: "bcaddress",
+      type: "bcaddress"
     },
     signature: {
-      type: "simplesignatureadvanced",
+      type: "simplesignatureadvanced"
     },
     number: {
       delimiter: true,
       applyMaskOn: "change",
       mask: false,
-      inputFormat: "plain",
+      inputFormat: "plain"
     },
     date: {
       tableView: false,
       enableTime: false,
       datePicker: {
         disableWeekends: false,
-        disableWeekdays: false,
+        disableWeekdays: false
       },
       enableMinDateInput: false,
       enableMaxDateInput: false,
@@ -57,19 +57,19 @@ class RequirementFormJsonService
         minDate: nil,
         disableWeekends: false,
         disableWeekdays: false,
-        maxDate: nil,
-      },
+        maxDate: nil
+      }
     },
     select: {
       widget: {
-        type: "choicesjs",
-      },
+        type: "choicesjs"
+      }
     },
     multi_option_select: {
       type: "selectboxes",
       inputType: "checkbox",
       optionsLabelPosition: "right",
-      tableView: false,
+      tableView: false
       # type: "select",
       # multiple: true,
       # widget: {
@@ -81,8 +81,8 @@ class RequirementFormJsonService
       action: "custom",
       title: I18n.t("formio.requirement_template.energy_step_code"),
       label: I18n.t("formio.requirement_template.energy_step_code"),
-      custom: "document.dispatchEvent(new Event('openStepCode'));",
-    },
+      custom: "document.dispatchEvent(new Event('openStepCode'));"
+    }
   }
 
   def initialize(requirement)
@@ -91,7 +91,8 @@ class RequirementFormJsonService
 
   def to_form_json(requirement_block_key = requirement&.requirement_block&.key)
     json =
-      if requirement.input_type_general_contact? || requirement.input_type_professional_contact?
+      if requirement.input_type_general_contact? ||
+           requirement.input_type_professional_contact?
         get_contact_form_json(requirement_block_key)
       elsif requirement.input_type_pid_info?
         get_pid_info_components(requirement_block_key, requirement.required)
@@ -104,8 +105,8 @@ class RequirementFormJsonService
           input: true,
           label: requirement.label,
           widget: {
-            type: "input",
-          },
+            type: "input"
+          }
         }.merge!(formio_type_options)
       end
 
@@ -116,18 +117,27 @@ class RequirementFormJsonService
     # assume all electives use a customConditional that defaults to false.  The customConditional works in tandem with the conditionals
     json.merge!({ elective: requirement.elective }) if requirement.elective
 
-    json.merge!({ data: { values: requirement.input_options["value_options"] } }) if requirement.input_type_select?
+    if requirement.input_type_select?
+      json.merge!(
+        { data: { values: requirement.input_options["value_options"] } }
+      )
+    end
 
-    if requirement.input_type_multi_option_select? || requirement.input_type_radio?
+    if requirement.input_type_multi_option_select? ||
+         requirement.input_type_radio?
       json.merge!({ values: requirement.input_options["value_options"] })
     end
 
     if requirement.computed_compliance?
-      json.merge!({ computedCompliance: requirement.input_options["computed_compliance"] })
+      json.merge!(
+        { computedCompliance: requirement.input_options["computed_compliance"] }
+      )
     end
 
     if requirement.input_type.to_sym == :energy_step_code
-      json.merge!({ energyStepCode: requirement.input_options["energy_step_code"] })
+      json.merge!(
+        { energyStepCode: requirement.input_options["energy_step_code"] }
+      )
     end
 
     if requirement.input_options["conditional"].present?
@@ -135,28 +145,44 @@ class RequirementFormJsonService
       conditional = requirement.input_options["conditional"].clone
       section = PermitApplication.section_from_key(requirement_block_key)
       if conditional["when"].present?
-        conditional.merge!("when" => "#{section}.#{requirement_block_key}|#{conditional["when"]}")
+        conditional.merge!(
+          "when" => "#{section}.#{requirement_block_key}|#{conditional["when"]}"
+        )
       end
       json.merge!({ conditional: conditional })
     end
 
     # indicates code-based conditionals.  Always merge elective show = false to end.
     if requirement.input_options["customConditional"].present?
-      json.merge!({ customConditional: requirement.input_options["customConditional"] })
+      json.merge!(
+        { customConditional: requirement.input_options["customConditional"] }
+      )
     end
-    json.merge!({ customConditional: "#{json[:customConditional]};show = false" }) if requirement.elective
+    if requirement.elective
+      json.merge!(
+        { customConditional: "#{json[:customConditional]};show = false" }
+      )
+    end
 
     json
   end
 
   private
 
-  def get_contact_form_json(requirement_block_key = requirement&.requirement_block&.key)
-    return {} unless requirement.input_type_general_contact? || requirement.input_type_professional_contact?
+  def get_contact_form_json(
+    requirement_block_key = requirement&.requirement_block&.key
+  )
+    unless requirement.input_type_general_contact? ||
+             requirement.input_type_professional_contact?
+      return {}
+    end
 
     if requirement.input_options["can_add_multiple_contacts"].blank?
       return(
-        get_contact_field_set_form_json("#{requirement.key(requirement_block_key)}|#{requirement.input_type}", false)
+        get_contact_field_set_form_json(
+          "#{requirement.key(requirement_block_key)}|#{requirement.input_type}",
+          false
+        )
       )
     end
 
@@ -176,19 +202,19 @@ class RequirementFormJsonService
       label: I18n.t("formio.requirement.contact.#{field_type.to_s}"),
       type: "textfield",
       validate: {
-        required: required,
+        required: required
       },
-      **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:text],
+      **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:text]
     }
 
     # TODO: address is a text now, replace with address type when implemented
     field_to_form_json = {
       email: {
-        **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:email],
+        **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:email]
       },
       phone: {
-        **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:phone],
-      },
+        **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:phone]
+      }
     }
 
     form_json =
@@ -210,12 +236,15 @@ class RequirementFormJsonService
       key: key,
       type: "columns",
       input: false,
-      tableView: false,
+      tableView: false
     }
   end
 
   def get_contact_field_set_form_json(key, is_multi)
-    return {} unless requirement.input_type_general_contact? || requirement.input_type_professional_contact?
+    unless requirement.input_type_general_contact? ||
+             requirement.input_type_professional_contact?
+      return {}
+    end
 
     contact_components =
       (
@@ -235,10 +264,15 @@ class RequirementFormJsonService
       hideLabel: true,
       input: false,
       tableView: false,
-      components: contact_components.unshift(get_autofill_contact_button_form_json(key, is_multi)),
+      components:
+        contact_components.unshift(
+          get_autofill_contact_button_form_json(key, is_multi)
+        )
     }
 
-    form_json[:id] = requirement.id if requirement.input_options["can_add_multiple_contacts"].blank?
+    form_json[:id] = requirement.id if requirement.input_options[
+      "can_add_multiple_contacts"
+    ].blank?
 
     form_json
   end
@@ -250,24 +284,24 @@ class RequirementFormJsonService
         "name_columns",
         [
           get_contact_field_form_json(:first_name, parent_key, required),
-          get_contact_field_form_json(:last_name, parent_key, required),
-        ],
+          get_contact_field_form_json(:last_name, parent_key, required)
+        ]
       ),
       get_columns_form_json(
         "reach_columns",
         [
           get_contact_field_form_json(:email, parent_key, required),
-          get_contact_field_form_json(:phone, parent_key, required),
-        ],
+          get_contact_field_form_json(:phone, parent_key, required)
+        ]
       ),
       get_contact_field_form_json(:address, parent_key, required),
       get_columns_form_json(
         "organization_columns",
         [
           get_contact_field_form_json(:organization, parent_key, false),
-          get_contact_field_form_json(:title, parent_key, required),
-        ],
-      ),
+          get_contact_field_form_json(:title, parent_key, required)
+        ]
+      )
     ]
   end
 
@@ -278,15 +312,15 @@ class RequirementFormJsonService
         "name_columns",
         [
           get_contact_field_form_json(:first_name, parent_key, required),
-          get_contact_field_form_json(:last_name, parent_key, required),
-        ],
+          get_contact_field_form_json(:last_name, parent_key, required)
+        ]
       ),
       get_columns_form_json(
         "reach_columns",
         [
           get_contact_field_form_json(:email, parent_key, required),
-          get_contact_field_form_json(:phone, parent_key, required),
-        ],
+          get_contact_field_form_json(:phone, parent_key, required)
+        ]
       ),
       get_contact_field_form_json(:address, parent_key, required),
       get_contact_field_form_json(:title, parent_key, required),
@@ -294,16 +328,20 @@ class RequirementFormJsonService
         "business_columns",
         [
           get_contact_field_form_json(:business_name, parent_key, false),
-          get_contact_field_form_json(:business_license, parent_key, false),
-        ],
+          get_contact_field_form_json(:business_license, parent_key, false)
+        ]
       ),
       get_columns_form_json(
         "professional_columns",
         [
-          get_contact_field_form_json(:professional_association, parent_key, false),
-          get_contact_field_form_json(:professional_number, parent_key, false),
-        ],
-      ),
+          get_contact_field_form_json(
+            :professional_association,
+            parent_key,
+            false
+          ),
+          get_contact_field_form_json(:professional_number, parent_key, false)
+        ]
+      )
     ]
   end
 
@@ -315,12 +353,17 @@ class RequirementFormJsonService
       title: I18n.t("formio.requirement_template.autofill_contact"),
       label: I18n.t("formio.requirement_template.autofill_contact"),
       custom:
-        "document.dispatchEvent(new CustomEvent('openAutofillContact', { detail: { key: `#{parent_key}|#{is_multi ? "${rowIndex}" : "in_section"}` } } ));",
+        "document.dispatchEvent(new CustomEvent('openAutofillContact', { detail: { key: `#{parent_key}|#{is_multi ? "${rowIndex}" : "in_section"}` } } ));"
     }
   end
 
-  def get_multi_contact_datagrid_form_json(requirement_block_key = requirement&.requirement_block&.key)
-    return {} unless requirement.input_type_general_contact? || requirement.input_type_professional_contact?
+  def get_multi_contact_datagrid_form_json(
+    requirement_block_key = requirement&.requirement_block&.key
+  )
+    unless requirement.input_type_general_contact? ||
+             requirement.input_type_professional_contact?
+      return {}
+    end
 
     key = "#{requirement.key(requirement_block_key)}|multi_contact"
     {
@@ -338,11 +381,22 @@ class RequirementFormJsonService
       key: key,
       type: "datagrid",
       input: false,
-      components: [get_contact_field_set_form_json("#{key}|#{requirement.input_type}", true)],
+      components: [
+        get_contact_field_set_form_json(
+          "#{key}|#{requirement.input_type}",
+          true
+        )
+      ]
     }
   end
 
-  def get_nested_info_component(field_key, parent_key, label, required, field_type = nil)
+  def get_nested_info_component(
+    field_key,
+    parent_key,
+    label,
+    required,
+    field_type = nil
+  )
     key = snake_to_camel(field_key.to_s)
     key = "#{parent_key}|#{key}" if parent_key.present?
 
@@ -356,11 +410,11 @@ class RequirementFormJsonService
         input: true,
         label: label,
         widget: {
-          type: "input",
+          type: "input"
         },
         validate: {
-          required: required,
-        },
+          required: required
+        }
       }.merge!(DEFAULT_FORMIO_TYPE_TO_OPTIONS[field_type.to_sym])
     else
       {
@@ -371,14 +425,17 @@ class RequirementFormJsonService
         label: label,
         type: "textfield",
         validate: {
-          required: required,
+          required: required
         },
-        **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:text],
+        **DEFAULT_FORMIO_TYPE_TO_OPTIONS[:text]
       }
     end
   end
 
-  def get_pid_info_components(requirement_block_key = requirement&.requirement_block&.key, required = false)
+  def get_pid_info_components(
+    requirement_block_key = requirement&.requirement_block&.key,
+    required = false
+  )
     return {} unless requirement.input_type_pid_info?
     key = "#{requirement.key(requirement_block_key)}|additional_pid_info"
     component = {
@@ -394,12 +451,28 @@ class RequirementFormJsonService
         get_columns_form_json(
           "pid_entry_columns",
           [
-            get_nested_info_component(:pid, requirement_block_key, "PID", required),
-            get_nested_info_component(:folio_number, requirement_block_key, "Folio Number", false),
-          ],
+            get_nested_info_component(
+              :pid,
+              requirement_block_key,
+              "PID",
+              required
+            ),
+            get_nested_info_component(
+              :folio_number,
+              requirement_block_key,
+              "Folio Number",
+              false
+            )
+          ]
         ),
-        get_nested_info_component(:address, requirement_block_key, "Address", false, :address),
-      ],
+        get_nested_info_component(
+          :address,
+          requirement_block_key,
+          "Address",
+          false,
+          :address
+        )
+      ]
     }
     multi_data_grid_form_json(key, component, true, "Add #{requirement.label}")
   end
@@ -426,7 +499,7 @@ class RequirementFormJsonService
       key: override_key,
       type: "datagrid",
       input: false,
-      components: [component],
+      components: [component]
     }
   end
 
@@ -440,14 +513,16 @@ class RequirementFormJsonService
       return(
         {
           type: "simplefile",
-          storage: "s3custom",
+          storage: "s3custom"
           # fileMaxSize driven by front end defaults, do not set in requirements as it fixes it
         }.tap do |file_hash|
-          file_hash[:computedCompliance] = input_options["computed_compliance"] if input_options[
+          file_hash[:computedCompliance] = input_options[
             "computed_compliance"
-          ].present?
+          ] if input_options["computed_compliance"].present?
           file_hash[:multiple] = true if input_options["multiple"].present?
-          file_hash[:custom_class] = "formio-component-file" if file_hash[:type] != "file"
+          file_hash[:custom_class] = "formio-component-file" if file_hash[
+            :type
+          ] != "file"
         end
       )
     end

--- a/app/services/requirement_template_copy_service.rb
+++ b/app/services/requirement_template_copy_service.rb
@@ -12,10 +12,14 @@ class RequirementTemplateCopyService
         (field_overrides[:type]&.constantize || requirement_template.class).new(
           activity_id: requirement_template.activity_id,
           permit_type_id: requirement_template.permit_type_id,
-          description: field_overrides[:description] || "Copy of #{requirement_template.description}",
+          description:
+            field_overrides[:description] ||
+              "Copy of #{requirement_template.description}",
           nickname: field_overrides[:nickname],
-          first_nations: field_overrides[:first_nations] || requirement_template.first_nations,
-          copied_from: requirement_template,
+          first_nations:
+            field_overrides[:first_nations] ||
+              requirement_template.first_nations,
+          copied_from: requirement_template
         )
 
       return new_template unless new_template.valid?
@@ -26,11 +30,13 @@ class RequirementTemplateCopyService
           new_template.requirement_template_sections.build(
             name: section.name,
             position: section.position,
-            copied_from: section,
+            copied_from: section
           )
 
         # Associate existing requirement blocks with the new section
-        section.requirement_blocks.each { |block| new_section.requirement_blocks << block }
+        section.requirement_blocks.each do |block|
+          new_section.requirement_blocks << block
+        end
       end
 
       # Save the new template first to get its ID

--- a/app/services/revision_reason_seeder.rb
+++ b/app/services/revision_reason_seeder.rb
@@ -1,17 +1,28 @@
 class RevisionReasonSeeder
   def self.seed
     revision_reasons = [
-      { reason_code: "zoning_non_compliance", description: "Zoning non-compliance" },
-      { reason_code: "inaccurate_documentation", description: "Inaccurate documentation" },
-      { reason_code: "failure_to_meet_building_code", description: "Failure to meet building code requirements" },
-      { reason_code: "other", description: "Other" },
+      {
+        reason_code: "zoning_non_compliance",
+        description: "Zoning non-compliance"
+      },
+      {
+        reason_code: "inaccurate_documentation",
+        description: "Inaccurate documentation"
+      },
+      {
+        reason_code: "failure_to_meet_building_code",
+        description: "Failure to meet building code requirements"
+      },
+      { reason_code: "other", description: "Other" }
     ]
 
     revision_reasons.each do |reason|
       SiteConfiguration
         .instance
         .revision_reasons
-        .find_or_create_by(reason_code: reason[:reason_code]) do |revision_reason|
+        .find_or_create_by(
+          reason_code: reason[:reason_code]
+        ) do |revision_reason|
           revision_reason.description = reason[:description]
         end
     end

--- a/app/services/step_code/building_characteristics/line/base.rb
+++ b/app/services/step_code/building_characteristics/line/base.rb
@@ -13,7 +13,11 @@ class StepCode::BuildingCharacteristics::Line::Base
   end
 
   def self.dump(arr)
-    (arr || []).all? { |item| item.is_a?(self.class) } ? (arr || []).map(&:attributes) : arr || []
+    if (arr || []).all? { |item| item.is_a?(self.class) }
+      (arr || []).map(&:attributes)
+    else
+      arr || []
+    end
   end
 
   def attributes

--- a/app/services/step_code/building_characteristics/line/hot_water.rb
+++ b/app/services/step_code/building_characteristics/line/hot_water.rb
@@ -1,7 +1,13 @@
 class StepCode::BuildingCharacteristics::Line::HotWater < StepCode::BuildingCharacteristics::Line::Base
   attr_accessor :details, :performance_value
 
-  PERFORMANCE_TYPES = { percent_eff: 0, afue: 1, uef: 2, ef: 3, eer: 4 }.with_indifferent_access
+  PERFORMANCE_TYPES = {
+    percent_eff: 0,
+    afue: 1,
+    uef: 2,
+    ef: 3,
+    eer: 4
+  }.with_indifferent_access
   include StepCode::BuildingCharacteristics::WithPerformanceType
 
   def fields

--- a/app/services/step_code/building_characteristics/line/space_heating_cooling.rb
+++ b/app/services/step_code/building_characteristics/line/space_heating_cooling.rb
@@ -11,7 +11,13 @@ class StepCode::BuildingCharacteristics::Line::SpaceHeatingCooling < StepCode::B
     VARIANTS.key(@variant)
   end
 
-  PERFORMANCE_TYPES = { afue: 0, hspf: 1, sse: 2, cop: 3, seer: 4 }.with_indifferent_access
+  PERFORMANCE_TYPES = {
+    afue: 0,
+    hspf: 1,
+    sse: 2,
+    cop: 3,
+    seer: 4
+  }.with_indifferent_access
   include StepCode::BuildingCharacteristics::WithPerformanceType
 
   def fields

--- a/app/services/step_code/building_characteristics/with_performance_type.rb
+++ b/app/services/step_code/building_characteristics/with_performance_type.rb
@@ -13,14 +13,17 @@ module StepCode::BuildingCharacteristics::WithPerformanceType
     validate :valid_performance_type
 
     def valid_performance_type
-      return if self.performance_type.blank? || self.class::PERFORMANCE_TYPES.keys.include?(self.performance_type)
+      if self.performance_type.blank? ||
+           self.class::PERFORMANCE_TYPES.keys.include?(self.performance_type)
+        return
+      end
       self.errors.add(
         :base,
         I18n.t(
           "step_code_building_characteristics_summary.performance_type.error",
           field_name: self.class.name.demodulize.underscore.humanize,
-          accepted_values: self.class::PERFORMANCE_TYPES.keys.join(", "),
-        ),
+          accepted_values: self.class::PERFORMANCE_TYPES.keys.join(", ")
+        )
       )
     end
   end

--- a/app/services/step_code/compliance/check_requirements/energy/base.rb
+++ b/app/services/step_code/compliance/check_requirements/energy/base.rb
@@ -7,7 +7,9 @@ class StepCode::Compliance::CheckRequirements::Energy::Base
   end
 
   def total_heated_floor_area
-    @total_heated_floor_area ||= total(:above_grade_heated_floor_area) + total(:below_grade_heated_floor_area)
+    @total_heated_floor_area ||=
+      total(:above_grade_heated_floor_area) +
+        total(:below_grade_heated_floor_area)
   end
 
   private
@@ -24,6 +26,10 @@ class StepCode::Compliance::CheckRequirements::Energy::Base
 
   def tedi_reference
     @tedi_reference ||=
-      ThermalEnergyDemandIntensityReference.find_by("hdd @> :hdd AND step = :step", hdd: total(:hdd), step: step)
+      ThermalEnergyDemandIntensityReference.find_by(
+        "hdd @> :hdd AND step = :step",
+        hdd: total(:hdd),
+        step: step
+      )
   end
 end

--- a/app/services/step_code/compliance/check_requirements/energy/meui.rb
+++ b/app/services/step_code/compliance/check_requirements/energy/meui.rb
@@ -2,7 +2,8 @@
 
 class StepCode::Compliance::CheckRequirements::Energy::MEUI < StepCode::Compliance::CheckRequirements::Energy::Base
   def requirements_met?
-    (meui != 0 && meui <= meui_requirement) || meui_percent_improvement >= meui_percent_improvement_requirement
+    (meui != 0 && meui <= meui_requirement) ||
+      meui_percent_improvement >= meui_percent_improvement_requirement
   end
 
   def meui
@@ -19,19 +20,21 @@ class StepCode::Compliance::CheckRequirements::Energy::MEUI < StepCode::Complian
       hdd: total(:hdd),
       step: step,
       conditioned_percent:,
-      conditioned_area: total_heated_floor_area.round,
+      conditioned_area: total_heated_floor_area.round
     ).meui
   end
 
   def conditioned_percent
-    @conditioned_percent ||= total_cooling_capacity / total(:design_cooling_load)
+    @conditioned_percent ||=
+      total_cooling_capacity / total(:design_cooling_load)
   end
 
   def total_cooling_capacity
     @total_cooling_capacity ||=
       (
         total(:ac_cooling_capacity) + total(:air_heat_pump_cooling_capacity) +
-          total(:grounded_heat_pump_cooling_capacity) + total(:water_heat_pump_cooling_capacity)
+          total(:grounded_heat_pump_cooling_capacity) +
+          total(:water_heat_pump_cooling_capacity)
       ) * 1000
   end
 
@@ -45,7 +48,10 @@ class StepCode::Compliance::CheckRequirements::Energy::MEUI < StepCode::Complian
 
   def meui_percent_improvement
     return nil if ref_energy_target == 0 || checklist.step_code?
-    @meui_improvement_percentage ||= ((ref_energy_target - energy_consumption) / ref_energy_target * 100).round(2)
+    @meui_improvement_percentage ||=
+      (
+        (ref_energy_target - energy_consumption) / ref_energy_target * 100
+      ).round(2)
   end
 
   def ref_energy_target

--- a/app/services/step_code/compliance/check_requirements/energy/tedi.rb
+++ b/app/services/step_code/compliance/check_requirements/energy/tedi.rb
@@ -4,11 +4,13 @@
 
 class StepCode::Compliance::CheckRequirements::Energy::TEDI < StepCode::Compliance::CheckRequirements::Energy::Base
   def requirements_met?
-    (tedi != 0 && tedi <= tedi_requirement) || tedi_hlr_percent >= tedi_hlr_percent_requirement
+    (tedi != 0 && tedi <= tedi_requirement) ||
+      tedi_hlr_percent >= tedi_hlr_percent_requirement
   end
 
   def tedi
-    @tedi ||= total(:aux_energy_required) / 1000 / total_heated_floor_area * KWH_PER_GJ
+    @tedi ||=
+      total(:aux_energy_required) / 1000 / total_heated_floor_area * KWH_PER_GJ
   end
 
   def tedi_requirement

--- a/app/services/step_code/compliance/check_requirements/zero_carbon/base.rb
+++ b/app/services/step_code/compliance/check_requirements/zero_carbon/base.rb
@@ -14,7 +14,9 @@ class StepCode::Compliance::CheckRequirements::ZeroCarbon::Base
   end
 
   def total_ghg
-    @total_ghg ||= other_ghg + district_energy_ghg + propane_ghg + natural_gas_ghg + electricity_ghg
+    @total_ghg ||=
+      other_ghg + district_energy_ghg + propane_ghg + natural_gas_ghg +
+        electricity_ghg
   end
 
   private
@@ -32,7 +34,9 @@ class StepCode::Compliance::CheckRequirements::ZeroCarbon::Base
   end
 
   def total_heated_floor_area
-    @total_heated_floor_area ||= total(:above_grade_heated_floor_area) + total(:below_grade_heated_floor_area)
+    @total_heated_floor_area ||=
+      total(:above_grade_heated_floor_area) +
+        total(:below_grade_heated_floor_area)
   end
 
   def electricity_ghg

--- a/app/services/step_code/compliance/check_requirements/zero_carbon/co2.rb
+++ b/app/services/step_code/compliance/check_requirements/zero_carbon/co2.rb
@@ -10,10 +10,18 @@ class StepCode::Compliance::CheckRequirements::ZeroCarbon::CO2 < StepCode::Compl
   end
 
   def co2_requirement
-    @co2_requirement ||= StepCode::References::ZERO_CARBON_REFERENCES.dig(step, :carbon_per_floor_area)
+    @co2_requirement ||=
+      StepCode::References::ZERO_CARBON_REFERENCES.dig(
+        step,
+        :carbon_per_floor_area
+      )
   end
 
   def co2_max_requirement
-    @co2_max_requirement ||= StepCode::References::ZERO_CARBON_REFERENCES.dig(step, :carbon_per_floor_area_max)
+    @co2_max_requirement ||=
+      StepCode::References::ZERO_CARBON_REFERENCES.dig(
+        step,
+        :carbon_per_floor_area_max
+      )
   end
 end

--- a/app/services/step_code/compliance/check_requirements/zero_carbon/ghg.rb
+++ b/app/services/step_code/compliance/check_requirements/zero_carbon/ghg.rb
@@ -8,6 +8,7 @@ class StepCode::Compliance::CheckRequirements::ZeroCarbon::GHG < StepCode::Compl
   end
 
   def total_ghg_requirement
-    @total_ghg_requirement ||= StepCode::References::ZERO_CARBON_REFERENCES.dig(step, :total_carbon)
+    @total_ghg_requirement ||=
+      StepCode::References::ZERO_CARBON_REFERENCES.dig(step, :total_carbon)
   end
 end

--- a/app/services/step_code/compliance/check_requirements/zero_carbon/prescriptive.rb
+++ b/app/services/step_code/compliance/check_requirements/zero_carbon/prescriptive.rb
@@ -6,12 +6,13 @@ class StepCode::Compliance::CheckRequirements::ZeroCarbon::Prescriptive < StepCo
   def prescriptive_heating
     @heating ||=
       min(
-        "CASE WHEN GREATEST(heating_furnace, heating_boiler, heating_combo) > 1 THEN 'carbon' ELSE 'zero_carbon' END",
+        "CASE WHEN GREATEST(heating_furnace, heating_boiler, heating_combo) > 1 THEN 'carbon' ELSE 'zero_carbon' END"
       ).to_sym
   end
 
   def prescriptive_heating_requirement
-    @prescriptive_heating_requirement ||= StepCode::References::ZERO_CARBON_REFERENCES.dig(step, :fuel_type_heating)
+    @prescriptive_heating_requirement ||=
+      StepCode::References::ZERO_CARBON_REFERENCES.dig(step, :fuel_type_heating)
   end
 
   def prescriptive_hot_water
@@ -19,41 +20,57 @@ class StepCode::Compliance::CheckRequirements::ZeroCarbon::Prescriptive < StepCo
   end
 
   def prescriptive_hot_water_requirement
-    @prescriptive_hot_water_requirement ||= StepCode::References::ZERO_CARBON_REFERENCES.dig(step, :fuel_type_hot_water)
+    @prescriptive_hot_water_requirement ||=
+      StepCode::References::ZERO_CARBON_REFERENCES.dig(
+        step,
+        :fuel_type_hot_water
+      )
   end
 
   def prescriptive_other
-    @prescriptive_other ||= min("CASE WHEN GREATEST(cooking, laundry) > 1 THEN 'carbon' ELSE 'zero_carbon' END").to_sym
+    @prescriptive_other ||=
+      min(
+        "CASE WHEN GREATEST(cooking, laundry) > 1 THEN 'carbon' ELSE 'zero_carbon' END"
+      ).to_sym
   end
 
   def prescriptive_other_requirement
-    @prescriptive_other_requirement ||= StepCode::References::ZERO_CARBON_REFERENCES.dig(step, :fuel_type_other)
+    @prescriptive_other_requirement ||=
+      StepCode::References::ZERO_CARBON_REFERENCES.dig(step, :fuel_type_other)
   end
 
   private
 
   def heating_passed?
-    !prescriptive_heating_requirement || heating_rating >= heating_requirement_rating
+    !prescriptive_heating_requirement ||
+      heating_rating >= heating_requirement_rating
   end
 
   def heating_rating
-    @heating_rating ||= StepCode::References::FUEL_TYPE_RATINGS[prescriptive_heating]
+    @heating_rating ||=
+      StepCode::References::FUEL_TYPE_RATINGS[prescriptive_heating]
   end
 
   def heating_requirement_rating
-    @heating_requirement_rating ||= StepCode::References::FUEL_TYPE_RATINGS[prescriptive_heating_requirement]
+    @heating_requirement_rating ||=
+      StepCode::References::FUEL_TYPE_RATINGS[prescriptive_heating_requirement]
   end
 
   def hot_water_passed?
-    !prescriptive_hot_water_requirement || hot_water_rating >= hot_water_requirement_rating
+    !prescriptive_hot_water_requirement ||
+      hot_water_rating >= hot_water_requirement_rating
   end
 
   def hot_water_rating
-    @hot_water_rating ||= StepCode::References::FUEL_TYPE_RATINGS[prescriptive_hot_water]
+    @hot_water_rating ||=
+      StepCode::References::FUEL_TYPE_RATINGS[prescriptive_hot_water]
   end
 
   def hot_water_requirement_rating
-    @hot_water_requirement_rating ||= StepCode::References::FUEL_TYPE_RATINGS[prescriptive_hot_water_requirement]
+    @hot_water_requirement_rating ||=
+      StepCode::References::FUEL_TYPE_RATINGS[
+        prescriptive_hot_water_requirement
+      ]
   end
 
   def other_passed?
@@ -61,10 +78,12 @@ class StepCode::Compliance::CheckRequirements::ZeroCarbon::Prescriptive < StepCo
   end
 
   def other_rating
-    @other_rating ||= StepCode::References::FUEL_TYPE_RATINGS[prescriptive_other]
+    @other_rating ||=
+      StepCode::References::FUEL_TYPE_RATINGS[prescriptive_other]
   end
 
   def other_requirement_rating
-    @other_requirement_rating ||= StepCode::References::FUEL_TYPE_RATINGS[prescriptive_other_requirement]
+    @other_requirement_rating ||=
+      StepCode::References::FUEL_TYPE_RATINGS[prescriptive_other_requirement]
   end
 end

--- a/app/services/step_code/compliance/generate_reports.rb
+++ b/app/services/step_code/compliance/generate_reports.rb
@@ -13,15 +13,19 @@ class StepCode::Compliance::GenerateReports
       energy_result =
         StepCode::Compliance::ProposeStep::Energy.new(
           checklist:,
-          min_required_step: requirement.energy_step_required,
+          min_required_step: requirement.energy_step_required
         ).call
       zero_carbon_result =
         StepCode::Compliance::ProposeStep::ZeroCarbon.new(
           checklist:,
-          min_required_step: requirement.zero_carbon_step_required,
+          min_required_step: requirement.zero_carbon_step_required
         ).call
 
-      @reports << { zero_carbon: zero_carbon_result, energy: energy_result, requirement_id: requirement.id }
+      @reports << {
+        zero_carbon: zero_carbon_result,
+        energy: energy_result,
+        requirement_id: requirement.id
+      }
     end
 
     return self

--- a/app/services/step_code/compliance/propose_step/energy.rb
+++ b/app/services/step_code/compliance/propose_step/energy.rb
@@ -12,14 +12,23 @@ class StepCode::Compliance::ProposeStep::Energy < StepCode::Compliance::ProposeS
   end
 
   def meui_checker
-    StepCode::Compliance::CheckRequirements::Energy::MEUI.new(step: step || min_required_step, checklist:)
+    StepCode::Compliance::CheckRequirements::Energy::MEUI.new(
+      step: step || min_required_step,
+      checklist:
+    )
   end
 
   def tedi_checker
-    StepCode::Compliance::CheckRequirements::Energy::TEDI.new(step: step || min_required_step, checklist:)
+    StepCode::Compliance::CheckRequirements::Energy::TEDI.new(
+      step: step || min_required_step,
+      checklist:
+    )
   end
 
   def airtightness_checker
-    StepCode::Compliance::CheckRequirements::Energy::Airtightness.new(step: step || min_required_step, checklist:)
+    StepCode::Compliance::CheckRequirements::Energy::Airtightness.new(
+      step: step || min_required_step,
+      checklist:
+    )
   end
 end

--- a/app/services/step_code/compliance/propose_step/zero_carbon.rb
+++ b/app/services/step_code/compliance/propose_step/zero_carbon.rb
@@ -12,14 +12,23 @@ class StepCode::Compliance::ProposeStep::ZeroCarbon < StepCode::Compliance::Prop
   end
 
   def ghg_checker
-    StepCode::Compliance::CheckRequirements::ZeroCarbon::GHG.new(step: step || min_required_step, checklist:)
+    StepCode::Compliance::CheckRequirements::ZeroCarbon::GHG.new(
+      step: step || min_required_step,
+      checklist:
+    )
   end
 
   def co2_checker
-    StepCode::Compliance::CheckRequirements::ZeroCarbon::CO2.new(step: step || min_required_step, checklist:)
+    StepCode::Compliance::CheckRequirements::ZeroCarbon::CO2.new(
+      step: step || min_required_step,
+      checklist:
+    )
   end
 
   def prescriptive_checker
-    StepCode::Compliance::CheckRequirements::ZeroCarbon::Prescriptive.new(step: step || min_required_step, checklist:)
+    StepCode::Compliance::CheckRequirements::ZeroCarbon::Prescriptive.new(
+      step: step || min_required_step,
+      checklist:
+    )
   end
 end

--- a/app/services/step_code/data_entry_hot2000_mapper.rb
+++ b/app/services/step_code/data_entry_hot2000_mapper.rb
@@ -45,7 +45,9 @@ class StepCode::DataEntryHot2000Mapper
   end
 
   def mappings
-    Hash[mapped_attributes.map { |attribute| [attribute, self.send(attribute)] }]
+    Hash[
+      mapped_attributes.map { |attribute| [attribute, self.send(attribute)] }
+    ]
   end
 
   private
@@ -59,58 +61,95 @@ class StepCode::DataEntryHot2000Mapper
   end
 
   def version
-    xml.at("HouseFile/Application/Version/Labels/#{I18n.locale == :fr ? "French" : "English"}").text
+    xml.at(
+      "HouseFile/Application/Version/Labels/#{I18n.locale == :fr ? "French" : "English"}"
+    ).text
   end
 
   def p_file_no
-    @p_file_no ||= xml.at("HouseFile/ProgramInformation/File/Identification")&.text
+    @p_file_no ||=
+      xml.at("HouseFile/ProgramInformation/File/Identification")&.text
   end
 
   def dwelling_units_count
-    @dwelling_units_count ||= xml.at("HouseFile/Program/Results/Tsv/NumDwellingUnits/@value")&.text
+    @dwelling_units_count ||=
+      xml.at("HouseFile/Program/Results/Tsv/NumDwellingUnits/@value")&.text
   end
 
   def ach # air changes per hour @ 50Pa (airgtightnes value)
-    @ach ||= xml.at("HouseFile/House/NaturalAirInfiltration/Specifications/BlowerTest/@airChangeRate")&.text&.to_f
+    @ach ||=
+      xml
+        .at(
+          "HouseFile/House/NaturalAirInfiltration/Specifications/BlowerTest/@airChangeRate"
+        )
+        &.text
+        &.to_f
   end
 
   def nla # Normalized Leakage Area
-    @nla ||= xml.at("HouseFile/Program/Results/Tsv/NLA/@value")&.text.to_f.round(2)
+    @nla ||=
+      xml.at("HouseFile/Program/Results/Tsv/NLA/@value")&.text.to_f.round(2)
   end
 
   def weather_location
     @weather_location ||=
-      xml.at("HouseFile/ProgramInformation/Weather/Location/#{I18n.locale == :fr ? "French" : "English"}").text
+      xml.at(
+        "HouseFile/ProgramInformation/Weather/Location/#{I18n.locale == :fr ? "French" : "English"}"
+      ).text
   end
 
   def building_volume
     @building_volume ||=
-      xml.at("HouseFile/House/NaturalAirInfiltration/Specifications/House/@volume")&.text&.to_f&.round(1)
+      xml
+        .at(
+          "HouseFile/House/NaturalAirInfiltration/Specifications/House/@volume"
+        )
+        &.text
+        &.to_f
+        &.round(1)
   end
 
   def building_envelope_surface_area
     @building_envelope_surface_area ||=
-      xml.at("HouseFile/AllResults/Results/Other/GrossArea/@buildingSurfaceArea")&.text&.to_f&.round(1)
+      xml
+        .at("HouseFile/AllResults/Results/Other/GrossArea/@buildingSurfaceArea")
+        &.text
+        &.to_f
+        &.round(1)
   end
 
   def fwdr
-    @fwdr ||= xml.at("HouseFile/Program/Results/RefHse/theHouseFDWR/@value").text.to_f
+    @fwdr ||=
+      xml.at("HouseFile/Program/Results/RefHse/theHouseFDWR/@value").text.to_f
   end
 
   def above_grade_heated_floor_area
-    @above_grade_heated_floor_area ||= xml.at("HouseFile/House/Specifications/HeatedFloorArea/@aboveGrade").text&.to_f
+    @above_grade_heated_floor_area ||=
+      xml
+        .at("HouseFile/House/Specifications/HeatedFloorArea/@aboveGrade")
+        .text
+        &.to_f
   end
 
   def below_grade_heated_floor_area
-    @below_grade_heated_floor_area ||= xml.at("HouseFile/House/Specifications/HeatedFloorArea/@belowGrade").text&.to_f
+    @below_grade_heated_floor_area ||=
+      xml
+        .at("HouseFile/House/Specifications/HeatedFloorArea/@belowGrade")
+        .text
+        &.to_f
   end
 
   def aec # annual energy consumption (GJ/year)
-    @aec ||= (xml.at("HouseFile/Program/Results/Tsv/EGHFconTotal/@value")&.text.to_f / 1000).round(2)
+    @aec ||=
+      (
+        xml.at("HouseFile/Program/Results/Tsv/EGHFconTotal/@value")&.text.to_f /
+          1000
+      ).round(2)
   end
 
   def ref_hse_results
-    @ref_hse_results ||= xml.at('HouseFile/AllResults/Results[@houseCode="Reference"]')
+    @ref_hse_results ||=
+      xml.at('HouseFile/AllResults/Results[@houseCode="Reference"]')
   end
 
   def soc_results
@@ -118,51 +157,89 @@ class StepCode::DataEntryHot2000Mapper
   end
 
   def baseloads # GJ/year
-    @baseloads ||= ref_hse_results&.at("Annual/Consumption/Electrical/@baseload")&.text.to_f.round(2)
+    @baseloads ||=
+      ref_hse_results
+        &.at("Annual/Consumption/Electrical/@baseload")
+        &.text
+        .to_f
+        .round(2)
   end
 
   def hdd # heating degree day
-    @hdd ||= xml.at("HouseFile/ProgramInformation/Weather/@heatingDegreeDay")&.text&.to_i
+    @hdd ||=
+      xml
+        .at("HouseFile/ProgramInformation/Weather/@heatingDegreeDay")
+        &.text
+        &.to_i
   end
 
   def design_cooling_load
-    @design_cooling_load ||= xml.at("HouseFile/AllResults/Results/Other/@designCoolLossRate")&.text&.to_f.round(2)
+    @design_cooling_load ||=
+      xml
+        .at("HouseFile/AllResults/Results/Other/@designCoolLossRate")
+        &.text
+        &.to_f
+        .round(2)
   end
 
   def ac_cooling_capacity
     @ac_cooling_capacity ||=
-      xml.at("HouseFile/House/HeatingCooling/Type2/AirConditioning/Specifications/RatedCapacity/@value")&.text&.to_f
+      xml
+        .at(
+          "HouseFile/House/HeatingCooling/Type2/AirConditioning/Specifications/RatedCapacity/@value"
+        )
+        &.text
+        &.to_f
   end
 
   def air_heat_pump_cooling_capacity
     @air_heat_pump_cooling_capacity ||=
-      xml.at("HouseFile/House/HeatingCooling/Type2/AirHeatPump/Specifications/OutputCapacity/@value")&.text&.to_f
+      xml
+        .at(
+          "HouseFile/House/HeatingCooling/Type2/AirHeatPump/Specifications/OutputCapacity/@value"
+        )
+        &.text
+        &.to_f
   end
 
   def grounded_heat_pump_cooling_capacity
     grounded_heat_pump ||=
-      xml.at("HouseFile/House/HeatingCooling/Type2/GroundHeatPump/Specifications/OutputCapacity/@value")&.text&.to_f
+      xml
+        .at(
+          "HouseFile/House/HeatingCooling/Type2/GroundHeatPump/Specifications/OutputCapacity/@value"
+        )
+        &.text
+        &.to_f
   end
 
   def water_heat_pump_cooling_capacity
     @water_heat_pump ||=
-      xml.at("HouseFile/House/HeatingCooling/Type2/WaterHeatPump/Specifications/OutputCapacity/@value")&.text&.to_f
+      xml
+        .at(
+          "HouseFile/House/HeatingCooling/Type2/WaterHeatPump/Specifications/OutputCapacity/@value"
+        )
+        &.text
+        &.to_f
   end
 
   def ref_aec # AEC of reference house (GJ/year)
-    @ref_aec ||= ref_hse_results&.at("Annual/Consumption/@total")&.text&.to_f&.round(2)
+    @ref_aec ||=
+      ref_hse_results&.at("Annual/Consumption/@total")&.text&.to_f&.round(2)
   end
 
   def aux_energy_required # MJ/year
-    @aux_energy_required ||= soc_results&.at("Annual/Load/@auxiliaryEnergy")&.text&.to_f&.round(2)
+    @aux_energy_required ||=
+      soc_results&.at("Annual/Load/@auxiliaryEnergy")&.text&.to_f&.round(2)
   end
 
   def ref_gshl # Reference Gross Space Heat Loss (GJ)
-    @ref_gshl ||= ref_hse_results.at("Annual/Load/@grossHeating").text.to_f.round(2)
+    @ref_gshl ||=
+      ref_hse_results.at("Annual/Load/@grossHeating").text.to_f.round(2)
   end
 
   def proposed_gshl # Proposed Gross Space Heat Loss (GJ)
-    @proposed_gshl ||= soc_results.at("Annual/Load/@grossHeating").text.to_f.round(2)
+    @proposed_gshl ||=
+      soc_results.at("Annual/Load/@grossHeating").text.to_f.round(2)
   end
 
   def electrical_consumption
@@ -177,55 +254,132 @@ class StepCode::DataEntryHot2000Mapper
   end
 
   def annual_electrical_consumption
-    @annual_electrical_consumption ||= soc_results.at("Annual/Consumption/Electrical/@total").text.to_f.round(2)
+    @annual_electrical_consumption ||=
+      soc_results.at("Annual/Consumption/Electrical/@total").text.to_f.round(2)
   end
 
   def monthly_electrical_consumption
     @monthly_electrical_consumption ||= [
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@january").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@february").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@march").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@april").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@may").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@june").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@july").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@august").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@september").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@october").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@november").text.to_f.round(2),
-      soc_results.at("Monthly/ElectricalConsumption/Gross/@december").text.to_f.round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@january")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@february")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@march")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@april")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@may")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@june")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@july")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@august")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@september")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@october")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@november")
+        .text
+        .to_f
+        .round(2),
+      soc_results
+        .at("Monthly/ElectricalConsumption/Gross/@december")
+        .text
+        .to_f
+        .round(2)
     ]
   end
 
   def natural_gas_consumption
-    @natural_gas_consumption ||= soc_results.at("Annual/Consumption/NaturalGas/@total").text.to_f.round(2)
+    @natural_gas_consumption ||=
+      soc_results.at("Annual/Consumption/NaturalGas/@total").text.to_f.round(2)
   end
 
   def propane_consumption
-    @propane_consumption ||= soc_results.at("Annual/Consumption/Propane/@total").text.to_f.round(2)
+    @propane_consumption ||=
+      soc_results.at("Annual/Consumption/Propane/@total").text.to_f.round(2)
   end
 
   def heating_furnace
-    xml.at("HouseFile/House/HeatingCooling/Type1/Furnace/Equipment/EnergySource/@code").text.to_f
+    xml
+      .at(
+        "HouseFile/House/HeatingCooling/Type1/Furnace/Equipment/EnergySource/@code"
+      )
+      .text
+      .to_f
   end
 
   def heating_boiler
-    xml.at("HouseFile/House/HeatingCooling/Type1/Boiler/Equipment/EnergySource/@code")&.text&.to_f
+    xml
+      .at(
+        "HouseFile/House/HeatingCooling/Type1/Boiler/Equipment/EnergySource/@code"
+      )
+      &.text
+      &.to_f
   end
 
   def heating_combo
-    xml.at("HouseFile/House/HeatingCooling/Type1/ComboHeatDhw/Equipment/EnergySource/@code")&.text&.to_f
+    xml
+      .at(
+        "HouseFile/House/HeatingCooling/Type1/ComboHeatDhw/Equipment/EnergySource/@code"
+      )
+      &.text
+      &.to_f
   end
 
   def hot_water
-    xml.at("HouseFile/House/Components/HotWater/Primary/EnergySource/@code").text.to_f
+    xml
+      .at("HouseFile/House/Components/HotWater/Primary/EnergySource/@code")
+      .text
+      .to_f
   end
 
   def cooking
-    xml.at("HouseFile/House/BaseLoads/ElectricalUsage/Stove/EnergySource/@code").text.to_f
+    xml
+      .at("HouseFile/House/BaseLoads/ElectricalUsage/Stove/EnergySource/@code")
+      .text
+      .to_f
   end
 
   def laundry
-    xml.at("HouseFile/House/BaseLoads/ElectricalUsage/ClothesDryer/EnergySource/@code").text.to_f
+    xml
+      .at(
+        "HouseFile/House/BaseLoads/ElectricalUsage/ClothesDryer/EnergySource/@code"
+      )
+      .text
+      .to_f
   end
 end

--- a/app/services/step_code/meui_references_seeder.rb
+++ b/app/services/step_code/meui_references_seeder.rb
@@ -6,7 +6,10 @@ class StepCode::MEUIReferencesSeeder
 
       MechanicalEnergyUseIntensityReference.transaction do
         header_row = xlsx.row(1)
-        data_rows = (2..xlsx.last_row).map { |i| xlsx.row(i).map { |cell| MAPPINGS[cell] || cell } }
+        data_rows =
+          (2..xlsx.last_row).map do |i|
+            xlsx.row(i).map { |cell| MAPPINGS[cell] || cell }
+          end
 
         data_rows.each do |row|
           data_hash = Hash[header_row.zip(row)]
@@ -30,6 +33,6 @@ class StepCode::MEUIReferencesSeeder
     "76 to 120" => 76..120,
     "121 to 165" => 121..165,
     "166 to 210" => 166..210,
-    "> 210" => 210..,
+    "> 210" => 210..
   }
 end

--- a/app/services/step_code/references.rb
+++ b/app/services/step_code/references.rb
@@ -6,7 +6,7 @@ class StepCode::References
       carbon_per_floor_area_max: nil,
       fuel_type_heating: nil,
       fuel_type_hot_water: nil,
-      fuel_type_other: nil,
+      fuel_type_other: nil
     },
     2 => {
       total_carbon: 1050,
@@ -14,7 +14,7 @@ class StepCode::References
       carbon_per_floor_area_max: 2400,
       fuel_type_heating: :zero_carbon,
       fuel_type_hot_water: nil,
-      fuel_type_other: nil,
+      fuel_type_other: nil
     },
     3 => {
       total_carbon: 440,
@@ -22,7 +22,7 @@ class StepCode::References
       carbon_per_floor_area_max: 800,
       fuel_type_heating: :zero_carbon,
       fuel_type_hot_water: :zero_carbon,
-      fuel_type_other: nil,
+      fuel_type_other: nil
     },
     4 => {
       total_carbon: 265,
@@ -30,8 +30,8 @@ class StepCode::References
       carbon_per_floor_area_max: 500,
       fuel_type_heating: :zero_carbon,
       fuel_type_hot_water: :zero_carbon,
-      fuel_type_other: :zero_carbon,
-    },
+      fuel_type_other: :zero_carbon
+    }
   }
 
   FUEL_TYPE_RATINGS = { carbon: 2, zero_carbon: 3 }

--- a/app/services/step_code/tedi_references_seeder.rb
+++ b/app/services/step_code/tedi_references_seeder.rb
@@ -6,7 +6,10 @@ class StepCode::TEDIReferencesSeeder
 
       ThermalEnergyDemandIntensityReference.transaction do
         header_row = xlsx.row(1)
-        data_rows = (2..xlsx.last_row).map { |i| xlsx.row(i).map { |cell| MAPPINGS[cell] || cell } }
+        data_rows =
+          (2..xlsx.last_row).map do |i|
+            xlsx.row(i).map { |cell| MAPPINGS[cell] || cell }
+          end
 
         data_rows.each do |row|
           data_hash = Hash[header_row.zip(row)]
@@ -22,6 +25,6 @@ class StepCode::TEDIReferencesSeeder
     "6 - 4000 to 4999" => 4000..4999,
     "7A - 5000 to 5999" => 5000..5999,
     "7B - 6000 to 6999" => 6000..6999,
-    "8 - More than 6999" => 7000..,
+    "8 - More than 6999" => 7000..
   }
 end

--- a/app/services/step_code_export_service.rb
+++ b/app/services/step_code_export_service.rb
@@ -9,12 +9,21 @@ class StepCodeExportService
         permit_types.each do |pt|
           jurisdiction_name = j.qualified_name
           permit_type = pt.name
-          permit_type_required_steps = j.permit_type_required_steps_by_classification(pt)
+          permit_type_required_steps =
+            j.permit_type_required_steps_by_classification(pt)
           permit_type_required_steps.each do |jtsc|
             energy_step_required = jtsc.energy_step_required
             zero_carbon_step_required = jtsc.zero_carbon_step_required
-            enabled = energy_step_required.positive? || zero_carbon_step_required.positive?
-            csv << [jurisdiction_name, permit_type, enabled, energy_step_required, zero_carbon_step_required]
+            enabled =
+              energy_step_required.positive? ||
+                zero_carbon_step_required.positive?
+            csv << [
+              jurisdiction_name,
+              permit_type,
+              enabled,
+              energy_step_required,
+              zero_carbon_step_required
+            ]
           end
         end
       end

--- a/app/services/template_export_service.rb
+++ b/app/services/template_export_service.rb
@@ -1,9 +1,13 @@
 class TemplateExportService
   attr_accessor :template_version, :customizations
 
-  def initialize(template_version, jurisdiction_template_version_customizations = nil)
+  def initialize(
+    template_version,
+    jurisdiction_template_version_customizations = nil
+  )
     self.template_version = template_version
-    self.customizations = jurisdiction_template_version_customizations&.customizations
+    self.customizations =
+      jurisdiction_template_version_customizations&.customizations
   end
 
   def summary_csv
@@ -20,7 +24,7 @@ class TemplateExportService
             if req["elective"]
               JurisdictionTemplateVersionCustomization.count_of_jurisdictions_using_requirement(
                 req["requirement_block_id"],
-                req["id"],
+                req["id"]
               )
             else
               jurisdictions_count
@@ -30,19 +34,19 @@ class TemplateExportService
           JurisdictionTemplateVersionCustomization.requirement_count_by_reason(
             req["requirement_block_id"],
             req["id"],
-            "bylaw",
+            "bylaw"
           )
         reason_policy_count =
           JurisdictionTemplateVersionCustomization.requirement_count_by_reason(
             req["requirement_block_id"],
             req["id"],
-            "policy",
+            "policy"
           )
         reason_zoning_count =
           JurisdictionTemplateVersionCustomization.requirement_count_by_reason(
             req["requirement_block_id"],
             req["id"],
-            "zoning",
+            "zoning"
           )
 
         csv << [
@@ -51,20 +55,25 @@ class TemplateExportService
           count_of_jurisdictions_using,
           reason_bylaw_count,
           reason_policy_count,
-          reason_zoning_count,
+          reason_zoning_count
         ]
       end
     end
   end
 
   def to_json
-    { "form_json" => template_version.form_json, "customizations" => customizations || {} }.to_json
+    {
+      "form_json" => template_version.form_json,
+      "customizations" => customizations || {}
+    }.to_json
   end
 
   def to_csv
     CSV.generate(headers: true) do |csv|
       csv << I18n.t("export.template_version_csv_headers").split(",")
-      template_version.requirement_blocks_json.each_pair do |block_id, requirement_block|
+      template_version
+        .requirement_blocks_json
+        .each_pair do |block_id, requirement_block|
         tip = customizations&.dig("requirement_block_changes", block_id, "tip")
         csv << [requirement_block["name"], tip, nil, nil, nil, nil, nil, nil]
         requirement_block["requirements"].each do |requirement|
@@ -75,16 +84,18 @@ class TemplateExportService
           is_elective = requirement["elective"] || false
 
           elective_enabled =
-            customizations&.dig("requirement_block_changes", block_id, "enabled_elective_field_ids")&.include?(
-              requirement["id"],
-            ) || false
+            customizations&.dig(
+              "requirement_block_changes",
+              block_id,
+              "enabled_elective_field_ids"
+            )&.include?(requirement["id"]) || false
 
           elective_reason =
             customizations&.dig(
               "requirement_block_changes",
               block_id,
               "enabled_elective_field_reasons",
-              requirement["id"],
+              requirement["id"]
             )
 
           csv << [
@@ -96,7 +107,7 @@ class TemplateExportService
             optional,
             is_elective,
             elective_enabled,
-            elective_reason,
+            elective_reason
           ]
         end
       end

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -11,7 +11,7 @@ class TemplateVersioningService
       .joins(:requirement_template)
       .where(
         "template_versions.status = #{TemplateVersion.statuses[:scheduled]} AND template_versions.version_date <= ?",
-        Date.current,
+        Date.current
       )
       .order("requirement_templates.id, template_versions.version_date DESC")
   end
@@ -34,22 +34,30 @@ class TemplateVersioningService
   def self.schedule!(requirement_template, version_date)
     if !is_valid_schedule_version_date?(requirement_template, version_date)
       raise TemplateVersionScheduleError.new(
-              "Version date must be in the future and after latest scheduled version date",
+              "Version date must be in the future and after latest scheduled version date"
             )
     end
 
     template_version =
       requirement_template.template_versions.build(
         denormalized_template_json:
-          RequirementTemplateBlueprint.render_as_hash(requirement_template, view: :template_snapshot),
+          RequirementTemplateBlueprint.render_as_hash(
+            requirement_template,
+            view: :template_snapshot
+          ),
         form_json: requirement_template.to_form_json,
-        requirement_blocks_json: form_requirement_blocks_hash(requirement_template),
+        requirement_blocks_json:
+          form_requirement_blocks_hash(requirement_template),
         version_diff: diff_of_current_changes_and_last_version,
         version_date: version_date,
-        status: "scheduled",
+        status: "scheduled"
       )
 
-    raise TemplateVersionScheduleError.new(template_version.errors.full_messages.join(", ")) if !template_version.save
+    if !template_version.save
+      raise TemplateVersionScheduleError.new(
+              template_version.errors.full_messages.join(", ")
+            )
+    end
 
     template_version
   end
@@ -58,11 +66,14 @@ class TemplateVersioningService
     return template_version unless template_version.status == "scheduled"
 
     template_version.status = "deprecated"
-    template_version.deprecation_reason = TemplateVersion.deprecation_reasons[:unscheduled]
+    template_version.deprecation_reason =
+      TemplateVersion.deprecation_reasons[:unscheduled]
     template_version.deprecated_by = deprecated_by
 
     unless template_version.save
-      raise TemplateVersionUnscheduleError.new(template_version.errors.full_messages.join(", "))
+      raise TemplateVersionUnscheduleError.new(
+              template_version.errors.full_messages.join(", ")
+            )
     end
 
     template_version
@@ -70,7 +81,9 @@ class TemplateVersioningService
 
   def self.force_publish_now!(requirement_template, for_early_access = false)
     unless ENV["ENABLE_TEMPLATE_FORCE_PUBLISH"] == "true" || for_early_access
-      raise TemplateVersionForcePublishNowError.new("Force publish is not enabled")
+      raise TemplateVersionForcePublishNowError.new(
+              "Force publish is not enabled"
+            )
     end
 
     version_date = Date.current
@@ -78,19 +91,31 @@ class TemplateVersioningService
     template_version =
       requirement_template.template_versions.build(
         denormalized_template_json:
-          RequirementTemplateBlueprint.render_as_hash(requirement_template, view: :template_snapshot),
+          RequirementTemplateBlueprint.render_as_hash(
+            requirement_template,
+            view: :template_snapshot
+          ),
         form_json: requirement_template.to_form_json,
-        requirement_blocks_json: form_requirement_blocks_hash(requirement_template),
+        requirement_blocks_json:
+          form_requirement_blocks_hash(requirement_template),
         version_diff: diff_of_current_changes_and_last_version,
         version_date: version_date,
-        status: "scheduled",
+        status: "scheduled"
       )
 
-    raise TemplateVersionScheduleError.new(template_version.errors.full_messages.join(", ")) if !template_version.save
+    if !template_version.save
+      raise TemplateVersionScheduleError.new(
+              template_version.errors.full_messages.join(", ")
+            )
+    end
 
     template_version.reload
 
-    ModelCallbackJob.perform_async(template_version.class.name, template_version.id, "force_publish_now!")
+    ModelCallbackJob.perform_async(
+      template_version.class.name,
+      template_version.id,
+      "force_publish_now!"
+    )
 
     template_version
   end
@@ -98,7 +123,7 @@ class TemplateVersioningService
   def self.publish_early_access_version!(requirement_template)
     unless requirement_template.type == EarlyAccessRequirementTemplate.name
       raise TemplateVersionPublishError.new(
-              "Cannot create early access version for a non-early access requirement template",
+              "Cannot create early access version for a non-early access requirement template"
             )
     end
 
@@ -106,12 +131,18 @@ class TemplateVersioningService
   end
 
   def self.publish_version!(template_version, skip_date_check = false)
-    return template_version if template_version.status == "published" || template_version.status == "deprecated"
+    if template_version.status == "published" ||
+         template_version.status == "deprecated"
+      return template_version
+    end
 
-    skip_date_check = skip_date_check && (ENV["ENABLE_TEMPLATE_FORCE_PUBLISH"] == "true")
+    skip_date_check =
+      skip_date_check && (ENV["ENABLE_TEMPLATE_FORCE_PUBLISH"] == "true")
 
     if template_version.version_date > Date.current && (!skip_date_check)
-      raise TemplateVersionPublishError.new("Version cannot be published before it's scheduled date")
+      raise TemplateVersionPublishError.new(
+              "Version cannot be published before it's scheduled date"
+            )
     end
 
     ActiveRecord::Base.transaction do
@@ -119,24 +150,37 @@ class TemplateVersioningService
 
       deprecate_versions_before_template(template_version)
 
-      raise TemplateVersionPublishError.new(template_version.errors.full_messages.join(", ")) if !template_version.save
+      if !template_version.save
+        raise TemplateVersionPublishError.new(
+                template_version.errors.full_messages.join(", ")
+              )
+      end
 
       previous_version = template_version.previous_version
 
       return template_version if previous_version.blank?
 
-      previous_version.jurisdiction_template_version_customizations.each do |customization|
+      previous_version
+        .jurisdiction_template_version_customizations
+        .each do |customization|
         begin
-          copy_jurisdiction_customizations_to_template_version(customization, template_version)
+          copy_jurisdiction_customizations_to_template_version(
+            customization,
+            template_version
+          )
         rescue => e
           # we want to know if an error is happening
           # but don't want to fail the whole publish process because of it
-          Rails.logger.error("Error copying customizations to new template version: #{e.message}")
+          Rails.logger.error(
+            "Error copying customizations to new template version: #{e.message}"
+          )
         end
       end
 
       # Publish the notification
-      NotificationService.publish_new_template_version_publish_event(template_version)
+      NotificationService.publish_new_template_version_publish_event(
+        template_version
+      )
     end
 
     return template_version
@@ -145,7 +189,8 @@ class TemplateVersioningService
   def self.update_draft_permit_with_new_template_version(permit_application)
     return if permit_application.submitted?
 
-    new_template_version = permit_application.template_version.published_template_version
+    new_template_version =
+      permit_application.template_version.published_template_version
 
     # TODO: Does submission_data need to be changed?
 
@@ -158,7 +203,9 @@ class TemplateVersioningService
         form_json["components"].each do |section|
           section_label = section["label"]
           section["components"].each do |block|
-            block["components"].each { |component| return section_label if component["id"] == id }
+            block["components"].each do |component|
+              return section_label if component["id"] == id
+            end
           end
         end
         nil
@@ -178,13 +225,21 @@ class TemplateVersioningService
     before_json = before_version&.requirement_blocks_json
     after_json = template_version.requirement_blocks_json
 
-    before_requirements = before_json&.values&.flat_map { |block| block["requirements"] }
+    before_requirements =
+      before_json&.values&.flat_map { |block| block["requirements"] }
 
-    after_requirements = after_json&.values&.flat_map { |block| block["requirements"] }
+    after_requirements =
+      after_json&.values&.flat_map { |block| block["requirements"] }
 
-    before_requirements_components = before_json&.values&.flat_map { |block| block["form_json"]["components"] } || []
+    before_requirements_components =
+      before_json&.values&.flat_map do |block|
+        block["form_json"]["components"]
+      end || []
 
-    after_requirements_components = after_json&.values&.flat_map { |block| block["form_json"]["components"] } || []
+    after_requirements_components =
+      after_json&.values&.flat_map do |block|
+        block["form_json"]["components"]
+      end || []
 
     before_ids = before_requirements&.map { |req| req["id"] } || []
     after_ids = after_requirements&.map { |req| req["id"] } || []
@@ -194,29 +249,54 @@ class TemplateVersioningService
     intersection_ids = before_ids & after_ids
     changed_ids =
       intersection_ids.select do |id|
-        before_req = before_requirements.find { |req| req["id"] == id }.reject { |key, _| key == "updated_at" }
-        after_req = after_requirements.find { |req| req["id"] == id }.reject { |key, _| key == "updated_at" }
+        before_req =
+          before_requirements
+            .find { |req| req["id"] == id }
+            .reject { |key, _| key == "updated_at" }
+        after_req =
+          after_requirements
+            .find { |req| req["id"] == id }
+            .reject { |key, _| key == "updated_at" }
         before_req != after_req
       end
 
-    added_requirement_blueprints = after_requirements&.select { |req| added_ids.include?(req["id"]) } || []
-    removed_requirement_blueprints = before_requirements&.select { |req| removed_ids.include?(req["id"]) } || []
-    changed_requirement_blueprints = after_requirements&.select { |req| changed_ids.include?(req["id"]) } || []
+    added_requirement_blueprints =
+      after_requirements&.select { |req| added_ids.include?(req["id"]) } || []
+    removed_requirement_blueprints =
+      before_requirements&.select { |req| removed_ids.include?(req["id"]) } ||
+        []
+    changed_requirement_blueprints =
+      after_requirements&.select { |req| changed_ids.include?(req["id"]) } || []
 
     # Workaround: need to add the fully formed form_json into the requirement blueprint
-    (changed_requirement_blueprints + added_requirement_blueprints + removed_requirement_blueprints).each do |blueprint|
+    (
+      changed_requirement_blueprints + added_requirement_blueprints +
+        removed_requirement_blueprints
+    ).each do |blueprint|
       matching_component =
-        (after_requirements_components + before_requirements_components).find do |component|
-          component["id"] == blueprint["id"]
-        end
+        (
+          after_requirements_components + before_requirements_components
+        ).find { |component| component["id"] == blueprint["id"] }
 
       blueprint["form_json"] = matching_component if matching_component
     end
 
     {
-      added: add_current_section_labels(template_version.form_json, added_requirement_blueprints),
-      changed: add_current_section_labels(template_version.form_json, changed_requirement_blueprints),
-      removed: add_current_section_labels(before_version.form_json, removed_requirement_blueprints),
+      added:
+        add_current_section_labels(
+          template_version.form_json,
+          added_requirement_blueprints
+        ),
+      changed:
+        add_current_section_labels(
+          template_version.form_json,
+          changed_requirement_blueprints
+        ),
+      removed:
+        add_current_section_labels(
+          before_version.form_json,
+          removed_requirement_blueprints
+        )
     }
   end
 
@@ -228,7 +308,7 @@ class TemplateVersioningService
         "version_date <=? AND status = ? AND deprecation_reason = ?",
         template_version.version_date,
         TemplateVersion.statuses[:deprecated],
-        TemplateVersion.deprecation_reasons[:new_publish],
+        TemplateVersion.deprecation_reasons[:new_publish]
       )
       .where.not(id: template_version.id)
       .order(version_date: :desc, created_at: :desc)
@@ -250,48 +330,74 @@ class TemplateVersioningService
     jurisdiction_template_version_customization,
     new_template_version
   )
-    return if jurisdiction_template_version_customization.blank? || new_template_version.blank?
+    if jurisdiction_template_version_customization.blank? ||
+         new_template_version.blank?
+      return
+    end
 
-    modified_copied_customizations = jurisdiction_template_version_customization.customizations.deep_dup
+    modified_copied_customizations =
+      jurisdiction_template_version_customization.customizations.deep_dup
     existing_customization_for_template =
       new_template_version.jurisdiction_template_version_customizations.find_by(
-        jurisdiction_id: jurisdiction_template_version_customization.jurisdiction_id,
+        jurisdiction_id:
+          jurisdiction_template_version_customization.jurisdiction_id
       )
-    does_new_template_already_have_customization = existing_customization_for_template.present?
+    does_new_template_already_have_customization =
+      existing_customization_for_template.present?
 
     return if modified_copied_customizations["requirement_block_changes"].blank?
 
     # Remove any requirement_block_changes if the requirement_block is not present in the new template version
-    modified_copied_customizations["requirement_block_changes"].delete_if do |key, _value|
+    modified_copied_customizations[
+      "requirement_block_changes"
+    ].delete_if do |key, _value|
       !new_template_version.requirement_blocks_json.key?(key)
     end
 
     # Remove any enabled_elective_field_ids and reasons that are not present in the new template version's
     # requirement_blocks
-    modified_copied_customizations["requirement_block_changes"].each do |key, current_requirement_block_change|
-      next if current_requirement_block_change["enabled_elective_field_ids"].blank?
+    modified_copied_customizations[
+      "requirement_block_changes"
+    ].each do |key, current_requirement_block_change|
+      if current_requirement_block_change["enabled_elective_field_ids"].blank?
+        next
+      end
 
       available_elective_field_ids =
         new_template_version.requirement_blocks_json[key]["requirements"]
           .select { |r| r["elective"] }
           .map { |r| r["id"] }
 
-      modified_copied_customizations["requirement_block_changes"][key]["enabled_elective_field_ids"].delete_if do |id|
-        !available_elective_field_ids.include?(id)
-      end
+      modified_copied_customizations["requirement_block_changes"][key][
+        "enabled_elective_field_ids"
+      ].delete_if { |id| !available_elective_field_ids.include?(id) }
 
-      if modified_copied_customizations.dig("requirement_block_changes", key, "enabled_elective_field_reasons").present?
+      if modified_copied_customizations.dig(
+           "requirement_block_changes",
+           key,
+           "enabled_elective_field_reasons"
+         ).present?
         modified_copied_customizations
-          .dig("requirement_block_changes", key, "enabled_elective_field_reasons")
+          .dig(
+            "requirement_block_changes",
+            key,
+            "enabled_elective_field_reasons"
+          )
           .delete_if { |id| !available_elective_field_ids.include?(id) }
       else
-        modified_copied_customizations["requirement_block_changes"][key]["enabled_elective_field_reasons"] = {}
+        modified_copied_customizations["requirement_block_changes"][key][
+          "enabled_elective_field_reasons"
+        ] = {}
       end
 
       if !does_new_template_already_have_customization ||
            existing_customization_for_template
              .customizations
-             .dig("requirement_block_changes", key, "enabled_elective_field_ids")
+             .dig(
+               "requirement_block_changes",
+               key,
+               "enabled_elective_field_ids"
+             )
              .blank?
         next
       end
@@ -302,35 +408,47 @@ class TemplateVersioningService
       ] = existing_customization_for_template.customizations.dig(
         "requirement_block_changes",
         key,
-        "enabled_elective_field_ids",
-      ) | modified_copied_customizations.dig("requirement_block_changes", key, "enabled_elective_field_ids")
+        "enabled_elective_field_ids"
+      ) |
+        modified_copied_customizations.dig(
+          "requirement_block_changes",
+          key,
+          "enabled_elective_field_ids"
+        )
 
       # Combine the enabled_elective_field_reasons from the old and new template versions and remove any duplicates
-      modified_copied_customizations.dig("requirement_block_changes", key, "enabled_elective_field_reasons").merge!(
+      modified_copied_customizations.dig(
+        "requirement_block_changes",
+        key,
+        "enabled_elective_field_reasons"
+      ).merge!(
         existing_customization_for_template.customizations.dig(
           "requirement_block_changes",
           key,
-          "enabled_elective_field_reasons",
-        ),
+          "enabled_elective_field_reasons"
+        )
       )
     end
 
     copied_jurisdiction_template_version_customization = nil
 
     if does_new_template_already_have_customization
-      copied_jurisdiction_template_version_customization = existing_customization_for_template
-      copied_jurisdiction_template_version_customization.customizations = modified_copied_customizations
+      copied_jurisdiction_template_version_customization =
+        existing_customization_for_template
+      copied_jurisdiction_template_version_customization.customizations =
+        modified_copied_customizations
     else
       copied_jurisdiction_template_version_customization =
         new_template_version.jurisdiction_template_version_customizations.build(
-          jurisdiction_id: jurisdiction_template_version_customization.jurisdiction_id,
-          customizations: modified_copied_customizations,
+          jurisdiction_id:
+            jurisdiction_template_version_customization.jurisdiction_id,
+          customizations: modified_copied_customizations
         )
     end
 
     if !copied_jurisdiction_template_version_customization.save
       raise TemplateVersionPublishError.new(
-              "Old jurisdiction customizations could not be copied to new template version for jurisdiction_id:#{jurisdiction_template_version_customization.jurisdiction_id}",
+              "Old jurisdiction customizations could not be copied to new template version for jurisdiction_id:#{jurisdiction_template_version_customization.jurisdiction_id}"
             )
     end
   end
@@ -349,7 +467,7 @@ class TemplateVersioningService
     else
       template_versions.update_all(
         status: "deprecated",
-        deprecation_reason: TemplateVersion.deprecation_reasons[:new_publish],
+        deprecation_reason: TemplateVersion.deprecation_reasons[:new_publish]
       )
     end
   end
@@ -357,11 +475,15 @@ class TemplateVersioningService
   def self.form_requirement_blocks_hash(requirement_template)
     requirement_blocks_json = {}
 
-    requirement_template.requirement_template_sections.each do |template_section|
+    requirement_template
+      .requirement_template_sections
+      .each do |template_section|
       template_section.requirement_blocks.each do |requirement_block|
-        requirement_blocks_json[requirement_block.id] = RequirementBlockBlueprint.render_as_hash(
+        requirement_blocks_json[
+          requirement_block.id
+        ] = RequirementBlockBlueprint.render_as_hash(
           requirement_block,
-          parent_key: template_section.key,
+          parent_key: template_section.key
         )
       end
     end
@@ -377,7 +499,11 @@ class TemplateVersioningService
         .order(version_date: :desc, created_at: :desc)
         .first
 
-    version_date > Date.current && (last_scheduled_version.blank? || version_date > last_scheduled_version.version_date)
+    version_date > Date.current &&
+      (
+        last_scheduled_version.blank? ||
+          version_date > last_scheduled_version.version_date
+      )
   end
 
   def self.diff_of_current_changes_and_last_version

--- a/app/services/websocket_broadcaster.rb
+++ b/app/services/websocket_broadcaster.rb
@@ -14,14 +14,21 @@ class WebsocketBroadcaster
   end
 
   def self.push_user_payloads(payloads_hash)
-    return unless Current.skip_websocket_broadcasts.blank? || payloads_hash.blank?
+    unless Current.skip_websocket_broadcasts.blank? || payloads_hash.blank?
+      return
+    end
 
-    payloads_hash.each { |user_id, payload| ActionCable.server.broadcast(user_channel(user_id), payload) }
+    payloads_hash.each do |user_id, payload|
+      ActionCable.server.broadcast(user_channel(user_id), payload)
+    end
   end
 
   def self.push_update_to_relevant_users(user_ids, domain, eventType, data)
     user_ids.each do |id|
-      ActionCable.server.broadcast(user_channel(id), { domain: domain, eventType: eventType, data: data })
+      ActionCable.server.broadcast(
+        user_channel(id),
+        { domain: domain, eventType: eventType, data: data }
+      )
     end
   end
 end

--- a/app/services/wrappers/base.rb
+++ b/app/services/wrappers/base.rb
@@ -15,7 +15,9 @@ class Wrappers::Base
 
   def handle_response(response)
     if response.success?
-      return(response.body.is_a?(Hash) ? response.body : JSON.parse(response.body))
+      return(
+        response.body.is_a?(Hash) ? response.body : JSON.parse(response.body)
+      )
     else
       handle_error(response)
     end
@@ -54,12 +56,12 @@ class Wrappers::Base
     when 400..499
       raise Errors::WrapperClientError.new(
               "Wrapper client error: #{response.status}. Details: #{response.body}",
-              response.status,
+              response.status
             )
     when 500..599
       raise Errors::WrapperServerError.new(
               "Wrapper server error: #{response.status}. Details: #{response.body}",
-              response.status,
+              response.status
             )
     else
       raise "HTTP error: #{response.status}"

--- a/app/services/wrappers/digital_seal_validator.rb
+++ b/app/services/wrappers/digital_seal_validator.rb
@@ -19,13 +19,20 @@ class Wrappers::DigitalSealValidator < Wrappers::Base
 
   def call(*args) # take file and the fie type
     # raise NameError.new("File not found") if !File.exist?(args[0])
-    form_data = { json: '{"in":"{file}"}', file: Faraday::FilePart.new(args[0], args[1]) }
+    form_data = {
+      json: '{"in":"{file}"}',
+      file: Faraday::FilePart.new(args[0], args[1])
+    }
     response = post("validatePDF", form_data, true)
     if response.success? && response.body.dig("response", "result") == "SUCCESS"
       signatures = response.body.dig("response", "singleSignatureResults") #contains all info to be parsed for display
       OpenStruct.new(success: true, signatures: signatures)
     else
-      OpenStruct.new(success: false, error: response.body.dig("response", "result"), signatures: [])
+      OpenStruct.new(
+        success: false,
+        error: response.body.dig("response", "result"),
+        signatures: []
+      )
     end
   rescue StandardError => e
     OpenStruct.new(success: false, error: "#{e.message}", signatures: [])

--- a/app/services/wrappers/geocoder.rb
+++ b/app/services/wrappers/geocoder.rb
@@ -6,7 +6,10 @@ class Wrappers::Geocoder < Wrappers::Base
   end
 
   def default_headers
-    { "Content-Type" => "application/json", "apiKey" => "#{ENV["BCGOV_ADDRESS_GEOCODER_API_KEY"]}" }
+    {
+      "Content-Type" => "application/json",
+      "apiKey" => "#{ENV["BCGOV_ADDRESS_GEOCODER_API_KEY"]}"
+    }
   end
 
   def site_options(address_string = nil, coordinates = nil)
@@ -15,7 +18,7 @@ class Wrappers::Geocoder < Wrappers::Base
       autoComplete: true,
       brief: true,
       maxResults: 10,
-      outputSRS: 4326,
+      outputSRS: 4326
       # A few more params available for experimentation:
       #   locationDescriptor: "any",
       #   interpolation: "adaptive",
@@ -25,13 +28,22 @@ class Wrappers::Geocoder < Wrappers::Base
     }
 
     site_params[:addressString] = address_string if address_string.present?
-    return nearest_options(coordinates.join(",")) if coordinates.present? && address_string.blank?
+    if coordinates.present? && address_string.blank?
+      return nearest_options(coordinates.join(","))
+    end
 
     r = get("/addresses.json", site_params)
     return(
       r["features"]
-        .filter { |f| %w[CIVIC_NUMBER BLOCK].include?(f["properties"]["matchPrecision"]) }
-        .map { |site| { label: site["properties"]["fullAddress"], value: site["properties"]["siteID"] } }
+        .filter do |f|
+          %w[CIVIC_NUMBER BLOCK].include?(f["properties"]["matchPrecision"])
+        end
+        .map do |site|
+          {
+            label: site["properties"]["fullAddress"],
+            value: site["properties"]["siteID"]
+          }
+        end
     )
   end
 
@@ -42,12 +54,17 @@ class Wrappers::Geocoder < Wrappers::Base
       locationDescriptor: "parcelPoint",
       maxDistance: 50,
       maxResults: 5,
-      excludeUnits: exclude_units,
+      excludeUnits: exclude_units
     }
     r = get("/sites/near.json", site_params)
     #matchPrecision does not exist on near
     return(
-      r["features"].map { |site| { label: site["properties"]["fullAddress"], value: site["properties"]["siteID"] } }
+      r["features"].map do |site|
+        {
+          label: site["properties"]["fullAddress"],
+          value: site["properties"]["siteID"]
+        }
+      end
     )
   end
 

--- a/app/services/wrappers/ltsa_parcel_map_bc.rb
+++ b/app/services/wrappers/ltsa_parcel_map_bc.rb
@@ -19,7 +19,7 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
       where: "PID='#{pid}'",
       returnGeometry: true,
       spatialRel: "esriSpatialRelIntersects",
-      outFields: fields,
+      outFields: fields
     }
 
     get("#{PARCEL_SERVICE}/query", query_params, true)
@@ -33,7 +33,7 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
       where: "PARCEL_NAME='#{pin}' AND PIN IS NOT NULL",
       returnGeometry: true,
       spatialRel: "esriSpatialRelIntersects",
-      outFields: fields,
+      outFields: fields
     }
 
     get("#{PARCEL_SERVICE}/query", query_params, true)
@@ -44,7 +44,7 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
       f: "json",
       where: "HISTORIC_SITE_IND='Y' AND PARCEL_DESCRIPTION='#{pid}'",
       returnGeometry: true,
-      outFields: "*",
+      outFields: "*"
     }
     response = get("#{HISTORIC_SERVICE}/query", query_params, true)
 
@@ -55,9 +55,11 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
 
     # Get geometry from PID
     response_for_geometry = get_details_by_pid(pid: pid, fields: "PID")
-    if response_for_geometry.success? && JSON.parse(response_for_geometry.body).dig("features", 0, "geometry")
+    if response_for_geometry.success? &&
+         JSON.parse(response_for_geometry.body).dig("features", 0, "geometry")
       # Intersect the geometry from the city over
-      pid_geo = JSON.parse(response_for_geometry.body).dig("features", 0, "geometry")
+      pid_geo =
+        JSON.parse(response_for_geometry.body).dig("features", 0, "geometry")
       pid_geo_query_params = {
         f: "json",
         where: "HISTORIC_SITE_IND='Y'",
@@ -65,10 +67,11 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
         spatialRel: "esriSpatialRelIntersects",
         geometry: pid_geo.to_json,
         geometryType: "esriGeometryPolygon",
-        outFields: "*",
+        outFields: "*"
       }
 
-      pid_geo_response = get("#{HISTORIC_SERVICE}/query", pid_geo_query_params, true)
+      pid_geo_response =
+        get("#{HISTORIC_SERVICE}/query", pid_geo_query_params, true)
       return parse_attributes_from_response(pid_geo_response)
     else
       raise Errors::GeometryError
@@ -140,7 +143,8 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
 
       raise Errors::FeatureAttributesRetrievalError if !valid_wkid?(wkid)
 
-      geometry_coords = parsed_response.dig("features", 0, "geometry", "rings", 0)
+      geometry_coords =
+        parsed_response.dig("features", 0, "geometry", "rings", 0)
 
       if (geometry_coords)
         #cartesians system for 102190 OR 3005 #{"wkid"=>, "latestWkid"=>3005}
@@ -158,7 +162,8 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
 
         target_factory = wkid_factory_lookup(4326) #default bc geo utilizes 4326
 
-        transformed_centroid = RGeo::Feature.cast(centroid, factory: target_factory, project: true)
+        transformed_centroid =
+          RGeo::Feature.cast(centroid, factory: target_factory, project: true)
 
         [transformed_centroid.x, transformed_centroid.y]
       else
@@ -177,7 +182,7 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
         proj4:
           "+proj=aea +lat_0=45 +lon_0=-126 +lat_1=50 +lat_2=58.5 +x_0=1000000 +y_0=0 +datum=NAD83 +units=m +no_defs +type=crs",
         coord_sys:
-          'PROJCS["NAD_1983_BC_Environment_Albers (deprecated)",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["latitude_of_center",45],PARAMETER["longitude_of_center",-126],PARAMETER["standard_parallel_1",50],PARAMETER["standard_parallel_2",58.5],PARAMETER["false_easting",1000000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["ESRI","102190"]]',
+          'PROJCS["NAD_1983_BC_Environment_Albers (deprecated)",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["latitude_of_center",45],PARAMETER["longitude_of_center",-126],PARAMETER["standard_parallel_1",50],PARAMETER["standard_parallel_2",58.5],PARAMETER["false_easting",1000000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["ESRI","102190"]]'
       )
     when 3005
       RGeo::Cartesian.factory(
@@ -185,14 +190,14 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
         proj4:
           "+proj=aea +lat_0=45 +lon_0=-126 +lat_1=50 +lat_2=58.5 +x_0=1000000 +y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs +type=crs",
         coord_sys:
-          'PROJCS["NAD83 / BC Albers",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101],TOWGS84[0,0,0,0,0,0,0]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["latitude_of_center",45],PARAMETER["longitude_of_center",-126],PARAMETER["standard_parallel_1",50],PARAMETER["standard_parallel_2",58.5],PARAMETER["false_easting",1000000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","3005"]]',
+          'PROJCS["NAD83 / BC Albers",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101],TOWGS84[0,0,0,0,0,0,0]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],PROJECTION["Albers_Conic_Equal_Area"],PARAMETER["latitude_of_center",45],PARAMETER["longitude_of_center",-126],PARAMETER["standard_parallel_1",50],PARAMETER["standard_parallel_2",58.5],PARAMETER["false_easting",1000000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","3005"]]'
       )
     when 4326
       RGeo::Geographic.spherical_factory(
         srid: 4326,
         proj4: "+proj=longlat +datum=WGS84 +no_defs +type=crs",
         coord_sys:
-          'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]',
+          'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]'
       )
     else
       raise StandardError unless wkid.is_a?(Integer)
@@ -200,7 +205,11 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
       espg = Faraday.new("https://epsg.io")
       response_proj4 = espg.get("#{wkid}.proj4")
       response_wkt = espg.get("#{wkid}.wkt")
-      RGeo::Cartesian.factory(srid: wkid, proj4: response_proj4.body, coord_sys: response_wkt.body)
+      RGeo::Cartesian.factory(
+        srid: wkid,
+        proj4: response_proj4.body,
+        coord_sys: response_wkt.body
+      )
       #this will raise an error if it fails
     end
   end
@@ -219,7 +228,12 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
   def parse_attributes_array_from_response(response)
     if response.success?
       #assumes there is one layer to these features at the moment
-      return(JSON.parse(response.body).dig("features")&.map { |f| f["attributes"] } || [])
+      return(
+        JSON
+          .parse(response.body)
+          .dig("features")
+          &.map { |f| f["attributes"] } || []
+      )
     else
       raise Errors::FeatureAttributesRetrievalError
     end

--- a/app/services/wrappers/ltsa_parcel_map_bc_gis.rb
+++ b/app/services/wrappers/ltsa_parcel_map_bc_gis.rb
@@ -9,7 +9,9 @@ class Wrappers::LtsaParcelMapBcGis < Wrappers::LtsaParcelMapBc
 
   def client
     @client ||=
-      Faraday.new(url: base_url, headers: default_headers) { |faraday| faraday.options.params_encoder = DoNotEncoder }
+      Faraday.new(url: base_url, headers: default_headers) do |faraday|
+        faraday.options.params_encoder = DoNotEncoder
+      end
   end
 
   def base_url
@@ -28,7 +30,7 @@ class Wrappers::LtsaParcelMapBcGis < Wrappers::LtsaParcelMapBc
       inSR: 4326,
       spatialRel: "esriSpatialRelIntersects",
       returnGeometry: true,
-      outFields: fields,
+      outFields: fields
     }
 
     get("#{PARCEL_SERVICE}/query", query_params, true)
@@ -46,7 +48,7 @@ class Wrappers::LtsaParcelMapBcGis < Wrappers::LtsaParcelMapBc
       inSR: 4326,
       spatialRel: "esriSpatialRelIntersects",
       returnGeometry: true,
-      outFields: fields,
+      outFields: fields
     }
 
     get("#{PARCEL_SERVICE}/query", query_params, true)

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -2,11 +2,19 @@ require "mini_magick"
 class AssetUploader < Shrine
   # callback that runs after a file has been promoted (aka saved)
   Attacher.promote_block do
-    DerivativesJob.perform_async(self.class.name, record.class.name, record.id, name, file_data)
+    DerivativesJob.perform_async(
+      self.class.name,
+      record.class.name,
+      record.id,
+      name,
+      file_data
+    )
   end
 
   # callback runs after file is destroyed
-  Attacher.destroy_block { DestroyAssetJob.perform_async(self.class.name, data) }
+  Attacher.destroy_block do
+    DestroyAssetJob.perform_async(self.class.name, data)
+  end
 
   Attacher.derivatives do |original|
     magick = ImageProcessing::MiniMagick.source(original)

--- a/app/validators/phone_validator.rb
+++ b/app/validators/phone_validator.rb
@@ -1,5 +1,10 @@
 class PhoneValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, (options[:message] || "is not a valid phone number")) unless Phonelib.valid?(value)
+    unless Phonelib.valid?(value)
+      record.errors.add(
+        attribute,
+        (options[:message] || "is not a valid phone number")
+      )
+    end
   end
 end

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "devDependencies": {
     "@chakra-ui/cli": "^2.4.1",
-    "@prettier/plugin-ruby": "^4.0.2",
     "@types/leaflet": "^1.9.8",
     "@types/node": "^20.12.2",
     "@types/quill": "^2.0.14",
@@ -98,7 +97,7 @@
     "generate-pdf": " node public/vite-ssr/ssr.js"
   },
   "lint-staged": {
-    "*.{js,css,md,rb,ts,tsx}": [
+    "*.{js,css,md,ts,tsx}": [
       "prettier --write"
     ],
     "*.rb": [


### PR DESCRIPTION
## Description

This consolidates our ruby formatting to use syntax_tree ONLY.
Prior to this we were set up to have syntax_tree formatting apply on save, and then prettier ruby formatting applied in lint-staged which led to confusing behaviour and large diffs.

This is being applied to the end of my preview branch to avoid merge conflict hell. We may want to consider applying this directly to develop ALSO.

To do this:

git cherry-pick 341383f35c21122f1b0fba481d82da57329df1dd
stree write ./app/**/*.rb
 