### PR TITLE
fix visibility check on blocks during copy

### DIFF
--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -43,9 +43,9 @@ class RequirementBlock < ApplicationRecord
 
   def allowed_in(requirement_template)
     if requirement_template.early_access?
-      %i[any early_access].include?(visibility)
+      %i[any early_access].include?(visibility.to_sym)
     else
-      %i[any live].include?(visibility)
+      %i[any live].include?(visibility.to_sym)
     end
   end
 


### PR DESCRIPTION
## Description

Template copy was being passed string visibility for block applicability check and then as comparing to symbols

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ x] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-2568

