### PR TITLE
Do not show release version in prod

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -7,10 +7,6 @@ on:
         description: "Branch Name"
         required: true
         default: "main"
-      release_version:
-        description: "Release Version (displayed on UI)"
-        required: true
-        type: string
 
 jobs:
   build-and-push-image:
@@ -40,6 +36,7 @@ jobs:
             app=prod-hous-permit-portal
             git-sha=${{ github.sha }}
           containerfiles: ./devops/docker/app/Dockerfile
+          # VITE_RELEASE_VERSION always blank in prod as we want to hide the banner
           build-args: |
             VITE_BASIC_BCEID_REGISTRATION_URL=${{ vars.VITE_BASIC_BCEID_REGISTRATION_URL }}
             VITE_BUSINESS_BCEID_REGISTRATION_URL=${{ vars.VITE_BUSINESS_BCEID_REGISTRATION_URL }}
@@ -47,7 +44,7 @@ jobs:
             VITE_SITEMINDER_LOGOUT_URL=${{ vars.VITE_SITEMINDER_LOGOUT_URL }}
             VITE_KEYCLOAK_LOGOUT_URL=${{ vars.VITE_KEYCLOAK_LOGOUT_URL }}
             VITE_POST_LOGOUT_REDIRECT_URL=${{ vars.VITE_POST_LOGOUT_REDIRECT_URL }}
-            VITE_RELEASE_VERSION=production-${{ github.event.inputs.release_version }}
+            VITE_RELEASE_VERSION=""
       - name: Push to Openshift Registry using Service Account
         uses: redhat-actions/push-to-registry@v2.7
         with:

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -430,18 +430,20 @@ const NavBarMenu = observer(function NavBarMenu({}: INavBarMenuProps) {
                 {t("site.giveFeedback")} <Envelope size={16} style={{ display: "inline", color: "inherit" }} />
               </Link>
             </MenuItem>
-            <MenuItem h={6} bg="greys.grey03" _hover={{ cursor: "auto" }}>
-              <Text
-                textAlign="center"
-                w="full"
-                color="greys.grey90"
-                fontWeight={"thin"}
-                fontStyle="italic"
-                fontSize="sm"
-              >
-                {import.meta.env.VITE_RELEASE_VERSION}
-              </Text>
-            </MenuItem>
+            {import.meta.env.VITE_RELEASE_VERSION && (
+              <MenuItem h={6} bg="greys.grey03" _hover={{ cursor: "auto" }}>
+                <Text
+                  textAlign="center"
+                  w="full"
+                  color="greys.grey90"
+                  fontWeight={"thin"}
+                  fontStyle="italic"
+                  fontSize="sm"
+                >
+                  {import.meta.env.VITE_RELEASE_VERSION}
+                </Text>
+              </MenuItem>
+            )}
           </MenuList>
         </Box>
       </Portal>


### PR DESCRIPTION
## Description

Sets `VITE_RELEASE_VERSION` to empty in production GHA and hides it on the frontend

