### PR TITLE
Fix single resource sandbox dependent reloading

### DIFF
--- a/app/frontend/hooks/resources/use-integration-mapping.ts
+++ b/app/frontend/hooks/resources/use-integration-mapping.ts
@@ -51,6 +51,8 @@ export const useIntegrationMapping = ({
 
           if (!integrationMapping) {
             setError(new Error(errorMessage))
+          } else {
+            setError(null)
           }
         } catch (e) {
           setError(e instanceof Error ? e : new Error(errorMessage))

--- a/app/frontend/hooks/resources/use-jurisdiction.ts
+++ b/app/frontend/hooks/resources/use-jurisdiction.ts
@@ -54,11 +54,17 @@ export const useJurisdiction = () => {
       try {
         if (isUUID(jurisdictionId)) {
           const jurisdiction = await fetchJurisdiction(jurisdictionId)
-          jurisdiction && setCurrentJurisdiction(jurisdictionId)
+          if (jurisdiction) {
+            setError(null)
+            setCurrentJurisdiction(jurisdictionId)
+          }
         } else {
           //assume slug
           const jurisdiction = await fetchJurisdiction(jurisdictionId)
-          jurisdiction && setCurrentJurisdictionBySlug(jurisdictionId)
+          if (jurisdiction) {
+            setError(null)
+            setCurrentJurisdictionBySlug(jurisdictionId)
+          }
         }
       } catch (e) {
         console.error(e.message)

--- a/app/frontend/hooks/resources/use-permit-application.ts
+++ b/app/frontend/hooks/resources/use-permit-application.ts
@@ -7,7 +7,8 @@ import { isUUID } from "../../utils/utility-functions"
 export const usePermitApplication = ({ review }: { review?: boolean } = {}) => {
   const { permitApplicationId } = useParams()
   const { pathname } = useLocation()
-  const { permitApplicationStore } = useMst()
+  const { permitApplicationStore, sandboxStore } = useMst()
+  const { currentSandbox } = sandboxStore
 
   const { currentPermitApplication, setCurrentPermitApplication, fetchPermitApplication } = permitApplicationStore
 
@@ -22,6 +23,7 @@ export const usePermitApplication = ({ review }: { review?: boolean } = {}) => {
           let permitApplication = await fetchPermitApplication(permitApplicationId, review)
           if (permitApplication) {
             setCurrentPermitApplication(permitApplicationId)
+            setError(null)
           }
         }
       } catch (e) {
@@ -29,7 +31,7 @@ export const usePermitApplication = ({ review }: { review?: boolean } = {}) => {
         setError(new Error(t("errors.fetchPermitApplication")))
       }
     })()
-  }, [pathname])
+  }, [pathname, currentSandbox?.id])
 
   return { currentPermitApplication, error }
 }

--- a/app/frontend/hooks/resources/use-permit-type-options.ts
+++ b/app/frontend/hooks/resources/use-permit-type-options.ts
@@ -19,6 +19,8 @@ export function usePermitTypeOptions() {
 
           if (!permitTypeOptions) {
             throw new Error(t("errors.fetchPermitTypeOptions"))
+          } else {
+            setError(null)
           }
 
           setPermitTypeOptions(permitTypeOptions)

--- a/app/frontend/hooks/resources/use-requirement-template.ts
+++ b/app/frontend/hooks/resources/use-requirement-template.ts
@@ -23,8 +23,11 @@ export const useRequirementTemplate = () => {
     ;(async () => {
       try {
         const isSuccess = await requirementTemplateStore.fetchRequirementTemplate(requirementTemplateId)
-
-        !isSuccess && setError(new Error(t("errors.fetchRequirementTemplate")))
+        if (isSuccess) {
+          setError(null)
+        } else {
+          setError(new Error(t("errors.fetchRequirementTemplate")))
+        }
       } catch (e) {
         setError(e instanceof Error ? e : new Error(t("errors.fetchRequirementTemplate")))
       }

--- a/app/frontend/hooks/resources/use-template-version.ts
+++ b/app/frontend/hooks/resources/use-template-version.ts
@@ -7,7 +7,8 @@ import { isUUID } from "../../utils/utility-functions"
 export const useTemplateVersion = ({ customErrorMessage }: { customErrorMessage?: string } = {}) => {
   const { templateVersionId } = useParams()
   const { pathname } = useLocation()
-  const { templateVersionStore } = useMst()
+  const { templateVersionStore, sandboxStore } = useMst()
+  const { currentSandbox } = sandboxStore
   const templateVersion = templateVersionStore.getTemplateVersionById(templateVersionId)
   const [error, setError] = useState<Error | undefined>(undefined)
   const { t } = useTranslation()
@@ -19,18 +20,17 @@ export const useTemplateVersion = ({ customErrorMessage }: { customErrorMessage?
       return
     }
 
-    if (!templateVersion || !templateVersion.isFullyLoaded) {
-      ;(async () => {
-        try {
-          const isSuccess = await templateVersionStore.fetchTemplateVersion(templateVersionId)
+    ;(async () => {
+      try {
+        const isSuccess = await templateVersionStore.fetchTemplateVersion(templateVersionId)
+        setError(null)
 
-          !isSuccess && setError(new Error(customErrorMessage ?? t("errors.fetchTemplateVersion")))
-        } catch (e) {
-          setError(e instanceof Error ? e : new Error(customErrorMessage ?? t("errors.fetchTemplateVersion")))
-        }
-      })()
-    }
-  }, [templateVersionId, templateVersion, pathname])
+        !isSuccess && setError(new Error(customErrorMessage ?? t("errors.fetchTemplateVersion")))
+      } catch (e) {
+        setError(e instanceof Error ? e : new Error(customErrorMessage ?? t("errors.fetchTemplateVersion")))
+      }
+    })()
+  }, [templateVersionId, templateVersion, pathname, currentSandbox?.id])
 
   return { templateVersion, error }
 }

--- a/app/frontend/hooks/resources/use-template-versions.ts
+++ b/app/frontend/hooks/resources/use-template-versions.ts
@@ -37,7 +37,11 @@ export const useTemplateVersions = ({
       try {
         const isSuccess = await fetchTemplateVersions(activityId, status, earlyAccess, isPublic)
 
-        !isSuccess && setError(new Error(errorMessage))
+        if (isSuccess) {
+          setError(null)
+        } else {
+          setError(new Error(errorMessage))
+        }
       } catch (e) {
         setError(e instanceof Error ? e : new Error(errorMessage))
       }

--- a/app/services/customization_copy_service.rb
+++ b/app/services/customization_copy_service.rb
@@ -64,7 +64,7 @@ class CustomizationCopyService
   )
     merged_blocks = to_blocks.deep_dup
 
-    from_blocks.each do |block_id, changes|
+    from_blocks&.each do |block_id, changes|
       merged_blocks[block_id] ||= {}
 
       merged_blocks[block_id]["tip"] = changes["tip"] if include_tips

--- a/app/services/requirement_template_copy_service.rb
+++ b/app/services/requirement_template_copy_service.rb
@@ -44,7 +44,7 @@ class RequirementTemplateCopyService
           )
 
         # Associate existing requirement blocks with the new section
-        section.requirement_blocks.each do |block|
+        section.requirement_blocks&.each do |block|
           new_section.requirement_blocks << block
         end
         new_section.save


### PR DESCRIPTION
make permit and template version hooks depend on sandbox and improve error resetting

## Description

reload permit application and template version when sandbox changes
Go through hooks and make errorr set to null when resource loads successfully

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-2510
