### PR TITLE
HUB-4524 rm rrm configuration api settings back navigation opens new api dialog

### DIFF
--- a/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
+++ b/app/frontend/components/domains/external-api-key/external-api-key-modal-sub-route.tsx
@@ -67,7 +67,7 @@ export const ExternalApiKeyModalSubRoute = observer(function ExternalApiKeyModal
   const [token, setToken] = useState("")
 
   const onClose = () => {
-    navigate(`/jurisdictions/${currentJurisdiction?.id}/api-settings`)
+    navigate(`/jurisdictions/${currentJurisdiction?.id}/api-settings`, { replace: true })
   }
 
   useEffect(() => {

--- a/app/frontend/components/domains/external-api-key/index.tsx
+++ b/app/frontend/components/domains/external-api-key/index.tsx
@@ -78,6 +78,7 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
               to={"create"}
               isDisabled={!externalApiEnabled}
               onClick={disableLinkClick}
+              replace
             >
               {t("externalApiKey.index.createExternalApiKey")}
             </RouterLinkButton>

--- a/app/frontend/components/domains/external-api-key/index.tsx
+++ b/app/frontend/components/domains/external-api-key/index.tsx
@@ -4,7 +4,7 @@ import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
-import { Outlet, useNavigate } from "react-router-dom"
+import { Outlet, useLocation, useNavigate } from "react-router-dom"
 import { datefnsTableDateFormat } from "../../../constants"
 import { useJurisdiction } from "../../../hooks/resources/use-jurisdiction"
 import { useMst } from "../../../setup/root"
@@ -28,6 +28,7 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
   const [isFetching, setIsFetching] = useState(false)
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const location = useLocation()
 
   useEffect(() => {
     if (currentJurisdiction) {
@@ -44,18 +45,23 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
   if (error) return <ErrorScreen error={error} />
   if (!currentUser || !currentJurisdiction) return <LoadingScreen />
 
+  const configurationManagementPath = `/jurisdictions/${currentJurisdiction.slug}/configuration-management`
+  const handleBack = () => {
+    // Check for a history entry; default is the initial location
+    if (location.key === "default") {
+      navigate(configurationManagementPath)
+    } else {
+      navigate(-1)
+    }
+  }
+
   const externalApiKeys = currentJurisdiction.externalApiKeys
   const externalApiEnabled = currentJurisdiction.externalApiEnabled
   const disableLinkClick = (e) => !externalApiEnabled && e.preventDefault()
 
   return (
     <Container maxW="container.lg" p={8} as={"main"} h={"full"} w={"full"} {...containerProps}>
-      <Button
-        variant="link"
-        onClick={() => navigate(`/jurisdictions/${currentJurisdiction?.slug}/configuration-management`)}
-        leftIcon={<CaretLeft size={20} />}
-        textDecoration="none"
-      >
+      <Button variant="link" onClick={handleBack} leftIcon={<CaretLeft size={20} />} textDecoration="none">
         {t("ui.back")}
       </Button>
       {/*This outlet will render the create/edit modal*/}

--- a/app/frontend/components/domains/external-api-key/index.tsx
+++ b/app/frontend/components/domains/external-api-key/index.tsx
@@ -50,7 +50,12 @@ export const ExternalApiKeysIndexScreen = observer(function ExternalApiKeysIndex
 
   return (
     <Container maxW="container.lg" p={8} as={"main"} h={"full"} w={"full"} {...containerProps}>
-      <Button variant="link" onClick={() => navigate(-1)} leftIcon={<CaretLeft size={20} />} textDecoration="none">
+      <Button
+        variant="link"
+        onClick={() => navigate(`/jurisdictions/${currentJurisdiction?.slug}/configuration-management`)}
+        leftIcon={<CaretLeft size={20} />}
+        textDecoration="none"
+      >
         {t("ui.back")}
       </Button>
       {/*This outlet will render the create/edit modal*/}

--- a/app/frontend/components/shared/navigation/router-link-button.tsx
+++ b/app/frontend/components/shared/navigation/router-link-button.tsx
@@ -1,8 +1,8 @@
 import { Button, ButtonProps } from "@chakra-ui/react"
 import React, { ReactElement, forwardRef } from "react"
-import { Link as ReactRouterLink } from "react-router-dom"
+import { Link as ReactRouterLink, LinkProps as ReactRouterLinkProps } from "react-router-dom"
 
-export interface IRouterLinkButtonProps extends ButtonProps {
+export interface IRouterLinkButtonProps extends ButtonProps, Omit<ReactRouterLinkProps, keyof ButtonProps> {
   to: string
   icon?: ReactElement
 }


### PR DESCRIPTION
## 📋 Description

Fix navigation issues caused by browser history stack management.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

[HUB-4524](https://hous-bssb.atlassian.net/browse/HUB-4524)

---

## ✨ Features / Changes Introduced

- Replace browser state instead of pushing new state when clicking the create button. 
- Prefer navigation to the previous page; if it doesn't exist use configuration-management screen as a default.

---

## 🧪 Steps to QA

1. Open the API Settings screen
2. Click create
3. Close it
4. Click back

**Expected Behaviour:**
Return to the previous page

**Before this change:**
Returns to the pushed state, i.e. the modal

**After this change:**
Returns to the previous page

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [x] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [x] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others


[HUB-4524]: https://hous-bssb.atlassian.net/browse/HUB-4524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ