### PR TITLE
BPHH-2252 update role of user on any re-invite

### DIFF
--- a/app/frontend/components/shared/base/inputs/user-input.tsx
+++ b/app/frontend/components/shared/base/inputs/user-input.tsx
@@ -118,10 +118,10 @@ const IInviteResultTag = ({ bg, icon, text, ...rest }: IInviteResultTagProps) =>
       noOfLines={1}
       bg={bg}
       color={color}
-      {...rest}
       display="flex"
       alignItems="center"
       gap={2}
+      {...rest}
     >
       {icon}
       <Text>{text}</Text>

--- a/app/frontend/components/shared/base/inputs/user-input.tsx
+++ b/app/frontend/components/shared/base/inputs/user-input.tsx
@@ -111,11 +111,20 @@ const IInviteResultTag = ({ bg, icon, text, ...rest }: IInviteResultTagProps) =>
   const color = (bg as string).replace(/Light/g, "")
 
   return (
-    <Tag border="1px solid" borderColor={color} mb={2} noOfLines={1} bg={bg} {...rest}>
-      <HStack color={color}>
-        {icon}
-        <Text>{text}</Text>
-      </HStack>
+    <Tag
+      border="1px solid"
+      borderColor={color}
+      mb={2}
+      noOfLines={1}
+      bg={bg}
+      color={color}
+      {...rest}
+      display="flex"
+      alignItems="center"
+      gap={2}
+    >
+      {icon}
+      <Text>{text}</Text>
     </Tag>
   )
 }

--- a/app/services/jurisdiction/user_inviter.rb
+++ b/app/services/jurisdiction/user_inviter.rb
@@ -51,11 +51,14 @@ class Jurisdiction::UserInviter
         self.results[:invited] << user
       else
         reinvited = user.present?
+        is_invitable_role =
+          inviter.invitable_roles.include?(user_params[:role].to_s)
         if reinvited
+          user.update(role: user_params[:role].to_sym) if is_invitable_role
           user.skip_confirmation_notification!
           user.invite!(inviter)
           self.results[:reinvited] << user
-        elsif inviter.invitable_roles.include?(user_params[:role].to_s)
+        elsif is_invitable_role
           jurisdiction_id =
             user_params.delete(:jurisdiction_id) ||
               inviter.jurisdictions.pluck(:id)


### PR DESCRIPTION
## Description

When a user is re-invited, update the users role if it is allowed.
bonus: fix the invite result tag display centering.

