### PR TITLE
Add baseline occupancies sections & show errors

### DIFF
--- a/app/blueprints/step_code/part_3/baseline_occupancy_blueprint.rb
+++ b/app/blueprints/step_code/part_3/baseline_occupancy_blueprint.rb
@@ -1,0 +1,9 @@
+class StepCode::Part3::BaselineOccupancyBlueprint < Blueprinter::Base
+  identifier :id
+
+  fields :key,
+         :modelled_floor_area,
+         :performance_requirement,
+         :percent_better_requirement,
+         :requirement_source
+end

--- a/app/blueprints/step_code/part_3/checklist_blueprint.rb
+++ b/app/blueprints/step_code/part_3/checklist_blueprint.rb
@@ -32,4 +32,7 @@ class StepCode::Part3::ChecklistBlueprint < Blueprinter::Base
         checklist.heating_degree_days
       )
   end
+
+  association :baseline_occupancies,
+              blueprint: StepCode::Part3::BaselineOccupancyBlueprint
 end

--- a/app/controllers/api/part_3_building/checklists_controller.rb
+++ b/app/controllers/api/part_3_building/checklists_controller.rb
@@ -27,7 +27,16 @@ class Api::Part3Building::ChecklistsController < Api::ApplicationController
       :heating_degree_days,
       :climate_zone,
       section_completion_status: {
-      }
+      },
+      baseline_occupancies_attributes: %i[
+        _destroy
+        id
+        key
+        modelled_floor_area
+        performance_requirement
+        percent_better_requirement
+        requirement_source
+      ]
     )
   end
 end

--- a/app/frontend/components/domains/step-code/part-3/form-section/baseline-occupancies.tsx
+++ b/app/frontend/components/domains/step-code/part-3/form-section/baseline-occupancies.tsx
@@ -1,7 +1,0 @@
-import { Heading } from "@chakra-ui/react"
-import { observer } from "mobx-react-lite"
-import React from "react"
-
-export const BaselineOccupancies = observer(function Part3StepCodeFormBaselineOccupancies() {
-  return <Heading>Baseline Occupancies</Heading>
-})

--- a/app/frontend/components/domains/step-code/part-3/form-section/baseline-occupancies/baseline-details.tsx
+++ b/app/frontend/components/domains/step-code/part-3/form-section/baseline-occupancies/baseline-details.tsx
@@ -1,0 +1,101 @@
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Text,
+} from "@chakra-ui/react"
+import { t } from "i18next"
+import { observer } from "mobx-react-lite"
+import React, { useEffect } from "react"
+import { FormProvider, useForm } from "react-hook-form"
+import { useLocation, useNavigate } from "react-router-dom"
+import { usePart3StepCode } from "../../../../../../hooks/resources/use-part-3-step-code"
+import { CustomMessageBox } from "../../../../../shared/base/custom-message-box"
+import { OccupancyPanel } from "./occupancy-panel"
+
+export const BaselineDetails = observer(function Part3StepCodeFormBaselineDetails() {
+  const i18nPrefix = "stepCode.part3.baselineDetails"
+  const { checklist } = usePart3StepCode()
+
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const formMethods = useForm({
+    defaultValues: {
+      baselineOccupanciesAttributes: checklist.baselineOccupancies.map((oc) => ({
+        id: oc.id,
+        modelledFloorArea: oc.modelledFloorArea,
+        performanceRequirement: oc.performanceRequirement,
+        percentBetterRequirement: oc.percentBetterRequirement,
+        requirementSource: oc.requirementSource,
+      })),
+    },
+  })
+  const { handleSubmit, formState, reset } = formMethods
+
+  const { isLoading, isValid, isSubmitted } = formState
+
+  const onSubmit = async (values) => {
+    if (!isValid) return
+
+    const updated = await checklist.update(values)
+    if (updated) {
+      await checklist.completeSection("baselineDetails")
+    } else {
+      return
+    }
+
+    navigate(location.pathname.replace("baseline-details", "district-energy"))
+  }
+
+  useEffect(() => {
+    if (isSubmitted) {
+      // reset form state to prevent message box from showing again until form is resubmitted
+      reset(undefined, { keepDirtyValues: true, keepErrors: true })
+    }
+  }, [isValid])
+
+  return (
+    <>
+      <Flex direction="column" gap={2}>
+        {!isValid && isSubmitted && <CustomMessageBox title={t("stepCode.part3.errorTitle")} status="error" />}
+        <Flex direction="column" gap={2} pb={4}>
+          <Heading as="h2" fontSize="2xl" variant="yellowline" pt={4} m={0}>
+            {t(`${i18nPrefix}.heading`)}
+          </Heading>
+          <Text fontSize="md">{t(`${i18nPrefix}.instructions`)}</Text>
+        </Flex>
+      </Flex>
+      <FormProvider {...formMethods}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <Flex direction="column" gap={{ base: 6, xl: 6 }} pb={4}>
+            <Accordion defaultIndex={[...Array(checklist.baselineOccupancies.length).keys()]} allowMultiple>
+              {checklist.baselineOccupancies.map((oc, idx) => (
+                <AccordionItem border="none" key={oc.id}>
+                  <AccordionButton bg="greys.grey04" rounded="lg">
+                    <Box as="span" flex="1" textAlign="left">
+                      {t(`stepCode.part3.baselineOccupancyKeys.${oc.key}`)}
+                    </Box>
+                    <AccordionIcon />
+                  </AccordionButton>
+                  <AccordionPanel pb={4}>
+                    <OccupancyPanel occupancy={oc} idx={idx} />
+                  </AccordionPanel>
+                </AccordionItem>
+              ))}
+            </Accordion>
+            <Button type="submit" variant="primary" isLoading={isLoading} isDisabled={isLoading}>
+              {t(`${i18nPrefix}.cta`)}
+            </Button>
+          </Flex>
+        </form>
+      </FormProvider>
+    </>
+  )
+})

--- a/app/frontend/components/domains/step-code/part-3/form-section/baseline-occupancies/index.tsx
+++ b/app/frontend/components/domains/step-code/part-3/form-section/baseline-occupancies/index.tsx
@@ -1,0 +1,175 @@
+import {
+  Button,
+  Checkbox,
+  CheckboxGroup,
+  Flex,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  ListItem,
+  Radio,
+  RadioGroup,
+  SimpleGrid,
+  Stack,
+  UnorderedList,
+} from "@chakra-ui/react"
+import { ErrorMessage } from "@hookform/error-message"
+import { t } from "i18next"
+import { observer } from "mobx-react-lite"
+import * as R from "ramda"
+import React, { useEffect, useState } from "react"
+import { Controller, useForm } from "react-hook-form"
+import { Trans } from "react-i18next"
+import { useLocation, useNavigate } from "react-router-dom"
+import { usePart3StepCode } from "../../../../../../hooks/resources/use-part-3-step-code"
+import { EBaselineOccupancyKey } from "../../../../../../types/enums"
+import { CustomMessageBox } from "../../../../../shared/base/custom-message-box"
+import { SectionHeading } from "../shared/section-heading"
+
+export const BaselineOccupancies = observer(function Part3StepCodeFormBaselineOccupancies() {
+  const i18nPrefix = "stepCode.part3.baselineOccupancies"
+  const { checklist } = usePart3StepCode()
+
+  const [isRelevant, setIsRelevant] = useState(
+    !R.isEmpty(checklist.baselineOccupancies) ? "yes" : checklist.isComplete("baselineOccupancies") && "no"
+  )
+
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const { handleSubmit, formState, control, reset } = useForm({
+    mode: "onSubmit",
+    defaultValues: {
+      baselineOccupancies: checklist.baselineOccupancies.map((oc) => oc.key),
+    },
+  })
+
+  const { isLoading, isValid, isSubmitted, errors } = formState
+
+  const onSubmit = async (values) => {
+    if (!isValid) return
+
+    if (isRelevant == "no") {
+      // update the checklist to remove baseline occupancies if there are any
+      const updated =
+        R.isEmpty(checklist.baselineOccupancies) ||
+        (await checklist.update({
+          baseline_occupancies_attributes: checklist.baselineOccupancies.map((oc) => ({ id: oc.id, _destroy: true })),
+        }))
+      if (updated) {
+        await checklist.completeSection("baselineOccupancies")
+      } else {
+        return
+      }
+    } else {
+      // create new selections, keep existing selections, delete removed selections
+      const newSelections = values.baselineOccupancies
+        .filter((ocKey) => !checklist.baselineOccupancies.map((oc) => oc.key).includes(ocKey))
+        .map((ocKey) => ({ key: ocKey }))
+      const existingSelections = checklist.baselineOccupancies
+        .filter((oc) => values.baselineOccupancies.includes(oc.key))
+        .map((oc) => ({ id: oc.id }))
+      const deletedSelections = checklist.baselineOccupancies
+        .filter((oc) => !values.baselineOccupancies.includes(oc.key))
+        .map((oc) => ({ id: oc.id, _destroy: true }))
+
+      values.baselineOccupanciesAttributes = [...newSelections, ...existingSelections, ...deletedSelections]
+      delete values.baselineOccupancies
+
+      const updated = await checklist.update(values)
+      if (updated) {
+        await checklist.bulkUpdateCompletionStatus({
+          baselineOccupancies: { complete: true },
+          baselineDetails: { relevant: true },
+        })
+      } else {
+        return
+      }
+    }
+
+    const nextSectionPath = isRelevant == "yes" ? "baseline-details" : "district-energy"
+
+    navigate(location.pathname.replace("baseline-occupancies", nextSectionPath))
+  }
+
+  useEffect(() => {
+    if (isSubmitted) {
+      // reset form state to prevent message box from showing again until form is resubmitted
+      reset(undefined, { keepDirtyValues: true, keepErrors: true })
+    }
+  }, [isValid])
+
+  return (
+    <>
+      <Flex direction="column" gap={2} pb={6}>
+        {!isValid && isSubmitted && <CustomMessageBox title={t("stepCode.part3.errorTitle")} status="error" />}
+        <SectionHeading>{t(`${i18nPrefix}.heading`)}</SectionHeading>
+        <Trans
+          i18nKey={`${i18nPrefix}.instructions`}
+          components={{
+            ul: <UnorderedList ml={0} pl={6} />,
+            li: <ListItem mb={0} />,
+            strong: <strong />,
+          }}
+        />
+      </Flex>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Flex direction="column" gap={{ base: 6, xl: 6 }} pb={4}>
+          <FormControl>
+            <FormLabel>{t(`${i18nPrefix}.isRelevant`)}</FormLabel>
+            <RadioGroup onChange={setIsRelevant} value={isRelevant}>
+              <Stack spacing={5} direction="row">
+                <Radio variant="binary" value={"yes"}>
+                  {t("ui.yes")}
+                </Radio>
+                <Radio variant="binary" value={"no"}>
+                  {t("ui.no")}
+                </Radio>
+              </Stack>
+            </RadioGroup>
+          </FormControl>
+          {isRelevant == "yes" ? (
+            <>
+              <FormControl>
+                <FormLabel pb={1}>{t(`${i18nPrefix}.occupancies.label`)}</FormLabel>
+                <FormHelperText mb={1} mt={0} color="semantic.error">
+                  <ErrorMessage errors={errors} name="baselineOccupancies" />
+                </FormHelperText>
+                <Controller
+                  name="baselineOccupancies"
+                  rules={{ required: t(`${i18nPrefix}.occupancies.error`) }}
+                  control={control}
+                  render={({ field: { onChange, value } }) => (
+                    <CheckboxGroup defaultValue={value} onChange={onChange}>
+                      <SimpleGrid columns={2} spacing={1}>
+                        {Object.values(EBaselineOccupancyKey).map((key) => (
+                          <Checkbox key={key} value={key}>
+                            <Trans
+                              i18nKey={`${i18nPrefix}.occupancyKeys.${key}`}
+                              components={{
+                                strong: <strong />,
+                              }}
+                            />
+                          </Checkbox>
+                        ))}
+                      </SimpleGrid>
+                    </CheckboxGroup>
+                  )}
+                />
+              </FormControl>
+              <FormControl>
+                <Button type="submit" variant="primary" isLoading={isLoading} isDisabled={isLoading}>
+                  {t(`${i18nPrefix}.cta`)}
+                </Button>
+              </FormControl>
+            </>
+          ) : isRelevant == "no" ? (
+            <Button type="submit" variant="primary" isLoading={isLoading} isDisabled={isLoading}>
+              {t(`${i18nPrefix}.cta`)}
+            </Button>
+          ) : null}
+        </Flex>
+      </form>
+    </>
+  )
+})

--- a/app/frontend/components/domains/step-code/part-3/form-section/baseline-occupancies/occupancy-panel.tsx
+++ b/app/frontend/components/domains/step-code/part-3/form-section/baseline-occupancies/occupancy-panel.tsx
@@ -1,0 +1,140 @@
+import {
+  Flex,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Radio,
+  RadioGroup,
+  Stack,
+} from "@chakra-ui/react"
+import { ErrorMessage } from "@hookform/error-message"
+import { t } from "i18next"
+import { observer } from "mobx-react-lite"
+import React, { useEffect, useState } from "react"
+import { Controller, useFormContext } from "react-hook-form"
+import { Trans } from "react-i18next"
+import { EBaselinePerformanceRequirement } from "../../../../../../types/enums"
+import { IBaselineOccupancy } from "../../../../../../types/types"
+
+interface IProps {
+  occupancy: IBaselineOccupancy
+  idx: number
+}
+
+export const OccupancyPanel = observer(function Part3StepCodeFormBaselineDetails({ occupancy, idx }: IProps) {
+  const { register, control, getValues, formState, resetField, setValue } = useFormContext()
+  const { errors } = formState
+
+  const i18nPrefix = "stepCode.part3.baselineDetails"
+  const oci18nPrefix = "stepCode.part3.baselineOccupancyKeys"
+
+  const [isCustomRequirement, setIsCustomRequirement] = useState(
+    getValues(`baselineOccupanciesAttributes.${idx}.requirementSource`) ? "yes" : "no"
+  )
+
+  useEffect(() => {
+    if (isCustomRequirement == "no") {
+      // reset the requirementSource field and clear the value
+      resetField(`baselineOccupanciesAttributes.${idx}.requirementSource`)
+      setValue(`baselineOccupanciesAttributes.${idx}.requirementSource`, "")
+    }
+  }, [isCustomRequirement])
+
+  return (
+    <Flex direction="column" gap={{ base: 6, xl: 6 }} pb={4}>
+      <FormControl>
+        <FormLabel>
+          {t(`${i18nPrefix}.modelledFloorArea.label`, { occupancyName: t(`${oci18nPrefix}.${occupancy.key}`) })}
+        </FormLabel>
+        <FormHelperText mb={1} mt={0} color="semantic.error">
+          <ErrorMessage errors={errors} name={`baselineOccupanciesAttributes.${idx}.modelledFloorArea`} />
+        </FormHelperText>
+        <InputGroup maxW={"200px"}>
+          <Input
+            type="number"
+            {...register(`baselineOccupanciesAttributes.${idx}.modelledFloorArea`, {
+              required: t(`${i18nPrefix}.modelledFloorArea.error`, {
+                occupancyName: t(`${oci18nPrefix}.${occupancy.key}`),
+              }),
+            })}
+          />
+          <InputRightElement pointerEvents="none">
+            <Trans
+              i18nKey={`${i18nPrefix}.modelledFloorArea.units`}
+              components={{
+                sup: <sup />,
+              }}
+            />
+          </InputRightElement>
+        </InputGroup>
+      </FormControl>
+
+      <FormControl>
+        <FormLabel pb={1}>
+          {t(`${i18nPrefix}.performanceRequirement.label`, { occupancyName: t(`${oci18nPrefix}.${occupancy.key}`) })}
+        </FormLabel>
+        <FormHelperText mb={1} mt={0} color="semantic.error">
+          <ErrorMessage errors={errors} name={`baselineOccupanciesAttributes.${idx}.performanceRequirement`} />
+        </FormHelperText>
+        <Controller
+          name={`baselineOccupanciesAttributes.${idx}.performanceRequirement`}
+          control={control}
+          rules={{
+            required: t(`${i18nPrefix}.performanceRequirement.error`, {
+              occupancyName: t(`${oci18nPrefix}.${occupancy.key}`),
+            }),
+          }}
+          render={({ field: { onChange, value } }) => (
+            <RadioGroup defaultValue={value} onChange={onChange}>
+              <Stack spacing={1}>
+                {Object.values(EBaselinePerformanceRequirement).map((requirement) => (
+                  <Radio key={requirement} value={requirement}>
+                    {t(`stepCode.part3.performanceRequirements.${requirement}`)}
+                  </Radio>
+                ))}
+              </Stack>
+            </RadioGroup>
+          )}
+        />
+      </FormControl>
+
+      <FormControl>
+        <FormLabel>
+          {t(`${i18nPrefix}.isCustomRequirement`, { occupancyName: t(`${oci18nPrefix}.${occupancy.key}`) })}
+        </FormLabel>
+        <RadioGroup onChange={setIsCustomRequirement} value={isCustomRequirement}>
+          <Stack spacing={5} direction="row">
+            <Radio variant="binary" value={"yes"}>
+              {t("ui.yes")}
+            </Radio>
+            <Radio variant="binary" value={"no"} defaultChecked>
+              {t("ui.no")}
+            </Radio>
+          </Stack>
+        </RadioGroup>
+      </FormControl>
+
+      {isCustomRequirement == "yes" && (
+        <FormControl>
+          <FormLabel>{t(`${i18nPrefix}.requirementSource.label`)}</FormLabel>
+          <FormHelperText mb={1} mt={0} maxW={"430px"}>
+            {t(`${i18nPrefix}.requirementSource.hint`)}
+          </FormHelperText>
+          <FormHelperText mb={1} mt={0} color="semantic.error">
+            <ErrorMessage errors={errors} name={`baselineOccupanciesAttributes.${idx}.requirementSource`} />
+          </FormHelperText>
+          <Input
+            {...register(`baselineOccupanciesAttributes.${idx}.requirementSource`, {
+              required: t(`${i18nPrefix}.requirementSource.error`, {
+                occupancyName: t(`${oci18nPrefix}.${occupancy.key}`),
+              }),
+            })}
+          />
+        </FormControl>
+      )}
+    </Flex>
+  )
+})

--- a/app/frontend/components/domains/step-code/part-3/form-section/baseline-occupancy.tsx
+++ b/app/frontend/components/domains/step-code/part-3/form-section/baseline-occupancy.tsx
@@ -1,7 +1,0 @@
-import { Heading } from "@chakra-ui/react"
-import { observer } from "mobx-react-lite"
-import React from "react"
-
-export const BaselineOccupancy = observer(function Part3StepCodeFormBaselineOccupancy() {
-  return <Heading>Baseline Occupancy</Heading>
-})

--- a/app/frontend/components/domains/step-code/part-3/form-section/index.tsx
+++ b/app/frontend/components/domains/step-code/part-3/form-section/index.tsx
@@ -2,7 +2,7 @@ import { observer } from "mobx-react-lite"
 import React from "react"
 import { useParams } from "react-router-dom"
 import { BaselineOccupancies } from "./baseline-occupancies"
-import { BaselineOccupancy } from "./baseline-occupancy"
+import { BaselineDetails } from "./baseline-occupancies/baseline-details"
 import { DistrictEnergy } from "./district-energy"
 import { FuelTypes } from "./fuel-types"
 import { LocationDetails } from "./location-details"
@@ -23,8 +23,8 @@ export const FormSection = observer(function Part3StepCodeFormSection() {
       return <DistrictEnergy />
     case "baseline-occupancies":
       return <BaselineOccupancies />
-    case "details":
-      return <BaselineOccupancy />
+    case "baseline-details":
+      return <BaselineDetails />
     case "fuel-types":
       return <FuelTypes />
   }

--- a/app/frontend/components/domains/step-code/part-3/form-section/project-details.tsx
+++ b/app/frontend/components/domains/step-code/part-3/form-section/project-details.tsx
@@ -4,7 +4,6 @@ import {
   FormControl,
   FormControlProps,
   FormLabel,
-  Heading,
   Input,
   InputGroup,
   InputLeftElement,
@@ -19,6 +18,7 @@ import { useForm } from "react-hook-form"
 import { Trans } from "react-i18next"
 import { useLocation, useNavigate, useParams } from "react-router-dom"
 import { usePart3StepCode } from "../../../../../hooks/resources/use-part-3-step-code"
+import { SectionHeading } from "./shared/section-heading"
 
 export const ProjectDetails = observer(function Part3StepCodeFormProjectDetails() {
   const i18nPrefix = "stepCode.part3.projectDetails"
@@ -39,14 +39,12 @@ export const ProjectDetails = observer(function Part3StepCodeFormProjectDetails(
 
   return (
     <>
-      <Flex direction="column" gap={2} pb={4}>
-        <Heading as="h2" fontSize="2xl" variant="yellowline">
-          {t(`${i18nPrefix}.heading`)}
-        </Heading>
+      <Flex direction="column" gap={2} pb={6}>
+        <SectionHeading>{t(`${i18nPrefix}.heading`)}</SectionHeading>
         <Text fontSize="md">{t(`${i18nPrefix}.instructions`)}</Text>
       </Flex>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <Flex direction="column" gap={{ base: 6, xl: 2 }} pb={4}>
+        <Flex direction="column" gap={{ base: 6, xl: 6 }} pb={4}>
           <Field label={t(`${i18nPrefix}.name`)} value={checklist.projectName} />
           <Flex gap={{ base: 6, xl: 6 }} direction={{ base: "column", xl: "row" }}>
             <FormControl width={{ base: "auto", xl: "430px" }}>
@@ -79,7 +77,7 @@ export const ProjectDetails = observer(function Part3StepCodeFormProjectDetails(
             label={t(`${i18nPrefix}.version`)}
             value={t(`${i18nPrefix}.buildingCodeVersions.${checklist.buildingCodeVersion}`)}
           />
-          <Flex direction="column" gap={2} pb={4}>
+          <Flex direction="column" gap={2}>
             <Text fontSize="md" fontWeight="bold">
               {t(`${i18nPrefix}.confirm`)}
             </Text>
@@ -108,7 +106,7 @@ interface IFieldProps extends FormControlProps {
 
 const Field = function Field({ label, value, ...props }: IFieldProps) {
   return (
-    <FormControl mb={{ base: 0, xl: 4 }} {...props}>
+    <FormControl {...props}>
       <FormLabel>{label}</FormLabel>
       <Input isDisabled value={value} textOverflow="ellipsis" />
     </FormControl>

--- a/app/frontend/components/domains/step-code/part-3/form-section/shared/section-heading.tsx
+++ b/app/frontend/components/domains/step-code/part-3/form-section/shared/section-heading.tsx
@@ -1,0 +1,10 @@
+import { Heading, HeadingProps } from "@chakra-ui/react"
+import React from "react"
+
+export function SectionHeading({ children, ...props }: HeadingProps) {
+  return (
+    <Heading as="h2" fontSize="2xl" variant="yellowline" pt={4} m={0} {...props}>
+      {children}
+    </Heading>
+  )
+}

--- a/app/frontend/components/domains/step-code/part-3/form-section/start-page.tsx
+++ b/app/frontend/components/domains/step-code/part-3/form-section/start-page.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form"
 import { Trans } from "react-i18next"
 import { useLocation, useNavigate } from "react-router-dom"
 import { usePart3StepCode } from "../../../../../hooks/resources/use-part-3-step-code"
+import { SectionHeading } from "./shared/section-heading"
 
 export const StartPage = observer(function Part3StepCodeFormStartPage() {
   const i18nPrefix = "stepCode.part3.startPage"
@@ -25,9 +26,7 @@ export const StartPage = observer(function Part3StepCodeFormStartPage() {
 
   return (
     <Flex direction="column" gap={6}>
-      <Heading as="h2" fontSize="2xl" variant="yellowline">
-        {t(`${i18nPrefix}.heading`)}
-      </Heading>
+      <SectionHeading>{t(`${i18nPrefix}.heading`)}</SectionHeading>
       <Text fontSize="md">{t(`${i18nPrefix}.description`)}</Text>
       <Flex direction="column" gap={4} p={4} bg="theme.blueLight" color="theme.blueAlt" rounded="lg">
         <Heading as="h4" fontSize="lg">

--- a/app/frontend/components/domains/step-code/part-3/index.tsx
+++ b/app/frontend/components/domains/step-code/part-3/index.tsx
@@ -1,4 +1,4 @@
-import { Center, Container, Flex, FormLabel, Show } from "@chakra-ui/react"
+import { Center, Flex, FormLabel, Show } from "@chakra-ui/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
 import React, { Suspense, useEffect } from "react"
@@ -90,11 +90,20 @@ export const Part3StepCodeForm = observer(function Part3StepCodeForm() {
                   <Sidebar />
                 </Flex>
               </Show>
-              <Flex direction="column" flex={1} pos="sticky" overflow="auto" top={0}>
+              <Flex
+                direction="column"
+                flex={1}
+                pos="sticky"
+                overflow="auto"
+                top={0}
+                pl={{ base: 0, xl: 20 }}
+                pt={{ base: 0, xl: 20 }}
+                pb={{ base: 0, xl: 10 }}
+              >
                 <FloatingHelpDrawer top="24" zIndex={1} />
-                <Container flex={1} my={10} maxW={{ base: "none", xl: "780px" }} px={{ base: 6, xl: 0 }} py={3}>
+                <Flex direction="column" flex={1} maxW="780px" px={6} py={3}>
                   <FormSection />
-                </Container>
+                </Flex>
               </Flex>
             </Flex>
           )}

--- a/app/frontend/components/domains/step-code/part-3/sidebar/index.tsx
+++ b/app/frontend/components/domains/step-code/part-3/sidebar/index.tsx
@@ -2,25 +2,31 @@ import { Box, VStack } from "@chakra-ui/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
 import React from "react"
+import { usePart3StepCode } from "../../../../../hooks/resources/use-part-3-step-code"
 import { navSections } from "./nav-sections"
 import { SectionHeader } from "./section-header"
 import { SectionLink } from "./section-link"
 import { SubLink } from "./sub-link"
 
 export const Sidebar = observer(function Part3StepCodeSidebar() {
+  const { checklist } = usePart3StepCode()
+
   return (
     <VStack w="full" align="stretch" pt={4}>
       {navSections.map((section) => (
         <React.Fragment key={section.key}>
           <SectionHeader title={t(`stepCode.part3.sidebar.${section.key}`)} />
-          {section.navLinks.map((navLink) => (
-            <React.Fragment key={navLink.key}>
-              <SectionLink navLink={navLink} />
-              {navLink.subLinks.map((subLink) => (
-                <SubLink key={subLink.key} subLink={subLink} />
-              ))}
-            </React.Fragment>
-          ))}
+          {section.navLinks.map(
+            (navLink) =>
+              checklist.isRelevant(navLink.key) && (
+                <React.Fragment key={navLink.key}>
+                  <SectionLink navLink={navLink} />
+                  {navLink.subLinks.map(
+                    (subLink) => checklist.isRelevant(subLink.key) && <SubLink key={subLink.key} subLink={subLink} />
+                  )}
+                </React.Fragment>
+              )
+          )}
         </React.Fragment>
       ))}
       {/* add some padding below the final element */}

--- a/app/frontend/components/domains/step-code/part-3/sidebar/nav-sections.ts
+++ b/app/frontend/components/domains/step-code/part-3/sidebar/nav-sections.ts
@@ -25,7 +25,7 @@ export const navLinks: IPart3NavLink[] = [
     subLinks: [
       {
         key: "baselineDetails",
-        location: "details",
+        location: "baseline-details",
         subLinks: [],
       },
     ],
@@ -146,11 +146,25 @@ export const navSections: IPart3NavSection[] = [
 ]
 
 export const defaultSectionCompletionStatus = {
-  start: false,
-  projectDetails: false,
-  energySetup: false,
-  districtEnergy: false,
-  baselineOccupancies: false,
-  baselineDetails: false,
-  fuelTypes: false,
+  start: { complete: false, relevant: true },
+  projectDetails: { complete: false, relevant: true },
+  locationDetails: { complete: false, relevant: true },
+  baselineOccupancies: { complete: false, relevant: true },
+  baselineDetails: { complete: false, relevant: false },
+  districtEnergy: { complete: false, relevant: true },
+  fuelTypes: { complete: false, relevant: true },
+  additionalFuelTypes: { complete: false, relevant: false },
+  baselinePerformance: { complete: false, relevant: false },
+  stepCodeOccupancies: { complete: false, relevant: true },
+  stepCodePerformanceRequirements: { complete: false, relevant: false },
+  modelledOutputs: { complete: false, relevant: true },
+  renewableEnergy: { complete: false, relevant: true },
+  overheatingRequirements: { complete: false, relevant: true },
+  projectAdjustments: { complete: false, relevant: true },
+  documentReferences: { complete: false, relevant: true },
+  performanceCharacteristics: { complete: false, relevant: true },
+  hvac: { complete: false, relevant: true },
+  contact: { complete: false, relevant: true },
+  requirementsSummary: { complete: false, relevant: true },
+  stepCodeSummary: { complete: false, relevant: true },
 }

--- a/app/frontend/components/shared/base/custom-message-box.tsx
+++ b/app/frontend/components/shared/base/custom-message-box.tsx
@@ -13,11 +13,11 @@ interface ICustomMessageBoxProps
 }
 
 const iconMap = {
-  success: <CheckCircle size={24} aria-label={"success icon"} />,
-  warning: <Warning size={24} aria-label={"warning icon"} />,
-  error: <WarningCircle size={24} aria-label={"error icon"} />,
-  info: <Info size={24} aria-label={"info icon"} />,
-  spacial: <Info size={24} aria-label={"info icon"} />,
+  success: <CheckCircle size={20} aria-label={"success icon"} />,
+  warning: <Warning size={20} aria-label={"warning icon"} />,
+  error: <WarningCircle size={20} aria-label={"error icon"} />,
+  info: <Info size={20} aria-label={"info icon"} />,
+  spacial: <Info size={20} aria-label={"info icon"} />,
 }
 
 export const CustomMessageBox = ({
@@ -43,7 +43,7 @@ export const CustomMessageBox = ({
         <Box color={`semantic.${status}`}>{iconMap[status]}</Box>
         <Flex direction="column" gap={2}>
           {title && (
-            <Heading as="h3" fontSize="md" {...headingProps}>
+            <Heading as="h3" fontSize="md" m={0} lineHeight={5} {...headingProps}>
               {title}
             </Heading>
           )}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -924,6 +924,7 @@ const options = {
         stepCode: {
           part3: {
             title: "Energy and Zero Carbon Step Codes for Step 3 Buildings",
+            errorTitle: "There is a problem",
             sidebar: {
               overview: "Overview",
               start: "Start page",
@@ -994,16 +995,22 @@ const options = {
             },
             locationDetails: {
               heading: "Building and location details",
+              errorDescription: "",
               instructions: "Set key parameters for your project.",
               aboveGradeStories: {
                 label: "Number of above grade stories",
                 hint: "Include half-storeys and relevant below-grade storeys",
+                error: "Enter the number of above grade stories for this project.",
               },
               hdd: {
                 label: "Heating degree days below 18°C",
                 hint: "HDD is specified by the AHJ",
+                error: "Enter the heating degree days below 18°C for this project.",
               },
-              climateZone: "Climate zone",
+              climateZone: {
+                label: "Climate zone",
+                error: "Select the climate zone for this project.",
+              },
               climateZones: {
                 zone_4: "Zone 4",
                 zone_5: "Zone 5",
@@ -1013,6 +1020,71 @@ const options = {
                 zone_8: "Zone 8",
               },
               cta: "Save and continue",
+            },
+            baselineOccupancies: {
+              heading: "Occupancy classifications for buildings with a baseline",
+              instructions:
+                "Building projects with occupancy classifications subject to Step 2 (NECB Part 8) requirements or Subsection 10.2.2.1.(1)(a) or (b) of Division B of the BC Building Code must provide certain details to compare against a baseline energy model.<br /><br/>These occupancy classifications are:<br /><br /><ul><li><strong>A1</strong> Assembly (viewing performing arts)</li><li><strong>A2</strong> Assembly (not elsewhere categorized)</li><li><strong>A3</strong> Assembly (area)</li><li><strong>B1</strong> Detention</li><li><strong>B2</strong> Treatment</li><li><strong>B3</strong> Care</li><li><strong>F1</strong> High-hazard industrial</li><li><strong>F2</strong> Medium-hazard industrial</li><li><strong>F3</strong> Low-hazard industrial</li></ul>",
+              isRelevant: "Does your project include any of the these occupancy classifications?",
+              disabledCtaTooltip: "Please select an occupancy",
+              cta: "Save and continue",
+              occupancies: {
+                label: "Which occupancy classifications apply to this building? Select all that apply:",
+                error: "Select the occupancy classifications from the list that are in this building.",
+              },
+              occupancyKeys: {
+                performing_arts_assembly: "<strong>A1</strong> Assembly (viewing performance arts)",
+                other_assembly: "<strong>A2</strong> Assembly (not elsewhere categorized)",
+                arena_assembly: "<strong>A3</strong> Assembly (arena)",
+                open_air_assembly: "<strong>A4</strong> Assembly (occupants in open air)",
+                detention: "<strong>B1</strong> Detention",
+                treatment: "<strong>B2</strong> Treatment",
+                care: "<strong>B3</strong> Care",
+                high_hazard_industrial: "<strong>F1</strong> High-hazard industrial",
+                medium_hazard_industrial: "<strong>F2</strong> Medium-hazard industrial",
+                low_hazard_industrial: "<strong>F3</strong> Low-hazard industrial",
+              },
+            },
+            baselineDetails: {
+              heading: "Baseline comparison details",
+              instructions:
+                "Enter the baseline comparison details for each occupancy classification subject to Step 2 (NECB Part 8) requirements or Subsection 10.2.2.1.(1)(a) or (b) of Division B of the BC Building Code.",
+              modelledFloorArea: {
+                label: "What is the modelled floor area for {{occupancyName}} in square metres?",
+                units: "m<sup>2</sup>",
+                error: "Enter the modelled floor area for {{occupancyName}}.",
+              },
+              performanceRequirement: {
+                label: "What is the performance requirement for {{occupancyName}}?",
+                error: "Select the performance requirement for {{occupancyName}}.",
+              },
+              isCustomRequirement:
+                "Does the authority having jurisdiction (AHJ) require higher performance than BC Building Code minimums for {{occupancyName}}?",
+              requirementSource: {
+                label: "What is the source of this performance requirement?",
+                hint: "If this project’s authority having jurisdiction requires higher performance than BC minimums, enter the bylaw, policy, or document(s) that dictate this project’s energy requirements. ",
+                error: "Enter the requirement source for {{occupancyName}}.",
+              },
+              cta: "Save and continue",
+            },
+            performanceRequirements: {
+              step_2_necb: "Step 2 (NECB)",
+              ashrae: "ASHRAE 90.1",
+              "%_better_ashrae": "Percent (%) better than ASHRAE 90.1",
+              necb: "NECB",
+              "%_better_necb": "Percent (%) better than NECB",
+            },
+            baselineOccupancyKeys: {
+              performing_arts_assembly: "A1 Assembly (viewing performance arts)",
+              other_assembly: "A2 Assembly (not elsewhere categorized)",
+              arena_assembly: "A3 Assembly (arena)",
+              open_air_assembly: "A4 Assembly (occupants in open air)",
+              detention: "B1 Detention",
+              treatment: "B2 Treatment",
+              care: "B3 Care",
+              high_hazard_industrial: "F1 High-hazard industrial",
+              medium_hazard_industrial: "F2 Medium-hazard industrial",
+              low_hazard_industrial: "F3 Low-hazard industrial",
             },
           },
           title: "Step code auto-compliance tool",

--- a/app/frontend/styles/theme/components/radio.ts
+++ b/app/frontend/styles/theme/components/radio.ts
@@ -1,0 +1,20 @@
+import { radioAnatomy } from "@chakra-ui/anatomy"
+import { createMultiStyleConfigHelpers } from "@chakra-ui/react"
+
+const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(radioAnatomy.keys)
+
+const binary = definePartsStyle({
+  container: {
+    py: 3,
+    px: 4,
+    borderRadius: "md",
+    border: "1px solid",
+    borderColor: "border.light",
+    _checked: {
+      borderColor: "border.base",
+      bg: "theme.blueLight",
+    },
+  },
+})
+
+export const Radio = defineMultiStyleConfig({ variants: { binary } })

--- a/app/frontend/styles/theme/index.ts
+++ b/app/frontend/styles/theme/index.ts
@@ -4,6 +4,7 @@ import { FormLabel } from "./components/form-label"
 import { Heading } from "./components/heading"
 import { Input } from "./components/input"
 import { Link } from "./components/link"
+import { Radio } from "./components/radio"
 import { Select } from "./components/select"
 import { Table } from "./components/table"
 import { Text } from "./components/text"
@@ -84,7 +85,7 @@ const styles = {
     },
   },
 }
-const components = { Button, FormLabel, Heading, Input, Link, Select, Text, Table }
+const components = { Button, FormLabel, Heading, Input, Link, Select, Text, Table, Radio }
 const overrides = { styles, colors, fonts, fontSizes, sizes, radii, space, shadows, components }
 
 export const theme = extendTheme(overrides)

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -472,6 +472,19 @@ export enum EProjectStage {
   resubmitted = "resubmitted",
 }
 
+export enum EBaselineOccupancyKey {
+  performingArtsAssembly = "performing_arts_assembly",
+  otherAssembly = "other_assembly",
+  arenaAssembly = "arena_assembly",
+  openAirassembly = "open_air_assembly",
+  detention = "detention",
+  treatment = "treatment",
+  care = "care",
+  highHazardindustrial = "high_hazard_industrial",
+  mediumHazardIndustrial = "medium_hazard_industrial",
+  lowHazardIndustrial = "low_hazard_industrial",
+}
+
 export enum EBaselinePerformanceRequirement {
   step2NECB = "step_2_necb",
   ASHRAE = "ashrae",

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -6,6 +6,7 @@ import { IRequirement } from "../models/requirement"
 import {
   EAutoComplianceModule,
   EAutoComplianceType,
+  EBaselineOccupancyKey,
   EBaselinePerformanceRequirement,
   ECollaborationType,
   ECollaboratorType,
@@ -34,6 +35,12 @@ import {
   EWindowsGlazedDoorsPerformanceType,
   EZeroCarbonStep,
 } from "./enums"
+
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>
+    }
+  : T
 
 export type TLatLngTuple = [number, number]
 
@@ -551,13 +558,17 @@ export type TVisibility =
   | EVisibilityValues
   | `${EVisibilityValues},${EVisibilityValues}`
   | `${EVisibilityValues},${EVisibilityValues},${EVisibilityValues}`
+
 export interface IBaselineOccupancy {
+  id?: string
+  key: EBaselineOccupancyKey
   modelledFloorArea: string
   performanceRequirement: EBaselinePerformanceRequirement
   percentBetterRequirement?: string
   requirementSource?: string
 }
 export interface IStepCodeOccupancy {
+  id?: string
   modelledFloorArea: string
   energyStepRequired: EEnergyStep
   zeroCarbonStepRequired: EZeroCarbonStep
@@ -600,28 +611,33 @@ export interface IPart3NavSection {
   navLinks: IPart3NavLink[]
 }
 
+export interface IPart3SectionCompletionStatusEntry {
+  complete: boolean
+  relevant: boolean
+}
+
 export interface IPart3SectionCompletionStatus {
-  start: boolean
-  projectDetails: boolean
-  locationDetails: boolean
-  baselineOccupancies: boolean
-  baselineDetails: boolean
-  districtEnergy: boolean
-  fuelTypes: boolean
-  additionalFuelTypes: boolean
-  baselinePerformance: boolean
-  stepCodeOccupancies: boolean
-  stepCodePerformanceRequirements: boolean
-  modelledOutputs: boolean
-  renewableEnergy: boolean
-  overheatingRequirements: boolean
-  projectAdjustments: boolean
-  documentReferences: boolean
-  performanceCharacteristics: boolean
-  hvac: boolean
-  contact: boolean
-  requirementsSummary: boolean
-  stepCodeSummary: boolean
+  start: IPart3SectionCompletionStatusEntry
+  projectDetails: IPart3SectionCompletionStatusEntry
+  locationDetails: IPart3SectionCompletionStatusEntry
+  baselineOccupancies: IPart3SectionCompletionStatusEntry
+  baselineDetails: IPart3SectionCompletionStatusEntry
+  districtEnergy: IPart3SectionCompletionStatusEntry
+  fuelTypes: IPart3SectionCompletionStatusEntry
+  additionalFuelTypes: IPart3SectionCompletionStatusEntry
+  baselinePerformance: IPart3SectionCompletionStatusEntry
+  stepCodeOccupancies: IPart3SectionCompletionStatusEntry
+  stepCodePerformanceRequirements: IPart3SectionCompletionStatusEntry
+  modelledOutputs: IPart3SectionCompletionStatusEntry
+  renewableEnergy: IPart3SectionCompletionStatusEntry
+  overheatingRequirements: IPart3SectionCompletionStatusEntry
+  projectAdjustments: IPart3SectionCompletionStatusEntry
+  documentReferences: IPart3SectionCompletionStatusEntry
+  performanceCharacteristics: IPart3SectionCompletionStatusEntry
+  hvac: IPart3SectionCompletionStatusEntry
+  contact: IPart3SectionCompletionStatusEntry
+  requirementsSummary: IPart3SectionCompletionStatusEntry
+  stepCodeSummary: IPart3SectionCompletionStatusEntry
 }
 
 export type TPart3NavLinkKey = keyof IPart3SectionCompletionStatus

--- a/app/models/part_3_step_code/checklist.rb
+++ b/app/models/part_3_step_code/checklist.rb
@@ -3,7 +3,16 @@ class Part3StepCode::Checklist < ApplicationRecord
 
   belongs_to :step_code, optional: true
 
-  has_many :occupancy_classifications
+  has_many :occupancy_classifications, dependent: :destroy
+  has_many :baseline_occupancies,
+           -> { where(occupancy_type: :baseline) },
+           class_name: "Part3StepCode::OccupancyClassification"
+  accepts_nested_attributes_for :baseline_occupancies, allow_destroy: true
+  has_many :step_code_occupancies,
+           -> { where(occupancy_type: :step_code) },
+           class_name: "Part3StepCode::OccupancyClassification"
+  accepts_nested_attributes_for :step_code_occupancies, allow_destroy: true
+
   has_many :fuel_types
   has_many :make_up_air_fuels
   has_many :document_references

--- a/app/models/part_3_step_code/occupancy_classification.rb
+++ b/app/models/part_3_step_code/occupancy_classification.rb
@@ -15,9 +15,5 @@ class Part3StepCode::OccupancyClassification < ApplicationRecord
        ]
   enum occupancy_type: %i[baseline step_code], _suffix: :occupancy
 
-  validates :performance_requirement, presence: true, if: :baseline_occupancy?
-  validates :energy_step_required, presence: true, if: :step_code_occupancy?
-  validates :zero_carbon_step_required,
-            presence: true,
-            if: :step_code_occupancy?
+  validates :key, presence: true, uniqueness: { scope: :checklist_id }
 end

--- a/db/migrate/20241206005741_add_unique_index_to_occupancy_classifications.rb
+++ b/db/migrate/20241206005741_add_unique_index_to_occupancy_classifications.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToOccupancyClassifications < ActiveRecord::Migration[7.1]
+  def change
+    add_index :occupancy_classifications, %i[key checklist_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_04_184650) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_06_005741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -317,6 +317,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_04_184650) do
     t.datetime "updated_at", null: false
     t.index ["checklist_id"],
             name: "index_occupancy_classifications_on_checklist_id"
+    t.index %w[key checklist_id],
+            name: "index_occupancy_classifications_on_key_and_checklist_id",
+            unique: true
   end
 
   create_table "part_3_step_code_checklists",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@emotion/styled": "^11.11.0",
         "@formio/js": "^5.0.0-rc.37",
         "@formio/react": "^5.3.0",
+        "@hookform/error-message": "^2.0.1",
         "@phosphor-icons/react": "^2.0.15",
         "@react-pdf/renderer": "^3.4.0",
         "@types/jest": "^29.5.10",
@@ -1249,6 +1250,16 @@
       "version": "5.1.1-formio.1",
       "resolved": "https://registry.npmjs.org/@formio/vanilla-text-mask/-/vanilla-text-mask-5.1.1-formio.1.tgz",
       "integrity": "sha512-rYBlvIPMNUd6sAaduOaiIwI4vfTAjHDRonko2qJn2RP1O//TQ7rcFIPYVYePJZ4OtOpwHiHAvAIh79McphZotQ=="
+    },
+    "node_modules/@hookform/error-message": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/error-message/-/error-message-2.0.1.tgz",
+      "integrity": "sha512-U410sAr92xgxT1idlu9WWOVjndxLdgPUHEB8Schr27C9eh7/xUnITWpCMF93s+lGiG++D4JnbSnrb5A21AdSNg==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "react-hook-form": "^7.0.0"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@emotion/styled": "^11.11.0",
     "@formio/js": "^5.0.0-rc.37",
     "@formio/react": "^5.3.0",
+    "@hookform/error-message": "^2.0.1",
     "@phosphor-icons/react": "^2.0.15",
     "@react-pdf/renderer": "^3.4.0",
     "@types/jest": "^29.5.10",


### PR DESCRIPTION
## Description

Add in the baseline occupancies screens along with support for error messaging.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

[BPHH-2444](https://hous-bssb.atlassian.net/browse/BPHH-2444)

## Steps to QA

- Baseline occupancies section UI is implemented and occupancies can be configured. 
- Error messaging behaves in a reasonable manner for baseline occupancies and building & location details screens

## UI Accessibility Checklist

<!--
    If the PR involves UI changes, please use this checklist.
-->

_Note the following checklist is not an exhaustive list. Check
the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for
a user-friendly checklist with more details. Aim to meet at least *AA* conformance level where applicable. Check
the [WCAG guidelines](https://webaim.org/standards/wcag/checklist) for the full guidelines._

- [ ] Markup uses semantic HTML?
- [ ] Additional context added through `aria-roles` and `aria-labels`?
- [ ] Checked
      with [Wave Browser Extension](https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
      for accessibility errors?
- [ ] Usable with a keyboard and navigable in a logical order?
- [ ] Usable using a screen reader (e.g. Voiceover for Mac) with enough context for the user?

## General Checklist

- [ ] ✅ Provide tests for your changes where relevant
- [x] 📝 Use descriptive commit messages
- [ ] 📗 Update any related documentation and include any relevant screenshots
- [ ] 📱 For UI-related tasks, ensure responsive design is implemented across multiple screen size
- [x] 🗂️ Move your relevant story/task to the _Ready for Code Review_ state

## [optional] Are there any post-deployment tasks we need to perform?

n/a


[BPHH-2444]: https://hous-bssb.atlassian.net/browse/BPHH-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ