### PR TITLE
add disabling logic and improve permit application sortability

### DIFF
--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -58,7 +58,7 @@ const ReviewManagerGlobalFeatureAccessScreen = lazy(() =>
     default: module.ReviewManagerGlobalFeatureAccessScreen,
   }))
 )
-const ReviewStaffSubmissionInboxScreen = lazy(() =>
+const ReviewStaffInboxFeatureAccessScreen = lazy(() =>
   import(
     "../home/review-manager/configuration-management-screen/global-feature-access-screen/inbox-feature-access"
   ).then((module) => ({
@@ -410,7 +410,7 @@ const AppRoutes = observer(() => {
       />
       <Route
         path="/jurisdictions/:jurisdictionId/configuration-management/global-feature-access/submission-inbox"
-        element={<ReviewStaffSubmissionInboxScreen />}
+        element={<ReviewStaffInboxFeatureAccessScreen />}
       />
       <Route
         path="/jurisdictions/:jurisdictionId/configuration-management/energy-step"

--- a/app/frontend/components/domains/permit-application/index.tsx
+++ b/app/frontend/components/domains/permit-application/index.tsx
@@ -47,9 +47,6 @@ export const PermitApplicationIndexScreen = observer(({}: IPermitApplicationInde
 
   const requirementTemplateId = query.get("requirementTemplateId")
   const templateVersionId = query.get("templateVersionId")
-  
-  
-
 
   useSearch(permitApplicationStore, [
     requirementTemplateId || "",
@@ -88,10 +85,7 @@ export const PermitApplicationIndexScreen = observer(({}: IPermitApplicationInde
                   {t("ui.resetFilters")}
                 </Button>
               )}
-              <PermitApplicationFiltersMenu 
-                searchModel={permitApplicationStore}
-                i18nPrefix="permitApplication"
-              />
+              <PermitApplicationFiltersMenu />
               <FormControl w="fit-content">
                 <FormLabel>{t("ui.search")}</FormLabel>
                 <ModelSearchInput searchModel={permitApplicationStore} />

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -562,6 +562,8 @@ const options = {
             submitted_at: "Submitted at",
             viewed_at: "Viewed at",
             status: "Status",
+            created_at: "Created at",
+            updated_at: "Updated at",
           },
           submissionInbox: {
             contactInviteWarning:
@@ -662,7 +664,7 @@ const options = {
             contactsSummary: "Contacts summary",
             inboxDisabledTitle: "Inbox disabled",
             inboxDisabled:
-              "Submissions for this local jurisdictions are currently disabled. You will be able to make edits to this permit application but will not be able to submit until this jurisdiction's is accepting submissions again.",
+              "Submissions for this local jurisdictions are currently disabled. You will be able to make edits to this permit application but will not be able to submit until this jurisdiction's is accepting submissions again and inboxes are enabled globally.",
             downloadApplication: "Download application",
             fetchingMissingPdf: "Fetching {{missingPdf}}...",
             missingPdfLabels: {

--- a/app/frontend/models/flash-message.ts
+++ b/app/frontend/models/flash-message.ts
@@ -34,7 +34,7 @@ export const FlashMessageModel = types
       isClosable: boolean = true,
       position: ToastPositionWithLogical = "top"
     ) {
-      self.isVisible = description ? true : false
+      self.isVisible = !!description
 
       self.status = status
       self.title = title

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -168,7 +168,7 @@ export const PermitApplicationModel = types.snapshotProcessor(
         return (self.latestSubmissionVersion?.revisionRequests || []).slice().sort((a, b) => a.createdAt - b.createdAt)
       },
       get inboxEnabled() {
-        return self.jurisdiction?.inboxEnabled
+        return self.jurisdiction?.inboxEnabled && self.rootStore.siteConfigurationStore.inboxEnabled
       },
     }))
     .views((self) => ({

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -139,6 +139,8 @@ export enum EPermitApplicationSubmitterSortFields {
   submittedAt = "submitted_at",
   viewedAt = "viewed_at",
   status = "status",
+  createdAt = "created_at",
+  updatedAt = "updated_at",
 }
 
 export enum EPermitApplicationReviewerSortFields {
@@ -150,7 +152,6 @@ export enum EPermitApplicationReviewerSortFields {
   viewedAt = "viewed_at",
   submittedAt = "submitted_at",
 }
-
 
 export enum ESortDirection {
   ascending = "asc",

--- a/app/models/concerns/permit_application_status.rb
+++ b/app/models/concerns/permit_application_status.rb
@@ -54,8 +54,7 @@ module PermitApplicationStatus
     end
 
     def can_submit?
-      return false unless SiteConfiguration.inbox_enabled? || sandbox.present?
-      return false unless jurisdiction.inbox_enabled? || sandbox.present?
+      return false unless inbox_enabled? || sandbox.present?
 
       signed =
         submission_data.dig("data", "section-completion-key", "signed").present?

--- a/app/models/concerns/permit_application_status.rb
+++ b/app/models/concerns/permit_application_status.rb
@@ -54,6 +54,7 @@ module PermitApplicationStatus
     end
 
     def can_submit?
+      return false unless SiteConfiguration.inbox_enabled? || sandbox.present?
       return false unless jurisdiction.inbox_enabled? || sandbox.present?
 
       signed =

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -385,8 +385,4 @@ class Jurisdiction < ApplicationRecord
       )
     end
   end
-
-  def self.update_inbox_enabled(desired_state)
-      update_all(inbox_enabled: desired_state)
-  end
 end

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -60,7 +60,6 @@ class PermitApplication < ApplicationRecord
   delegate :code, :name, to: :permit_type, prefix: true
   delegate :code, :name, to: :activity, prefix: true
   delegate :published_template_version, to: :template_version
-  delegate :inbox_enabled, to: :jurisdiction
 
   before_validation :assign_default_nickname, on: :create
   before_validation :assign_unique_number, on: :create
@@ -82,6 +81,14 @@ class PermitApplication < ApplicationRecord
         end
 
   COMPLETION_SECTION_KEY = "section-completion-key"
+
+  def inbox_enabled?
+    jurisdiction&.inbox_enabled? && SiteConfiguration.inbox_enabled?
+  end
+
+  def inbox_enabled
+    inbox_enabled?
+  end
 
   def supporting_documents_for_submitter_based_on_user_permissions(
     supporting_documents,

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -199,6 +199,7 @@ class PermitApplication < ApplicationRecord
       template_version_id: template_version.id,
       requirement_template_id: template_version.requirement_template.id,
       created_at: created_at,
+      updated_at: updated_at,
       using_current_template_version: using_current_template_version,
       user_ids_with_submission_edit_permissions:
         [submitter.id] +

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -33,6 +33,10 @@ class SiteConfiguration < ApplicationRecord
     first_or_create
   end
 
+  def self.inbox_enabled?
+    instance.inbox_enabled
+  end
+
   # This override allows discarding of reasons and updating them by reason_code
   # if a discarded reason of a particular code is found and updated, it will be undiscarded.
   def revision_reasons_attributes=(attributes)

--- a/db/data/20250402151321_reindex_permit_applications_for_updated_at.rb
+++ b/db/data/20250402151321_reindex_permit_applications_for_updated_at.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ReindexPermitApplicationsForUpdatedAt < ActiveRecord::Migration[7.1]
+  def up
+    PermitApplication.reindex
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20_241_217_193_925)
+DataMigrate::Data.define(version: 20_250_402_151_321)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -311,3 +311,9 @@ if Rails.env.development?
     u.save
   end
 end
+
+if Rails.env.development?
+  puts "Ensuring site configuration inbox is enabled for development..."
+  site_config = SiteConfiguration.instance
+  site_config.update(inbox_enabled: true)
+end


### PR DESCRIPTION
## Description

Show a message and disable submit when the global inbox toggle is disabled.
Also improve sort fields on permit application for sorting by updated at (useful for finding things you were working on recently)

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ x] 📦 Chore (Release)
- [ ] ✅ Test

## Related Tickets & Documents

BPHH-2960

## Steps to QA

Log in as super admin
disable inbox in site configuration
create a permit application under a jurisdiction with an enabled inbox
The inbox disabled message should appear at the top of the permit application, and you should not be able to submit.
