### PR TITLE
never shortcut generating ephemeral permit application

### DIFF
--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -306,6 +306,8 @@ export const PermitApplicationModel = types.snapshotProcessor(
         return self.permitCollaborationMap.get(collaborationId)
       },
       shouldShowApplicationDiff(isEditing: boolean) {
+        if (self.templateVersion.earlyAccess) return false
+
         return isEditing && (!self.usingCurrentTemplateVersion || self.showingCompareAfter)
       },
       get contacts() {

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -280,7 +280,6 @@ export const PermitApplicationStoreModel = types
       requirementTemplate: IRequirementTemplate,
       overrides: Partial<IPermitApplication> = {}
     ) {
-      if (self.currentPermitApplication?.isEphemeral) return self.currentPermitApplication
       const permitApplication = PermitApplicationModel.create({
         id: `ephemeral-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
         nickname: overrides.nickname || "Ephemeral Application",

--- a/app/policies/permit_classification_policy.rb
+++ b/app/policies/permit_classification_policy.rb
@@ -21,7 +21,7 @@ class PermitClassificationPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.enabled
+      PermitClassification.all
     end
   end
 end


### PR DESCRIPTION
## Description

bonus: don't show template changes on early access, and fix re-enabling classifications
