### PR TITLE
add synchronous json reports for step code

### DIFF
--- a/app/blueprints/step_code/part_3/checklist_blueprint.rb
+++ b/app/blueprints/step_code/part_3/checklist_blueprint.rb
@@ -111,6 +111,18 @@ class StepCode::Part3::ChecklistBlueprint < Blueprinter::Base
     )
   end
 
+  view :metrics_export do
+    exclude :completed_by_name
+    exclude :completed_by_title
+    exclude :completed_by_email
+    exclude :completed_by_phone_number
+    exclude :completed_by_organization_name
+
+    association :document_references,
+                blueprint: StepCode::Part3::DocumentReferenceBlueprint,
+                view: :metrics_export
+  end
+
   view :extended do
     include_view :default
   end

--- a/app/blueprints/step_code/part_3/document_reference_blueprint.rb
+++ b/app/blueprints/step_code/part_3/document_reference_blueprint.rb
@@ -6,4 +6,8 @@ class StepCode::Part3::DocumentReferenceBlueprint < Blueprinter::Base
          :document_name,
          :date_issued,
          :prepared_by
+
+  view :metrics_export do
+    exclude :prepared_by
+  end
 end

--- a/app/blueprints/step_code/part_9/checklist_blueprint.rb
+++ b/app/blueprints/step_code/part_9/checklist_blueprint.rb
@@ -69,6 +69,18 @@ class StepCode::Part9::ChecklistBlueprint < Blueprinter::Base
            :notes
   end
 
+  view :mid_construction_testing_results_metrics do
+    fields :site_visit_completed,
+           :site_visit_date,
+           :testing_pressure,
+           :testing_pressure_direction,
+           :testing_result_type,
+           :testing_result,
+           :home_state,
+           :compliance_status,
+           :notes
+  end
+
   view :compliance_reports do
     transform StepCode::Part9::ComplianceReportsTransformer
 
@@ -85,6 +97,23 @@ class StepCode::Part9::ChecklistBlueprint < Blueprinter::Base
         checklist.selected_report || checklist.passing_compliance_reports[0] ||
           checklist.compliance_reports[0]
       StepCode::Part9::ComplianceReportBlueprint.render_as_hash(report)
+    end
+  end
+
+  view :metrics_export do
+    include_view :project_info_metrics
+    include_view :compliance_summary
+    include_view :building_characteristics_summary
+    include_view :mid_construction_testing_results_metrics
+    include_view :compliance_reports
+  end
+
+  view :project_info_metrics do
+    fields :building_permit_number, :jurisdiction_name, :pid, :building_type
+    field :full_address, name: :address
+
+    field :dwelling_units_count do |checklist, _options|
+      checklist.data_entries.sum(:dwelling_units_count)
     end
   end
 end

--- a/app/controllers/api/step_codes_controller.rb
+++ b/app/controllers/api/step_codes_controller.rb
@@ -14,29 +14,39 @@ class Api::StepCodesController < Api::ApplicationController
     send_data csv_data, type: "text/csv"
   end
 
-  def download_step_code_metrics_csv
-    authorize :step_code, :download_step_code_metrics_csv?
+  def download_step_code_metrics_json
+    authorize :step_code, :download_step_code_metrics_json?
 
     step_code_type = step_code_metrics_params[:step_code_type]
+    timeframe_from = step_code_metrics_params[:timeframe_from]
+    timeframe_to = step_code_metrics_params[:timeframe_to]
     service = StepCodeExportService.new
 
-    csv_data =
+    result =
       case step_code_type
       when "Part3StepCode"
-        service.part_3_metrics_csv
+        service.part_3_metrics_json(
+          timeframe_from: timeframe_from,
+          timeframe_to: timeframe_to
+        )
       when "Part9StepCode"
-        service.part_9_metrics_csv
+        service.part_9_metrics_json(
+          timeframe_from: timeframe_from,
+          timeframe_to: timeframe_to
+        )
       else
         raise ActionController::BadRequest, "Invalid step code type"
       end
-
-    send_data csv_data, type: "text/csv"
+    send_data result.to_json,
+              type: "text/plain",
+              disposition: "attachment",
+              filename: "#{step_code_type.downcase}_metrics.json"
   end
 
   private
 
   def step_code_metrics_params
-    params.permit(:step_code_type)
+    params.permit(:step_code_type, :timeframe_from, :timeframe_to)
   end
 
   def step_code_params

--- a/app/frontend/components/domains/super-admin/reporting/reporting-screen.tsx
+++ b/app/frontend/components/domains/super-admin/reporting/reporting-screen.tsx
@@ -1,11 +1,26 @@
-import { Box, Button, Container, Flex, Heading, Input, Menu, MenuButton, MenuList, VStack } from "@chakra-ui/react"
-import { FileCsv } from "@phosphor-icons/react"
+import {
+  Box,
+  Button,
+  Container,
+  Flex,
+  Heading,
+  HStack,
+  Input,
+  Menu,
+  MenuButton,
+  MenuList,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
+import { BracketsCurly, FileCsv } from "@phosphor-icons/react"
+import { subDays } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useMst } from "../../../../setup/root"
 import { EStepCodeType } from "../../../../types/enums"
 import { ManageMenuItem, ManageMenuItemButton } from "../../../shared/base/manage-menu-item"
+import { DatePicker } from "../../../shared/date-picker"
 import { SearchGrid } from "../../../shared/grid/search-grid"
 import { SearchGridItem } from "../../../shared/grid/search-grid-item"
 import { GridHeaders } from "./grid-header"
@@ -17,14 +32,18 @@ export const ReportingScreen = observer(() => {
   const { downloadApplicationMetrics } = permitApplicationStore
 
   const [filter, setFilter] = useState("")
+  const [timeframeFrom, setTimeframeFrom] = useState<Date>(subDays(new Date(), 365))
+  const [timeframeTo, setTimeframeTo] = useState<Date>(new Date())
 
   interface IReportBase {
     name: string
     description: string
+    displayTimeframe?: boolean
     dropdown: Array<{
       text: string
       onClick?: () => void
       href?: string
+      icon?: React.ReactElement
     }>
   }
 
@@ -62,15 +81,26 @@ export const ReportingScreen = observer(() => {
     },
     {
       name: t("reporting.stepCodeMetrics.name"),
-      description: t("reporting.stepCodeMetrics.description"),
+      description: t("reporting.applicationMetrics.description"),
+      displayTimeframe: true,
       dropdown: [
         {
-          text: t("reporting.stepCodeMetrics.downloadPart3"),
-          onClick: () => downloadStepCodeMetrics(EStepCodeType.Part3),
+          text: t("reporting.stepCodeMetrics.downloadPart9"),
+          onClick: () =>
+            downloadStepCodeMetrics(EStepCodeType.Part9, {
+              timeframeFrom,
+              timeframeTo,
+            }),
+          icon: <BracketsCurly size={24} />,
         },
         {
-          text: t("reporting.stepCodeMetrics.downloadPart9"),
-          onClick: () => downloadStepCodeMetrics(EStepCodeType.Part9),
+          text: t("reporting.stepCodeMetrics.downloadPart3"),
+          onClick: () =>
+            downloadStepCodeMetrics(EStepCodeType.Part3, {
+              timeframeFrom,
+              timeframeTo,
+            }),
+          icon: <BracketsCurly size={24} />,
         },
       ],
     },
@@ -114,13 +144,38 @@ export const ReportingScreen = observer(() => {
                         {t("ui.manage")}
                       </MenuButton>
                       <MenuList>
+                        {reportType.displayTimeframe && (
+                          <Box p={3} borderBottom="1px solid" borderColor="border.input">
+                            <HStack spacing={2} align="stretch">
+                              <Box>
+                                <Text fontSize="sm" mb={1}>
+                                  {t("ui.from")}
+                                </Text>
+                                <DatePicker
+                                  selected={timeframeFrom}
+                                  onChange={(date: Date) => setTimeframeFrom(date)}
+                                />
+                              </Box>
+                              <Box>
+                                <Text fontSize="sm" mb={1}>
+                                  {t("ui.to")}
+                                </Text>
+                                <DatePicker selected={timeframeTo} onChange={(date: Date) => setTimeframeTo(date)} />
+                              </Box>
+                            </HStack>
+                          </Box>
+                        )}
                         {reportType.dropdown.map((item, index) =>
                           item.href ? (
-                            <ManageMenuItem key={index} icon={<FileCsv size={24} />} to={item.href}>
+                            <ManageMenuItem key={index} icon={item.icon || <FileCsv size={24} />} to={item.href}>
                               {item.text}
                             </ManageMenuItem>
                           ) : (
-                            <ManageMenuItemButton key={index} leftIcon={<FileCsv size={24} />} onClick={item.onClick}>
+                            <ManageMenuItemButton
+                              key={index}
+                              leftIcon={item.icon || <FileCsv size={24} />}
+                              onClick={item.onClick}
+                            >
                               {item.text}
                             </ManageMenuItemButton>
                           )

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -164,6 +164,8 @@ const options = {
           },
         },
         ui: {
+          from: "From",
+          to: "To",
           okay: "Okay",
           filter: "Filter",
           until: "til",

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -593,8 +593,18 @@ export class Api {
     return this.client.get<BlobPart>(`/step_codes/download_step_code_summary_csv`)
   }
 
-  async downloadStepCodeMetricsCsv(stepCodeType: EStepCodeType) {
-    return this.client.get<BlobPart>(`/step_codes/download_step_code_metrics_csv`, { stepCodeType })
+  async downloadStepCodeMetricsJson(
+    stepCodeType: EStepCodeType,
+    options?: {
+      timeframeFrom?: string
+      timeframeTo?: string
+    }
+  ) {
+    return this.client.get<BlobPart>(`/step_codes/download_step_code_metrics_json`, {
+      stepCodeType,
+      timeframeFrom: options?.timeframeFrom,
+      timeframeTo: options?.timeframeTo,
+    })
   }
 
   async downloadApplicationMetricsCsv() {

--- a/app/frontend/stores/step-code-store.ts
+++ b/app/frontend/stores/step-code-store.ts
@@ -125,17 +125,28 @@ export const StepCodeStoreModel = types
         throw error
       }
     }),
-    downloadStepCodeMetrics: flow(function* (stepCodeType: EStepCodeType) {
+    downloadStepCodeMetrics: flow(function* (
+      stepCodeType: EStepCodeType,
+      options?: {
+        timeframeFrom?: Date
+        timeframeTo?: Date
+      }
+    ) {
       try {
-        const response = yield* toGenerator(self.environment.api.downloadStepCodeMetricsCsv(stepCodeType))
+        const response = yield* toGenerator(
+          self.environment.api.downloadStepCodeMetricsJson(stepCodeType, {
+            timeframeFrom: options?.timeframeFrom?.toISOString(),
+            timeframeTo: options?.timeframeTo?.toISOString(),
+          })
+        )
         if (!response.ok) {
           return response.ok
         }
 
-        const blobData = response.data
-        const fileName = `${t(`reporting.stepCodeMetrics.filename${stepCodeType === EStepCodeType.Part3 ? "Part3" : "Part9"}`)}.csv`
-        const mimeType = "text/csv"
-        startBlobDownload(blobData, mimeType, fileName)
+        const jsonData = response.data
+        const blobData = new Blob([JSON.stringify(jsonData, null, 2)], { type: "application/json" })
+        const fileName = `${t(`reporting.stepCodeMetrics.filename${stepCodeType === EStepCodeType.Part3 ? "Part3" : "Part9"}`)}.json`
+        startBlobDownload(blobData, "application/json", fileName)
 
         return response
       } catch (error) {

--- a/app/jobs/cache_step_code_metrics_job.rb
+++ b/app/jobs/cache_step_code_metrics_job.rb
@@ -1,0 +1,79 @@
+class CacheStepCodeMetricsJob
+  include Sidekiq::Worker
+  sidekiq_options retry: 3 # Optional: Configure retry attempts
+
+  def perform
+    Rails.logger.info "Starting CacheStepCodeMetricsJob..."
+    total_processed = 0
+    total_updated = 0
+    start_time = Time.current
+
+    process_step_code_type(Part3StepCode) do |processed, updated|
+      total_processed += processed
+      total_updated += updated
+    end
+
+    process_step_code_type(Part9StepCode) do |processed, updated|
+      total_processed += processed
+      total_updated += updated
+    end
+
+    duration = Time.current - start_time
+    Rails.logger.info "CacheStepCodeMetricsJob finished in #{duration.round(2)} seconds."
+    Rails.logger.info "Total records processed: #{total_processed}. Total records updated/cached: #{total_updated}."
+  end
+
+  private
+
+  def process_step_code_type(model_class)
+    model_name = model_class.name
+    blueprint_class = model_class.checklist_blueprint # Get blueprint from model class
+    Rails.logger.info "Processing #{model_name} for metrics caching using #{blueprint_class.name}..."
+    processed_count = 0
+    updated_count = 0
+
+    model_class.find_each do |step_code|
+      processed_count += 1
+      checklist = step_code.primary_checklist
+
+      unless checklist
+        Rails.logger.warn "Skipping #{model_name} ID: #{step_code.id} due to missing primary checklist."
+        next
+      end
+
+      needs_caching = false
+      if step_code.metrics_cached_at.nil?
+        needs_caching = true
+        Rails.logger.info "Recaching #{model_name} ID: #{step_code.id} (never cached)."
+      elsif step_code.updated_at > step_code.metrics_cached_at
+        needs_caching = true
+        Rails.logger.info "Recaching #{model_name} ID: #{step_code.id} (record updated)."
+      elsif checklist.updated_at > step_code.metrics_cached_at
+        needs_caching = true
+        Rails.logger.info "Recaching #{model_name} ID: #{step_code.id} (checklist updated)."
+      end
+
+      if needs_caching
+        begin
+          json_data =
+            blueprint_class.render_as_hash(checklist, view: :metrics_export)
+          step_code.update_columns(
+            cached_metrics_json: json_data,
+            metrics_cached_at: Time.current
+          )
+          updated_count += 1
+          Rails.logger.info "Successfully cached metrics for #{model_name} ID: #{step_code.id}."
+        rescue => e
+          Rails.logger.error "Error caching metrics for #{model_name} ID: #{step_code.id} - #{e.message}\n#{e.backtrace.join("\n")}"
+        end
+      end
+      # Optional: Log if a record was checked but didn't need updating
+      # else
+      #   Rails.logger.debug "Metrics for #{model_name} ID: #{step_code.id} are up to date."
+      # end
+    end
+
+    Rails.logger.info "Finished processing #{model_name}. Processed: #{processed_count}, Updated: #{updated_count}."
+    yield(processed_count, updated_count) if block_given?
+  end
+end

--- a/app/policies/step_code_policy.rb
+++ b/app/policies/step_code_policy.rb
@@ -3,7 +3,7 @@ class StepCodePolicy < ApplicationPolicy
     user.super_admin?
   end
 
-  def download_step_code_metrics_csv?
+  def download_step_code_metrics_json?
     user.super_admin?
   end
 end

--- a/app/services/step_code_export_service.rb
+++ b/app/services/step_code_export_service.rb
@@ -30,188 +30,105 @@ class StepCodeExportService
     end
   end
 
-  def part_3_metrics_csv
-    CSV.generate(headers: true) do |csv|
-      # Headers for Part 3 metrics
-      csv << [
-        "Application ID",
-        "Jurisdiction",
-        "Address",
-        "Building Height",
-        "Building Code Version",
-        "Heating Degree Days",
-        "Climate Zone",
-        "Reference Annual Thermal Energy Demand",
-        "Total Annual Thermal Energy Demand",
-        "Total Annual Cooling Energy Demand",
-        "Step Code Annual Thermal Energy Demand",
-        "Generated Electricity",
-        "Overheating Hours",
-        "Pressurized Doors Count",
-        "Pressurization Airflow Per Door",
-        "Pressurized Corridors Area",
-        "Suite Heating Energy",
-        "Software",
-        "Software Name",
-        "Simulation Weather File",
-        "Above Ground Wall Area",
-        "Window to Wall Area Ratio",
-        "Design Airtightness",
-        "Tested Airtightness",
-        "Modelled Infiltration Rate",
-        "As Built Infiltration Rate",
-        "Average Wall Clear Field R-Value",
-        "Average Wall Effective R-Value",
-        "Average Roof Clear Field R-Value",
-        "Average Roof Effective R-Value",
-        "Average Window Effective U-Value",
-        "Average Window Solar Heat Gain Coefficient",
-        "Average Occupant Density",
-        "Average Lighting Power Density",
-        "Average Ventilation Rate",
-        "DHW Low Flow Savings",
-        "Is Demand Control Ventilation Used",
-        "Sensible Recovery Efficiency",
-        "Heating System Plant",
-        "Heating System Type",
-        "Heating System Type Description",
-        "Cooling System Plant",
-        "Cooling System Type",
-        "Cooling System Type Description",
-        "DHW System Type",
-        "DHW System Description",
-        "Is Suite Sub Metered"
-      ]
-
-      # Get all submitted Part 3 step codes with their checklist
-      Part3StepCode
-        .includes(:permit_application, :checklist)
-        .where(permit_applications: { status: %i[newly_submitted resubmitted] })
-        .find_each do |step_code|
-          checklist = step_code.checklist
-          next unless checklist
-
-          csv << [
-            step_code.building_permit_number,
-            step_code.jurisdiction_name,
-            step_code.full_address,
-            checklist.building_height,
-            checklist.building_code_version,
-            checklist.heating_degree_days,
-            checklist.climate_zone,
-            checklist.ref_annual_thermal_energy_demand,
-            checklist.total_annual_thermal_energy_demand,
-            checklist.total_annual_cooling_energy_demand,
-            checklist.step_code_annual_thermal_energy_demand,
-            checklist.generated_electricity,
-            checklist.overheating_hours,
-            checklist.pressurized_doors_count,
-            checklist.pressurization_airflow_per_door,
-            checklist.pressurized_corridors_area,
-            checklist.suite_heating_energy,
-            checklist.software,
-            checklist.software_name,
-            checklist.simulation_weather_file,
-            checklist.above_ground_wall_area,
-            checklist.window_to_wall_area_ratio,
-            checklist.design_airtightness,
-            checklist.tested_airtightness,
-            checklist.modelled_infiltration_rate,
-            checklist.as_built_infiltration_rate,
-            checklist.average_wall_clear_field_r_value,
-            checklist.average_wall_effective_r_value,
-            checklist.average_roof_clear_field_r_value,
-            checklist.average_roof_effective_r_value,
-            checklist.average_window_effective_u_value,
-            checklist.average_window_solar_heat_gain_coefficient,
-            checklist.average_occupant_density,
-            checklist.average_lighting_power_density,
-            checklist.average_ventilation_rate,
-            checklist.dhw_low_flow_savings,
-            checklist.is_demand_control_ventilation_used,
-            checklist.sensible_recovery_efficiency,
-            checklist.heating_system_plant,
-            checklist.heating_system_type,
-            checklist.heating_system_type_description,
-            checklist.cooling_system_plant,
-            checklist.cooling_system_type,
-            checklist.cooling_system_type_description,
-            checklist.dhw_system_type,
-            checklist.dhw_system_description,
-            checklist.is_suite_sub_metered
-          ]
-        end
-    end
+  def part_3_metrics_json(timeframe_from: nil, timeframe_to: Time.current)
+    generate_metrics_json(
+      model_class: Part3StepCode,
+      blueprint_class: StepCode::Part3::ChecklistBlueprint,
+      timeframe_from: timeframe_from,
+      timeframe_to: timeframe_to,
+      includes: %i[permit_application checklist]
+    )
   end
 
-  def part_9_metrics_csv
-    CSV.generate(headers: true) do |csv|
-      # Headers for Part 9 metrics
-      csv << [
-        "Application ID",
-        "Jurisdiction",
-        "Address",
-        "Building Type",
-        "Compliance Path",
-        "Energy Step",
-        "Zero Carbon Step",
-        "Building Status",
-        "Compliance Status",
-        "Site Visit Completed",
-        "Site Visit Date",
-        "Testing Pressure",
-        "Testing Result",
-        "HVAC Consumption",
-        "DWH Heating Consumption",
-        "Reference HVAC Consumption",
-        "Reference DWH Heating Consumption",
-        "EPC Calculation Airtightness",
-        "EPC Calculation Testing Target Type",
-        "EPC Calculation Compliance",
-        "CODECO",
-        "Notes"
-      ]
+  def part_9_metrics_json(timeframe_from: nil, timeframe_to: Time.current)
+    generate_metrics_json(
+      model_class: Part9StepCode,
+      blueprint_class: StepCode::Part9::ChecklistBlueprint,
+      timeframe_from: timeframe_from,
+      timeframe_to: timeframe_to,
+      includes: %i[permit_application checklists]
+    )
+  end
 
-      # Get all submitted Part 9 step codes with their checklists
-      Part9StepCode
-        .includes(:permit_application, :checklists)
-        .where(permit_applications: { status: %i[newly_submitted resubmitted] })
-        .find_each do |step_code|
-          checklist = step_code.primary_checklist
-          next unless checklist
+  private
 
-          # Get compliance reports to extract energy and zero carbon steps
-          compliance_report =
-            checklist.selected_report ||
-              checklist.passing_compliance_reports.first
-          energy_step = compliance_report&.dig(:energy)&.step
-          zero_carbon_step = compliance_report&.dig(:zero_carbon)&.step
-
-          csv << [
-            step_code.building_permit_number,
-            step_code.jurisdiction_name,
-            step_code.full_address,
-            checklist.building_type,
-            checklist.compliance_path,
-            energy_step,
-            zero_carbon_step,
-            checklist.status,
-            checklist.compliance_status,
-            checklist.site_visit_completed,
-            checklist.site_visit_date,
-            checklist.testing_pressure,
-            checklist.testing_result,
-            checklist.hvac_consumption,
-            checklist.dwh_heating_consumption,
-            checklist.ref_hvac_consumption,
-            checklist.ref_dwh_heating_consumption,
-            checklist.epc_calculation_airtightness,
-            checklist.epc_calculation_testing_target_type,
-            checklist.epc_calculation_compliance,
-            checklist.codeco,
-            checklist.notes
-          ]
+  def generate_metrics_json(
+    model_class:,
+    blueprint_class:,
+    timeframe_from:,
+    timeframe_to:,
+    includes:
+  )
+    # Ensure timeframe_from and timeframe_to are Time objects
+    parsed_timeframe_from =
+      (
+        if timeframe_from.is_a?(String)
+          Time.zone.parse(timeframe_from)
+        else
+          timeframe_from
         end
+      )
+    parsed_timeframe_to =
+      timeframe_to.is_a?(String) ? Time.zone.parse(timeframe_to) : timeframe_to
+
+    if parsed_timeframe_from.blank? || parsed_timeframe_from < 366.days.ago
+      raise ArgumentError,
+            "Timeframe from cannot be more than 365 days in the past"
     end
+
+    query =
+      model_class.includes(*includes).where(
+        permit_applications: {
+          status: %i[newly_submitted resubmitted]
+        }
+      )
+
+    query = query.where("step_codes.created_at >= ?", parsed_timeframe_from)
+
+    # Adjust timeframe_to to include records up to the end of the specified day or extend by one day
+    adjusted_timeframe_to = parsed_timeframe_to + 1.day
+
+    query = query.where("step_codes.created_at <= ?", adjusted_timeframe_to)
+
+    step_codes = query.to_a
+    type = model_class.name
+    metadata = {
+      type: type,
+      timeframe_from: parsed_timeframe_from, # Use parsed versions for metadata too
+      timeframe_to: parsed_timeframe_to, # Use parsed versions for metadata too
+      total_records: step_codes.length,
+      generated_at: Time.current.iso8601
+    }
+
+    # Add Part 9 specific metadata
+    if type == Part9StepCode.name
+      metadata.merge!(
+        energy_steps:
+          (
+            ENV["PART_9_MIN_ENERGY_STEP"].to_i..ENV[
+              "PART_9_MAX_ENERGY_STEP"
+            ].to_i
+          ).to_a.map(&:to_s),
+        zero_carbon_steps:
+          (
+            ENV["PART_9_MIN_ZERO_CARBON_STEP"].to_i..ENV[
+              "PART_9_MAX_ZERO_CARBON_STEP"
+            ].to_i
+          ).to_a.map(&:to_s)
+      )
+    end
+    {
+      metadata: metadata,
+      data:
+        step_codes
+          .map do |step_code|
+            checklist = step_code.primary_checklist
+            next unless checklist
+
+            # binding.pry
+            blueprint_class.render_as_hash(checklist, view: :metrics_export)
+          end
+          .compact
+    }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -218,9 +218,9 @@ Rails.application.routes.draw do
       get "download_step_code_summary_csv",
           on: :collection,
           to: "step_codes#download_step_code_summary_csv"
-      get "download_step_code_metrics_csv",
+      get "download_step_code_metrics_json",
           on: :collection,
-          to: "step_codes#download_step_code_metrics_csv"
+          to: "step_codes#download_step_code_metrics_json"
     end
 
     namespace :part_9_building do

--- a/config/sidekiq_cron_schedule.yml
+++ b/config/sidekiq_cron_schedule.yml
@@ -21,3 +21,8 @@ check_expiring_api_keys:
   class: "CheckExpiringApiKeysJob"
   queue: default
   active_job: false
+
+  cache_step_code_metrics:
+  cron: "0 2 * * *" # Every day at 2:00 AM
+  class: "CacheStepCodeMetricsJob"
+  queue: default # Or your preferred queue

--- a/db/migrate/20250520212811_add_cached_metrics_json_to_step_codes.rb
+++ b/db/migrate/20250520212811_add_cached_metrics_json_to_step_codes.rb
@@ -1,0 +1,6 @@
+class AddCachedMetricsJsonToStepCodes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :step_codes, :cached_metrics_json, :jsonb
+    add_column :step_codes, :metrics_cached_at, :datetime
+  end
+end


### PR DESCRIPTION
## Description

Convert step code report generation to JSON,
being sure to remove submitter info.

Because this report is so large, it may not work with more than a few step code records. In the future we may need to architect an async websokcet notification / generation job / new attachment model system, that generates reports asynchronously, then websockets down a download link after attaching and uploading the generated file.

We need to triple check that no submitter info ever gets attached to this report.