### PR TITLE
rework past submission version viewing and switching

### DIFF
--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -348,7 +348,11 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
                   permitApplication={currentPermitApplication}
                   collaborationType={ECollaborationType.submission}
                 />
-                <Button variant="primary" onClick={handleClickFinishLater}>
+                <Button
+                  variant="primary"
+                  onClick={handleClickFinishLater}
+                  isDisabled={currentPermitApplication.isViewingPastRequests}
+                >
                   {t("permitApplication.edit.saveDraft")}
                 </Button>
                 <Button
@@ -425,7 +429,12 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
               triggerSave={handleSave}
               showHelpButton
               isEditing={currentPermitApplication?.isDraft}
-              renderSaveButton={() => <SaveButton handleSave={handleSave} />}
+              renderSaveButton={() => (
+                <SaveButton
+                  handleSave={handleSave}
+                  isViewingPastRequests={currentPermitApplication?.isViewingPastRequests}
+                />
+              )}
               updateCollaborationAssignmentNodes={updateRequirementBlockAssignmentNode}
             />
           </Flex>
@@ -453,7 +462,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
   )
 })
 
-function SaveButton({ handleSave }) {
+function SaveButton({ handleSave, isViewingPastRequests }) {
   const { handleSubmit, formState } = useForm()
   const { isSubmitting } = formState
 
@@ -467,7 +476,7 @@ function SaveButton({ handleSave }) {
         leftIcon={<FloppyDiskBack />}
         type="submit"
         isLoading={isSubmitting}
-        isDisabled={isSubmitting}
+        isDisabled={isSubmitting || isViewingPastRequests}
       >
         {t("ui.onlySave")}
       </Button>

--- a/app/frontend/components/domains/permit-application/revision-sidebar.tsx
+++ b/app/frontend/components/domains/permit-application/revision-sidebar.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useMountStatus } from "../../../hooks/use-mount-status"
 import { IPermitApplication } from "../../../models/permit-application"
+import { useMst } from "../../../setup/root"
 import { IRevisionRequestsAttributes } from "../../../types/api-request"
 import { IFormIORequirement, IRevisionRequest, ISubmissionVersion } from "../../../types/types"
 import { getRequirementByKey } from "../../../utils/formio-component-traversal"
@@ -352,6 +353,9 @@ interface IRevisionRequestListItemProps {
 const RevisionRequestListItem = ({ revisionRequest }: IRevisionRequestListItemProps) => {
   const { t } = useTranslation()
 
+  const { permitApplicationStore } = useMst()
+  const { currentPermitApplication } = permitApplicationStore
+
   const { requirementJson, reasonCode, comment, user } = revisionRequest
 
   const clickHandleView = () => {
@@ -360,7 +364,9 @@ const RevisionRequestListItem = ({ revisionRequest }: IRevisionRequestListItemPr
 
   return (
     <ListItem mb={4} w="full">
-      <ScrollLink to={`formio-component-${requirementJson.key}`}>{requirementJson.label}</ScrollLink>
+      <ScrollLink to={`formio-component-${requirementJson.key}`} trigger={currentPermitApplication?.formFormatKey}>
+        {requirementJson.label}
+      </ScrollLink>
       <Flex fontStyle="italic">
         {t("permitApplication.show.revision.reasonCode")}: {reasonCode}
       </Flex>

--- a/app/frontend/components/domains/permit-application/revision-sidebar.tsx
+++ b/app/frontend/components/domains/permit-application/revision-sidebar.tsx
@@ -54,8 +54,10 @@ export const RevisionSideBar = observer(
     const [revisionRequest, setRevisionRequest] = useState<IRevisionRequest>()
     const [revisionRequestDefault, setRevisionRequestDefault] = useState<IRevisionRequest>()
     const {
-      selectedPastSubmissionVersion,
-      setSelectedPastSubmissionVersion,
+      selectedSubmissionVersion,
+      setSelectedSubmissionVersion,
+      latestSubmissionVersion,
+      pastSubmissionVersionOptions,
       isViewingPastRequests,
       setIsViewingPastRequests,
     } = permitApplication
@@ -64,6 +66,11 @@ export const RevisionSideBar = observer(
     const handleSetTabIndex = (index: number) => {
       setTabIndex(index)
       setIsViewingPastRequests(index === 1)
+      if (index === 0) {
+        setSelectedSubmissionVersion(latestSubmissionVersion)
+      } else if (index === 1) {
+        setSelectedSubmissionVersion(pastSubmissionVersionOptions?.[0]?.value ?? null)
+      }
     }
 
     const inNewRequest = tabIndex === 0
@@ -90,6 +97,10 @@ export const RevisionSideBar = observer(
     useEffect(() => {
       reset(getDefaultRevisionRequestValues())
     }, [permitApplication?.latestRevisionRequests?.length])
+
+    useEffect(() => {
+      setSelectedSubmissionVersion(latestSubmissionVersion)
+    }, [latestSubmissionVersion, setSelectedSubmissionVersion])
 
     const onSaveRevision = (formData: IRevisionRequestForm) => {
       setTabIndex(0)
@@ -128,7 +139,7 @@ export const RevisionSideBar = observer(
 
       const finder = (rr) => rr.requirementJson?.key === event.detail.key
       const foundRevisionRequestDefault =
-        isViewingPastRequests && selectedPastSubmissionVersion?.revisionRequests?.find(finder)
+        isViewingPastRequests && selectedSubmissionVersion?.revisionRequests?.find(finder)
       const foundRevisionRequest = upToDateFields.find(finder)
       const foundRequirement = getRequirementByKey(permitApplication.formJson, event.detail.key)
       const foundSubmissionJson = getSinglePreviousSubmissionJson(permitApplication.submissionData, event.detail.key)
@@ -147,11 +158,11 @@ export const RevisionSideBar = observer(
       return () => {
         document.removeEventListener("openRequestRevision", handleOpenEvent)
       }
-    }, [fields, tabIndex, selectedPastSubmissionVersion?.id])
+    }, [fields, tabIndex, selectedSubmissionVersion?.id])
 
     const handleSelectPastVersionChange = (pastVersion: ISubmissionVersion | null) => {
       if (pastVersion) {
-        setSelectedPastSubmissionVersion(pastVersion)
+        setSelectedSubmissionVersion(pastVersion)
       }
     }
 
@@ -203,10 +214,10 @@ export const RevisionSideBar = observer(
     }
 
     const sortedPastRevisionRequests = useMemo(() => {
-      return Array.from((selectedPastSubmissionVersion?.revisionRequests as IRevisionRequest[]) ?? []).sort((a, b) => {
+      return Array.from((selectedSubmissionVersion?.revisionRequests as IRevisionRequest[]) ?? []).sort((a, b) => {
         return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
       })
-    }, [selectedPastSubmissionVersion?.revisionRequests])
+    }, [selectedSubmissionVersion?.revisionRequests])
 
     return (
       <>
@@ -260,7 +271,7 @@ export const RevisionSideBar = observer(
                 <SubmissionVersionSelect
                   options={permitApplication.pastSubmissionVersionOptions}
                   onChange={handleSelectPastVersionChange}
-                  value={selectedPastSubmissionVersion}
+                  value={selectedSubmissionVersion}
                 />
                 <OrderedList mt={4} ml={0}>
                   {sortedPastRevisionRequests.map((rr) => (

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -4,12 +4,13 @@ import { observer } from "mobx-react-lite"
 import { ArrowSquareOut } from "@phosphor-icons/react"
 import { format } from "date-fns"
 import * as R from "ramda"
-import React, { useEffect, useRef, useState } from "react"
+import React, { useEffect, useMemo, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
 import { useMountStatus } from "../../../hooks/use-mount-status"
 import { IPermitApplication } from "../../../models/permit-application"
 import { useMst } from "../../../setup/root"
+import { EFlashMessageStatus } from "../../../types/enums"
 import { IErrorsBoxData } from "../../../types/types"
 import { getCompletedBlocksFromForm, getRequirementByKey } from "../../../utils/formio-component-traversal"
 import { singleRequirementFormJson, singleRequirementSubmissionData } from "../../../utils/formio-helpers"
@@ -58,8 +59,9 @@ export const RequirementForm = observer(
       formattedFormJson,
       isDraft,
       previousSubmissionVersion,
-      selectedPastSubmissionVersion,
+      selectedSubmissionVersion,
       isViewingPastRequests,
+      previousToSelectedSubmissionVersion,
       inboxEnabled,
       sandbox,
     } = permitApplication
@@ -69,7 +71,7 @@ export const RequirementForm = observer(
     const shouldShowDiff = permitApplication?.shouldShowApplicationDiff(isEditing)
     const userShouldSeeDiff = permitApplication?.currentUserShouldSeeApplicationDiff
 
-    const pastVersion = isViewingPastRequests ? selectedPastSubmissionVersion : previousSubmissionVersion
+    const pastVersion = previousToSelectedSubmissionVersion || previousSubmissionVersion
     const isMounted = useMountStatus()
     const { t } = useTranslation()
     const navigate = useNavigate()
@@ -85,6 +87,27 @@ export const RequirementForm = observer(
     const [previousSubmissionKey, setPreviousSubmissionKey] = useState(null)
     const [firstComponentKey, setFirstComponentKey] = useState(null)
     const [isCollapsedAll, setIsCollapsedAllState] = useState(false)
+
+    const currentSubmissionData = useMemo(() => {
+      return R.clone(submissionData)
+    }, [submissionData])
+
+    const pastClonedDataCache = useRef(new Map())
+
+    const displayedSubmissionData = useMemo(() => {
+      if (selectedSubmissionVersion) {
+        const cacheKey = selectedSubmissionVersion.id
+        if (pastClonedDataCache.current.has(cacheKey)) {
+          return pastClonedDataCache.current.get(cacheKey)
+        } else {
+          const clonedData = R.clone(selectedSubmissionVersion.submissionData)
+          pastClonedDataCache.current.set(cacheKey, clonedData)
+          return clonedData
+        }
+      } else {
+        return currentSubmissionData
+      }
+    }, [selectedSubmissionVersion, currentSubmissionData])
 
     const [unsavedSubmissionData, setUnsavedSubmissionData] = useState(() => R.clone(submissionData))
 
@@ -107,6 +130,11 @@ export const RequirementForm = observer(
         permitApplication.fetchDiff()
       }
     }, [])
+
+    useEffect(() => {
+      setUnsavedSubmissionData(displayedSubmissionData)
+      // We don't want to trigger a re-render if the permitApplication itself changes, only if the derived data changes
+    }, [displayedSubmissionData])
 
     useEffect(() => {
       // The box observers need to be re-registered whenever a panel is collapsed
@@ -360,17 +388,20 @@ export const RequirementForm = observer(
               description={t("permitApplication.show.revisionsWereRequested", {
                 date: format(permitApplication.revisionsRequestedAt, "MMM d, yyyy h:mm a"),
               })}
-              status="warning"
+              status={EFlashMessageStatus.warning}
             />
           )}
           {showVersionDiffContactWarning && (
-            <CustomMessageBox description={t("permitApplication.show.versionDiffContactWarning")} status="warning" />
+            <CustomMessageBox
+              description={t("permitApplication.show.versionDiffContactWarning")}
+              status={EFlashMessageStatus.warning}
+            />
           )}
           {!inboxEnabled && !sandbox && (
             <CustomMessageBox
               title={t("permitApplication.show.inboxDisabledTitle")}
               description={t("permitApplication.show.inboxDisabled")}
-              status="error"
+              status={EFlashMessageStatus.error}
             />
           )}
           {permitApplication?.isSubmitted ? (
@@ -379,7 +410,7 @@ export const RequirementForm = observer(
                 date: format(permitApplication.submittedAt, "MMM d, yyyy h:mm a"),
                 jurisdictionName: jurisdiction.qualifiedName,
               })}
-              status="info"
+              status={EFlashMessageStatus.info}
             />
           ) : (
             <CustomMessageBox
@@ -413,7 +444,7 @@ export const RequirementForm = observer(
                   }}
                 />
               }
-              status="info"
+              status={EFlashMessageStatus.info}
             />
           )}
           <Box bg="greys.grey03" p={3} borderRadius="sm">

--- a/app/frontend/components/shared/permit-applications/scroll-link.tsx
+++ b/app/frontend/components/shared/permit-applications/scroll-link.tsx
@@ -5,10 +5,11 @@ import { useMountStatus } from "../../../hooks/use-mount-status"
 interface ScrollLinkProps {
   to: string
   children: React.ReactNode
+  trigger?: any
   [key: string]: any
 }
 
-export const ScrollLink: React.FC<ScrollLinkProps> = ({ to, children, ...props }) => {
+export const ScrollLink: React.FC<ScrollLinkProps> = ({ to, children, trigger, ...props }) => {
   const [targetElement, setTargetElement] = useState<HTMLElement | null>(null)
   const isMounted = useMountStatus()
 
@@ -21,7 +22,7 @@ export const ScrollLink: React.FC<ScrollLinkProps> = ({ to, children, ...props }
       }
     }
     setTargetElement(element)
-  }, [to, isMounted])
+  }, [to, isMounted, trigger])
 
   const handleClick = (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     event.preventDefault()

--- a/app/frontend/components/shared/revisions/revision-modal.tsx
+++ b/app/frontend/components/shared/revisions/revision-modal.tsx
@@ -144,6 +144,7 @@ export const RevisionModal: React.FC<IRevisionModalProps> = ({
                   placeholder={t("ui.pleaseSelect")}
                   value={reasonCode}
                   onChange={(e) => setReasonCode(e.target.value)}
+                  isDisabled={disableInput}
                 >
                   {revisionReasonOptions.map((opt) => (
                     <option value={opt.value} key={opt.value}>
@@ -160,7 +161,7 @@ export const RevisionModal: React.FC<IRevisionModalProps> = ({
                 onChange={(e) => setComment(e.target.value)}
                 placeholder={t("permitApplication.show.revision.comment")}
                 maxLength={350}
-                isDisabled={isRevisionsRequested}
+                isDisabled={disableInput}
                 sx={{
                   _disabled: {
                     color: "text.primary",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -690,7 +690,7 @@ const options = {
             clickQuestion: "Click on the question(s) or requirement(s) you want the submitter to revise.",
             revision: {
               newRevision: "New revision",
-              pastRequests: "Past requests",
+              pastRequests: "Past submissions",
               reason: "Reason",
               reasonCode: "Reason code",
               revisionRequest: "Revision request",

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -89,7 +89,7 @@ export const PermitApplicationModel = types.snapshotProcessor(
       revisionMode: types.optional(types.boolean, false),
       diff: types.maybeNull(types.frozen<ITemplateVersionDiff>()),
       submissionVersions: types.array(types.frozen<ISubmissionVersion>()),
-      selectedPastSubmissionVersion: types.maybeNull(types.frozen<ISubmissionVersion>()),
+      selectedSubmissionVersion: types.maybeNull(types.frozen<ISubmissionVersion>()),
       permitCollaborationMap: types.map(PermitCollaborationModel),
       permitBlockStatusMap: types.map(PermitBlockStatusModel),
       isViewingPastRequests: types.optional(types.boolean, false),
@@ -154,15 +154,17 @@ export const PermitApplicationModel = types.snapshotProcessor(
         return self.sortedSubmissionVersions[1]
       },
       get previousToSelectedSubmissionVersion() {
-        if (!self.selectedPastSubmissionVersion) return null
+        if (!self.selectedSubmissionVersion) return null
 
         // Find the index of the selected version
         const selectedIndex = self.sortedSubmissionVersions.findIndex(
-          (version) => version.createdAt === self.selectedPastSubmissionVersion?.createdAt
+          (version) => version.createdAt === self.selectedSubmissionVersion?.createdAt
         )
 
         // Return the previous version if it exists
-        return selectedIndex > 0 ? self.sortedSubmissionVersions[selectedIndex - 1] : null
+        return selectedIndex < self.sortedSubmissionVersions.length - 1
+          ? self.sortedSubmissionVersions[selectedIndex + 1]
+          : null
       },
       get latestRevisionRequests() {
         return (self.latestSubmissionVersion?.revisionRequests || []).slice().sort((a, b) => a.createdAt - b.createdAt)
@@ -222,13 +224,13 @@ export const PermitApplicationModel = types.snapshotProcessor(
         )
         const diffColoredFormJson = combineDiff(complianceHintedFormJson, self.diff)
         const revisionRequestsToUse = self.isViewingPastRequests
-          ? self.selectedPastSubmissionVersion?.revisionRequests
+          ? self.selectedSubmissionVersion?.revisionRequests
           : self.latestRevisionRequests
         let changedKeys = []
-        if (self.isViewingPastRequests && self.selectedPastSubmissionVersion) {
+        if (self.isViewingPastRequests && self.selectedSubmissionVersion) {
           changedKeys = compareSubmissionData(
             self.previousToSelectedSubmissionVersion?.submissionData,
-            self.selectedPastSubmissionVersion?.submissionData
+            self.selectedSubmissionVersion?.submissionData
           )
         } else if (self.previousSubmissionVersion) {
           changedKeys = compareSubmissionData(
@@ -236,11 +238,16 @@ export const PermitApplicationModel = types.snapshotProcessor(
             self.latestSubmissionVersion.submissionData
           )
         }
-        const changedMarkedFormJson = combineChangeMarkers(diffColoredFormJson, self.isSubmitted, changedKeys)
+        const changedMarkedFormJson = combineChangeMarkers(
+          diffColoredFormJson,
+          self.isSubmitted || self.isViewingPastRequests,
+          changedKeys
+        )
         const revisionModeFormJson =
           self.revisionMode || self.isRevisionsRequested
             ? combineRevisionButtons(changedMarkedFormJson, self.isSubmitted, revisionRequestsToUse)
-            : diffColoredFormJson
+            : changedMarkedFormJson // Use changedMarkedFormJson if not in revision mode
+
         return revisionModeFormJson
       },
       sectionKey(sectionId) {
@@ -273,9 +280,7 @@ export const PermitApplicationModel = types.snapshotProcessor(
         return (
           (R.isNil(self.diff) ? `${self.templateVersion.id}` : `${self.templateVersion.id}-diff`) +
           (self.revisionMode ? "-revision" : "") +
-          (self.selectedPastSubmissionVersion
-            ? `-past-submission-version-${self.selectedPastSubmissionVersion.id}`
-            : "") +
+          (self.selectedSubmissionVersion ? `-past-submission-version-${self.selectedSubmissionVersion.id}` : "") +
           (self.isViewingPastRequests ? "-past-requests" : "")
         )
       },
@@ -548,8 +553,8 @@ export const PermitApplicationModel = types.snapshotProcessor(
       setIsDirty(isDirty: boolean) {
         self.isDirty = isDirty
       },
-      setSelectedPastSubmissionVersion(submissionVersion: ISubmissionVersion) {
-        self.selectedPastSubmissionVersion = submissionVersion
+      setSelectedSubmissionVersion(submissionVersion: ISubmissionVersion) {
+        self.selectedSubmissionVersion = submissionVersion
       },
       resetDiff() {
         self.showingCompareAfter = false

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -262,7 +262,7 @@ export const PermitApplicationStoreModel = types
         revisionMode: overrides.revisionMode ?? false,
         diff: overrides.diff || null,
         submissionVersions: overrides.submissionVersions || [],
-        selectedPastSubmissionVersion: overrides.selectedPastSubmissionVersion || null,
+        selectedSubmissionVersion: overrides.selectedSubmissionVersion || null,
         permitCollaborationMap: overrides.permitCollaborationMap || {},
         permitBlockStatusMap: overrides.permitBlockStatusMap || {},
         isViewingPastRequests: overrides.isViewingPastRequests ?? false,

--- a/app/frontend/utils/formio-helpers.ts
+++ b/app/frontend/utils/formio-helpers.ts
@@ -33,6 +33,8 @@ export const isFieldSetKey = (key: string) => {
 export const compareSubmissionData = (beforeSubmissionData: ISubmissionData, afterSubmissionData: ISubmissionData) => {
   const changedFields: string[] = []
 
+  if (!beforeSubmissionData) return changedFields
+
   for (const sectionKey in afterSubmissionData.data) {
     if (afterSubmissionData.data.hasOwnProperty(sectionKey)) {
       const afterSection = afterSubmissionData.data[sectionKey]


### PR DESCRIPTION
## Description

Fix the revision flow:

- improve form input and save button disabling
- make first tab correspond to the current version, second tab correspond to all previous versions: align tab switching with this.
- Rework selectedPastSubmissionVersion as selectedSubmissionVersion (may be past or present)
- cache and memoize formJson data for performance
- Use enums where applicable
- Improve labelling to align with streamlined logic