### PR TITLE
move users to jurisdicton config management

### DIFF
--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/index.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/index.tsx
@@ -1,5 +1,5 @@
 import { Container, Flex, FormControl, FormLabel, Grid, GridItem, Heading, Input, Text, VStack } from "@chakra-ui/react"
-import { FileText, Info, SlidersHorizontal, Tray } from "@phosphor-icons/react"
+import { FileText, Info, SlidersHorizontal, Tray, Users } from "@phosphor-icons/react"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
 import React, { Suspense } from "react"
@@ -95,6 +95,18 @@ export const ConfigurationManagementScreen = observer(function ConfigurationMana
                   icon={<SlidersHorizontal size={24} />}
                   href={`/jurisdictions/${currentJurisdiction.slug}/api-settings`}
                   h="full"
+                />
+              </GridItem>
+
+              <GridItem>
+                <HomeScreenBox
+                  title={t(`${i18nPrefix}.users.title`)}
+                  description={t(`${i18nPrefix}.users.description`)}
+                  linkText={t("ui.edit")}
+                  icon={<Users size={24} />}
+                  href={`/jurisdictions/${currentJurisdiction.slug}/users`}
+                  h="full"
+                  disableForSandbox
                 />
               </GridItem>
             </Grid>

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -306,7 +306,6 @@ const NavBarMenu = observer(function NavBarMenu({}: INavBarMenuProps) {
         label={t("site.breadcrumb.configurationManagement")}
         to={`/jurisdictions/${currentUser?.jurisdiction?.slug}/configuration-management`}
       />
-      <NavMenuItem label={t("site.breadcrumb.users")} to={`/jurisdictions/${currentUser?.jurisdiction?.slug}/users`} />
       <NavMenuItem
         label={t("site.breadcrumb.apiSettings")}
         to={`/jurisdictions/${currentUser?.jurisdiction?.slug}/api-settings`}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1323,6 +1323,10 @@ const options = {
               description:
                 "Customize the informational page that submitters will see when they are in the Building Permit Hub.",
             },
+            users: {
+              title: "Users",
+              description: "Manage and invite reviewers and other staff for this jurisdiciton",
+            },
             submissionsInboxSetup: {
               title: "Submissions inbox setup",
               description: "Specify email addresses that should receive applications.",


### PR DESCRIPTION
## Description

Disable user management page for jurisdictions by removing it from the menu dropdown

https://hous-bssb.atlassian.net/browse/BPHH-2624
