### PR TITLE
Adjusts Openshift limits for all three environments

### DIFF
--- a/devops/helm-charts/anycable-go/values-dev.yaml
+++ b/devops/helm-charts/anycable-go/values-dev.yaml
@@ -8,6 +8,3 @@ anycable-go:
     requests:
       cpu: 50m
       memory: 256Mi
-    limits:
-      cpu: 100m
-      memory: 512Mi

--- a/devops/helm-charts/anycable-go/values-prod.yaml
+++ b/devops/helm-charts/anycable-go/values-prod.yaml
@@ -8,6 +8,3 @@ anycable-go:
     requests:
       cpu: 50m
       memory: 128Mi
-    limits:
-      cpu: 100m
-      memory: 256Mi

--- a/devops/helm-charts/anycable-go/values-test.yaml
+++ b/devops/helm-charts/anycable-go/values-test.yaml
@@ -8,6 +8,3 @@ anycable-go:
     requests:
       cpu: 50m
       memory: 256Mi
-    limits:
-      cpu: 100m
-      memory: 512Mi

--- a/devops/helm-charts/anycable-go/values.yaml
+++ b/devops/helm-charts/anycable-go/values.yaml
@@ -27,6 +27,3 @@ anycable-go:
     requests:
       cpu: 20m
       memory: 128Mi
-    limits:
-      cpu: 150m
-      memory: 128Mi

--- a/devops/helm-charts/app/templates/compliance-logging-cleanup-cronjob.yaml
+++ b/devops/helm-charts/app/templates/compliance-logging-cleanup-cronjob.yaml
@@ -21,9 +21,6 @@ spec:
                 requests:
                   memory: "64Mi"
                   cpu: "50m"
-                limits:
-                  memory: "128Mi"
-                  cpu: "100m"
           restartPolicy: OnFailure
           volumes:
             - name: compliance-log-pvc

--- a/devops/helm-charts/app/templates/deployment.yaml
+++ b/devops/helm-charts/app/templates/deployment.yaml
@@ -55,9 +55,6 @@ spec:
             - containerPort: 3000
               protocol: TCP
           resources:
-            limits:
-              cpu: {{ .spec.containers.resources.limits.cpu }}
-              memory: {{ .spec.containers.resources.limits.memory }}
             requests:
               cpu: {{ .spec.containers.resources.requests.cpu }}
               memory: {{ .spec.containers.resources.requests.memory }}

--- a/devops/helm-charts/app/values-dev.yaml
+++ b/devops/helm-charts/app/values-dev.yaml
@@ -20,9 +20,6 @@ deployments:
           requests:
             cpu: 300m
             memory: 256Mi
-          limits:
-            cpu: 750m
-            memory: 512Mi
   - process: worker
     replicaCount: 1
     spec:
@@ -35,9 +32,6 @@ deployments:
           requests:
             cpu: 100m
             memory: 256Mi
-          limits:
-            cpu: 250m
-            memory: 512Mi
   - process: anycable-rpc
     replicaCount: 1
     spec:
@@ -50,6 +44,3 @@ deployments:
           requests:
             cpu: 50m
             memory: 128Mi
-          limits:
-            cpu: 100m
-            memory: 256Mi

--- a/devops/helm-charts/app/values-prod.yaml
+++ b/devops/helm-charts/app/values-prod.yaml
@@ -22,10 +22,7 @@ deployments:
         resources:
           requests:
             cpu: 300m
-            memory: 128Mi
-          limits:
-            cpu: 800m
-            memory: 512Mi
+            memory: 256Mi
   - process: worker
     replicaCount: 2
     spec:
@@ -37,10 +34,7 @@ deployments:
         resources:
           requests:
             cpu: 100m
-            memory: 128Mi
-          limits:
-            cpu: 400m
-            memory: 512Mi
+            memory: 256Mi
   - process: anycable-rpc
     replicaCount: 2
     spec:
@@ -53,6 +47,3 @@ deployments:
           requests:
             cpu: 50m
             memory: 128Mi
-          limits:
-            cpu: 100m
-            memory: 256Mi

--- a/devops/helm-charts/app/values-test.yaml
+++ b/devops/helm-charts/app/values-test.yaml
@@ -20,9 +20,6 @@ deployments:
           requests:
             cpu: 300m
             memory: 256Mi
-          limits:
-            cpu: 750m
-            memory: 512Mi
   - process: worker
     replicaCount: 1
     spec:
@@ -35,9 +32,6 @@ deployments:
           requests:
             cpu: 100m
             memory: 256Mi
-          limits:
-            cpu: 250m
-            memory: 512Mi
   - process: anycable-rpc
     replicaCount: 1
     spec:
@@ -50,6 +44,3 @@ deployments:
           requests:
             cpu: 50m
             memory: 128Mi
-          limits:
-            cpu: 100m
-            memory: 256Mi

--- a/devops/helm-charts/app/values.yaml
+++ b/devops/helm-charts/app/values.yaml
@@ -18,9 +18,6 @@ deployments:
           requests:
             cpu: 50m
             memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 256Mi
   - process: worker
     replicaCount: 1
     spec:
@@ -33,9 +30,6 @@ deployments:
           requests:
             cpu: 50m
             memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 256Mi
   - process: anycable-rpc
     replicaCount: 1
     spec:
@@ -48,6 +42,3 @@ deployments:
           requests:
             cpu: 50m
             memory: 64Mi
-          limits:
-            cpu: 200m
-            memory: 256Mi

--- a/devops/helm-charts/consigno-verifio-notarius-server/templates/deployment.yaml
+++ b/devops/helm-charts/consigno-verifio-notarius-server/templates/deployment.yaml
@@ -54,9 +54,6 @@ spec:
           args:
             - set -a; . /vault/secrets/secrets.env; set +a; exec ./entrypoint.sh
           resources:
-            limits:
-              cpu: {{ $.Values.deployment.spec.containers.resources.limits.cpu }}
-              memory: {{ $.Values.deployment.spec.containers.resources.limits.memory }}
             requests:
               cpu: {{ $.Values.deployment.spec.containers.resources.requests.cpu }}
               memory: {{ $.Values.deployment.spec.containers.resources.requests.memory }}

--- a/devops/helm-charts/consigno-verifio-notarius-server/values-dev.yaml
+++ b/devops/helm-charts/consigno-verifio-notarius-server/values-dev.yaml
@@ -8,6 +8,3 @@ deployment:
         requests:
           cpu: 150m
           memory: 256Mi
-        limits:
-          cpu: 200m
-          memory: 512Mi

--- a/devops/helm-charts/consigno-verifio-notarius-server/values-prod.yaml
+++ b/devops/helm-charts/consigno-verifio-notarius-server/values-prod.yaml
@@ -9,6 +9,3 @@ deployment:
         requests:
           cpu: 150m
           memory: 256Mi
-        limits:
-          cpu: 200m
-          memory: 512Mi

--- a/devops/helm-charts/consigno-verifio-notarius-server/values-test.yaml
+++ b/devops/helm-charts/consigno-verifio-notarius-server/values-test.yaml
@@ -1,4 +1,4 @@
-STAGE: test
+STAGE: dev
 
 deployment:
   replicaCount: 1
@@ -8,6 +8,3 @@ deployment:
         requests:
           cpu: 150m
           memory: 256Mi
-        limits:
-          cpu: 200m
-          memory: 512Mi

--- a/devops/helm-charts/consigno-verifio-notarius-server/values.yaml
+++ b/devops/helm-charts/consigno-verifio-notarius-server/values.yaml
@@ -13,6 +13,3 @@ deployment:
         requests:
           cpu: 150m
           memory: 64Mi
-        limits:
-          cpu: 200m
-          memory: 384Mi

--- a/devops/helm-charts/ha-elasticsearch/values-dev.yaml
+++ b/devops/helm-charts/ha-elasticsearch/values-dev.yaml
@@ -6,9 +6,6 @@ elasticsearch:
       requests:
         cpu: "50m"
         memory: "512Mi"
-      limits:
-        cpu: "150m"
-        memory: "1024Mi"
     persistence:
       enabled: true
       accessModes:
@@ -21,9 +18,6 @@ elasticsearch:
       requests:
         cpu: "200m"
         memory: "1024Mi"
-      limits:
-        cpu: "400m"
-        memory: "1.5Gi"
     persistence:
       enabled: true
       accessModes:

--- a/devops/helm-charts/ha-elasticsearch/values-prod.yaml
+++ b/devops/helm-charts/ha-elasticsearch/values-prod.yaml
@@ -7,24 +7,18 @@ elasticsearch:
       requests:
         cpu: "100m"
         memory: "256Mi"
-      limits:
-        cpu: "200m"
-        memory: "1024Mi"
     persistence:
       enabled: true
       accessModes:
         - ReadWriteOnce
       size: "500Mi"
   data:
-    replicaCount: 2
+    replicaCount: 3
     heapSize: "1024m"
     resources:
       requests:
         cpu: "200m"
         memory: "1024Mi"
-      limits:
-        cpu: "400m"
-        memory: "2048Mi"
     persistence:
       enabled: true
       accessModes:

--- a/devops/helm-charts/ha-elasticsearch/values-test.yaml
+++ b/devops/helm-charts/ha-elasticsearch/values-test.yaml
@@ -6,9 +6,6 @@ elasticsearch:
       requests:
         cpu: "50m"
         memory: "512Mi"
-      limits:
-        cpu: "150m"
-        memory: "1024Mi"
     persistence:
       enabled: true
       accessModes:
@@ -21,9 +18,6 @@ elasticsearch:
       requests:
         cpu: "200m"
         memory: "1024Mi"
-      limits:
-        cpu: "400m"
-        memory: "1.5Gi"
     persistence:
       enabled: true
       accessModes:

--- a/devops/helm-charts/ha-elasticsearch/values.yaml
+++ b/devops/helm-charts/ha-elasticsearch/values.yaml
@@ -18,9 +18,6 @@ elasticsearch:
       requests:
         cpu: "20m"
         memory: "128Mi"
-      limits:
-        cpu: "100m"
-        memory: "512Mi"
     persistence:
       enabled: true
       accessModes:
@@ -47,9 +44,6 @@ elasticsearch:
       requests:
         cpu: "20m"
         memory: "256Mi"
-      limits:
-        cpu: "150m"
-        memory: "512Mi"
     persistence:
       enabled: true
       accessModes:

--- a/devops/helm-charts/ha-postgres-crunchydb/values-dev.yaml
+++ b/devops/helm-charts/ha-postgres-crunchydb/values-dev.yaml
@@ -6,16 +6,10 @@ crunchy-postgres:
     requests:
       cpu: 200m
       memory: 256Mi
-    limits:
-      cpu: 400m
-      memory: 512Mi
     replicaCertCopy:
       requests:
         cpu: 10m
         memory: 32Mi
-      limits:
-        cpu: 50m
-        memory: 64Mi
 
   pgBackRest:
     retention: "1"
@@ -26,16 +20,10 @@ crunchy-postgres:
       requests:
         cpu: 1m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi
     sidecars:
       requests:
         cpu: 1m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi
 
   patroni:
     postgresql:
@@ -52,6 +40,3 @@ crunchy-postgres:
       requests:
         cpu: 10m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi

--- a/devops/helm-charts/ha-postgres-crunchydb/values-prod.yaml
+++ b/devops/helm-charts/ha-postgres-crunchydb/values-prod.yaml
@@ -6,16 +6,13 @@ crunchy-postgres:
     requests:
       cpu: 200m
       memory: 256Mi
-    limits:
-      cpu: 400m
-      memory: 512Mi
+    limits: # wanted to just leave limits blank here, but the underlying chart speciffies it, so instead just specify a large number
+      cpu: 2
+      memory: 8Gi
     replicaCertCopy:
       requests:
         cpu: 10m
         memory: 32Mi
-      limits:
-        cpu: 50m
-        memory: 64Mi
 
   pgBackRest:
     retention: "3"
@@ -26,16 +23,10 @@ crunchy-postgres:
       requests:
         cpu: 1m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi
     sidecars:
       requests:
         cpu: 1m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi
 
   patroni:
     postgresql:
@@ -52,6 +43,3 @@ crunchy-postgres:
       requests:
         cpu: 50m
         memory: 64Mi
-      limits:
-        cpu: 100m
-        memory: 128Mi

--- a/devops/helm-charts/ha-postgres-crunchydb/values-test.yaml
+++ b/devops/helm-charts/ha-postgres-crunchydb/values-test.yaml
@@ -6,16 +6,10 @@ crunchy-postgres:
     requests:
       cpu: 200m
       memory: 256Mi
-    limits:
-      cpu: 400m
-      memory: 512Mi
     replicaCertCopy:
       requests:
         cpu: 10m
         memory: 32Mi
-      limits:
-        cpu: 50m
-        memory: 64Mi
 
   pgBackRest:
     retention: "1"
@@ -26,16 +20,10 @@ crunchy-postgres:
       requests:
         cpu: 1m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi
     sidecars:
       requests:
         cpu: 1m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi
 
   patroni:
     postgresql:
@@ -52,6 +40,3 @@ crunchy-postgres:
       requests:
         cpu: 10m
         memory: 64Mi
-      limits:
-        cpu: 50m
-        memory: 128Mi

--- a/devops/helm-charts/ha-postgres-crunchydb/values.yaml
+++ b/devops/helm-charts/ha-postgres-crunchydb/values.yaml
@@ -16,9 +16,9 @@ crunchy-postgres:
     requests:
       cpu: 10m
       memory: 256Mi
-    limits:
-      cpu: 100m
-      memory: 512Mi
+    limits: # wanted to just leave limits blank here, but the underlying chart speciffies it, so instead just specify a large number
+      cpu: 2
+      memory: 8Gi
     replicaCertCopy:
       requests:
         cpu: 10m
@@ -46,15 +46,15 @@ crunchy-postgres:
         cpu: 1m
         memory: 64Mi
       limits:
-        cpu: 50m
-        memory: 128Mi
+        cpu: 200m
+        memory: 512Mi
     sidecars:
       requests:
         cpu: 1m
         memory: 64Mi
       limits:
-        cpu: 50m
-        memory: 128Mi
+        cpu: 200m
+        memory: 256Mi
     s3:
       enabled: false
       createS3Secret: true
@@ -96,8 +96,8 @@ crunchy-postgres:
         cpu: 50m
         memory: 64Mi
       limits:
-        cpu: 100m
-        memory: 128Mi
+        cpu: 500m
+        memory: 256Mi
 
   # Postgres Cluster resource values:
   pgmonitor:
@@ -108,5 +108,5 @@ crunchy-postgres:
         cpu: 1m
         memory: 64Mi
       limits:
-        cpu: 50m
-        memory: 128Mi
+        cpu: 200m
+        memory: 256Mi

--- a/devops/helm-charts/ha-postgres-crunchydb/values.yaml
+++ b/devops/helm-charts/ha-postgres-crunchydb/values.yaml
@@ -17,8 +17,8 @@ crunchy-postgres:
       cpu: 10m
       memory: 256Mi
     limits: # wanted to just leave limits blank here, but the underlying chart speciffies it, so instead just specify a large number
-      cpu: 2
-      memory: 8Gi
+      cpu: 1
+      memory: 4Gi
     replicaCertCopy:
       requests:
         cpu: 10m

--- a/devops/helm-charts/ha-redis/values-dev.yaml
+++ b/devops/helm-charts/ha-redis/values-dev.yaml
@@ -2,11 +2,8 @@ redis:
   sentinel:
     resources:
       requests:
-        memory: "64Mi"
-        cpu: "100m"
-      limits:
         memory: "128Mi"
-        cpu: "150m"
+        cpu: "100m"
   replica:
     replicaCount: 1
     persistence:
@@ -14,8 +11,5 @@ redis:
       size: 500Mi
     resources:
       requests:
-        memory: "128Mi"
-        cpu: "250m"
-      limits:
         memory: "256Mi"
-        cpu: "300m"
+        cpu: "250m"

--- a/devops/helm-charts/ha-redis/values-prod.yaml
+++ b/devops/helm-charts/ha-redis/values-prod.yaml
@@ -4,18 +4,12 @@ redis:
       requests:
         memory: "128Mi"
         cpu: "100m"
-      limits:
-        memory: "256Mi"
-        cpu: "100m"
   replica:
-    replicaCount: 2
+    replicaCount: 3
     persistence:
       enabled: true
       size: 1Gi
     resources:
       requests:
         memory: "256Mi"
-        cpu: "250m"
-      limits:
-        memory: "512Mi"
-        cpu: "300m"
+        cpu: "200m"

--- a/devops/helm-charts/ha-redis/values-test.yaml
+++ b/devops/helm-charts/ha-redis/values-test.yaml
@@ -2,9 +2,6 @@ redis:
   sentinel:
     resources:
       requests:
-        memory: "64Mi"
-        cpu: "100m"
-      limits:
         memory: "128Mi"
         cpu: "100m"
   replica:
@@ -14,8 +11,5 @@ redis:
       size: 500Mi
     resources:
       requests:
-        memory: "128Mi"
-        cpu: "250m"
-      limits:
         memory: "256Mi"
-        cpu: "300m"
+        cpu: "250m"

--- a/devops/helm-charts/ha-redis/values.yaml
+++ b/devops/helm-charts/ha-redis/values.yaml
@@ -28,9 +28,6 @@ redis:
       requests:
         memory: "128Mi"
         cpu: "20m"
-      limits:
-        memory: "256Mi"
-        cpu: "50m"
   replica:
     replicaCount: 1
     podSecurityContext:
@@ -42,11 +39,8 @@ redis:
       size: 500Mi
     resources:
       requests:
-        memory: "128Mi"
-        cpu: "20m"
-      limits:
         memory: "256Mi"
-        cpu: "100m"
+        cpu: "20m"
   # don't need this since we are using sentinel, it will only look at replicas
   # master:
   #   persistence:


### PR DESCRIPTION
## Description

The Openshift team has recently removed the concept of `limit` in namespaces. As such, we are able to remove in most cases our limits as well so that the pod can be unconstrained. This will allow dev / test to be provisioned with more stable resources and for prod to increase resiliency (since we can then add another replica of Elasticsearch and Redis).

These values are for record only.

```
Removal of Resource Limits - The concept of limit has been removed. OpenShift now uses only request values configured by the OpenShift Provisioner... etc.
```

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents
https://hous-bssb.atlassian.net/browse/BPHH-2625
