### PR TITLE
BPHH-2322 add data migration to save all users regenerating preference

### DIFF
--- a/db/data/20241104163503_save_users_for_preference_regen.rb
+++ b/db/data/20241104163503_save_users_for_preference_regen.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SaveUsersForPreferenceRegen < ActiveRecord::Migration[7.1]
+  def up
+    User.find_each(&:save)
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
## Description

Some users were missing preference records.
This was fixed manually in prod, but this data migration should obviate the need to do this manually ever again.

https://hous-bssb.atlassian.net/browse/BPHH-2322
