### PR TITLE
Updates to the GHA deploy actions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,21 +22,24 @@ jobs:
           sudo apt-get update
           sudo apt-get install git-lfs
           git lfs install
-      - name: Confirm branch to deploy
-        run: echo "Deploying branch ${{ github.event.inputs.branch }} to Dev"
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
           lfs: true
+      - name: Update GITHUB_SHA with checked-out commit SHA
+        run: echo "GITHUB_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      - name: Confirm branch and SHA to deploy
+        run: |
+          echo "Deploying branch: ${{ github.event.inputs.branch }} @ ${{ env.GITHUB_SHA }} to Dev"
       - name: Build Docker Image
         uses: redhat-actions/buildah-build@v2
         with:
           image: dev-hous-permit-portal
-          tags: latest ${{ github.sha }}
+          tags: latest ${{ env.GITHUB_SHA }}
           labels: |
             app=dev-hous-permit-portal
-            git-sha=${{ github.sha }}
+            git-sha=${{ env.GITHUB_SHA }}
           containerfiles: ./devops/docker/app/Dockerfile
           build-args: |
             VITE_ENABLE_TEMPLATE_FORCE_PUBLISH=${{ vars.VITE_ENABLE_TEMPLATE_FORCE_PUBLISH }}
@@ -47,7 +50,7 @@ jobs:
             VITE_SITEMINDER_LOGOUT_URL=${{ vars.VITE_SITEMINDER_LOGOUT_URL }}
             VITE_KEYCLOAK_LOGOUT_URL=${{ vars.VITE_KEYCLOAK_LOGOUT_URL }}
             VITE_POST_LOGOUT_REDIRECT_URL=${{ vars.VITE_POST_LOGOUT_REDIRECT_URL }}
-            VITE_RELEASE_VERSION=dev-${{ github.event.inputs.branch }}-${{ github.sha }}
+            VITE_RELEASE_VERSION=dev-${{ github.event.inputs.branch }}-${{ env.GITHUB_SHA }}
       - name: Push to Openshift Registry using Service Account
         uses: redhat-actions/push-to-registry@v2.7
         with:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -20,21 +20,22 @@ jobs:
           sudo apt-get update
           sudo apt-get install git-lfs
           git lfs install
-      - name: Confirm branch to deploy
-        run: echo "Deploying branch ${{ github.event.inputs.branch }} to Production"
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
           lfs: true
+      - name: Confirm branch and SHA to deploy
+        run: |
+          echo "Deploying branch: ${{ github.event.inputs.branch }} @ ${{ env.GITHUB_SHA }} to Production"
       - name: Build Docker Image
         uses: redhat-actions/buildah-build@v2
         with:
           image: prod-hous-permit-portal
-          tags: latest ${{ github.sha }}
+          tags: latest ${{ env.GITHUB_SHA }}
           labels: |
             app=prod-hous-permit-portal
-            git-sha=${{ github.sha }}
+            git-sha=${{ env.GITHUB_SHA }}
           containerfiles: ./devops/docker/app/Dockerfile
           # VITE_RELEASE_VERSION always blank in prod as we want to hide the banner
           build-args: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,21 +20,22 @@ jobs:
           sudo apt-get update
           sudo apt-get install git-lfs
           git lfs install
-      - name: Confirm branch to deploy
-        run: echo "Deploying branch ${{ github.event.inputs.branch }} to Test"
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
           lfs: true
+      - name: Confirm branch and SHA to deploy
+        run: |
+          echo "Deploying branch: ${{ github.event.inputs.branch }} @ ${{ env.GITHUB_SHA }} to Test"
       - name: Build Docker Image
         uses: redhat-actions/buildah-build@v2
         with:
           image: test-hous-permit-portal
-          tags: latest ${{ github.sha }}
+          tags: latest ${{ env.GITHUB_SHA }}
           labels: |
             app=test-hous-permit-portal
-            git-sha=${{ github.sha }}
+            git-sha=${{ env.GITHUB_SHA }}
           containerfiles: ./devops/docker/app/Dockerfile
           build-args: |
             VITE_ENABLE_TEMPLATE_FORCE_PUBLISH=${{ vars.VITE_ENABLE_TEMPLATE_FORCE_PUBLISH }}
@@ -45,7 +46,7 @@ jobs:
             VITE_SITEMINDER_LOGOUT_URL=${{ vars.VITE_SITEMINDER_LOGOUT_URL }}
             VITE_KEYCLOAK_LOGOUT_URL=${{ vars.VITE_KEYCLOAK_LOGOUT_URL }}
             VITE_POST_LOGOUT_REDIRECT_URL=${{ vars.VITE_POST_LOGOUT_REDIRECT_URL }}
-            VITE_RELEASE_VERSION=test-${{ github.event.inputs.branch }}-${{ github.sha }}
+            VITE_RELEASE_VERSION=test-${{ github.event.inputs.branch }}-${{ env.GITHUB_SHA }}
       - name: Push to Openshift Registry using Service Account
         uses: redhat-actions/push-to-registry@v2.7
         with:


### PR DESCRIPTION
Updates the GHA deploy actions:
- Upgrade to `actions/checkout@v4`
- Captures Github SHA of the code being checked out (not the SHA of the code that kicked off the workflow as is currently set)