### PR TITLE
Bphh 2312 story remove ability to switch to preview only add copy to preview button when editing any visibility block on early access draft

### DIFF
--- a/app/controllers/api/requirement_blocks_controller.rb
+++ b/app/controllers/api/requirement_blocks_controller.rb
@@ -36,7 +36,7 @@ class Api::RequirementBlocksController < Api::ApplicationController
     if @requirement_block.save
       RequirementBlock.search_index.refresh
       render_success @requirement_block,
-                     nil,
+                     "requirement_block.create_success",
                      { blueprint: RequirementBlockBlueprint }
     else
       render_error "requirement_block.create_error",

--- a/app/frontend/components/domains/requirements-library/grid-header.tsx
+++ b/app/frontend/components/domains/requirements-library/grid-header.tsx
@@ -15,11 +15,12 @@ interface IProps {
 }
 
 export const GridHeaders = observer(function GridHeaders({ forEarlyAccess }: IProps) {
-  const { requirementBlockStore } = useMst()
-  const { sort, getSortColumnHeader, toggleSort } = requirementBlockStore
+  const { requirementBlockStore, earlyAccessRequirementBlockStore } = useMst()
+  const searchModel = forEarlyAccess ? earlyAccessRequirementBlockStore : requirementBlockStore
+
+  const { sort, getSortColumnHeader, toggleSort } = searchModel
   const { t } = useTranslation()
 
-  console.log()
   return (
     <Box display={"contents"} role={"rowgroup"} position="fixed">
       <Box display={"contents"} role={"row"}>
@@ -39,7 +40,7 @@ export const GridHeaders = observer(function GridHeaders({ forEarlyAccess }: IPr
               position: "sticky",
               right: 6,
             }}
-            searchModel={requirementBlockStore as ISearch}
+            searchModel={searchModel as ISearch}
           />
         </GridItem>
       </Box>

--- a/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
@@ -114,9 +114,10 @@ export const RequirementBlockAccordion = observer(function RequirementBlockAccor
             <HStack spacing={2}>
               <VisibilityTag visibility={requirementBlock.visibility} />
               <Box mr={2}>{requirementBlock.firstNations && <FirstNationsTag />}</Box>
-              {isOpen && isEditable && !renderEdit && (
+              {isOpen && !renderEdit && (
                 <RequirementsBlockModal
                   showEditWarning={showEditWarning}
+                  isEditable={isEditable}
                   requirementBlock={requirementBlock}
                   triggerButtonProps={{
                     color: "text.primary",
@@ -127,7 +128,7 @@ export const RequirementBlockAccordion = observer(function RequirementBlockAccor
                   }}
                 />
               )}
-              {isEditable && renderEdit?.()}
+              {renderEdit?.()}
               <IconButton variant="unstyled" aria-label="Collapse or expand accordion">
                 <AccordionIcon color={"text.primary"} />
               </IconButton>

--- a/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
@@ -15,7 +15,7 @@ import { X } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React, { useEffect } from "react"
 import { useTranslation } from "react-i18next"
-import { ERequirementType } from "../../../types/enums"
+import { ERequirementType, EVisibility } from "../../../types/enums"
 import {
   IDenormalizedRequirement,
   IDenormalizedRequirementBlock,
@@ -116,6 +116,7 @@ export const RequirementBlockAccordion = observer(function RequirementBlockAccor
               <Box mr={2}>{requirementBlock.firstNations && <FirstNationsTag />}</Box>
               {isOpen && !renderEdit && (
                 <RequirementsBlockModal
+                  forEarlyAccess={requirementBlock.visibility === EVisibility.earlyAccess}
                   showEditWarning={showEditWarning}
                   isEditable={isEditable}
                   requirementBlock={requirementBlock}

--- a/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
@@ -125,7 +125,7 @@ export const RequirementBlocksTable = observer(function RequirementBlocksTable({
                     <RequirementsBlockModal
                       withOptionsMenu
                       requirementBlock={requirementBlock}
-                      forEarlyAccess={forEarlyAccess}
+                      forEarlyAccess={requirementBlock.isEarlyAccess}
                     />
                   )}
                 </SearchGridItem>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/block-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/block-setup.tsx
@@ -32,9 +32,11 @@ const helperTextStyles: Partial<TextProps> = {
 export const BlockSetup = observer(function BlockSetup({
   requirementBlock,
   withOptionsMenu,
+  forEarlyAccess,
 }: {
   requirementBlock?: IRequirementBlock
   withOptionsMenu?: boolean
+  forEarlyAccess?: boolean
 }) {
   const { requirementBlockStore } = useMst()
   const { isEditingEarlyAccess } = requirementBlockStore
@@ -91,7 +93,7 @@ export const BlockSetup = observer(function BlockSetup({
             <Info size={15} />
           </Tooltip>
         </HStack>
-        <BlockVisibilitySelect name="visibility" forEarlyAccess={isEditingEarlyAccess} />
+        <BlockVisibilitySelect name="visibility" forEarlyAccess={forEarlyAccess} />
       </FormControl>
       <VStack spacing={4} w={"full"} alignItems={"flex-start"} px={6} pb={6} pt={3}>
         <Text color={"text.secondary"} fontSize={"sm"} fontWeight={700}>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/block-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/block-setup.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Button,
   Checkbox,
   FormControl,
   FormHelperText,
@@ -36,9 +37,14 @@ export const BlockSetup = observer(function BlockSetup({
   withOptionsMenu?: boolean
 }) {
   const { requirementBlockStore } = useMst()
+  const { isEditingEarlyAccess } = requirementBlockStore
   const { t } = useTranslation()
   const { register, control, watch } = useFormContext<IRequirementBlockForm>()
   const containerRef = useRef<HTMLDivElement>(null)
+
+  const handleCopyToEarlyAccess = async () => {
+    await requirementBlockStore.copyRequirementBlock(requirementBlock, true)
+  }
 
   const fetchAssociationOptions = async (query: string) => {
     const associations = await requirementBlockStore.searchAssociations(query)
@@ -85,7 +91,7 @@ export const BlockSetup = observer(function BlockSetup({
             <Info size={15} />
           </Tooltip>
         </HStack>
-        <BlockVisibilitySelect name="visibility" />
+        <BlockVisibilitySelect name="visibility" forEarlyAccess={isEditingEarlyAccess} />
       </FormControl>
       <VStack spacing={4} w={"full"} alignItems={"flex-start"} px={6} pb={6} pt={3}>
         <Text color={"text.secondary"} fontSize={"sm"} fontWeight={700}>
@@ -170,7 +176,14 @@ export const BlockSetup = observer(function BlockSetup({
             {t("requirementsLibrary.fieldDescriptions.requirementSku")}
           </FormHelperText>
         </FormControl>
-        {requirementBlock && withOptionsMenu && <BlockSetupOptionsMenu requirementBlock={requirementBlock} />}
+        {withOptionsMenu
+          ? requirementBlock && <BlockSetupOptionsMenu requirementBlock={requirementBlock} />
+          : isEditingEarlyAccess && (
+              <Button variant="primary" onClick={handleCopyToEarlyAccess}>
+                {t("requirementsLibrary.copyToEarlyAccess")}
+              </Button>
+            )}
+        {}
       </VStack>
     </Box>
   )

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
@@ -40,6 +40,7 @@ interface IRequirementsBlockProps {
   triggerButtonProps?: Partial<ButtonProps>
   withOptionsMenu?: boolean
   forEarlyAccess?: boolean
+  isEditable?: boolean
 }
 
 export const RequirementsBlockModal = observer(function RequirementsBlockModal({
@@ -48,6 +49,7 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
   triggerButtonProps,
   withOptionsMenu,
   forEarlyAccess,
+  isEditable,
 }: IRequirementsBlockProps) {
   const { requirementBlockStore, earlyAccessRequirementBlockStore } = useMst()
   const searchModel = forEarlyAccess ? earlyAccessRequirementBlockStore : requirementBlockStore
@@ -262,7 +264,7 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
                     }
                     withOptionsMenu={withOptionsMenu}
                   />
-                  <FieldsSetup requirementBlock={requirementBlock} />
+                  <FieldsSetup requirementBlock={requirementBlock} isEditable={isEditable} />
                 </HStack>
               </ModalBody>
             </ModalContent>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
@@ -39,8 +39,8 @@ interface IRequirementsBlockProps {
   showEditWarning?: boolean
   triggerButtonProps?: Partial<ButtonProps>
   withOptionsMenu?: boolean
-  forEarlyAccess?: boolean
   isEditable?: boolean
+  forEarlyAccess?: boolean
 }
 
 export const RequirementsBlockModal = observer(function RequirementsBlockModal({
@@ -48,8 +48,8 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
   showEditWarning,
   triggerButtonProps,
   withOptionsMenu,
-  forEarlyAccess,
   isEditable,
+  forEarlyAccess,
 }: IRequirementsBlockProps) {
   const { requirementBlockStore, earlyAccessRequirementBlockStore } = useMst()
   const searchModel = forEarlyAccess ? earlyAccessRequirementBlockStore : requirementBlockStore
@@ -257,6 +257,7 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
                 )}
                 <HStack spacing={9} w={"full"} h={"full"} alignItems={"flex-start"}>
                   <BlockSetup
+                    forEarlyAccess={forEarlyAccess}
                     requirementBlock={
                       (requirementBlock as IRequirementBlock)?.restore
                         ? (requirementBlock as IRequirementBlock)
@@ -264,6 +265,7 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
                     }
                     withOptionsMenu={withOptionsMenu}
                   />
+
                   <FieldsSetup requirementBlock={requirementBlock} isEditable={isEditable} />
                 </HStack>
               </ModalBody>

--- a/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
@@ -27,7 +27,6 @@ interface IProps {
   renderTriggerButton?: (props: ButtonProps & { ref: Ref<HTMLElement> }) => JSX.Element
   onUse?: (requirementBlock: IRequirementBlock, closeDrawer?: () => void) => void
   disabledUseForBlockIds?: Set<string>
-  forEarlyAccess?: boolean
   disabledReason?: string
 }
 
@@ -37,7 +36,6 @@ export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDr
   onUse,
   disabledUseForBlockIds,
   disabledReason,
-  forEarlyAccess,
 }: IProps) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()

--- a/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
@@ -27,6 +27,7 @@ interface IProps {
   renderTriggerButton?: (props: ButtonProps & { ref: Ref<HTMLElement> }) => JSX.Element
   onUse?: (requirementBlock: IRequirementBlock, closeDrawer?: () => void) => void
   disabledUseForBlockIds?: Set<string>
+  forEarlyAccess?: boolean
   disabledReason?: string
 }
 
@@ -36,6 +37,7 @@ export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDr
   onUse,
   disabledUseForBlockIds,
   disabledReason,
+  forEarlyAccess,
 }: IProps) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()

--- a/app/frontend/components/shared/select/block-visibility-select.tsx
+++ b/app/frontend/components/shared/select/block-visibility-select.tsx
@@ -109,8 +109,12 @@ export const BlockVisibilitySelect = ({ name, forEarlyAccess }: IBlockVisibility
   const cancelRef = useRef()
   const selectRef = useRef()
 
+  const visibilityWatch = watch(name)
+
   // Handle the option change
   const handleChange = (selectedOption) => {
+    if (selectedOption.value === visibilityWatch) return
+
     // Show confirmation modal
     setPendingOption(selectedOption)
     onOpen()

--- a/app/frontend/components/shared/select/block-visibility-select.tsx
+++ b/app/frontend/components/shared/select/block-visibility-select.tsx
@@ -18,10 +18,10 @@ import Select, { components } from "react-select"
 
 // BlockVisibility Option component
 export const BlockVisibilityOption = (props) => {
-  const { data } = props
+  const { data, isDisabled } = props
   return (
-    <components.Option {...props}>
-      <Box>
+    <components.Option {...props} isDisabled={isDisabled}>
+      <Box opacity={isDisabled ? 0.5 : 1} cursor={isDisabled ? "not-allowed" : "pointer"}>
         <Text color="text.link" fontWeight="bold" mb={1}>
           {data.label}
         </Text>
@@ -30,7 +30,6 @@ export const BlockVisibilityOption = (props) => {
     </components.Option>
   )
 }
-
 // BlockVisibility SingleValue component
 const BlockVisibilitySingleValue = (props) => {
   const { data } = props
@@ -74,8 +73,13 @@ const chakraStyles = (theme) => ({
   }),
 })
 
-export const BlockVisibilitySelect = ({ name }) => {
-  const { control, setValue } = useFormContext() // Access form methods from context
+interface IBlockVisibilitySelectProps {
+  name: string
+  forEarlyAccess?: boolean
+}
+
+export const BlockVisibilitySelect = ({ name, forEarlyAccess }: IBlockVisibilitySelectProps) => {
+  const { control, setValue, watch } = useFormContext() // Access form methods from context
   const theme = useTheme() // Access Chakra UI theme
   const { t } = useTranslation() // Access translation function
 
@@ -95,6 +99,7 @@ export const BlockVisibilitySelect = ({ name }) => {
       value: "early_access",
       label: t(`requirementsLibrary.visibility.earlyAccess`),
       description: t(`requirementsLibrary.visibilityDescriptions.earlyAccess`),
+      isDisabled: !forEarlyAccess,
     },
   ]
 

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -670,6 +670,7 @@ const options = {
           hasAutomatedCompliance: "Has automated compliance",
           inputNotSupported: "Input type not yet supported",
           associationsInfo: "Sections, tags, etc...",
+          copyToEarlyAccess: "Copy to early access",
           index: {
             title: "Requirements library",
             description: "List of all Requirement Blocks in the system that can be used inside Templates.",

--- a/app/frontend/models/requirement-block.ts
+++ b/app/frontend/models/requirement-block.ts
@@ -98,6 +98,9 @@ export const RequirementBlockModel = types
     get isDiscarded() {
       return self.discardedAt !== null
     },
+    get isEarlyAccess() {
+      return self.visibility === EVisibility.earlyAccess
+    },
   }))
   .actions((self) => ({
     update: flow(function* (requirementParams: IRequirementBlockParams) {

--- a/app/frontend/stores/early-access-requirement-block-store.ts
+++ b/app/frontend/stores/early-access-requirement-block-store.ts
@@ -20,6 +20,9 @@ export const EarlyAccessRequirementBlockStoreModel = types
     get tableRequirementBlocks() {
       return self.tableEarlyAccessRequirementBlocks
     },
+    get getSortColumnHeader() {
+      return self.rootStore.requirementBlockStore.getSortColumnHeader
+    },
   }))
   .actions((self) => ({
     fetchEarlyAccessRequirementBlocks: flow(function* (opts?: {

--- a/app/frontend/stores/requirement-block-store.ts
+++ b/app/frontend/stores/requirement-block-store.ts
@@ -178,7 +178,7 @@ export const RequirementBlockStoreModel = types
     }),
   }))
   .actions((self) => ({
-    copyRequirementBlock: flow(function* (requirementBlock: IRequirementBlock) {
+    copyRequirementBlock: flow(function* (requirementBlock: IRequirementBlock, toEarlyAccess = false) {
       const { id, requirements, ...copyableRequirementsAttributes } = requirementBlock
 
       const clonedParams: IRequirementBlockParams = {
@@ -188,6 +188,7 @@ export const RequirementBlockStoreModel = types
           return rest
         }),
         name: incrementLastWord(requirementBlock.name),
+        visibility: toEarlyAccess ? EVisibility.earlyAccess : requirementBlock.visibility,
       }
 
       return yield self.createRequirementBlock(clonedParams)

--- a/app/frontend/stores/requirement-block-store.ts
+++ b/app/frontend/stores/requirement-block-store.ts
@@ -20,7 +20,7 @@ import {
   TAutoComplianceModuleConfigurations,
   TValueExtractorAutoComplianceModuleConfiguration,
 } from "../types/types"
-import { incrementLastWord, isValueExtractorModuleConfiguration } from "../utils/utility-functions"
+import { isValueExtractorModuleConfiguration } from "../utils/utility-functions"
 
 export const RequirementBlockStoreModel = types
   .compose(
@@ -187,7 +187,7 @@ export const RequirementBlockStoreModel = types
           const { id, ...rest } = attr
           return rest
         }),
-        name: incrementLastWord(requirementBlock.name),
+        name: requirementBlock.name,
         visibility: toEarlyAccess ? EVisibility.earlyAccess : requirementBlock.visibility,
       }
 

--- a/app/frontend/utils/utility-functions.ts
+++ b/app/frontend/utils/utility-functions.ts
@@ -221,28 +221,6 @@ export function convertToDate(property: any) {
   return property
 }
 
-export function incrementLastWord(input: string): string {
-  // Split the string by spaces
-  const words = input.trim().split(" ")
-
-  // Get the last word in the array
-  const lastWord = words[words.length - 1]
-
-  // Check if the last word is a number
-  const lastNumber = parseInt(lastWord, 10)
-
-  if (!isNaN(lastNumber)) {
-    // If it's a number, increment it
-    words[words.length - 1] = (lastNumber + 1).toString()
-  } else {
-    // If it's not a number, append " 2" to the original string
-    return `${input.trim()} 2`
-  }
-
-  // Join the array back into a string and return
-  return words.join(" ")
-}
-
 export function formatPidValue(pid?: string) {
   if (!pid) return null
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,6 +299,9 @@ en:
         title: "Error"
         message: "Could not fetch super users"
     requirement_block:
+      create_success:
+        title: ""
+        message: "Successfully created requirement block!"
       create_error:
         title: Error
         message: "%{error_message}"


### PR DESCRIPTION
## Description

Fixes for the editability behaviour of requirement blocks as per discussion with Skye.
Also, add copy to preview, move copy name assignment to backend, and fix the early access requirement block table search and sort.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

Fixes for the editability behaviour of requirement blocks as per discussion with Skye.


