### PR TITLE
disable add permits button for other sandbox jurisdiciton

### DIFF
--- a/app/blueprints/sandbox_blueprint.rb
+++ b/app/blueprints/sandbox_blueprint.rb
@@ -1,4 +1,4 @@
 class SandboxBlueprint < Blueprinter::Base
   identifier :id
-  fields :name, :template_version_status_scope, :description
+  fields :name, :template_version_status_scope, :description, :jurisdiction_id
 end

--- a/app/frontend/components/domains/permit-project/overview-tab-panel-content.tsx
+++ b/app/frontend/components/domains/permit-project/overview-tab-panel-content.tsx
@@ -1,5 +1,5 @@
-import { Box, Flex, Grid, Heading, HStack, Icon, VStack } from "@chakra-ui/react"
-import { CaretRight, Info, Plus, SquaresFour, Steps } from "@phosphor-icons/react"
+import { Box, Flex, Grid, Heading, HStack, VStack } from "@chakra-ui/react"
+import { CaretRight, Info, SquaresFour, Steps } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -12,6 +12,7 @@ import {
 import { CustomMessageBox } from "../../shared/base/custom-message-box"
 import { SearchGrid } from "../../shared/grid/search-grid"
 import { RouterLinkButton } from "../../shared/navigation/router-link-button"
+import { AddPermitsButton } from "../../shared/permit-projects/add-permits-button"
 import ProjectInfoRow from "../../shared/project/project-info-row"
 import { PermitApplicationGridHeaders } from "./permit-application-grid-headers"
 import { PermitApplicationGridRow } from "./permit-application-grid-row"
@@ -89,13 +90,7 @@ export const OverviewTabPanelContent = observer(({ permitProject }: IProps) => {
           <Heading as="h3" size="md">
             {t("permitProject.overview.recentPermits")}
           </Heading>
-          <RouterLinkButton
-            variant="primary"
-            leftIcon={<Icon as={Plus} />}
-            to={`/projects/${permitProject.id}/add-permits`}
-          >
-            {t("permitProject.addPermits.title")}
-          </RouterLinkButton>
+          <AddPermitsButton permitProject={permitProject} />
         </Flex>
         {permitProject.rollupStatus === EPermitProjectRollupStatus.empty ? (
           <CustomMessageBox status={EFlashMessageStatus.info} description={t("permitProject.index.empty")} mt={2} />

--- a/app/frontend/components/domains/permit-project/permits-tab-panel-content.tsx
+++ b/app/frontend/components/domains/permit-project/permits-tab-panel-content.tsx
@@ -1,5 +1,4 @@
-import { Box, Flex, Heading, Icon } from "@chakra-ui/react"
-import { Plus } from "@phosphor-icons/react"
+import { Box, Flex, Heading } from "@chakra-ui/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -15,7 +14,7 @@ import { CustomMessageBox } from "../../shared/base/custom-message-box"
 import { Paginator } from "../../shared/base/inputs/paginator"
 import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
 import { SearchGrid } from "../../shared/grid/search-grid"
-import { RouterLinkButton } from "../../shared/navigation/router-link-button"
+import { AddPermitsButton } from "../../shared/permit-projects/add-permits-button"
 import { PermitApplicationGridHeaders } from "./permit-application-grid-headers"
 import { PermitApplicationGridRow } from "./permit-application-grid-row"
 import { RequirementTemplateFilter } from "./requirement-template-filter"
@@ -30,7 +29,6 @@ export const PermitsTabPanelContent = observer(({ permitProject }: IProps) => {
   const { permitApplicationStore, userStore } = useMst()
   const { currentPage, totalPages, totalCount, countPerPage, handleCountPerPageChange, handlePageChange } =
     permitApplicationStore
-  const { currentUser } = userStore
 
   useSearch(permitApplicationStore, [permitProject.id])
 
@@ -43,13 +41,7 @@ export const PermitsTabPanelContent = observer(({ permitProject }: IProps) => {
           <Heading as="h3" size="md">
             {t("permitProject.permits.title")}
           </Heading>
-          <RouterLinkButton
-            variant="primary"
-            leftIcon={<Icon as={Plus} />}
-            to={`/projects/${permitProject.id}/add-permits`}
-          >
-            {t("permitProject.addPermits.button")}
-          </RouterLinkButton>
+          <AddPermitsButton permitProject={permitProject} />
         </Flex>
         {permitProject.rollupStatus === EPermitProjectRollupStatus.empty ? (
           <CustomMessageBox status={EFlashMessageStatus.info} description={t("permitProject.index.empty")} mt={2} />

--- a/app/frontend/components/shared/permit-projects/add-permits-button.tsx
+++ b/app/frontend/components/shared/permit-projects/add-permits-button.tsx
@@ -1,0 +1,40 @@
+import { Box, Icon, Tooltip } from "@chakra-ui/react"
+import { Plus } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { IPermitProject } from "../../../models/permit-project"
+import { RouterLinkButton } from "../navigation/router-link-button"
+
+interface IProps {
+  permitProject: IPermitProject
+}
+
+export const AddPermitsButton = observer(({ permitProject }: IProps) => {
+  const { t } = useTranslation()
+  const isDisabled = permitProject.jurisdictionDifferentFromSandbox
+
+  const preventWhenDisabled = (e: React.MouseEvent) => {
+    if (isDisabled) e.preventDefault()
+  }
+
+  const button = (
+    <RouterLinkButton
+      variant="primary"
+      leftIcon={<Icon as={Plus} />}
+      to={`/projects/${permitProject.id}/add-permits`}
+      isDisabled={isDisabled}
+      onClick={preventWhenDisabled}
+    >
+      {t("permitProject.addPermits.button")}
+    </RouterLinkButton>
+  )
+
+  if (!isDisabled) return button
+
+  return (
+    <Tooltip label={t("permitProject.addPermits.sandboxWarning")} hasArrow openDelay={200} placement="top">
+      <Box display="inline-block">{button}</Box>
+    </Tooltip>
+  )
+})

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -635,6 +635,7 @@ Thank you,
           addPermits: {
             title: "Add permits to your project",
             fn: "These are First Nations specific permits",
+            sandboxWarning: "Sandbox permits can only be added into your own jurisdiction's sandbox",
             button: "Add permits",
             bcbcPartHeading: "BCBC Part",
             bcbcPart:

--- a/app/frontend/models/permit-project.ts
+++ b/app/frontend/models/permit-project.ts
@@ -66,6 +66,10 @@ export const PermitProjectModel = types
     get isOwner() {
       return self.ownerId === self.rootStore.userStore.currentUser?.id
     },
+    get jurisdictionDifferentFromSandbox() {
+      if (!self.rootStore.sandboxStore.currentSandbox) return false
+      return self.jurisdiction?.id !== self.rootStore.sandboxStore.currentSandbox?.jurisdictionId
+    },
   }))
   .actions((self) => ({
     setIsPinned(isPinned: boolean) {

--- a/app/frontend/models/sandbox.ts
+++ b/app/frontend/models/sandbox.ts
@@ -1,4 +1,4 @@
-import { getParent, Instance, types } from "mobx-state-tree"
+import { Instance, types } from "mobx-state-tree"
 import { ETemplateVersionStatus } from "../types/enums"
 
 export const SandboxModel = types
@@ -8,12 +8,8 @@ export const SandboxModel = types
     name: types.string,
     description: types.maybeNull(types.string),
     templateVersionStatusScope: types.enumeration(Object.values(ETemplateVersionStatus)),
+    jurisdictionId: types.string,
   })
-  .views((self) => ({
-    get jurisdiction() {
-      return getParent(self, 2)
-    },
-  }))
   .views((self) => ({}))
 
 export interface ISandbox extends Instance<typeof SandboxModel> {}


### PR DESCRIPTION
## Description

Disable button and add helpful tooltip to prevent users from attempting to submit into sandbox other than their current jurisdictions' sandbox
