### PR TITLE
remove problem console log to prevent codeql scanning error

### DIFF
--- a/app/frontend/components/shared/chefs/additional-formio/providers/storage/s3custom.js
+++ b/app/frontend/components/shared/chefs/additional-formio/providers/storage/s3custom.js
@@ -25,7 +25,6 @@ const s3custom = function Provider(formio) {
       groupId,
       abortCallback
     ) => {
-      import.meta.env.DEV && console.log("[DEV] file uploading with options", fileKey, options)
       try {
         const presignedUploadResponse = await uploadFile(file, fileName, progressCallback)
 


### PR DESCRIPTION
## Description

Codeql did not like the use of import.meta in a JS file. Simplest solution is to remove the dev debug statement.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-2243
