### PR TITLE
modify project item delegations and migrations to reenable pa creation

### DIFF
--- a/app/models/concerns/project_item.rb
+++ b/app/models/concerns/project_item.rb
@@ -3,17 +3,13 @@ module ProjectItem
 
   included do
     belongs_to :permit_project, touch: true, optional: true
-    has_one :jurisdiction, through: :permit_project
+    belongs_to :jurisdiction, optional: true # Added for direct association
     has_one :owner, through: :permit_project
 
     after_commit :reindex_permit_project
 
     # Delegations to PermitProject for core project details
-    delegate :title,
-             :jurisdiction,
-             :permit_date,
-             to: :permit_project,
-             allow_nil: true # allow_nil should be false if permit_project is truly non-optional and always present
+    delegate :title, :permit_date, to: :permit_project, allow_nil: true # allow_nil should be false if permit_project is truly non-optional and always present
 
     delegate :qualified_name,
              :heating_degree_days,
@@ -48,10 +44,9 @@ module ProjectItem
     # validates :permit_project, presence: true # Uncomment if strict presence is required by including models
 
     # Custom method for jurisdiction to ensure it safely accesses through permit_project
-    # This is somewhat redundant if using delegate with allow_nil: true but can be kept for clarity
-    # or if more complex logic were needed.
+    # or falls back to its own direct association.
     def jurisdiction
-      permit_project&.jurisdiction
+      permit_project&.jurisdiction || super
     end
 
     private

--- a/db/migrate/20250529185100_migrate_data_to_permit_projects_and_drop_old_columns.rb
+++ b/db/migrate/20250529185100_migrate_data_to_permit_projects_and_drop_old_columns.rb
@@ -7,26 +7,7 @@ class MigrateDataToPermitProjectsAndDropOldColumns < ActiveRecord::Migration[
     # Might need to explicitly require if run in certain contexts, but usually not for db:migrate.
     PermitProjectSeederService.call
 
-    # Step 2: Drop old columns
-    # From permit_applications
-    if column_exists?(:permit_applications, :jurisdiction_id)
-      # Check if this is the *old* direct jurisdiction_id, not one related to property_plan_jurisdiction if that was also named jurisdiction_id
-      # Assuming this is the one we want to drop, that was for PA's direct jurisdiction
-      # We might need to be more specific if there's ambiguity with other jurisdiction references.
-      # For now, proceeding with simple removal if it exists.
-      remove_column :permit_applications, :jurisdiction_id, :uuid # remove_reference might fail if FK constraint name is unknown or already gone
-    end
-    if column_exists?(:permit_applications, :full_address)
-      remove_column :permit_applications, :full_address, :text
-    end
-    if column_exists?(:permit_applications, :pid)
-      remove_column :permit_applications, :pid, :string
-    end
-    if column_exists?(:permit_applications, :pin)
-      remove_column :permit_applications, :pin, :string
-    end
-
-    # From step_codes
+    # remove columns from step_codes
     if column_exists?(:step_codes, :project_name)
       remove_column :step_codes, :project_name, :string
     end

--- a/db/migrate/20250616204159_add_designated_reviewer_to_jurisdictions.rb
+++ b/db/migrate/20250616204159_add_designated_reviewer_to_jurisdictions.rb
@@ -1,7 +1,10 @@
 class AddDesignatedReviewerToJurisdictions < ActiveRecord::Migration[7.1]
   def up
     unless column_exists?(:jurisdictions, :allow_designated_reviewer)
-      add_column :jurisdictions, :allow_designated_reviewer, :boolean
+      add_column :jurisdictions,
+                 :allow_designated_reviewer,
+                 :boolean,
+                 default: false
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -223,8 +223,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_10_191449) do
     t.integer "heating_degree_days"
     t.boolean "inbox_enabled", default: false, null: false
     t.boolean "show_about_page", default: false, null: false
+    t.boolean "allow_designated_reviewer", default: false
     t.string "disambiguator"
-    t.boolean "allow_designated_reviewer"
     t.index ["prefix"], name: "index_jurisdictions_on_prefix", unique: true
     t.index ["regional_district_id"], name: "index_jurisdictions_on_regional_district_id"
     t.index ["slug"], name: "index_jurisdictions_on_slug", unique: true
@@ -393,6 +393,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_10_191449) do
     t.uuid "sandbox_id"
     t.datetime "newly_submitted_at", precision: nil
     t.uuid "permit_project_id"
+    t.uuid "jurisdiction_id"
+    t.text "full_address"
+    t.string "pid"
+    t.string "pin"
     t.index ["activity_id"], name: "index_permit_applications_on_activity_id"
     t.index ["number"], name: "index_permit_applications_on_number", unique: true
     t.index ["permit_project_id"], name: "index_permit_applications_on_permit_project_id"


### PR DESCRIPTION
Notice that the migrations were changed which means they had to be reversed on develop. This stuff should not be anywhere else so that's fine.
This fixes the errors currently present on develop that require a project object when creating a permit application through the existing method. Delegations to project specific fields can now be overridden by the previously PA specific fields.
