### PR TITLE
rework preview versioning to fix bugs with viewing after update

### DIFF
--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -43,7 +43,13 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     if @requirement_template.save
       render_success @requirement_template,
                      "requirement_template.create_success",
-                     { blueprint: RequirementTemplateBlueprint }
+                     {
+                       blueprint: RequirementTemplateBlueprint,
+                       blueprint_opts: {
+                         view: :extended,
+                         current_user: current_user
+                       }
+                     }
     else
       render_error "requirement_template.create_error",
                    message_opts: {
@@ -79,7 +85,13 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     if @requirement_template.save
       render_success @requirement_template,
                      "requirement_template.copy_success",
-                     { blueprint: RequirementTemplateBlueprint }
+                     {
+                       blueprint: RequirementTemplateBlueprint,
+                       blueprint_opts: {
+                         view: :extended,
+                         current_user: current_user
+                       }
+                     }
     else
       render_error "requirement_template.copy_error",
                    message_opts: {
@@ -91,7 +103,6 @@ class Api::RequirementTemplatesController < Api::ApplicationController
 
   def update
     authorize @requirement_template
-
     if @requirement_template.update(requirement_template_params)
       render_success @requirement_template,
                      "requirement_template.update_success",

--- a/app/frontend/components/domains/super-admin/early-access/requirement-templates/edit-early-access-requirement-template-screen.tsx
+++ b/app/frontend/components/domains/super-admin/early-access/requirement-templates/edit-early-access-requirement-template-screen.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useMst } from "../../../../../setup/root"
 import { ConfirmationModal } from "../../../../shared/confirmation-modal"
+import { RouterLinkButton } from "../../../../shared/navigation/router-link-button"
 import {
   BaseEditRequirementTemplateScreen,
   IEditRequirementActionsProps,
@@ -108,9 +109,13 @@ const EditEarlyAccessRequirementActions = ({ requirementTemplate }: IEditRequire
       <Button variant="primary">
         {t("ui.share")} ({requirementTemplate.numberSharedWith})
       </Button>
-      <Button variant="secondary" rightIcon={<ArrowSquareOut />}>
+      <RouterLinkButton
+        rightIcon={<ArrowSquareOut />}
+        variant="secondary"
+        to={`/early-access/requirement-templates/${requirementTemplate.id}`}
+      >
         {t("ui.view")}
-      </Button>
+      </RouterLinkButton>
     </>
   )
 }

--- a/app/frontend/models/requirement-template.ts
+++ b/app/frontend/models/requirement-template.ts
@@ -122,6 +122,9 @@ export const RequirementTemplateModel = types.snapshotProcessor(
         // TODO
         return 0
       },
+      get isEarlyAccess() {
+        return self.type === ERequirementTemplateType.EarlyAccessRequirementTemplate
+      },
     }))
     .actions((self) => ({
       setIsFullyLoaded(val: boolean) {

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -143,7 +143,7 @@ class TemplateVersioningService
     }
     version =
       requirement_template.published_template_version ||
-        requirement_template.build_template_version
+        requirement_template.template_versions.build
     version.assign_attributes(attributes)
     version.save!
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,7 +64,7 @@ en:
           nonunique_classification: "There can only be one requirement template per permit type, activity, and First Nations combination"
           attributes:
             template_versions:
-              published_required_for_early_access: "requires one published template version"
+              published_required_for_early_access: "requires one or less published template version on early access"
         requirement_block:
           attributes:
             visibility:


### PR DESCRIPTION
## Description

Related to the view button:

https://hous-bssb.atlassian.net/browse/BPHH-2195

The view button has been enabled and getting it to work correctly directly after clicking "save as draft" took the rework below.

All parts of generating the preview template version are now synchronous, and is now totally separate from the publish/force publish logic.


