### PR TITLE
Fix issue generating step code summary CSV

### DIFF
--- a/app/services/step_code_export_service.rb
+++ b/app/services/step_code_export_service.rb
@@ -15,8 +15,8 @@ class StepCodeExportService
             energy_step_required = jtsc.energy_step_required
             zero_carbon_step_required = jtsc.zero_carbon_step_required
             enabled =
-              energy_step_required.positive? ||
-                zero_carbon_step_required.positive?
+              energy_step_required.present? ||
+                zero_carbon_step_required.present?
             csv << [
               jurisdiction_name,
               permit_type,


### PR DESCRIPTION
## Description

This [fix](https://github.com/bcgov/HOUS-permit-portal/commit/ca45923f3dbed44ec0aed11e77b7aa800291a553) changed the permit type required steps to be set to `nil` instead of `0` when the user selected "Not Applicable".

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

[BPHH-2409](https://hous-bssb.atlassian.net/browse/BPHH-2409)

## Steps to QA

n/a

## UI Accessibility Checklist

n/a

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a

[BPHH-2409]: https://hous-bssb.atlassian.net/browse/BPHH-2409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ