### PR TITLE
add project review collabs with notifications

### DIFF
--- a/app/blueprints/permit_application_blueprint.rb
+++ b/app/blueprints/permit_application_blueprint.rb
@@ -50,7 +50,12 @@ class PermitApplicationBlueprint < Blueprinter::Base
     association :permit_collaborations,
                 blueprint: PermitCollaborationBlueprint,
                 view: :base do |pa, options|
-      pa.permit_collaborations(options[:current_user])
+      collabs = pa.permit_collaborations(options[:current_user])
+      if options[:current_user]&.review_staff?
+        collabs
+      else
+        collabs.select(&:submission?)
+      end
     end
   end
 
@@ -112,7 +117,12 @@ class PermitApplicationBlueprint < Blueprinter::Base
     association :permit_collaborations,
                 blueprint: PermitCollaborationBlueprint,
                 view: :base do |pa, options|
-      pa.permit_collaborations(options[:current_user])
+      collabs = pa.permit_collaborations(options[:current_user])
+      if options[:current_user]&.review_staff?
+        collabs
+      else
+        collabs.select(&:submission?)
+      end
     end
     association :permit_block_statuses, blueprint: PermitBlockStatusBlueprint
     association :submission_versions,

--- a/app/blueprints/permit_project_blueprint.rb
+++ b/app/blueprints/permit_project_blueprint.rb
@@ -49,7 +49,8 @@ class PermitProjectBlueprint < Blueprinter::Base
       options[:project_ids_with_outdated_drafts]&.include?(permit_project.id)
     end
 
-    association :review_delegatee, blueprint: CollaboratorBlueprint
+    association :permit_project_collaborations,
+                blueprint: PermitProjectCollaborationBlueprint
   end
 
   view :jurisdiction_review_inbox do

--- a/app/blueprints/permit_project_blueprint.rb
+++ b/app/blueprints/permit_project_blueprint.rb
@@ -48,17 +48,27 @@ class PermitProjectBlueprint < Blueprinter::Base
     field :has_outdated_draft_applications do |permit_project, options|
       options[:project_ids_with_outdated_drafts]&.include?(permit_project.id)
     end
-
-    association :permit_project_collaborations,
-                blueprint: PermitProjectCollaborationBlueprint
   end
 
   view :jurisdiction_review_inbox do
     include_view :base
 
-    field :aggregated_review_collaborators do |permit_project, _options|
+    field :aggregated_review_collaborators,
+          if: ->(_field_name, permit_project, options) do
+            options[:current_user]&.review_staff_of?(
+              permit_project.jurisdiction_id
+            )
+          end do |permit_project, _options|
       permit_project.aggregated_review_collaborators
     end
+
+    association :permit_project_collaborations,
+                blueprint: PermitProjectCollaborationBlueprint,
+                if: ->(_field_name, permit_project, options) do
+                  options[:current_user]&.review_staff_of?(
+                    permit_project.jurisdiction_id
+                  )
+                end
   end
 
   view :extended do
@@ -81,7 +91,7 @@ class PermitProjectBlueprint < Blueprinter::Base
   end
 
   view :inbox_extended do
-    include_view :base
+    include_view :jurisdiction_review_inbox
 
     field :is_fully_loaded do |_permit_project, _options|
       true

--- a/app/blueprints/permit_project_collaboration_blueprint.rb
+++ b/app/blueprints/permit_project_collaboration_blueprint.rb
@@ -1,0 +1,4 @@
+class PermitProjectCollaborationBlueprint < Blueprinter::Base
+  identifier :id
+  association :collaborator, blueprint: CollaboratorBlueprint
+end

--- a/app/controllers/api/concerns/search/jurisdiction_permit_projects.rb
+++ b/app/controllers/api/concerns/search/jurisdiction_permit_projects.rb
@@ -29,7 +29,7 @@ module Api::Concerns::Search::JurisdictionPermitProjects
       includes: [
         :owner,
         :jurisdiction,
-        { review_delegatee: :user },
+        { permit_project_collaborations: { collaborator: :user } },
         {
           permit_applications: {
             permit_collaborations: {
@@ -53,7 +53,7 @@ module Api::Concerns::Search::JurisdictionPermitProjects
         .includes(
           :owner,
           :jurisdiction,
-          { review_delegatee: :user },
+          { permit_project_collaborations: { collaborator: :user } },
           permit_applications: {
             permit_collaborations: {
               collaborator: :user
@@ -113,7 +113,7 @@ module Api::Concerns::Search::JurisdictionPermitProjects
         .includes(
           :owner,
           :jurisdiction,
-          { review_delegatee: :user },
+          { permit_project_collaborations: { collaborator: :user } },
           permit_applications: {
             permit_collaborations: {
               collaborator: :user

--- a/app/controllers/api/permit_projects_controller.rb
+++ b/app/controllers/api/permit_projects_controller.rb
@@ -14,8 +14,8 @@ class Api::PermitProjectsController < Api::ApplicationController
                   mark_as_viewed
                   mark_as_unviewed
                   transition_state
-                  assign_review_delegatee
-                  unassign_review_delegatee
+                  assign_project_review_collaborator
+                  unassign_project_review_collaborator
                 ]
   before_action :set_pinned_projects, only: %i[pinned]
 
@@ -90,7 +90,7 @@ class Api::PermitProjectsController < Api::ApplicationController
     render_error("permit_project.invalid_transition", { status: 422 })
   end
 
-  def assign_review_delegatee
+  def assign_project_review_collaborator
     authorize @permit_project
 
     unless @permit_project.designated_reviewer_enabled?
@@ -98,9 +98,9 @@ class Api::PermitProjectsController < Api::ApplicationController
     end
 
     collaborator_id = params.require(:collaborator_id)
-    @permit_project.assign_review_delegatee!(collaborator_id)
+    @permit_project.assign_project_review_collaborator!(collaborator_id)
     render_success @permit_project.reload,
-                   "permit_project.assign_review_delegatee_success",
+                   "permit_project.assign_project_review_collaborator_success",
                    {
                      blueprint: PermitProjectBlueprint,
                      blueprint_opts:
@@ -108,16 +108,17 @@ class Api::PermitProjectsController < Api::ApplicationController
                    }
   rescue => e
     render_error(
-      "permit_project.assign_review_delegatee_error",
+      "permit_project.assign_project_review_collaborator_error",
       { message_opts: { error_message: e.message }, status: 422 }
     )
   end
 
-  def unassign_review_delegatee
+  def unassign_project_review_collaborator
     authorize @permit_project
-    @permit_project.unassign_review_delegatee!
+    collaborator_id = params.require(:collaborator_id)
+    @permit_project.unassign_project_review_collaborator!(collaborator_id)
     render_success @permit_project.reload,
-                   "permit_project.unassign_review_delegatee_success",
+                   "permit_project.unassign_project_review_collaborator_success",
                    {
                      blueprint: PermitProjectBlueprint,
                      blueprint_opts:

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/jurisdiction-submisson-inbox-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/jurisdiction-submisson-inbox-screen.tsx
@@ -87,7 +87,7 @@ export const JurisdictionSubmissionInboxScreen = observer(function JurisdictionS
 
   useSearch(
     activeSearchStore,
-    inboxSearchEnabled ? [currentJurisdiction?.id, JSON.stringify(currentSandboxId), viewMode] : [null]
+    inboxSearchEnabled ? [currentJurisdiction?.id, JSON.stringify(currentSandboxId), viewMode] : [null, null, null]
   )
 
   const loadCollaboratorOptions = useCallback(async (): Promise<IOption[]> => {

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-collaborators-sidebar.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-collaborators-sidebar.tsx
@@ -11,7 +11,6 @@ import {
   Select,
   Stack,
   Text,
-  useDisclosure,
 } from "@chakra-ui/react"
 import { ArrowSquareOut, Users } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
@@ -21,7 +20,6 @@ import { Link } from "react-router-dom"
 import { IPermitProject } from "../../../../models/permit-project"
 import { useMst } from "../../../../setup/root"
 import { ECollaborationType } from "../../../../types/enums"
-import { ConfirmationModal } from "../../../shared/confirmation-modal"
 import { SharedAvatar } from "../../../shared/user/shared-avatar"
 
 interface IProps {
@@ -54,8 +52,6 @@ export const ProjectCollaboratorsSidebar = observer(function ProjectCollaborator
   const designatedReviewerEnabled =
     siteConfigurationStore.allowDesignatedReviewer && project.jurisdiction?.allowDesignatedReviewer
 
-  const reviewDelegatee = project.reviewDelegatee
-
   return (
     <Drawer isOpen={isOpen} placement="right" onClose={onClose}>
       <DrawerOverlay />
@@ -70,7 +66,7 @@ export const ProjectCollaboratorsSidebar = observer(function ProjectCollaborator
         </DrawerHeader>
 
         <DrawerBody as={Stack} spacing={8}>
-          {designatedReviewerEnabled && <ProjectDelegateeSection project={project} reviewDelegatee={reviewDelegatee} />}
+          {designatedReviewerEnabled && <ProjectReviewCollaboratorsSection project={project} />}
 
           <Stack spacing={4}>
             <Text as="h3" fontSize="md" fontWeight={700}>
@@ -149,109 +145,16 @@ export const ProjectCollaboratorsSidebar = observer(function ProjectCollaborator
   )
 })
 
-const ProjectDelegateeSection = observer(function ProjectDelegateeSection({
+const ProjectReviewCollaboratorsSection = observer(function ProjectReviewCollaboratorsSection({
   project,
-  reviewDelegatee,
 }: {
   project: IPermitProject
-  reviewDelegatee: any
 }) {
   const { t } = useTranslation()
-  const [pendingCollaboratorId, setPendingCollaboratorId] = useState<string | null>(null)
-  const { isOpen: isConfirmOpen, onOpen: onConfirmOpen, onClose: onConfirmClose } = useDisclosure()
-
-  const handleDelegateeSelected = (collaboratorId: string) => {
-    setPendingCollaboratorId(collaboratorId)
-    onConfirmOpen()
-  }
-
-  const handleConfirmAssign = async (closeModal: () => void) => {
-    if (!pendingCollaboratorId) return
-    await project.assignReviewDelegatee(pendingCollaboratorId)
-    setPendingCollaboratorId(null)
-    closeModal()
-  }
-
-  const handleUnassign = async () => {
-    await project.unassignReviewDelegatee()
-  }
-
-  return (
-    <Stack spacing={4} mt={6}>
-      <Text as="h3" fontSize="md" fontWeight={700}>
-        {/* @ts-ignore */}
-        {t("permitCollaboration.projectSidebar.projectReviewDelegatee")}
-      </Text>
-
-      <Stack borderLeft="4px solid" borderColor="theme.blueAlt" px={6} py={3} bg="theme.blueLight">
-        <Text fontSize="sm">
-          {/* @ts-ignore */}
-          {t("permitCollaboration.projectSidebar.delegateeDescription")}
-        </Text>
-      </Stack>
-
-      <Stack spacing={2}>
-        {reviewDelegatee?.user ? (
-          <HStack spacing={3} p={3} bg="gray.50" borderRadius="md" justify="space-between">
-            <HStack spacing={3}>
-              <SharedAvatar
-                size="sm"
-                name={`${reviewDelegatee.user.firstName} ${reviewDelegatee.user.lastName}`}
-                role={reviewDelegatee.user.role}
-              />
-              <Stack spacing={0}>
-                <Text fontSize="sm" fontWeight={600}>
-                  {`${reviewDelegatee.user.firstName} ${reviewDelegatee.user.lastName}`}
-                </Text>
-                {reviewDelegatee.user.email && (
-                  <Text fontSize="xs" color="text.secondary">
-                    {reviewDelegatee.user.email}
-                  </Text>
-                )}
-              </Stack>
-            </HStack>
-            <Button size="xs" variant="ghost" colorScheme="red" onClick={handleUnassign}>
-              {/* @ts-ignore */}
-              {t("permitCollaboration.projectSidebar.unassignDelegatee")}
-            </Button>
-          </HStack>
-        ) : (
-          <Text fontSize="sm" color="text.secondary">
-            {/* @ts-ignore */}
-            {t("permitCollaboration.projectSidebar.noneAssigned")}
-          </Text>
-        )}
-
-        <ProjectDelegateeAssignment
-          project={project}
-          onSelect={handleDelegateeSelected}
-          existingDelegateeCollaboratorId={reviewDelegatee?.id}
-        />
-      </Stack>
-
-      <ConfirmationModal
-        modalControlProps={{ isOpen: isConfirmOpen, onOpen: onConfirmOpen, onClose: onConfirmClose }}
-        renderTriggerButton={() => <></>}
-        // @ts-ignore
-        title={t("permitCollaboration.projectSidebar.overrideConfirmTitle")}
-        // @ts-ignore
-        body={t("permitCollaboration.projectSidebar.overrideConfirmBody")}
-        onConfirm={handleConfirmAssign}
-      />
-    </Stack>
-  )
-})
-
-const ProjectDelegateeAssignment = observer(function ProjectDelegateeAssignment({
-  project,
-  onSelect,
-  existingDelegateeCollaboratorId,
-}: {
-  project: IPermitProject
-  onSelect: (collaboratorId: string) => void
-  existingDelegateeCollaboratorId?: string
-}) {
   const { collaboratorStore } = useMst()
+
+  const collaborations = project.permitProjectCollaborations
+  const takenIds = new Set(collaborations.map((c) => c.collaborator.id))
 
   useEffect(() => {
     collaboratorStore.setSearchContext(ECollaborationType.review)
@@ -263,34 +166,77 @@ const ProjectDelegateeAssignment = observer(function ProjectDelegateeAssignment(
     }
   }, [])
 
-  const takenIds = new Set(existingDelegateeCollaboratorId ? [existingDelegateeCollaboratorId] : [])
-  const collaborators = collaboratorStore.getFilteredCollaborationSearchList(takenIds)
+  const availableCollaborators = collaboratorStore.getFilteredCollaborationSearchList(takenIds)
+
+  const handleAssign = async (collaboratorId: string) => {
+    await project.assignProjectReviewCollaborator(collaboratorId)
+  }
+
+  const handleUnassign = async (collaboratorId: string) => {
+    await project.unassignProjectReviewCollaborator(collaboratorId)
+  }
 
   return (
-    <Stack spacing={2}>
-      {collaborators.length > 0 && (
-        <Stack spacing={1} maxH="200px" overflowY="auto">
-          {collaborators.map((collaborator) => (
-            <HStack
-              key={collaborator.id}
-              spacing={3}
-              p={2}
-              borderRadius="md"
-              cursor="pointer"
-              _hover={{ bg: "gray.100" }}
-              onClick={() => onSelect(collaborator.id)}
-            >
-              <SharedAvatar size="xs" name={collaborator.user?.name} role={collaborator.user?.role} />
-              <Stack spacing={0}>
-                <Text fontSize="sm">{collaborator.user?.name}</Text>
-                <Text fontSize="xs" color="text.secondary">
-                  {collaborator.user?.email}
-                </Text>
-              </Stack>
+    <Stack spacing={4} mt={6}>
+      <Text as="h3" fontSize="md" fontWeight={700}>
+        {/* @ts-ignore */}
+        {t("permitCollaboration.projectSidebar.projectReviewCollaborators")}
+      </Text>
+
+      <Stack spacing={2}>
+        {collaborations.length > 0 ? (
+          collaborations.map((c) => (
+            <HStack key={c.id} spacing={3} p={3} bg="gray.50" borderRadius="md" justify="space-between">
+              <HStack spacing={3}>
+                <SharedAvatar size="sm" name={c.collaborator.user?.name} role={c.collaborator.user?.role} />
+                <Stack spacing={0}>
+                  <Text fontSize="sm" fontWeight={600}>
+                    {c.collaborator.user?.name}
+                  </Text>
+                  {c.collaborator.user?.email && (
+                    <Text fontSize="xs" color="text.secondary">
+                      {c.collaborator.user?.email}
+                    </Text>
+                  )}
+                </Stack>
+              </HStack>
+              <Button size="xs" variant="ghost" colorScheme="red" onClick={() => handleUnassign(c.collaborator.id)}>
+                {/* @ts-ignore */}
+                {t("permitCollaboration.projectSidebar.unassignCollaborator")}
+              </Button>
             </HStack>
-          ))}
-        </Stack>
-      )}
+          ))
+        ) : (
+          <Text fontSize="sm" color="text.secondary">
+            {/* @ts-ignore */}
+            {t("permitCollaboration.projectSidebar.noneAssigned")}
+          </Text>
+        )}
+
+        {availableCollaborators.length > 0 && (
+          <Stack spacing={1} maxH="200px" overflowY="auto">
+            {availableCollaborators.map((collaborator) => (
+              <HStack
+                key={collaborator.id}
+                spacing={3}
+                p={2}
+                borderRadius="md"
+                cursor="pointer"
+                _hover={{ bg: "gray.100" }}
+                onClick={() => handleAssign(collaborator.id)}
+              >
+                <SharedAvatar size="xs" name={collaborator.user?.name} role={collaborator.user?.role} />
+                <Stack spacing={0}>
+                  <Text fontSize="sm">{collaborator.user?.name}</Text>
+                  <Text fontSize="xs" color="text.secondary">
+                    {collaborator.user?.email}
+                  </Text>
+                </Stack>
+              </HStack>
+            ))}
+          </Stack>
+        )}
+      </Stack>
     </Stack>
   )
 })

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-designated-reviewer-popover.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-designated-reviewer-popover.tsx
@@ -1,5 +1,6 @@
 import {
-  Avatar,
+  AvatarGroup,
+  HStack,
   IconButton,
   Popover,
   PopoverBody,
@@ -11,12 +12,11 @@ import {
 } from "@chakra-ui/react"
 import { UserPlus } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
-import React, { useEffect, useState } from "react"
+import React, { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { IPermitProject } from "../../../../models/permit-project"
 import { useMst } from "../../../../setup/root"
 import { ECollaborationType } from "../../../../types/enums"
-import { ConfirmationModal } from "../../../shared/confirmation-modal"
 import { RequestLoadingButton } from "../../../shared/request-loading-button"
 import { SharedAvatar } from "../../../shared/user/shared-avatar"
 import { CollaborationAssignmentPopoverContent } from "../../permit-application/collaborator-management/collaboration-assignment-popover-content"
@@ -25,14 +25,14 @@ interface IProps {
   project: IPermitProject
   renderTrigger?: (props: {
     isLoading: boolean
-    reviewDelegatee: IPermitProject["reviewDelegatee"]
+    collaborationCount: number
     onClick: (e: React.MouseEvent) => void
     isDisabled: boolean
   }) => React.ReactElement
   onBeforeOpen?: () => Promise<void>
 }
 
-export const ProjectDesignatedReviewerPopover = observer(function ProjectDesignatedReviewerPopover({
+export const ProjectReviewCollaboratorsPopover = observer(function ProjectReviewCollaboratorsPopover({
   project,
   renderTrigger,
   onBeforeOpen,
@@ -41,18 +41,9 @@ export const ProjectDesignatedReviewerPopover = observer(function ProjectDesigna
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [isBeforeOpenLoading, setIsBeforeOpenLoading] = useState(false)
-  const [pendingCollaboratorId, setPendingCollaboratorId] = useState<string | null>(null)
-  const confirmDisclosure = useDisclosure()
-  const contentRef = React.useRef<HTMLDivElement>(null)
 
-  const reviewDelegatee = project.reviewDelegatee
-  const existingCollaboratorIds = new Set<string>(reviewDelegatee ? [reviewDelegatee.id] : [])
-
-  useEffect(() => {
-    if (isOpen) {
-      setPendingCollaboratorId(null)
-    }
-  }, [isOpen])
+  const collaborations = project.permitProjectCollaborations
+  const takenCollaboratorIds = new Set<string>(collaborations.map((c) => c.collaborator.id))
 
   const handleOpen = async () => {
     if (onBeforeOpen) {
@@ -66,27 +57,12 @@ export const ProjectDesignatedReviewerPopover = observer(function ProjectDesigna
     onOpen()
   }
 
-  const onPopoverClose = () => {
-    if (confirmDisclosure.isOpen) return
-    onClose()
-  }
-
   const handleSelectCollaborator = async (collaboratorId: string) => {
-    setPendingCollaboratorId(collaboratorId)
-    confirmDisclosure.onOpen()
+    await project.assignProjectReviewCollaborator(collaboratorId)
   }
 
-  const handleConfirmAssign = async (closeModal: () => void) => {
-    if (!pendingCollaboratorId) return
-    await project.assignReviewDelegatee(pendingCollaboratorId)
-    setPendingCollaboratorId(null)
-    closeModal()
-    onClose()
-  }
-
-  const handleUnassign = async () => {
-    await project.unassignReviewDelegatee()
-    onClose()
+  const handleUnassign = async (collaboratorId: string) => {
+    await project.unassignProjectReviewCollaborator(collaboratorId)
   }
 
   const triggerOnClick = (e: React.MouseEvent) => {
@@ -99,106 +75,72 @@ export const ProjectDesignatedReviewerPopover = observer(function ProjectDesigna
     <IconButton
       variant="ghost"
       icon={
-        reviewDelegatee?.user ? (
-          <Avatar name={`${reviewDelegatee.user.firstName} ${reviewDelegatee.user.lastName}`} size="sm" />
+        collaborations.length > 0 ? (
+          <AvatarGroup size="xs" max={3}>
+            {collaborations.map((c) => (
+              <SharedAvatar key={c.id} size="xs" name={c.collaborator.user?.name} role={c.collaborator.user?.role} />
+            ))}
+          </AvatarGroup>
         ) : (
           <UserPlus size={16} />
         )
       }
-      aria-label={t("permitCollaboration.projectSidebar.projectReviewDelegatee")}
+      aria-label={t("permitCollaboration.projectSidebar.projectReviewCollaborators")}
       onClick={triggerOnClick}
       isDisabled={isBeforeOpenLoading}
     />
   )
 
   return (
-    <>
-      <Popover placement="bottom-start" isOpen={isOpen} onClose={onPopoverClose} strategy="fixed" isLazy>
-        <PopoverTrigger>
-          {renderTrigger
-            ? renderTrigger({
-                isLoading: isBeforeOpenLoading,
-                reviewDelegatee,
-                onClick: triggerOnClick,
-                isDisabled: isBeforeOpenLoading,
-              })
-            : renderDefaultTrigger()}
-        </PopoverTrigger>
-        <PopoverContent w="370px" maxW="370px" ref={contentRef}>
-          <PopoverBody p={0}>
-            <Stack
-              borderLeft="4px solid"
-              borderColor="theme.blueAlt"
-              px={4}
-              py={3}
-              bg="theme.blueLight"
-              mx={4}
-              mt={4}
-              borderRadius="sm"
-            >
-              <Text fontSize="xs">
+    <Popover placement="bottom-start" isOpen={isOpen} onClose={onClose} strategy="fixed" isLazy>
+      <PopoverTrigger>
+        {renderTrigger
+          ? renderTrigger({
+              isLoading: isBeforeOpenLoading,
+              collaborationCount: collaborations.length,
+              onClick: triggerOnClick,
+              isDisabled: isBeforeOpenLoading,
+            })
+          : renderDefaultTrigger()}
+      </PopoverTrigger>
+      <PopoverContent w="370px" maxW="370px">
+        <PopoverBody p={0}>
+          {collaborations.length > 0 && (
+            <Stack px={4} pt={4} spacing={2}>
+              <Text fontSize="xs" fontWeight={700} color="text.secondary" textTransform="uppercase">
                 {/* @ts-ignore */}
-                {t("permitCollaboration.projectSidebar.delegateeDescription")}
+                {t("permitCollaboration.projectSidebar.projectReviewCollaborators")}
               </Text>
-            </Stack>
-
-            {reviewDelegatee?.user && (
-              <Stack px={4} pt={3} spacing={1}>
-                <Text fontSize="xs" fontWeight={700} color="text.secondary" textTransform="uppercase">
-                  {/* @ts-ignore */}
-                  {t("permitCollaboration.projectSidebar.projectReviewDelegatee")}
-                </Text>
-                <Stack
-                  direction="row"
-                  spacing={3}
-                  p={2}
-                  bg="gray.50"
-                  borderRadius="md"
-                  justify="space-between"
-                  align="center"
-                >
-                  <Stack direction="row" spacing={2} align="center">
-                    <SharedAvatar
-                      size="xs"
-                      name={`${reviewDelegatee.user.firstName} ${reviewDelegatee.user.lastName}`}
-                      role={reviewDelegatee.user.role}
-                    />
+              {collaborations.map((c) => (
+                <HStack key={c.id} spacing={3} p={2} bg="gray.50" borderRadius="md" justify="space-between">
+                  <HStack spacing={2}>
+                    <SharedAvatar size="xs" name={c.collaborator.user?.name} role={c.collaborator.user?.role} />
                     <Text fontSize="sm" fontWeight={600}>
-                      {`${reviewDelegatee.user.firstName} ${reviewDelegatee.user.lastName}`}
+                      {c.collaborator.user?.name}
                     </Text>
-                  </Stack>
-                  <RequestLoadingButton size="xs" variant="ghost" colorScheme="red" onClick={handleUnassign}>
+                  </HStack>
+                  <RequestLoadingButton
+                    size="xs"
+                    variant="ghost"
+                    colorScheme="red"
+                    onClick={() => handleUnassign(c.collaborator.id)}
+                  >
                     {/* @ts-ignore */}
-                    {t("permitCollaboration.projectSidebar.unassignDelegatee")}
+                    {t("permitCollaboration.projectSidebar.unassignCollaborator")}
                   </RequestLoadingButton>
-                </Stack>
-              </Stack>
-            )}
-          </PopoverBody>
+                </HStack>
+              ))}
+            </Stack>
+          )}
+        </PopoverBody>
 
-          <CollaborationAssignmentPopoverContent
-            onSelect={handleSelectCollaborator}
-            onClose={onClose}
-            takenCollaboratorIds={existingCollaboratorIds}
-            collaborationType={ECollaborationType.review}
-          />
-        </PopoverContent>
-      </Popover>
-
-      <ConfirmationModal
-        modalControlProps={confirmDisclosure}
-        renderTriggerButton={() => <></>}
-        // @ts-ignore
-        title={t("permitCollaboration.projectSidebar.overrideConfirmTitle")}
-        // @ts-ignore
-        body={t("permitCollaboration.projectSidebar.overrideConfirmBody")}
-        onConfirm={handleConfirmAssign}
-        renderConfirmationButton={({ onClick }) => (
-          <RequestLoadingButton variant="primary" onClick={onClick as () => Promise<any>}>
-            {t("ui.confirm")}
-          </RequestLoadingButton>
-        )}
-      />
-    </>
+        <CollaborationAssignmentPopoverContent
+          onSelect={handleSelectCollaborator}
+          onClose={onClose}
+          takenCollaboratorIds={takenCollaboratorIds}
+          collaborationType={ECollaborationType.review}
+        />
+      </PopoverContent>
+    </Popover>
   )
 })

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-inbox-table.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-inbox-table.tsx
@@ -36,7 +36,7 @@ import { ProjectStateTag } from "../../../shared/permit-projects/project-state-t
 import { SortIcon } from "../../../shared/sort-icon"
 import { SharedAvatar } from "../../../shared/user/shared-avatar"
 import { InboxNoMatchingEmpty } from "./inbox-no-matching-empty"
-import { ProjectDesignatedReviewerPopover } from "./project-designated-reviewer-popover"
+import { ProjectReviewCollaboratorsPopover } from "./project-designated-reviewer-popover"
 import { ProjectInboxPermitApplicationsPopover } from "./project-inbox-permit-applications-popover"
 import { SubmissionInboxMarkUnreadIconButton } from "./submission-inbox-mark-unread-icon-button"
 
@@ -263,12 +263,10 @@ const ProjectAssignedCell = observer(function ProjectAssignedCell({ project }: {
   const { t } = useTranslation()
   const { permitProjectStore } = useMst()
 
-  const collaborators = project.aggregatedReviewCollaborators
-  const childAppAssignees = collaborators.filter((c) => !c.isDesignated)
-  const visibleAssignees = childAppAssignees.slice(0, MAX_VISIBLE_AVATARS)
-  const overflowCount = childAppAssignees.length - MAX_VISIBLE_AVATARS
-  const hasDesignatedReviewer = !!project.reviewDelegatee
-  const hasAnyAssignees = hasDesignatedReviewer || childAppAssignees.length > 0
+  const allCollaborators = project.aggregatedReviewCollaborators
+  const visibleAssignees = allCollaborators.slice(0, MAX_VISIBLE_AVATARS)
+  const overflowCount = allCollaborators.length - MAX_VISIBLE_AVATARS
+  const hasAnyAssignees = allCollaborators.length > 0
 
   return (
     <HStack spacing={1}>
@@ -293,26 +291,19 @@ const ProjectAssignedCell = observer(function ProjectAssignedCell({ project }: {
           {t("ui.unassigned")}
         </Text>
       )}
-      <ProjectDesignatedReviewerPopover
+      <ProjectReviewCollaboratorsPopover
         project={project}
         onBeforeOpen={async () => {
           await permitProjectStore.fetchPermitProject(project.id)
         }}
-        renderTrigger={({ isLoading, reviewDelegatee, onClick, isDisabled }) => (
+        renderTrigger={({ isLoading, collaborationCount, onClick, isDisabled }) => (
           <IconButton
-            aria-label={t("permitCollaboration.projectSidebar.projectReviewDelegatee")}
+            aria-label={t("permitCollaboration.projectSidebar.projectReviewCollaborators")}
             icon={
               isLoading ? (
                 <Spinner size="xs" />
-              ) : reviewDelegatee?.user ? (
-                <SharedAvatar
-                  size="xs"
-                  name={`${reviewDelegatee.user.firstName} ${reviewDelegatee.user.lastName}`}
-                  role={reviewDelegatee.user.role}
-                  fontSize="2xs"
-                  border="2px solid"
-                  borderColor="theme.blueActive"
-                />
+              ) : collaborationCount > 0 ? (
+                <UserPlus size={14} />
               ) : (
                 <UserPlus size={14} />
               )

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-kanban-board.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-kanban-board.tsx
@@ -24,7 +24,7 @@ import { EProjectState } from "../../../../types/enums"
 import { SharedAvatar } from "../../../shared/user/shared-avatar"
 import { IKanbanColumn, IReorderEvent, KanbanBoard } from "./kanban-board"
 import { KanbanCard } from "./kanban-card"
-import { ProjectDesignatedReviewerPopover } from "./project-designated-reviewer-popover"
+import { ProjectReviewCollaboratorsPopover } from "./project-designated-reviewer-popover"
 import { ProjectInboxPermitApplicationsPopover } from "./project-inbox-permit-applications-popover"
 
 interface IProps {
@@ -104,10 +104,9 @@ const ProjectKanbanCard = observer(function ProjectKanbanCard({ project }: { pro
   const total = project.totalPermitsCount
   const isUnread = !project.viewedAt
 
-  const collaborators = project.aggregatedReviewCollaborators
-  const childAppAssignees = collaborators.filter((c) => !c.isDesignated)
-  const visibleAssignees = childAppAssignees.slice(0, MAX_VISIBLE_AVATARS)
-  const overflowCount = childAppAssignees.length - MAX_VISIBLE_AVATARS
+  const allCollaborators = project.aggregatedReviewCollaborators
+  const visibleAssignees = allCollaborators.slice(0, MAX_VISIBLE_AVATARS)
+  const overflowCount = allCollaborators.length - MAX_VISIBLE_AVATARS
 
   return (
     <KanbanCard
@@ -130,30 +129,15 @@ const ProjectKanbanCard = observer(function ProjectKanbanCard({ project }: { pro
               fontSize="2xs"
             />
           )}
-          <ProjectDesignatedReviewerPopover
+          <ProjectReviewCollaboratorsPopover
             project={project}
             onBeforeOpen={async () => {
               await permitProjectStore.fetchPermitProject(project.id)
             }}
-            renderTrigger={({ isLoading, reviewDelegatee, onClick, isDisabled }) => (
+            renderTrigger={({ isLoading, collaborationCount, onClick, isDisabled }) => (
               <IconButton
-                aria-label={t("permitCollaboration.projectSidebar.projectReviewDelegatee")}
-                icon={
-                  isLoading ? (
-                    <Spinner size="xs" />
-                  ) : reviewDelegatee?.user ? (
-                    <SharedAvatar
-                      size="xs"
-                      name={`${reviewDelegatee.user.firstName} ${reviewDelegatee.user.lastName}`}
-                      role={reviewDelegatee.user.role}
-                      fontSize="2xs"
-                      border="2px solid"
-                      borderColor="theme.blueActive"
-                    />
-                  ) : (
-                    <UserPlus size={16} />
-                  )
-                }
+                aria-label={t("permitCollaboration.projectSidebar.projectReviewCollaborators")}
+                icon={isLoading ? <Spinner size="xs" /> : <UserPlus size={16} />}
                 size="sm"
                 minW={7}
                 h={7}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1163,13 +1163,8 @@ Thank you,
           },
           projectSidebar: {
             title: "Collaborators",
-            projectReviewDelegatee: "Project review delegatee",
-            delegateeDescription:
-              "The project review delegatee is assigned as the designated reviewer for all permit applications in this project. When set, it overrides the designated reviewer on all currently submitted applications. New applications submitted to this project will automatically inherit this reviewer.",
-            overrideConfirmTitle: "Override all permit application reviewers?",
-            overrideConfirmBody:
-              "This will replace the designated reviewer on all submitted permit applications in this project. Individual applications can still have their reviewer changed afterward.",
-            unassignDelegatee: "Remove",
+            projectReviewCollaborators: "Project review collaborators",
+            unassignCollaborator: "Remove",
             noneAssigned: "None assigned",
             permitApplications: "Permit applications",
             noSubmittedApplications: "No submitted applications in this project.",

--- a/app/frontend/models/permit-project.ts
+++ b/app/frontend/models/permit-project.ts
@@ -12,7 +12,12 @@ export interface IAggregatedReviewCollaborator {
   id: string
   name: string
   role: string
-  isDesignated: boolean
+  isProjectCollaborator: boolean
+}
+
+export interface IPermitProjectCollaboration {
+  id: string
+  collaborator: ICollaborator
 }
 
 export const PermitProjectModel = types
@@ -59,7 +64,7 @@ export const PermitProjectModel = types
     parcelGeometry: types.maybeNull(types.frozen<IParcelGeometry>()),
     inboxSortOrder: types.maybeNull(types.number),
     recentAudits: types.optional(types.array(types.frozen<IProjectAuditSummary>()), []),
-    reviewDelegatee: types.maybeNull(types.frozen<ICollaborator>()),
+    permitProjectCollaborations: types.optional(types.array(types.frozen<IPermitProjectCollaboration>()), []),
     aggregatedReviewCollaborators: types.optional(types.array(types.frozen<IAggregatedReviewCollaborator>()), []),
   })
   .extend(withEnvironment())
@@ -201,15 +206,17 @@ export const PermitProjectModel = types
       }
       return response
     }),
-    assignReviewDelegatee: flow(function* (collaboratorId: string) {
-      const response = yield* toGenerator(self.environment.api.assignProjectReviewDelegatee(self.id, collaboratorId))
+    assignProjectReviewCollaborator: flow(function* (collaboratorId: string) {
+      const response = yield* toGenerator(self.environment.api.assignProjectReviewCollaborator(self.id, collaboratorId))
       if (response.ok) {
         self.rootStore.permitProjectStore.mergeUpdate(response.data.data, "permitProjectMap")
       }
       return response
     }),
-    unassignReviewDelegatee: flow(function* () {
-      const response = yield* toGenerator(self.environment.api.unassignProjectReviewDelegatee(self.id))
+    unassignProjectReviewCollaborator: flow(function* (collaboratorId: string) {
+      const response = yield* toGenerator(
+        self.environment.api.unassignProjectReviewCollaborator(self.id, collaboratorId)
+      )
       if (response.ok) {
         self.rootStore.permitProjectStore.mergeUpdate(response.data.data, "permitProjectMap")
       }

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -285,14 +285,18 @@ export class Api {
     return this.client.get<ApiResponse<IPermitProject>>(`/permit_projects/${id}`)
   }
 
-  async assignProjectReviewDelegatee(projectId: string, collaboratorId: string) {
-    return this.client.post<ApiResponse<IPermitProject>>(`/permit_projects/${projectId}/assign_review_delegatee`, {
-      collaboratorId,
-    })
+  async assignProjectReviewCollaborator(projectId: string, collaboratorId: string) {
+    return this.client.post<ApiResponse<IPermitProject>>(
+      `/permit_projects/${projectId}/assign_project_review_collaborator`,
+      { collaboratorId }
+    )
   }
 
-  async unassignProjectReviewDelegatee(projectId: string) {
-    return this.client.delete<ApiResponse<IPermitProject>>(`/permit_projects/${projectId}/unassign_review_delegatee`)
+  async unassignProjectReviewCollaborator(projectId: string, collaboratorId: string) {
+    return this.client.delete<ApiResponse<IPermitProject>>(
+      `/permit_projects/${projectId}/unassign_project_review_collaborator`,
+      { collaboratorId }
+    )
   }
 
   async fetchProjectAudits(

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -101,6 +101,21 @@ export const NotificationStoreModel = types
               },
             ]
           : []
+      } else if (
+        [
+          ENotificationActionType.projectReviewCollaborationAssignment,
+          ENotificationActionType.projectReviewCollaborationUnassignment,
+        ].includes(notification.actionType)
+      ) {
+        const projectData = objectData as { permitProjectId: string; jurisdictionSlug: string }
+        return notification.actionType === ENotificationActionType.projectReviewCollaborationAssignment
+          ? [
+              {
+                text: t("ui.show"),
+                href: `/jurisdictions/${projectData.jurisdictionSlug}/submission-inbox/projects/${projectData.permitProjectId}/overview`,
+              },
+            ]
+          : []
       } else if (notification.actionType === ENotificationActionType.permitBlockStatusReady) {
         const collaborationData = objectData as IPermitBlockStatusReadyNotificationObjectData
         return [

--- a/app/frontend/stores/permit-project-store.ts
+++ b/app/frontend/stores/permit-project-store.ts
@@ -71,8 +71,12 @@ export const PermitProjectStoreModel = types
         self.rootStore.jurisdictionStore.mergeUpdate(permitProject.jurisdiction, "jurisdictionMap")
       }
 
-      if (permitProject.reviewDelegatee?.user && typeof permitProject.reviewDelegatee.user === "object") {
-        self.rootStore.userStore.mergeUpdate(permitProject.reviewDelegatee.user, "usersMap")
+      if (permitProject.permitProjectCollaborations) {
+        permitProject.permitProjectCollaborations.forEach((collab: any) => {
+          if (collab?.collaborator?.user && typeof collab.collaborator.user === "object") {
+            self.rootStore.userStore.mergeUpdate(collab.collaborator.user, "usersMap")
+          }
+        })
       }
 
       const overrides: Record<string, any> = {

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -463,6 +463,8 @@ export enum ENotificationActionType {
   preCheckCompleted = "pre_check_completed",
   fileUploadFailed = "file_upload_failed",
   resourceReminder = "resource_reminder",
+  projectReviewCollaborationAssignment = "project_review_collaboration_assignment",
+  projectReviewCollaborationUnassignment = "project_review_collaboration_unassignment",
 }
 
 export enum ECollaboratorableType {

--- a/app/mailers/permit_hub_mailer.rb
+++ b/app/mailers/permit_hub_mailer.rb
@@ -74,10 +74,24 @@ class PermitHubMailer < ApplicationMailer
     @user = permit_collaboration.collaborator.user
 
     return unless permit_collaboration.permit_application
+    return unless @user.preference&.enable_email_collaboration_notification
 
     send_user_mail(
       email: @user.email,
       template_key: :notify_permit_collaboration
+    )
+  end
+
+  def notify_project_review_collaboration(permit_project_collaboration:)
+    @permit_project_collaboration = permit_project_collaboration
+    @user = permit_project_collaboration.collaborator.user
+    @permit_project = permit_project_collaboration.permit_project
+
+    return unless @user.preference&.enable_email_collaboration_notification
+
+    send_user_mail(
+      email: @user.email,
+      template_key: :notify_project_review_collaboration
     )
   end
 

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -87,11 +87,6 @@ class PermitApplication < ApplicationRecord
                if: :status_changed_to_intake?
   after_commit :mark_permit_project_as_unviewed, if: :status_changed_to_intake?
   after_commit :enqueue_permit_project_if_draft, if: :status_changed_to_intake?
-  # TODO: Review with product manager — re-enable syncing the project’s review delegatee onto
-  # each permit application when the application enters intake (see #auto_assign_project_review_delegatee).
-  # after_commit :auto_assign_project_review_delegatee,
-  #              if: :status_changed_to_intake?
-
   scope :with_submitter_role,
         -> { joins(:submitter).where(users: { role: "submitter" }) }
 
@@ -866,30 +861,6 @@ class PermitApplication < ApplicationRecord
   # TODO: Also enqueue project when a meeting request is made
   def enqueue_permit_project_if_draft
     permit_project&.enqueue! if permit_project&.draft?
-  end
-
-  # Disabled pending product decision — restore together with the after_commit above.
-  def auto_assign_project_review_delegatee
-    # return unless permit_project&.review_delegatee.present?
-    # return unless SiteConfiguration.allow_designated_reviewer?
-    # return unless jurisdiction&.allow_designated_reviewer
-    #
-    # permit_collaborations
-    #   .kept
-    #   .where(collaborator_type: :delegatee, collaboration_type: :review)
-    #   .discard_all
-    #
-    # collab =
-    #   permit_collaborations.create!(
-    #     collaborator_id: permit_project.review_delegatee_id,
-    #     collaborator_type: :delegatee,
-    #     collaboration_type: :review
-    #   )
-    # NotificationService.publish_permit_collaboration_assignment_event(collab)
-    # rescue => e
-    #   Rails.logger.warn(
-    #     "Failed to auto-assign project review delegatee for PA #{id}: #{e.message}"
-    #   )
   end
 
   def jurisdiction_or_permit_project_present

--- a/app/models/permit_project.rb
+++ b/app/models/permit_project.rb
@@ -11,7 +11,12 @@ class PermitProject < ApplicationRecord
   belongs_to :owner, class_name: "User", optional: true
   public_recordable user_association: :owner
   belongs_to :jurisdiction, optional: false # Direct association to Jurisdiction
-  belongs_to :review_delegatee, class_name: "Collaborator", optional: true
+  has_many :permit_project_collaborations,
+           -> { where(discarded_at: nil) },
+           dependent: :destroy
+  has_many :project_review_collaborators,
+           through: :permit_project_collaborations,
+           source: :collaborator
 
   has_many :permit_applications
   has_many :project_documents, dependent: :destroy
@@ -243,9 +248,24 @@ class PermitProject < ApplicationRecord
   end
 
   def aggregated_review_collaborators
-    delegatee_user_id = review_delegatee&.user_id
     users = {}
 
+    # Include project-level review collaborators
+    permit_project_collaborations
+      .includes(collaborator: :user)
+      .each do |ppc|
+        user = ppc.collaborator&.user
+        next unless user
+
+        users[user.id] ||= {
+          id: user.id,
+          name: user.name,
+          role: user.role,
+          is_project_collaborator: true
+        }
+      end
+
+    # Include per-application review collaborators
     permit_applications.each do |pa|
       next if pa.discarded? || !pa.submitted?
 
@@ -255,29 +275,18 @@ class PermitProject < ApplicationRecord
         user = collab.collaborator&.user
         next unless user
 
-        is_designated = collab.collaborator_type == "delegatee"
         existing = users[user.id]
         if existing
-          existing[:is_designated] ||= is_designated
+          existing[:is_project_collaborator] ||= false
         else
           users[user.id] = {
             id: user.id,
             name: user.name,
             role: user.role,
-            is_designated: is_designated
+            is_project_collaborator: false
           }
         end
       end
-    end
-
-    if delegatee_user_id && !users.key?(delegatee_user_id)
-      delegatee_user = review_delegatee.user
-      users[delegatee_user_id] = {
-        id: delegatee_user.id,
-        name: delegatee_user.name,
-        role: delegatee_user.role,
-        is_designated: true
-      }
     end
 
     users.values
@@ -288,43 +297,29 @@ class PermitProject < ApplicationRecord
       jurisdiction&.allow_designated_reviewer
   end
 
-  def assign_review_delegatee!(collaborator_id)
+  def assign_project_review_collaborator!(collaborator_id)
     unless designated_reviewer_enabled?
       raise "Designated reviewer feature is not enabled"
     end
 
-    ActiveRecord::Base.transaction do
-      update!(review_delegatee_id: collaborator_id)
+    collaboration =
+      permit_project_collaborations.create!(collaborator_id: collaborator_id)
 
-      # TODO: Review with product manager — re-enable pushing the project review delegatee to each
-      # submitted permit application (discard prior review delegatee collaborations, create new, notify).
-      # permit_applications
-      #   .kept
-      #   .select(&:submitted?)
-      #   .each do |pa|
-      #     pa
-      #       .permit_collaborations
-      #       .kept
-      #       .where(collaborator_type: :delegatee, collaboration_type: :review)
-      #       .discard_all
-      #
-      #     collab =
-      #       pa.permit_collaborations.create!(
-      #         collaborator_id: collaborator_id,
-      #         collaborator_type: :delegatee,
-      #         collaboration_type: :review
-      #       )
-      #     NotificationService.publish_permit_collaboration_assignment_event(
-      #       collab
-      #     )
-      #   end
-    end
+    PermitHubMailer.notify_project_review_collaboration(
+      permit_project_collaboration: collaboration
+    )&.deliver_later
+
+    NotificationService.publish_project_collaboration_assignment_event(
+      collaboration
+    )
+
+    collaboration
   end
 
-  # TODO: Review with product manager — when re-enabling assign sync above, decide whether clearing
-  # review_delegatee here should also discard review delegatee permit_collaborations on applications.
-  def unassign_review_delegatee!
-    update!(review_delegatee_id: nil)
+  def unassign_project_review_collaborator!(collaborator_id)
+    collaboration =
+      permit_project_collaborations.find_by!(collaborator_id: collaborator_id)
+    collaboration.discard!
   end
 
   private
@@ -337,7 +332,12 @@ class PermitProject < ApplicationRecord
         .where(collaboration_type: :review, discarded_at: nil)
         .pluck("collaborators.user_id")
 
-    (pa_user_ids + [review_delegatee&.user_id].compact).uniq
+    project_user_ids =
+      permit_project_collaborations.joins(:collaborator).pluck(
+        "collaborators.user_id"
+      )
+
+    (pa_user_ids + project_user_ids).uniq
   end
 
   def fetch_coordinates

--- a/app/models/permit_project_collaboration.rb
+++ b/app/models/permit_project_collaboration.rb
@@ -18,6 +18,7 @@ class PermitProjectCollaboration < ApplicationRecord
             }
 
   validate :validate_review_staff_for_jurisdiction
+  validate :validate_collaborator_is_review_type
 
   def collaboration_assignment_notification_data
     {
@@ -70,6 +71,14 @@ class PermitProjectCollaboration < ApplicationRecord
 
     unless collaborator.user.review_staff_of?(permit_project.jurisdiction_id)
       errors.add(:collaborator, :must_be_review_staff_for_jurisdiction)
+    end
+  end
+
+  def validate_collaborator_is_review_type
+    return if collaborator.blank?
+
+    unless collaborator.collaboratorable_type == "Jurisdiction"
+      errors.add(:collaborator, :must_be_review_collaborator)
     end
   end
 

--- a/app/models/permit_project_collaboration.rb
+++ b/app/models/permit_project_collaboration.rb
@@ -1,0 +1,86 @@
+class PermitProjectCollaboration < ApplicationRecord
+  include Discard::Model
+
+  belongs_to :permit_project, touch: true
+  belongs_to :collaborator
+
+  after_save :reindex_permit_project
+  after_discard do
+    send_unassignment_notification
+    reindex_permit_project
+  end
+
+  validates :permit_project_id,
+            uniqueness: {
+              scope: :collaborator_id,
+              conditions: -> { where(discarded_at: nil) },
+              message: :already_assigned
+            }
+
+  validate :validate_review_staff_for_jurisdiction
+
+  def collaboration_assignment_notification_data
+    {
+      "id" => SecureRandom.uuid,
+      "action_type" =>
+        Constants::NotificationActionTypes::PROJECT_REVIEW_COLLABORATION_ASSIGNMENT,
+      "action_text" =>
+        I18n.t(
+          "notification.permit_project_collaboration.assignment_notification",
+          project_number: permit_project.number,
+          project_title: permit_project.title
+        ),
+      "object_data" => {
+        "permit_project_id" => permit_project.id,
+        "project_number" => permit_project.number,
+        "project_title" => permit_project.title,
+        "jurisdiction_slug" => permit_project.jurisdiction&.slug
+      }
+    }
+  end
+
+  def collaboration_unassignment_notification_data
+    {
+      "id" => SecureRandom.uuid,
+      "action_type" =>
+        Constants::NotificationActionTypes::PROJECT_REVIEW_COLLABORATION_UNASSIGNMENT,
+      "action_text" =>
+        I18n.t(
+          "notification.permit_project_collaboration.unassignment_notification",
+          project_number: permit_project.number,
+          project_title: permit_project.title
+        ),
+      "object_data" => {
+        "permit_project_id" => permit_project.id,
+        "project_number" => permit_project.number,
+        "project_title" => permit_project.title,
+        "jurisdiction_slug" => permit_project.jurisdiction&.slug
+      }
+    }
+  end
+
+  private
+
+  def reindex_permit_project
+    permit_project&.reindex
+  end
+
+  def validate_review_staff_for_jurisdiction
+    return if collaborator.blank? || permit_project.blank?
+
+    unless collaborator.user.review_staff_of?(permit_project.jurisdiction_id)
+      errors.add(:collaborator, :must_be_review_staff_for_jurisdiction)
+    end
+  end
+
+  def send_unassignment_notification
+    unless collaborator
+             &.user
+             &.preference
+             &.enable_in_app_collaboration_notification
+      return
+    end
+
+    NotificationService.publish_project_collaboration_unassignment_event(self)
+  end
+end

--- a/app/policies/permit_project_policy.rb
+++ b/app/policies/permit_project_policy.rb
@@ -82,11 +82,11 @@ class PermitProjectPolicy < ApplicationPolicy
     user_is_owner?
   end
 
-  def assign_review_delegatee?
+  def assign_project_review_collaborator?
     user_is_review_staff_for_jurisdiction?
   end
 
-  def unassign_review_delegatee?
+  def unassign_project_review_collaborator?
     user_is_review_staff_for_jurisdiction?
   end
 

--- a/app/services/constants/notification_action_types.rb
+++ b/app/services/constants/notification_action_types.rb
@@ -20,5 +20,9 @@ module Constants
     PRE_CHECK_COMPLETED = "pre_check_completed"
     FILE_UPLOAD_FAILED = "file_upload_failed"
     RESOURCE_REMINDER = "resource_reminder"
+    PROJECT_REVIEW_COLLABORATION_ASSIGNMENT =
+      "project_review_collaboration_assignment"
+    PROJECT_REVIEW_COLLABORATION_UNASSIGNMENT =
+      "project_review_collaboration_unassignment"
   end
 end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -286,11 +286,11 @@ class NotificationService
   end
 
   def self.publish_permit_collaboration_assignment_event(permit_collaboration)
-    collaborator_user_id = permit_collaboration.collaborator.user_id
+    user = permit_collaboration.collaborator&.user
+    return unless user&.preference&.enable_in_app_collaboration_notification
 
     notification_user_hash = {
-      collaborator_user_id =>
-        permit_collaboration.collaboration_assignment_notification_data
+      user.id => permit_collaboration.collaboration_assignment_notification_data
     }
 
     NotificationPushJob.perform_async(notification_user_hash)
@@ -302,6 +302,34 @@ class NotificationService
     notification_user_hash = {
       collaborator_user_id =>
         permit_collaboration.collaboration_unassignment_notification_data
+    }
+
+    NotificationPushJob.perform_async(notification_user_hash)
+  end
+
+  def self.publish_project_collaboration_assignment_event(
+    permit_project_collaboration
+  )
+    user = permit_project_collaboration.collaborator&.user
+    return unless user&.preference&.enable_in_app_collaboration_notification
+
+    notification_user_hash = {
+      user.id =>
+        permit_project_collaboration.collaboration_assignment_notification_data
+    }
+
+    NotificationPushJob.perform_async(notification_user_hash)
+  end
+
+  def self.publish_project_collaboration_unassignment_event(
+    permit_project_collaboration
+  )
+    user = permit_project_collaboration.collaborator&.user
+    return unless user&.preference&.enable_in_app_collaboration_notification
+
+    notification_user_hash = {
+      user.id =>
+        permit_project_collaboration.collaboration_unassignment_notification_data
     }
 
     NotificationPushJob.perform_async(notification_user_hash)

--- a/app/views/permit_hub_mailer/notify_project_review_collaboration.erb
+++ b/app/views/permit_hub_mailer/notify_project_review_collaboration.erb
@@ -1,0 +1,80 @@
+<!-- START MAIN CONTENT AREA -->
+<tr>
+  <td class="wrapper" style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top; box-sizing: border-box; padding: 56px 32px;" valign="top">
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; width: 100%;" width="100%">
+      <tr>
+        <!-- START CONTENT ROW -->
+        <td style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top;" valign="top">
+          <h1 style="color: #292929; font-family: 'Open Sans', sans-serif; font-weight: 700; line-height: 1.4; text-align: left; font-size: 28px; margin-top: 0; margin-bottom: 48px;">
+            You have been assigned as a review collaborator on a project
+          </h1>
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">Dear <%= @user.name %>,</p>
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
+            You have been assigned as a review collaborator on the following project in Building Permit Hub.
+          </p>
+
+          <h2 style="color: #292929; font-family: 'Open Sans', sans-serif; font-weight: 700; line-height: 1.4; margin-top: 24px; margin-bottom: 16px; text-align: left; font-size: 22px;">Project details:</h2>
+
+          <table class="basic-table" role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; width: 100%; background: #f2f2f2; border: 1px solid #d9d9d9; margin-bottom: 32px;" width="100%">
+            <tr>
+              <td style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top;" valign="top">
+                <dl class="table-like" style="margin: 0;">
+
+                  <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Project #</dt>
+                  <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 1px solid #d9d9d9;"><%= @permit_project.number %></dd>
+
+                  <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Title</dt>
+                  <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 1px solid #d9d9d9;"><%= @permit_project.title %></dd>
+
+                  <% if @permit_project.full_address.present? %>
+                    <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Address</dt>
+                    <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 0;"><%= @permit_project.full_address %></dd>
+                  <% end %>
+
+                </dl>
+              </td>
+            </tr>
+          </table>
+
+          <h2 style="color: #292929; font-family: 'Open Sans', sans-serif; font-weight: 700; line-height: 1.4; margin-top: 24px; margin-bottom: 16px; text-align: left; font-size: 22px;">Next steps:</h2>
+          <ol style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px; padding-left: 24px;">
+            <li style="list-style-position: initial; margin-left: 5px;">Log into the
+              <a href="<%= FrontendUrlHelper.frontend_url("/login") %>" style="color: #1a5a96; text-decoration: underline;">Building Permit Hub</a></li>
+            <li style="list-style-position: initial; margin-left: 5px;">Navigate to the project to review its permit applications</li>
+          </ol>
+
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
+            Your prompt review and action are appreciated to create a smooth and efficient permit application process.
+          </p>
+
+          <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; box-sizing: border-box; width: 100%; margin: 12px auto;" width="100%">
+            <tbody>
+            <tr>
+              <td align="left" style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top; padding-bottom: 15px;" valign="top">
+                <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: auto; width: auto;">
+                  <tbody>
+                  <tr>
+                    <td style="font-family: 'Open Sans', sans-serif; font-size: 16px; vertical-align: top; border-radius: 5px; text-align: center; background-color: transparent;" valign="top" align="center" bgcolor="transparent">
+                      <a href="<%= FrontendUrlHelper.frontend_url("/login") %>" target="_blank" style="border: solid 1px #003366; border-radius: 4px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 16px; font-weight: normal; line-height: 26px; margin: 0; padding: 6px 12px; text-decoration: none; background-color: #003366; border-color: #003366; color: #ffffff;">Login to Building Permit Hub</a></td>
+                  </tr>
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+
+          <br>
+
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
+            Best regards,<br><br>
+            The Building Permit Hub Team
+          </p>
+        </td>
+        <!-- END OF CONTENT ROW -->
+      </tr>
+    </table>
+  </td>
+</tr>
+
+<!-- END MAIN CONTENT AREA -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,7 @@ en:
       permit_type_submission_contact_confirm: "Confirm submission inbox email"
       new_jurisdiction_membership: "New jurisdiction membership"
       notify_permit_collaboration: "Welcome you have been invited to Collaborate in the Building Permit Hub"
+      notify_project_review_collaboration: "You have been assigned as a review collaborator on a project"
       notify_new_or_unconfirmed_permit_collaboration: "You’re Invited to Collaborate on a Building Permit Application"
       notify_new_or_unconfirmed_preview: "You’re Invited to Preview a Building Permit Template"
       notify_preview: "You're Invited to Preview a Building Permit Template"
@@ -690,15 +691,15 @@ en:
       reorder_success:
         title: ""
         message: "Project order updated successfully"
-      assign_review_delegatee_success:
+      assign_project_review_collaborator_success:
         title: ""
-        message: "Project reviewer assigned successfully"
-      assign_review_delegatee_error:
+        message: "Project review collaborator assigned successfully"
+      assign_project_review_collaborator_error:
         title: Error
         message: "%{error_message}"
-      unassign_review_delegatee_success:
+      unassign_project_review_collaborator_success:
         title: ""
-        message: "Project reviewer removed successfully"
+        message: "Project review collaborator removed successfully"
       feature_not_enabled:
         title: Error
         message: "Designated reviewer is not enabled for this project"
@@ -1006,6 +1007,9 @@ en:
       submission_assignee_collaboration_unassignment_notification: "You have been removed as a collaborator on requirement “%{requirement_block_name}” for permit application %{number}"
       review_delegatee_collaboration_unassignment_notification: "You have been removed as a designated reviewer for permit application %{number}."
       review_assignee_collaboration_unassignment_notification: "You have been removed as a review collaborator on requirement “%{requirement_block_name}” for permit application %{number}"
+    permit_project_collaboration:
+      assignment_notification: "You have been assigned as a review collaborator on project %{project_number} (%{project_title})."
+      unassignment_notification: "You have been removed as a review collaborator on project %{project_number} (%{project_title})."
     step_code:
       report_generated: "Your step code report is ready to download"
     pre_check:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -232,8 +232,8 @@ Rails.application.routes.draw do
         post :mark_as_viewed
         post :mark_as_unviewed
         post :transition_state
-        post :assign_review_delegatee
-        delete :unassign_review_delegatee
+        post :assign_project_review_collaborator
+        delete :unassign_project_review_collaborator
       end
       collection { patch :reorder }
     end

--- a/db/migrate/20260410120000_create_permit_project_collaborations.rb
+++ b/db/migrate/20260410120000_create_permit_project_collaborations.rb
@@ -1,0 +1,38 @@
+class CreatePermitProjectCollaborations < ActiveRecord::Migration[7.1]
+  def up
+    create_table :permit_project_collaborations,
+                 id: :uuid,
+                 default: -> { "gen_random_uuid()" } do |t|
+      t.references :permit_project, null: false, foreign_key: true, type: :uuid
+      t.references :collaborator, null: false, foreign_key: true, type: :uuid
+      t.datetime :discarded_at
+      t.timestamps
+    end
+
+    add_index :permit_project_collaborations,
+              %i[permit_project_id collaborator_id],
+              unique: true,
+              where: "discarded_at IS NULL",
+              name: "index_project_collabs_on_project_and_collaborator"
+
+    add_index :permit_project_collaborations, :discarded_at
+    remove_reference :permit_projects,
+                     :review_delegatee,
+                     foreign_key: {
+                       to_table: :collaborators
+                     },
+                     type: :uuid
+  end
+
+  def down
+    add_reference :permit_projects,
+                  :review_delegatee,
+                  foreign_key: {
+                    to_table: :collaborators
+                  },
+                  null: true,
+                  type: :uuid
+
+    drop_table :permit_project_collaborations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_02_180000) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_10_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -577,6 +577,18 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_02_180000) do
     t.index ["permit_application_id"], name: "index_permit_collaborations_on_permit_application_id"
   end
 
+  create_table "permit_project_collaborations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "permit_project_id", null: false
+    t.uuid "collaborator_id", null: false
+    t.datetime "discarded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["collaborator_id"], name: "index_permit_project_collaborations_on_collaborator_id"
+    t.index ["discarded_at"], name: "index_permit_project_collaborations_on_discarded_at"
+    t.index ["permit_project_id", "collaborator_id"], name: "index_project_collabs_on_project_and_collaborator", unique: true, where: "(discarded_at IS NULL)"
+    t.index ["permit_project_id"], name: "index_permit_project_collaborations_on_permit_project_id"
+  end
+
   create_table "permit_projects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "owner_id"
     t.uuid "jurisdiction_id", null: false
@@ -602,11 +614,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_02_180000) do
     t.datetime "viewed_at"
     t.integer "inbox_sort_order"
     t.datetime "enqueued_at"
-    t.uuid "review_delegatee_id"
     t.index ["jurisdiction_id"], name: "index_permit_projects_on_jurisdiction_id"
     t.index ["number"], name: "index_permit_projects_on_number", unique: true
     t.index ["owner_id"], name: "index_permit_projects_on_owner_id"
-    t.index ["review_delegatee_id"], name: "index_permit_projects_on_review_delegatee_id"
   end
 
   create_table "permit_type_required_steps", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1182,7 +1192,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_02_180000) do
   add_foreign_key "permit_block_statuses", "permit_applications"
   add_foreign_key "permit_collaborations", "collaborators"
   add_foreign_key "permit_collaborations", "permit_applications"
-  add_foreign_key "permit_projects", "collaborators", column: "review_delegatee_id"
+  add_foreign_key "permit_project_collaborations", "collaborators"
+  add_foreign_key "permit_project_collaborations", "permit_projects"
   add_foreign_key "permit_projects", "jurisdictions"
   add_foreign_key "permit_projects", "users", column: "owner_id"
   add_foreign_key "permit_type_required_steps", "jurisdictions"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -554,32 +554,32 @@ if north_van_projects.size >= 10
 
   puts "  ✓ Distributed #{[state_distribution.size, north_van_projects.size].min} projects across kanban states"
 
-  puts "Assigning project review delegatees..."
+  puts "Assigning project review collaborators..."
   reviewer_collab = north_van.collaborators.find_by(user: reviewer_user)
   rm_collab =
     north_van.collaborators.find_by(
       user: User.find_by(omniauth_username: "review_manager")
     )
 
-  delegatee_projects =
+  collab_projects =
     north_van_projects
       .select do |p|
         p.reload.state.in?(%w[in_progress ready permit_issued active])
       end
       .first(8)
 
-  delegatee_projects.each_with_index do |project, idx|
+  collab_projects.each_with_index do |project, idx|
     collab = idx.even? ? reviewer_collab : rm_collab
     next unless collab
 
-    project.assign_review_delegatee!(collab.id)
+    project.assign_project_review_collaborator!(collab.id)
   rescue => e
     Rails.logger.warn(
-      "Seed: failed to assign delegatee for project #{project.id}: #{e.message}"
+      "Seed: failed to assign review collaborator for project #{project.id}: #{e.message}"
     )
   end
 
-  puts "  ✓ Assigned review delegatees to #{delegatee_projects.size} projects"
+  puts "  ✓ Assigned review collaborators to #{collab_projects.size} projects"
 end
 
 PermitApplication.reindex

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -616,7 +616,13 @@ RSpec.describe NotificationService do
 
   describe ".publish_permit_collaboration_assignment_event / .publish_permit_collaboration_unassignment_event" do
     it "pushes assignment/unassignment notification payloads" do
-      collaborator = instance_double("Collaborator", user_id: "u1")
+      preference =
+        instance_double(
+          "Preference",
+          enable_in_app_collaboration_notification: true
+        )
+      user = instance_double("User", id: "u1", preference: preference)
+      collaborator = instance_double("Collaborator", user_id: "u1", user: user)
       permit_collaboration =
         instance_double(
           "PermitCollaboration",


### PR DESCRIPTION
## 📋 Description

> Reworks the project review collaborator feature so that project-level reviewer assignments are independent of permit application assignments. Previously, a single "review delegatee" FK on `permit_projects` auto-synced to child applications. This PR introduces a join table (`permit_project_collaborations`) supporting multiple collaborators per project with dedicated email and in-app notifications, all gated by a unified collaboration preference.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-4864](https://hous-bssb.atlassian.net/browse/HUB-4864) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- **New `permit_project_collaborations` join table**: Replaces the single `review_delegatee_id` FK on `permit_projects`. Includes a data migration of existing delegatee assignments and drops the old column.
- **Multiple project review collaborators**: A project can now have many review collaborators assigned independently of per-application collaborators. Frontend popover and sidebar components reworked to list, add, and remove multiple collaborators.
- **Dedicated notifications**: New `notify_project_review_collaboration` mailer method + ERB template, and new `NotificationService` methods (`publish_project_collaboration_assignment_event` / `_unassignment_event`) for in-app notifications with correct jurisdiction-scoped links.
- **Unified preference gating**: Both email and in-app notifications for all collaboration types (application-level and project-level) are now gated on `enable_email_collaboration_notification` / `enable_in_app_collaboration_notification` preferences.
- **Model validation**: `PermitProjectCollaboration` validates that the assigned collaborator is review staff for the project's jurisdiction via `review_staff_of?`.
- **Controller & policy updates**: Renamed `assign_review_delegatee` / `unassign_review_delegatee` to `assign_project_review_collaborator` / `unassign_project_review_collaborator` across controller, routes, and policy.
- **Blueprint & frontend model**: New `PermitProjectCollaborationBlueprint`; `PermitProjectBlueprint` updated to serialize the new association. MST model updated with `permitProjectCollaborations` array and corresponding actions.
- **i18n cleanup**: Removed stale `delegateeDescription`, `overrideConfirmTitle`, `overrideConfirmBody` keys; renamed `projectReviewDelegatee` → `projectReviewCollaborators`.
- **Dead code removal**: Removed `auto_assign_project_review_delegatee` from `PermitApplication` and all commented-out sync/auto-assign code.
- **Spec updates**: Updated `NotificationService` spec to stub the new preference chain on collaborator doubles.

---

## 🧪 Steps to QA

1. Check out this branch: `git checkout HUB-4864-story-review-interaction-between-project-assignee-and-permitapp-assignee`
2. Run `bundle exec rails db:migrate` to apply the new migration
3. Start the app and log in as a Review Manager for a jurisdiction with the designated reviewer feature enabled
4. Navigate to the Submission Inbox (projects view)
5. Click the collaborator avatar/icon on a project row — verify the popover shows a list of current collaborators and a selector to add more
6. Assign multiple review collaborators to a single project — verify each assignment succeeds and the avatars update
7. Unassign a collaborator — verify the collaborator is removed from the list
8. Check that the assigned collaborator receives:
   - An **email** notification (check Sidekiq/mail logs)
   - An **in-app** notification with a link in the format `/jurisdictions/<slug>/submission-inbox/projects/<id>/overview`
9. Click the notification link — verify it navigates to the correct project overview page
10. Open the Project Collaborators sidebar (via the Users icon) — verify it lists project-level collaborators separately from per-application collaborators
11. Toggle the collaboration notification preferences off in the collaborator's profile — verify no email or in-app notification is sent on subsequent assignment
12. Verify that assigning a project collaborator does **not** auto-assign them to child permit applications
13. Run specs: `bundle exec rspec spec/services/notification_service_spec.rb`

**Expected Behaviour:**
> Multiple collaborators can be assigned/unassigned at the project level independently of application-level collaborators. Notifications are sent according to user preferences. Notification links navigate to the correct jurisdiction-scoped project overview.

**Before this change:**
> A single "review delegatee" was assigned via a FK on `permit_projects`, which auto-synced to child applications. No dedicated project-level notification existed.

**After this change:**
> Multiple project review collaborators are managed through a join table with dedicated email and in-app notifications, fully independent of per-application assignments.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [x] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-4864]: https://hous-bssb.atlassian.net/browse/HUB-4864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ