### PR TITLE
default visibility in visibility tag for outdated denormalized blocks

### DIFF
--- a/app/frontend/components/shared/visibility-tag.tsx.tsx
+++ b/app/frontend/components/shared/visibility-tag.tsx.tsx
@@ -6,10 +6,10 @@ import { EVisibility } from "../../types/enums"
 import { toCamelCase } from "../../utils/utility-functions"
 
 interface IVisibilityTagProps {
-  visibility: EVisibility
+  visibility?: EVisibility
 }
 
-export const VisibilityTag = ({ visibility }: IVisibilityTagProps) => {
+export const VisibilityTag = ({ visibility = EVisibility.any }: IVisibilityTagProps) => {
   const { t } = useTranslation()
 
   const backgroundColors = {

--- a/app/frontend/models/requirement-block.ts
+++ b/app/frontend/models/requirement-block.ts
@@ -20,7 +20,7 @@ export const RequirementBlockModel = types
     requirements: types.array(RequirementModel),
     associations: types.array(types.string),
     description: types.maybeNull(types.string),
-    visibility: types.optional(types.enumeration(Object.values(EVisibility)), EVisibility.any),
+    visibility: types.enumeration(Object.values(EVisibility)),
     displayDescription: types.maybeNull(types.string),
     sku: types.string,
     createdAt: types.Date,

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -177,7 +177,7 @@ export interface IDenormalizedRequirementBlock {
   sku: string
   formJson?: IFormIOBlock
   description?: string
-  visibility: EVisibility
+  visibility?: EVisibility
   displayName: string
   displayDescription?: string
   requirements: IDenormalizedRequirement[]


### PR DESCRIPTION
## Description

Previous published template versions do not have visibility data
therefore, we must assume that visibility on denormalized blocks is optional. Default the value where necessary.