### PR TITLE
fix jurisdiction input and make pin optional

### DIFF
--- a/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/new-permit-application-screen.tsx
@@ -174,7 +174,7 @@ export const NewPermitApplicationScreen = observer(({}: INewPermitApplicationScr
                   {pinMode ? t("permitApplication.new.dontHavePin") : t("permitApplication.new.onlyHavePin")}
                 </Button>
               </Flex>
-              {jurisdictionIdWatch && (pidWatch || pinWatch) && (
+              {jurisdictionIdWatch && (
                 <Flex as="section" direction="column" gap={8}>
                   {jurisdiction?.sandboxOptions && (
                     <Can action="jurisdiction:create">
@@ -301,10 +301,10 @@ interface IPinModeInputsProps {
   disabled?: boolean
 }
 
-export const PinModeInputs = ({ disabled }: IPinModeInputsProps) => {
+export const PinModeInputs = observer(({ disabled }: IPinModeInputsProps) => {
   const { register, control, setValue } = useFormContext()
   const { jurisdictionStore, geocoderStore } = useMst()
-  const { addJurisdiction } = jurisdictionStore
+  const { addJurisdiction, getJurisdictionById } = jurisdictionStore
   const { fetchPinVerification } = geocoderStore
   const { t } = useTranslation()
 
@@ -335,7 +335,7 @@ export const PinModeInputs = ({ disabled }: IPinModeInputsProps) => {
         </FormControl>
 
         <Controller
-          name="jurisdiction"
+          name="jurisdictionId"
           control={control}
           render={({ field: { onChange, value } }) => {
             return (
@@ -343,12 +343,12 @@ export const PinModeInputs = ({ disabled }: IPinModeInputsProps) => {
                 <FormLabel>{t("jurisdiction.index.title")}</FormLabel>
                 <InputGroup w="full">
                   <JurisdictionSelect
-                    onChange={(value) => {
-                      if (value) addJurisdiction(value)
-                      onChange(value)
+                    onChange={(selectValue) => {
+                      if (selectValue) addJurisdiction(selectValue)
+                      onChange(selectValue.id)
                     }}
-                    onFetch={() => setValue("jurisdiction", null)}
-                    selectedOption={value ? { label: value?.reverseQualifiedName, value } : null}
+                    onFetch={() => setValue("jurisdictionId", null)}
+                    selectedOption={value ? { label: getJurisdictionById(value)?.reverseQualifiedName, value } : null}
                     menuPortalTarget={document.body}
                   />
                 </InputGroup>
@@ -359,7 +359,7 @@ export const PinModeInputs = ({ disabled }: IPinModeInputsProps) => {
       </Flex>
     </Flex>
   )
-}
+})
 
 const DisclaimerInfo = () => {
   const { t } = useTranslation()

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -541,8 +541,8 @@ const options = {
             submitToOwn:
               "Make sure you are submitting to a jurisdiction that you have inbox access to so that you can see it.",
             sandboxIdHeading: "Submit into Sandbox",
-            onlyHavePin: "I only have a PIN",
-            dontHavePin: "I don't have a PIN",
+            onlyHavePin: "I don't have a PID or address",
+            dontHavePin: "Hide",
             selectSandboxLabel: "Select a sandbox to submit into",
             firstNationsTitle: "First Nations",
             permitTypeHeading: "Permit type",
@@ -590,7 +590,7 @@ const options = {
               "Upon receipt by the local jurisdiction, you will be notified via email or phone of any updates to your application's status or if additional documentation is required.",
             emailed:
               "A confirmation email has also been sent to the applicant and the {{ jurisdictionName }} building permit office",
-            pinRequired: "PID not found or unavailable. Please select a PIN and jurisdiction below:",
+            pinRequired: "PID not found or unavailable. Please optionally select a PIN and jurisdiction below:",
             pinVerified: "PIN is verified.",
             pinUnableToVerify: "Unable to verify PIN, please confirm and proceed as applicable.",
             needToKnow: "What you need to know",

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -49,7 +49,6 @@ class PermitApplication < ApplicationRecord
   # Custom validation
 
   validate :jurisdiction_has_matching_submission_contact
-  validate :pid_or_pin_presence
   validates :nickname, presence: true
   validates :number, presence: true
   validates :reference_number, length: { maximum: 300 }, allow_nil: true
@@ -691,17 +690,6 @@ class PermitApplication < ApplicationRecord
         :jurisdiction,
         I18n.t(
           "activerecord.errors.models.permit_application.attributes.jurisdiction.no_contact"
-        )
-      )
-    end
-  end
-
-  def pid_or_pin_presence
-    if pin.blank? && pid.blank?
-      errors.add(
-        :base,
-        I18n.t(
-          "activerecord.errors.models.permit_application.attributes.pid_or_pin"
         )
       )
     end


### PR DESCRIPTION
## Description

This removes the pin or pid requirement on PAs and fixes the jurisdiction input.


## What type of PR is this? (check all applicable)

- [ x] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

https://hous-bssb.atlassian.net/browse/BPHH-2498

QA instructions:

create new PA
click I dont have a PIN
set a jurisdiction
the next section should show up.