### PR TITLE
refactor early access filter as visibility and finish early access re…

### DIFF
--- a/app/blueprints/requirement_template_blueprint.rb
+++ b/app/blueprints/requirement_template_blueprint.rb
@@ -1,6 +1,15 @@
 class RequirementTemplateBlueprint < Blueprinter::Base
   identifier :id
-  fields :nickname, :type, :description, :first_nations, :label, :discarded_at, :fetched_at, :created_at, :updated_at
+  fields :nickname,
+         :type,
+         :description,
+         :first_nations,
+         :label,
+         :discarded_at,
+         :fetched_at,
+         :created_at,
+         :updated_at,
+         :visibility
 
   association :permit_type, blueprint: PermitClassificationBlueprint
   association :activity, blueprint: PermitClassificationBlueprint

--- a/app/controllers/api/concerns/search/requirement_blocks.rb
+++ b/app/controllers/api/concerns/search/requirement_blocks.rb
@@ -9,7 +9,7 @@ module Api::Concerns::Search::RequirementBlocks
         match: :word_start,
         where: {
           discarded: discarded,
-          early_access: early_access,
+          visibility: visibility,
         },
         page: search_params[:page],
         per_page:
@@ -27,7 +27,7 @@ module Api::Concerns::Search::RequirementBlocks
   private
 
   def search_params
-    params.permit(:query, :page, :show_archived, :per_page, sort: %i[field direction])
+    params.permit(:query, :page, :show_archived, :visibility, :per_page, sort: %i[field direction])
   end
 
   def query
@@ -38,8 +38,8 @@ module Api::Concerns::Search::RequirementBlocks
     search_params[:show_archived].present?
   end
 
-  def early_access
-    search_params[:early_access].present?
+  def visibility
+    search_params[:visibility].split(",")
   end
 
   def order

--- a/app/controllers/api/concerns/search/requirement_templates.rb
+++ b/app/controllers/api/concerns/search/requirement_templates.rb
@@ -5,17 +5,10 @@ module Api::Concerns::Search::RequirementTemplates
     @search =
       RequirementTemplate.search(
         query,
-        includes: %i[
-          activity
-          permit_type
-          last_three_deprecated_template_versions
-          scheduled_template_versions
-          published_template_version
-        ],
         order: order,
         where: {
           discarded: discarded,
-          early_access: early_access,
+          visibility: visibility,
         },
         match: :word_start,
         page: search_params[:page],
@@ -27,14 +20,26 @@ module Api::Concerns::Search::RequirementTemplates
               nil
             end
           ),
-        includes: RequirementTemplate::SEARCH_INCLUDES,
+        includes: model_klass::SEARCH_INCLUDES,
       )
   end
 
   private
 
+  def model_klass
+    if search_params[:visibility] == "early_access"
+      EarlyAccessRequirementTemplate
+    else
+      LiveRequirementTemplate
+    end
+  end
+
   def search_params
-    params.permit(:query, :show_archived, :early_access, :page, :per_page, sort: %i[field direction])
+    params.permit(:query, :show_archived, :visibility, :page, :per_page, sort: %i[field direction])
+  end
+
+  def visibility
+    search_params[:visibility].split(",")
   end
 
   def query
@@ -43,10 +48,6 @@ module Api::Concerns::Search::RequirementTemplates
 
   def discarded
     search_params[:show_archived].present?
-  end
-
-  def early_access
-    search_params[:early_access].present?
   end
 
   def order

--- a/app/frontend/components/domains/requirements-library/grid-header.tsx
+++ b/app/frontend/components/domains/requirements-library/grid-header.tsx
@@ -10,7 +10,11 @@ import { ModelSearchInput } from "../../shared/base/model-search-input"
 import { GridHeader } from "../../shared/grid/grid-header"
 import { SortIcon } from "../../shared/sort-icon"
 
-export const GridHeaders = observer(function GridHeaders() {
+interface IProps {
+  forEarlyAccess?: boolean
+}
+
+export const GridHeaders = observer(function GridHeaders({ forEarlyAccess }: IProps) {
   const { requirementBlockStore } = useMst()
   const { sort, getSortColumnHeader, toggleSort } = requirementBlockStore
   const { t } = useTranslation()
@@ -23,11 +27,13 @@ export const GridHeaders = observer(function GridHeaders() {
           as={Flex}
           gridColumn={"span 7"}
           p={6}
-          bg={"greys.grey10"}
+          bg={forEarlyAccess ? "semantic.warningLight" : "greys.grey10"}
           justifyContent={"space-between"}
           align="center"
         >
-          <Text role={"heading"}>{t("requirementsLibrary.index.tableHeading")}</Text>
+          <Text role={"heading"}>
+            {t(`${forEarlyAccess ? "earlyAccessRequirementsLibrary" : "requirementsLibrary"}.index.tableHeading`)}
+          </Text>
           <ModelSearchInput
             inputGroupProps={{
               position: "sticky",

--- a/app/frontend/components/domains/requirements-library/index.tsx
+++ b/app/frontend/components/domains/requirements-library/index.tsx
@@ -25,9 +25,7 @@ export const RequirementsLibraryScreen = observer(function RequirementsLibrary()
           </Box>
           <RequirementsBlockModal />
         </Flex>
-
         <RequirementBlocksTable alignItems={"flex-start"} w={"full"} />
-
         <ToggleArchivedButton searchModel={requirementBlockStore} mt={3} />
       </VStack>
     </Container>

--- a/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
@@ -32,15 +32,18 @@ import { RequirementsBlockModal } from "./requirements-block-modal"
 
 interface IProps extends Partial<StackProps> {
   renderActionButton?: (props: ButtonProps & { requirementBlock: IRequirementBlock }) => JSX.Element
+  forEarlyAccess?: boolean
 }
 
 const ROW_CLASS_NAME = "requirements-library-grid-row"
 
 export const RequirementBlocksTable = observer(function RequirementBlocksTable({
   renderActionButton,
+  forEarlyAccess,
   ...containerProps
 }: IProps) {
-  const { requirementBlockStore } = useMst()
+  const { requirementBlockStore, earlyAccessRequirementBlockStore } = useMst()
+  const storeToUse = forEarlyAccess ? earlyAccessRequirementBlockStore : requirementBlockStore
   const {
     tableRequirementBlocks,
     currentPage,
@@ -51,20 +54,20 @@ export const RequirementBlocksTable = observer(function RequirementBlocksTable({
     handlePageChange,
     isSearching,
     showArchived,
-  } = requirementBlockStore
+  } = storeToUse
 
-  useSearch(requirementBlockStore as ISearch, [showArchived])
+  useSearch(storeToUse as ISearch, [showArchived])
 
   useEffect(() => {
     return () => {
-      requirementBlockStore.setShowArchived(false)
+      storeToUse.setShowArchived(false)
     }
   }, [])
 
   return (
     <VStack as={"article"} spacing={5} {...containerProps}>
       <SearchGrid gridRowClassName={ROW_CLASS_NAME} templateColumns="repeat(7, 1fr)" pos={"relative"}>
-        <GridHeaders />
+        <GridHeaders forEarlyAccess={forEarlyAccess} />
 
         {isSearching ? (
           <Flex py={50} gridColumn={"span 6"}>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
@@ -39,6 +39,7 @@ interface IRequirementsBlockProps {
   showEditWarning?: boolean
   triggerButtonProps?: Partial<ButtonProps>
   withOptionsMenu?: boolean
+  forEarlyAccess?: boolean
 }
 
 export const RequirementsBlockModal = observer(function RequirementsBlockModal({
@@ -46,6 +47,7 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
   showEditWarning,
   triggerButtonProps,
   withOptionsMenu,
+  forEarlyAccess,
 }: IRequirementsBlockProps) {
   const { requirementBlockStore } = useMst()
   const { t } = useTranslation()

--- a/app/frontend/components/domains/super-admin/early-access/requirements-library/index.tsx
+++ b/app/frontend/components/domains/super-admin/early-access/requirements-library/index.tsx
@@ -3,6 +3,9 @@ import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { useMst } from "../../../../../setup/root"
+import { ToggleArchivedButton } from "../../../../shared/buttons/show-archived-button"
+import { RequirementBlocksTable } from "../../../requirements-library/requirement-blocks-table"
+import { RequirementsBlockModal } from "../../../requirements-library/requirements-block-modal"
 
 export const EarlyAccessRequirementsLibraryScreen = observer(function RequirementsLibrary() {
   const { t } = useTranslation()
@@ -20,12 +23,11 @@ export const EarlyAccessRequirementsLibraryScreen = observer(function Requiremen
               {t("earlyAccessRequirementsLibrary.index.description")}
             </Text>
           </Box>
-          {/* <RequirementsBlockModal /> */}
+          <RequirementsBlockModal forEarlyAccess />
         </Flex>
 
-        {/* <RequirementBlocksTable alignItems={"flex-start"} w={"full"} /> */}
-
-        {/* <ToggleArchivedButton searchModel={requirementBlockStore} mt={3} /> */}
+        <RequirementBlocksTable alignItems={"flex-start"} w={"full"} forEarlyAccess />
+        <ToggleArchivedButton searchModel={requirementBlockStore} mt={3} />
       </VStack>
     </Container>
   )

--- a/app/frontend/hooks/use-search.ts
+++ b/app/frontend/hooks/use-search.ts
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom"
 import { ISearch } from "../lib/create-search-model"
 import { useMst } from "../setup/root"
 import { ESortDirection } from "../types/enums"
+import { TVisibility } from "../types/types"
 import { parseBoolean } from "../utils/utility-functions"
 
 export const useSearch = (searchModel: ISearch, dependencyArray: any[] = []) => {
@@ -28,7 +29,7 @@ export const useSearch = (searchModel: ISearch, dependencyArray: any[] = []) => 
     const currentPage = queryParams.get("currentPage")
     const countPerPage = queryParams.get("countPerPage")
     const showArchived = queryParams.get("showArchived")
-    const earlyAccess = queryParams.get("earlyAccess")
+    const visibility = queryParams.get("visibility") as TVisibility
     const sortDirection = queryParams.get("sortDirection") as ESortDirection
     const sortField = queryParams.get("sortField")
 
@@ -40,7 +41,7 @@ export const useSearch = (searchModel: ISearch, dependencyArray: any[] = []) => 
     }
     if (countPerPage) searchModel.setCountPerPage(parseInt(decodeURIComponent(countPerPage)))
     if (showArchived) searchModel.setShowArchived(parseBoolean(showArchived))
-    if (earlyAccess) searchModel.setEarlyAccess(parseBoolean(earlyAccess))
+    if (visibility) searchModel.setVisibility(visibility)
     if (sortDirection && sortField) {
       searchModel.applySort({ direction: sortDirection, field: sortField })
     } else {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -239,6 +239,8 @@ const options = {
           share: "Share",
           unassigned: "Unassigned",
           unassign: "Unassign",
+          seeEarlyAccessButton: "See Early Access",
+          seeLiveButton: "See Live",
         },
         notification: {
           title: "Notifications",
@@ -650,8 +652,8 @@ const options = {
         earlyAccessRequirementsLibrary: {
           index: {
             title: "Early access requirements library",
-            description: "List of all Early Access Requirement Blocks in the system that can be used inside Templates.",
-            tableHeading: "previews",
+            description: "TODO description",
+            tableHeading: "Early access requirement blocks",
           },
         },
         requirementsLibrary: {

--- a/app/frontend/lib/create-search-model.ts
+++ b/app/frontend/lib/create-search-model.ts
@@ -1,6 +1,6 @@
 import { flow, Instance, types } from "mobx-state-tree"
 import { ESortDirection } from "../types/enums"
-import { ISort } from "../types/types"
+import { ISort, TVisibility } from "../types/types"
 import { setQueryParam } from "../utils/utility-functions"
 
 interface IFetchOptions {
@@ -21,7 +21,7 @@ export const createSearchModel = <TSortField, TFetchOptions extends IFetchOption
       sort: types.maybeNull(types.frozen<ISort<TSortField>>()),
       currentPage: types.optional(types.number, 1),
       showArchived: types.optional(types.boolean, false),
-      earlyAccess: types.optional(types.boolean, false),
+      visibility: types.maybeNull(types.frozen<TVisibility>()),
       totalPages: types.maybeNull(types.number),
       totalCount: types.maybeNull(types.number),
       countPerPage: types.optional(types.number, 10),
@@ -50,9 +50,9 @@ export const createSearchModel = <TSortField, TFetchOptions extends IFetchOption
         !skipQueryParam && setQueryParam("showArchived", bool.toString())
         self.showArchived = bool
       },
-      setEarlyAccess(bool) {
-        !skipQueryParam && setQueryParam("earlyAccess", bool.toString())
-        self.earlyAccess = bool
+      setVisibility(value: TVisibility) {
+        !skipQueryParam && setQueryParam("visibility", value)
+        self.visibility = value
       },
       fetchData: flow(function* (opts?: TFetchOptions) {
         if (fetchDataActionName in self) {

--- a/app/frontend/stores/early-access-requirement-block-store.ts
+++ b/app/frontend/stores/early-access-requirement-block-store.ts
@@ -1,0 +1,58 @@
+import { Instance, cast, flow, toGenerator, types } from "mobx-state-tree"
+import { createSearchModel } from "../lib/create-search-model"
+import { withEnvironment } from "../lib/with-environment"
+import { withMerge } from "../lib/with-merge"
+import { withRootStore } from "../lib/with-root-store"
+import { RequirementBlockModel } from "../models/requirement-block"
+import { ERequirementLibrarySortFields, EVisibility } from "../types/enums"
+
+export const EarlyAccessRequirementBlockStoreModel = types
+  .compose(
+    types.model("EarlyAccessRequirementBlockStoreModel").props({
+      tableEarlyAccessRequirementBlocks: types.array(types.safeReference(RequirementBlockModel)),
+    }),
+    createSearchModel<ERequirementLibrarySortFields>("fetchEarlyAccessRequirementBlocks")
+  )
+  .extend(withEnvironment())
+  .extend(withRootStore())
+  .extend(withMerge())
+  .views((self) => ({
+    get tableRequirementBlocks() {
+      return self.tableEarlyAccessRequirementBlocks
+    },
+  }))
+  .actions((self) => ({
+    fetchEarlyAccessRequirementBlocks: flow(function* (opts?: {
+      reset?: boolean
+      page?: number
+      countPerPage?: number
+    }) {
+      if (opts?.reset) {
+        self.resetPages()
+      }
+
+      const response = yield* toGenerator(
+        self.environment.api.fetchRequirementBlocks({
+          query: self.query,
+          sort: self.sort,
+          page: opts?.page ?? self.currentPage,
+          showArchived: self.showArchived,
+          visibility: EVisibility.earlyAccess,
+          perPage: opts?.countPerPage ?? self.countPerPage,
+        })
+      )
+
+      if (response.ok) {
+        self.rootStore.requirementBlockStore.mergeUpdateAll(response.data.data, "requirementBlockMap")
+        self.tableEarlyAccessRequirementBlocks = cast(response.data.data.map((requirementBlock) => requirementBlock.id))
+        self.currentPage = opts?.page ?? self.currentPage
+        self.totalPages = response.data.meta.totalPages
+        self.totalCount = response.data.meta.totalCount
+        self.countPerPage = opts?.countPerPage ?? self.countPerPage
+      }
+      return response.ok
+    }),
+  }))
+
+export interface IEarlyAccessRequirementBlockStoreModel
+  extends Instance<typeof EarlyAccessRequirementBlockStoreModel> {}

--- a/app/frontend/stores/early-access-requirement-template-store.ts
+++ b/app/frontend/stores/early-access-requirement-template-store.ts
@@ -5,7 +5,7 @@ import { withEnvironment } from "../lib/with-environment"
 import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
 import { RequirementTemplateModel } from "../models/requirement-template"
-import { EEarlyAccessRequirementTemplateSortFields } from "../types/enums"
+import { EEarlyAccessRequirementTemplateSortFields, EVisibility } from "../types/enums"
 import { toCamelCase } from "../utils/utility-functions"
 
 export const EarlyAccessRequirementTemplateStoreModel = types
@@ -41,7 +41,7 @@ export const EarlyAccessRequirementTemplateStoreModel = types
           page: opts?.page ?? self.currentPage,
           perPage: opts?.countPerPage ?? self.countPerPage,
           showArchived: self.showArchived,
-          earlyAccess: true,
+          visibility: EVisibility.earlyAccess,
         })
       )
 

--- a/app/frontend/stores/requirement-block-store.ts
+++ b/app/frontend/stores/requirement-block-store.ts
@@ -12,6 +12,7 @@ import {
   ERequirementLibrarySortFields,
   ERequirementType,
   ETagType,
+  EVisibility,
 } from "../types/enums"
 import {
   TAutoComplianceModuleConfiguration,
@@ -112,6 +113,7 @@ export const RequirementBlockStoreModel = types
           sort: self.sort,
           page: opts?.page ?? self.currentPage,
           showArchived: self.showArchived,
+          visibility: `${EVisibility.live},${EVisibility.any}`,
           perPage: opts?.countPerPage ?? self.countPerPage,
         })
       )

--- a/app/frontend/stores/requirement-template-store.ts
+++ b/app/frontend/stores/requirement-template-store.ts
@@ -9,7 +9,7 @@ import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
 import { IRequirementTemplate, RequirementTemplateModel } from "../models/requirement-template"
 import { IRequirementTemplateUpdateParams } from "../types/api-request"
-import { ERequirementTemplateSortFields } from "../types/enums"
+import { ERequirementTemplateSortFields, EVisibility } from "../types/enums"
 import { ICopyRequirementTemplateFormData, TCreateRequirementTemplateFormData } from "../types/types"
 import { toCamelCase } from "../utils/utility-functions"
 
@@ -81,7 +81,7 @@ export const RequirementTemplateStoreModel = types
           page: opts?.page ?? self.currentPage,
           perPage: opts?.countPerPage ?? self.countPerPage,
           showArchived: self.showArchived,
-          earlyAccess: false,
+          visibility: `${EVisibility.live},${EVisibility.any}`,
         })
       )
 

--- a/app/frontend/stores/root-store.ts
+++ b/app/frontend/stores/root-store.ts
@@ -5,6 +5,10 @@ import { withEnvironment } from "../lib/with-environment"
 import { CollaboratorStoreModel, ICollaboratorStore } from "./collaborator-store"
 import { ContactStoreModel, IContactStore } from "./contact-store"
 import {
+  EarlyAccessRequirementBlockStoreModel,
+  IEarlyAccessRequirementBlockStoreModel,
+} from "./early-access-requirement-block-store"
+import {
   EarlyAccessRequirementTemplateStoreModel,
   IEarlyAccessRequirementTemplateStoreModel,
 } from "./early-access-requirement-template-store"
@@ -33,6 +37,7 @@ export const RootStoreModel = types
     permitClassificationStore: types.optional(PermitClassificationStoreModel, {}),
     jurisdictionStore: types.optional(JurisdictionStoreModel, {}),
     requirementBlockStore: types.optional(RequirementBlockStoreModel, {}),
+    earlyAccessRequirementBlockStore: types.optional(EarlyAccessRequirementBlockStoreModel, {}),
     requirementTemplateStore: types.optional(RequirementTemplateStoreModel, {}),
     earlyAccessRequirementTemplateStore: types.optional(EarlyAccessRequirementTemplateStoreModel, {}),
     collaboratorStore: types.optional(CollaboratorStoreModel, {}),
@@ -94,6 +99,7 @@ export interface IRootStore extends IStateTreeNode {
   permitClassificationStore: IPermitClassificationStore
   jurisdictionStore: IJurisdictionStore
   userStore: IUserStore
+  earlyAccessRequirementBlockStore: IEarlyAccessRequirementBlockStoreModel
   requirementBlockStore: IRequirementBlockStoreModel
   requirementTemplateStore: IRequirementTemplateStoreModel
   earlyAccessRequirementTemplateStore: IEarlyAccessRequirementTemplateStoreModel

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -422,3 +422,9 @@ export enum ECollaboratorType {
   delegatee = "delegatee",
   assignee = "assignee",
 }
+
+export enum EVisibility {
+  live = "live",
+  earlyAccess = "early_access",
+  any = "any",
+}

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -29,6 +29,7 @@ import {
   EStepCodeEPCTestingTargetType,
   ETemplateVersionStatus,
   EUserRoles,
+  EVisibility,
   EWindowsGlazedDoorsPerformanceType,
   EZeroCarbonStep,
 } from "./enums"
@@ -80,7 +81,7 @@ export type TSearchParams<IModelSortFields, IModelFilterFields = {}> = {
   page?: number
   perPage?: number
   showArchived?: boolean
-  earlyAccess?: boolean
+  visibility?: TVisibility
   filters?: IModelFilterFields
 }
 
@@ -543,3 +544,10 @@ export type TCreateRequirementTemplateFormData = {
 export interface ICopyRequirementTemplateFormData extends Partial<TCreateRequirementTemplateFormData> {
   id?: string
 }
+
+type EVisibilityValues = EVisibility.live | EVisibility.earlyAccess | EVisibility.any
+
+export type TVisibility =
+  | EVisibilityValues
+  | `${EVisibilityValues},${EVisibilityValues}`
+  | `${EVisibilityValues},${EVisibilityValues},${EVisibilityValues}`

--- a/app/models/early_access_requirement_template.rb
+++ b/app/models/early_access_requirement_template.rb
@@ -1,4 +1,6 @@
 class EarlyAccessRequirementTemplate < RequirementTemplate
+  SEARCH_INCLUDES = RequirementTemplate::SEARCH_INCLUDES + [:assignee]
+
   has_one :template_version, dependent: :destroy, foreign_key: :requirement_template_id
 
   belongs_to :assignee, class_name: "User", optional: true
@@ -10,6 +12,10 @@ class EarlyAccessRequirementTemplate < RequirementTemplate
   rescue TemplateVersionPublishError => e
     errors.add(:base, e.message)
     raise ActiveRecord::Rollback
+  end
+
+  def visibility
+    "early_access"
   end
 
   private

--- a/app/models/live_requirement_template.rb
+++ b/app/models/live_requirement_template.rb
@@ -1,10 +1,6 @@
 class LiveRequirementTemplate < RequirementTemplate
   validate :unique_classification_for_undiscarded, on: :create
 
-  def assignee
-    nil
-  end
-
   def visibility
     "live"
   end

--- a/app/models/live_requirement_template.rb
+++ b/app/models/live_requirement_template.rb
@@ -5,6 +5,10 @@ class LiveRequirementTemplate < RequirementTemplate
     nil
   end
 
+  def visibility
+    "live"
+  end
+
   def unique_classification_for_undiscarded
     existing_record =
       LiveRequirementTemplate.find_by(

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -45,7 +45,7 @@ class RequirementBlock < ApplicationRecord
       associations: association_list,
       configurations: configurations_search_list,
       discarded: discarded_at.present?,
-      early_access: early_access?,
+      visibility: visibility,
     }
   end
 

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -52,15 +52,19 @@ class RequirementTemplate < ApplicationRecord
   validate :validate_step_code_related_dependencies
 
   def assignee
-    raise NotImplementedError, "The assignee method is not implemented"
-  end
-
-  def visibility
-    raise NotImplementedError, "The assignee method is not implemented"
+    nil
   end
 
   def early_access?
     type == "EarlyAccessRequirementTemplate"
+  end
+
+  def visibility
+    if early_access?
+      return "early_access"
+    else
+      return "live"
+    end
   end
 
   def sections

--- a/app/models/requirement_template.rb
+++ b/app/models/requirement_template.rb
@@ -1,6 +1,5 @@
 class RequirementTemplate < ApplicationRecord
   SEARCH_INCLUDES = %i[
-    assignee
     published_template_version
     permit_type
     last_three_deprecated_template_versions
@@ -53,6 +52,10 @@ class RequirementTemplate < ApplicationRecord
   validate :validate_step_code_related_dependencies
 
   def assignee
+    raise NotImplementedError, "The assignee method is not implemented"
+  end
+
+  def visibility
     raise NotImplementedError, "The assignee method is not implemented"
   end
 
@@ -163,7 +166,7 @@ class RequirementTemplate < ApplicationRecord
       activity: activity.name,
       discarded: discarded_at.present?,
       assignee: assignee&.name,
-      early_access: early_access?,
+      visibility: visibility,
     }
   end
 

--- a/spec/controllers/requirement_templates_controller_spec.rb
+++ b/spec/controllers/requirement_templates_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Api::RequirementTemplatesController, type: :controller do
         expect(json_response["data"]["description"]).to eq("a new template with first nations")
       end
 
-      it "copies sections from an existing non-first-nation requirement template when copy_existing_by_classifications is true" do
+      it "copies sections from an existing non-first-nation requirement template when providing classifications to copy endpoint" do
         create(
           :live_requirement_template,
           activity: activity,
@@ -88,14 +88,13 @@ RSpec.describe Api::RequirementTemplatesController, type: :controller do
         )
 
         expect {
-          post :create,
+          post :copy,
                params: {
                  requirement_template: {
                    description: "a copied template with first nations",
                    first_nations: true,
                    activity_id: activity.id,
                    permit_type_id: permit_type.id,
-                   copy_existing_by_classifications: true,
                  },
                }
         }.to change(RequirementTemplate, :count).by(1)


### PR DESCRIPTION
## Description

Refactor early access search flag as a full string to allow searching for different combinations of any, live, and early_access.
Create a page for requirement blocks that uses a particular store for early access requirement blocks. 

https://hous-bssb.atlassian.net/browse/BPHH-2149

