### PR TITLE
allow create of permit applications under live requirement templates

### DIFF
--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -54,6 +54,7 @@ class PermitApplication < ApplicationRecord
   validates :number, presence: true
   validates :reference_number, length: { maximum: 300 }, allow_nil: true
   validate :sandbox_belongs_to_jurisdiction
+  validate :template_version_of_live_template
 
   delegate :qualified_name, to: :jurisdiction, prefix: true
   delegate :name, to: :jurisdiction, prefix: true
@@ -256,7 +257,7 @@ class PermitApplication < ApplicationRecord
 
   def current_published_template_version
     # this will eventually be different, if there is a new version it should notify the user
-    RequirementTemplate.published_requirement_template_version(
+    LiveRequirementTemplate.published_requirement_template_version(
       activity,
       permit_type,
       first_nations
@@ -712,6 +713,14 @@ class PermitApplication < ApplicationRecord
 
     unless jurisdiction.sandboxes.include?(sandbox)
       errors.add(:sandbox, "must belong to the jurisdiction")
+    end
+  end
+
+  def template_version_of_live_template
+    return unless template_version.present?
+
+    unless template_version.live?
+      errors.add(:template_version, "must be for a live requirement template")
     end
   end
 end

--- a/app/models/template_version.rb
+++ b/app/models/template_version.rb
@@ -14,6 +14,7 @@ class TemplateVersion < ApplicationRecord
   delegate :published_template_version, to: :requirement_template
   delegate :first_nations, to: :requirement_template
   delegate :early_access?, to: :requirement_template
+  delegate :live?, to: :requirement_template
   delegate :public?, to: :requirement_template
 
   enum status: { scheduled: 0, published: 1, deprecated: 2 }, _default: 0


### PR DESCRIPTION
## Description

Use of superclass here was causing new permit applications to find correctly classified early access requirement template versions.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-2573
