### PR TITLE
always make obtained customizations sandbox specific

### DIFF
--- a/app/blueprints/integration_mapping_blueprint.rb
+++ b/app/blueprints/integration_mapping_blueprint.rb
@@ -4,10 +4,19 @@ class IntegrationMappingBlueprint < Blueprinter::Base
   view :base do
     fields :jurisdiction_id, :template_version_id
 
-    field :elective_filtered_requirements_mapping, name: :requirements_mapping
+    field :elective_filtered_requirements_mapping,
+          name: :requirements_mapping do |mapping, options|
+      mapping.elective_filtered_requirements_mapping(options[:sandbox])
+    end
 
-    field :requirements_mapping_json do |integration_mapping|
-      integration_mapping.elective_filtered_requirements_mapping.to_json
+    field :missing_requirements_mapping do |mapping, options|
+      mapping.missing_requirements_mapping(options[:sandbox])
+    end
+
+    field :requirements_mapping_json do |integration_mapping, options|
+      integration_mapping.elective_filtered_requirements_mapping(
+        options[:sandbox]
+      ).to_json
     end
   end
 

--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -196,7 +196,8 @@ class Api::TemplateVersionsController < Api::ApplicationController
     authorize @template_version, :show?
 
     @integration_mapping =
-      @template_version.integration_mappings.find_by(
+      IntegrationMapping.find_or_create_by!(
+        template_version_id: @template_version.id,
         jurisdiction_id: params[:jurisdiction_id]
       )
 
@@ -208,7 +209,8 @@ class Api::TemplateVersionsController < Api::ApplicationController
                      {
                        blueprint: IntegrationMappingBlueprint,
                        blueprint_opts: {
-                         view: :base
+                         view: :base,
+                         sandbox: current_sandbox
                        }
                      }
     else

--- a/app/frontend/components/domains/navigation/sandbox-menu-item.tsx
+++ b/app/frontend/components/domains/navigation/sandbox-menu-item.tsx
@@ -19,6 +19,7 @@ import { observer } from "mobx-react-lite"
 import * as R from "ramda"
 import React, { useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
+import { useNavigate } from "react-router-dom"
 import { useMst } from "../../../setup/root"
 import { EFlashMessageStatus } from "../../../types/enums"
 import { CustomMessageBox } from "../../shared/base/custom-message-box"
@@ -34,6 +35,8 @@ export const SandboxMenuItem: React.FC = observer(() => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [selectedOption, setSelectedOption] = useState(sandboxOptions[0]?.value)
 
+  const navigate = useNavigate()
+
   // Handler for toggling the switch
   const handleToggle = () => {
     onOpen() // Open modal in both cases
@@ -47,6 +50,7 @@ export const SandboxMenuItem: React.FC = observer(() => {
       setCurrentSandboxId(selectedOption) // Turn on sandbox mode
     }
     onClose()
+    navigate(0)
   }
 
   if (!currentUser.jurisdiction || R.isEmpty(sandboxOptions)) return <></>

--- a/app/frontend/stores/collaborator-store.ts
+++ b/app/frontend/stores/collaborator-store.ts
@@ -6,7 +6,6 @@ import { withMerge } from "../lib/with-merge"
 import { withRootStore } from "../lib/with-root-store"
 import { CollaboratorModel, ICollaborator } from "../models/collaborator"
 import { IJurisdiction } from "../models/jurisdiction"
-import { IUser } from "../models/user"
 import { ECollaborationType, ECollaboratorableType } from "../types/enums"
 import { TSearchParams } from "../types/types"
 
@@ -55,7 +54,7 @@ export const CollaboratorStoreModel = types
 
       //find all unique submitters
       const users = R.uniqBy(
-        (u: IUser) => u.id,
+        (u: { id: string }) => u.id,
         collaboratorsData
           .filter((c) => c.collaboratorableType === ECollaboratorableType.User)
           .map((c) => c.collaboratorable)

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -197,7 +197,10 @@ export const PermitApplicationStoreModel = types
     },
     setStatusFilter(statuses: TFilterableStatus[] | undefined) {
       if (!statuses) return
+
       setQueryParam("status", statuses)
+
+      if (statuses.some((status) => !filterableStatus.includes(status))) return
       // @ts-ignore
       self.statusFilter = statuses
     },

--- a/app/models/integration_mapping.rb
+++ b/app/models/integration_mapping.rb
@@ -23,16 +23,10 @@ class IntegrationMapping < ApplicationRecord
 
   attr_accessor :simplified_map_to_sync
 
-  def jurisdiction_template_version_customization
-    JurisdictionTemplateVersionCustomization.find_by(
-      jurisdiction:,
-      template_version:
-    )
-  end
-
-  def missing_requirements_mapping
+  def missing_requirements_mapping(sandbox = nil)
     missing_mapping = {}
-    template_version_customization = jurisdiction_template_version_customization
+    template_version_customization =
+      jurisdiction_template_version_customization(sandbox)
 
     requirements_mapping.each do |requirement_block_sku, requirement_block|
       requirement_block["requirements"]&.each do |requirement_code, requirement|
@@ -216,8 +210,9 @@ class IntegrationMapping < ApplicationRecord
     "/jurisdictions/#{jurisdiction.slug}/api-settings/api-mappings/digital-building-permits/#{template_version.id}/edit"
   end
 
-  def elective_filtered_requirements_mapping
-    template_version_customization = jurisdiction_template_version_customization
+  def elective_filtered_requirements_mapping(sandbox = nil)
+    template_version_customization =
+      jurisdiction_template_version_customization(sandbox)
 
     elective_filtered_mapping = {}
 
@@ -248,6 +243,14 @@ class IntegrationMapping < ApplicationRecord
     end
 
     elective_filtered_mapping
+  end
+
+  def jurisdiction_template_version_customization(sandbox = nil)
+    JurisdictionTemplateVersionCustomization.find_by(
+      jurisdiction:,
+      template_version:,
+      sandbox:
+    )
   end
 
   private


### PR DESCRIPTION
## Description

- make obtaining customizations sandbox-specific in all scanarios (espcially pertaining to external API and mappings)
- fix store filter resetting edge case for permit application store
- refresh page after selecting sandbox
