### PR TITLE
do not sandbox scope permit application for super admin

### DIFF
--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -429,7 +429,11 @@ class Api::PermitApplicationsController < Api::ApplicationController
 
   def set_permit_application
     @permit_application =
-      PermitApplication.for_sandbox(current_sandbox).find(params[:id])
+      if current_user.super_admin?
+        PermitApplication.find(params[:id])
+      else
+        PermitApplication.for_sandbox(current_sandbox).find(params[:id])
+      end
   end
 
   def permit_application_params # params for submitters


### PR DESCRIPTION
## Description

Sandbox scoping was breaking sandboxed permit application show for super admin
Similar to how the index should not consider sandbox when rendering for super admin, a sngle sandbox should be found when no sandbox is provided by super admin.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-2459
