### PR TITLE
add hmac header to webhook payloads, specs and docs

### DIFF
--- a/app/services/constants/webhooks.rb
+++ b/app/services/constants/webhooks.rb
@@ -1,5 +1,8 @@
 module Constants
   module Webhooks
+    # Header on outgoing permit webhooks; value is HMAC-SHA256(request body, API key token) as lowercase hex.
+    WEBHOOK_SIGNATURE_HEADER = "X-Webhook-Signature"
+
     module Events
       module PermitApplication
         PERMIT_SUBMITTED = "permit_submitted"

--- a/app/services/permit_webhook_service.rb
+++ b/app/services/permit_webhook_service.rb
@@ -1,6 +1,11 @@
 class PermitWebhookService
   attr_accessor :external_api_key, :client
 
+  # HMAC-SHA256 hex digest of +body+ using +secret+ (the integrator's API key token).
+  def self.webhook_signature_hex(secret, body)
+    OpenSSL::HMAC.hexdigest("SHA256", secret.to_s, body.to_s)
+  end
+
   def initialize(external_api_key)
     @external_api_key = external_api_key
 
@@ -54,9 +59,15 @@ and name: #{external_api_key.name}"
   end
 
   def send_webhook(payload)
+    body = payload.to_json
+    signature = self.class.webhook_signature_hex(external_api_key.token, body)
+    headers = {
+      "Content-Type" => "application/json",
+      Constants::Webhooks::WEBHOOK_SIGNATURE_HEADER => signature
+    }
+
     begin
-      response = client.post(external_api_key.webhook_url, payload.to_json) # should automatically throw an error if
-      # 4xx or 5xx
+      response = client.post(external_api_key.webhook_url, body, headers)
 
       response.success?
     rescue Faraday::Error => e

--- a/spec/services/permit_webhook_service_spec.rb
+++ b/spec/services/permit_webhook_service_spec.rb
@@ -1,6 +1,20 @@
 require "rails_helper"
 
 RSpec.describe PermitWebhookService do
+  describe ".webhook_signature_hex" do
+    it "returns lowercase hex HMAC-SHA256 of the body with the given secret" do
+      secret = "live_testsecret"
+      body = '{"event":"permit_submitted","payload":{}}'
+      expected = OpenSSL::HMAC.hexdigest("SHA256", secret, body)
+      expect(described_class.webhook_signature_hex(secret, body)).to eq(
+        expected
+      )
+      expect(described_class.webhook_signature_hex(secret, body)).to match(
+        /\A[a-f0-9]{64}\z/
+      )
+    end
+  end
+
   let(:jurisdiction) { create(:sub_district, external_api_state: "j_on") }
   let(:external_api_key) do
     create(
@@ -57,7 +71,7 @@ RSpec.describe PermitWebhookService do
       ).and_return(permit_application)
       allow(permit_application).to receive(:newly_submitted?).and_return(true)
 
-      expect(service.client).to receive(:post) do |url, body|
+      expect(service.client).to receive(:post) do |url, body, headers|
         expect(url).to eq(external_api_key.webhook_url)
         json = JSON.parse(body)
         expect(json["event"]).to eq(
@@ -67,6 +81,10 @@ RSpec.describe PermitWebhookService do
         expect(json["payload"]["submitted_at"]).to eq(
           permit_application.submitted_at.as_json
         )
+        expect(headers[Constants::Webhooks::WEBHOOK_SIGNATURE_HEADER]).to eq(
+          described_class.webhook_signature_hex(external_api_key.token, body)
+        )
+        expect(headers["Content-Type"]).to eq("application/json")
         instance_double(Faraday::Response, success?: true)
       end
 
@@ -81,11 +99,14 @@ RSpec.describe PermitWebhookService do
         resubmitted_pa.id
       ).and_return(resubmitted_pa)
 
-      expect(service.client).to receive(:post) do |url, body|
+      expect(service.client).to receive(:post) do |url, body, headers|
         expect(url).to eq(external_api_key.webhook_url)
         json = JSON.parse(body)
         expect(json["event"]).to eq(
           Constants::Webhooks::Events::PermitApplication::PERMIT_RESUBMITTED
+        )
+        expect(headers[Constants::Webhooks::WEBHOOK_SIGNATURE_HEADER]).to eq(
+          described_class.webhook_signature_hex(external_api_key.token, body)
         )
         instance_double(Faraday::Response, success?: true)
       end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -54,6 +54,32 @@ Authorization: Bearer {Your_API_Key_Here}
 ```
 Please note that a unique API key is required for each jurisdiction you wish to access, enhancing security and data integrity.
 
+### Webhook signatures:
+Each webhook delivery is an HTTP POST with `Content-Type: application/json` and an `X-Webhook-Signature` header. The header value is the
+lowercase hexadecimal HMAC-SHA256 digest of the **raw request body** bytes, using your API key token (the same value you send as the Bearer token for API requests)
+as the HMAC secret.
+
+To verify a request:
+1. Read the raw request body before parsing JSON.
+2. Compute HMAC-SHA256 with your API key token as the key and the raw body as the message; encode the digest as lowercase hex.
+3. Compare that value to `X-Webhook-Signature` using a constant-time comparison to avoid timing attacks.
+
+Example (Node.js):
+
+```javascript
+const crypto = require("crypto");
+
+function verifyPermitWebhook(rawBody, signatureHeader, apiKeyToken) {
+  const expected = crypto.createHmac("sha256", apiKeyToken)
+    .update(rawBody, "utf8")
+    .digest("hex");
+  return crypto.timingSafeEqual(
+    Buffer.from(signatureHeader.trim(), "utf8"),
+    Buffer.from(expected, "utf8")
+  );
+}
+```
+
 ### Rate limits:
 To ensure fair usage, the API is rate-limited to 100 requests per minute per API key and 300 requests per IP in a 3 minute interval. Exceeding these
 limits will result in a 429 response. If this occurs, we recommend spacing out your requests. Continued exceeding of rate limits
@@ -85,6 +111,9 @@ in this document.
         permit_submitted: {
           tags: ["Webhooks"],
           post: {
+            parameters: [
+              { "$ref" => "#/components/parameters/WebhookSignature" }
+            ],
             requestBody: {
               description:
                 "### Request body:\nThis webhook sends information about a recently submitted permit
@@ -114,6 +143,9 @@ in this document.
         permit_resubmitted: {
           tags: ["Webhooks"],
           post: {
+            parameters: [
+              { "$ref" => "#/components/parameters/WebhookSignature" }
+            ],
             requestBody: {
               description:
                 "### Request body:\nThis webhook sends information about a recently resubmitted permit
@@ -157,6 +189,18 @@ in this document.
             type: :http,
             scheme: :bearer,
             description: "Bearer token"
+          }
+        },
+        parameters: {
+          WebhookSignature: {
+            name: "X-Webhook-Signature",
+            in: :header,
+            required: true,
+            schema: {
+              type: :string
+            },
+            description:
+              "Lowercase hex-encoded HMAC-SHA256 of the raw JSON request body, using the integrator API key token as the secret (same value as the Bearer token for Integration API requests). See **Webhook signatures** in the overview."
           }
         },
         schemas: {

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -18,6 +18,19 @@ info:
     be included in the Authorization header as a Bearer token like so:\n```\nAuthorization:
     Bearer {Your_API_Key_Here}\n```\nPlease note that a unique API key is required
     for each jurisdiction you wish to access, enhancing security and data integrity.\n\n###
+    Webhook signatures:\nEach webhook delivery is an HTTP POST with `Content-Type:
+    application/json` and an `X-Webhook-Signature` header. The header value is the
+    lowercase hexadecimal HMAC-SHA256 digest of the **raw request body** bytes, using
+    your API key token (the same value you send as the Bearer token for API requests)
+    as the HMAC secret.\nTo verify a request:\n1. Read the raw request body before
+    parsing JSON.\n2. Compute HMAC-SHA256 with your API key token as the key and
+    the raw body as the message; encode the digest as lowercase hex.\n3. Compare that
+    value to `X-Webhook-Signature` using a constant-time comparison to avoid timing
+    attacks.\n\nExample (Node.js):\n```javascript\nconst crypto = require(\"crypto\");\n\nfunction
+    verifyPermitWebhook(rawBody, signatureHeader, apiKeyToken) {\n  const expected
+    = crypto.createHmac(\"sha256\", apiKeyToken)\n    .update(rawBody, \"utf8\")\n
+    \   .digest(\"hex\");\n  return crypto.timingSafeEqual(\n    Buffer.from(signatureHeader.trim(),
+    \"utf8\"),\n    Buffer.from(expected, \"utf8\")\n  );\n}\n```\n\n###
     Rate limits:\nTo ensure fair usage, the API is rate-limited to 100 requests per
     minute per API key and 300 requests per IP in a 3 minute interval. Exceeding these\nlimits
     will result in a 429 response. If this occurs, we recommend spacing out your requests.
@@ -47,6 +60,8 @@ webhooks:
     tags:
     - Webhooks
     post:
+      parameters:
+      - "$ref": "#/components/parameters/WebhookSignature"
       requestBody:
         description: |-
           ### Request body:
@@ -77,6 +92,8 @@ webhooks:
     tags:
     - Webhooks
     post:
+      parameters:
+      - "$ref": "#/components/parameters/WebhookSignature"
       requestBody:
         description: |-
           ### Request body:
@@ -310,6 +327,16 @@ components:
       type: http
       scheme: bearer
       description: Bearer token
+  parameters:
+    WebhookSignature:
+      name: X-Webhook-Signature
+      in: header
+      required: true
+      schema:
+        type: string
+      description: 'Lowercase hex-encoded HMAC-SHA256 of the raw JSON request body,
+        using the integrator API key token as the secret (same value as the Bearer
+        token for Integration API requests). See **Webhook signatures** in the overview.'
   schemas:
     PermitApplication:
       type: object


### PR DESCRIPTION
## Summary
Adds **HMAC-SHA256 signing** to outgoing permit webhooks so partners can verify that POSTs genuinely come from Building Permit Hub. Each request now includes an **`X-Webhook-Signature`** header (hex digest of the raw JSON body, keyed with the same **External API Key token** used as the Bearer token for Integration API calls).
## Problem
Webhooks were plain JSON POSTs with no auth or signature, which made it hard for integrators to secure endpoints and led to confusion (e.g. expecting credentials we did not send).
## Solution
- **`PermitWebhookService#send_webhook`**: Serialize the payload once to JSON, compute `OpenSSL::HMAC.hexdigest("SHA256", api_key.token, body)`, and send via Faraday with `Content-Type: application/json` and `X-Webhook-Signature`.
- **`PermitWebhookService.webhook_signature_hex(secret, body)`**: Class method for signing so behavior is easy to unit test without HTTP.
- **`Constants::Webhooks::WEBHOOK_SIGNATURE_HEADER`**: Single source for the header name (`X-Webhook-Signature`).
## Documentation
- **`swagger/external_api/v1/swagger.yaml`**: Overview section on webhook verification (raw body, HMAC-SHA256, constant-time compare), Node.js example, `components.parameters.WebhookSignature`, and both webhook operations reference that parameter.
- **`spec/swagger_helper.rb`**: Same content so **`rake rswag:specs:swaggerize`** does not drop signing docs from the generated spec.
## Testing
- **`spec/services/permit_webhook_service_spec.rb`**: Examples for `.webhook_signature_hex` and assertions that `send_submitted_event` passes headers whose signature matches the body + token.
## Out of scope / unchanged
- **`PermitWebhookJob`**: No code changes; still delegates to `PermitWebhookService`.
- Retry / error handling: Same Faraday rescue → `PermitWebhookError` path as before.
## Checklist (from ticket)
- [x] Outgoing webhook POSTs include `X-Webhook-Signature` (HMAC-SHA256 hex of body, secret = API key token).
- [x] Signature generation covered by unit tests.
- [x] External API docs updated (Swagger YAML + `swagger_helper` for Rswag).
- [x] Existing retry/error behavior preserved.