### PR TITLE
HUB-4814 update inviter and spec

### DIFF
--- a/app/services/jurisdiction/user_inviter.rb
+++ b/app/services/jurisdiction/user_inviter.rb
@@ -33,8 +33,12 @@ class Jurisdiction::UserInviter
         else
           handle_reinvitation_or_invitation(user, user_params, jurisdiction_id)
         end
-      rescue StandardError
-        results[:failed] << { email: user_params[:email] }
+      rescue StandardError => e
+        Rails.logger.error(
+          "UserInviter failed for #{user_params[:email]}: #{e.class}: #{e.message}"
+        )
+        Rails.logger.error(e.backtrace.first(10).join("\n")) if e.backtrace
+        results[:failed] << { email: user_params[:email], error: e.message }
       end
     end
   end
@@ -51,13 +55,31 @@ class Jurisdiction::UserInviter
   def find_existing_invited_user(email, selected_role)
     # Inviting submitters causes a second user to be created with the same email
     # After accepting the invite, only the non-submitter User remains
-    users = User.where.not(role: :submitter).where(email: email.strip)
+    #
+    # Devise downcases email on save (case_insensitive_keys default), so we
+    # must normalize the search term to match.
+    normalized = email.to_s.strip.downcase
+    base =
+      User.where.not(role: :submitter).where("LOWER(email) = ?", normalized)
 
     if selected_role.to_sym == :regional_review_manager
-      users.find_by(role: :review_manager) ||
-        users.find_by(role: :regional_review_manager) || users.first
+      # Prefer a kept RM, then a kept RRM, then any discarded RM/RRM
+      # (promote_to_regional_rm will un-discard). Do NOT fall back to a
+      # non-manager row so that "create alongside" can happen when only
+      # non-managers share this email.
+      base.kept.where(role: :review_manager).order(:created_at).first ||
+        base
+          .kept
+          .where(role: :regional_review_manager)
+          .order(:created_at)
+          .first ||
+        base
+          .discarded
+          .where(role: %i[review_manager regional_review_manager])
+          .order(:created_at)
+          .first
     else
-      users.first
+      base.kept.order(:created_at).first || base.order(:created_at).first
     end
   end
 
@@ -67,28 +89,31 @@ class Jurisdiction::UserInviter
 
   def should_promote_to_regional_rm?(user, selected_role, jurisdiction_id)
     selected_role.to_sym == :regional_review_manager && user.present? &&
-      !user.discarded? && user.promotable_to_regional_rm? &&
-      jurisdiction_id.present?
+      user.promotable_to_regional_rm? && jurisdiction_id.present?
   end
 
   def promote_to_regional_rm(user, jurisdiction_id)
-    # May already be RRM, in which case this method just adds new jurisdiction memberships
-    user.update(role: :regional_review_manager)
+    # May already be RRM, in which case this method just adds new jurisdiction
+    # memberships. If the user was discarded, we revive them as part of the
+    # promotion (the caller has already decided they should be promoted).
+    ActiveRecord::Base.transaction do
+      user.undiscard if user.discarded?
+      user.update!(role: :regional_review_manager)
 
-    membership =
-      user
-        .jurisdiction_memberships
-        .find_or_create_by(jurisdiction_id: jurisdiction_id) do |_|
-          if user.confirmed?
-            PermitHubMailer.new_jurisdiction_membership(
-              user,
-              jurisdiction_id
-            ).deliver_later
-          end
+      Array(jurisdiction_id).each do |jid|
+        created = false
+        membership =
+          user
+            .jurisdiction_memberships
+            .find_or_create_by!(jurisdiction_id: jid) { created = true }
+        membership.touch
+        if created && user.confirmed?
+          PermitHubMailer.new_jurisdiction_membership(user, jid).deliver_later
         end
+      end
 
-    membership.touch
-    user.invite!(inviter) unless user.confirmed?
+      user.invite!(inviter) unless user.confirmed?
+    end
   end
 
   def handle_reinvitation_or_invitation(user, user_params, jurisdiction_id)

--- a/spec/services/jurisdiction/user_inviter_spec.rb
+++ b/spec/services/jurisdiction/user_inviter_spec.rb
@@ -121,9 +121,111 @@ RSpec.describe Jurisdiction::UserInviter, type: :service do
     context "and only a super_admin exists with that email (no RM)" do
       let!(:existing_super_admin) { create(:user, :super_admin, email:) }
 
-      it "reports email_taken since there is no promotable user" do
+      it "creates a new RRM row alongside the existing super_admin" do
+        expect { subject.call }.to change { User.count }.by(1)
+      end
+
+      it "does not report email_taken" do
         service = subject.call
-        expect(service.results[:email_taken]).to include(existing_super_admin)
+        expect(service.results[:email_taken]).to be_empty
+      end
+
+      it "does not modify the existing super_admin" do
+        expect { subject.call }.not_to change {
+          existing_super_admin.reload.role
+        }
+      end
+
+      it "places the newly created RRM in invited results" do
+        service = subject.call
+        new_user =
+          User.where(email:).where.not(id: existing_super_admin.id).first
+        expect(service.results[:invited]).to include(new_user)
+      end
+    end
+
+    context "and a discarded RM plus a kept super_admin exist with that email" do
+      let!(:existing_rm) do
+        create(
+          :user,
+          :review_manager,
+          email:,
+          discarded_at: Time.current - 1.week
+        )
+      end
+      let!(:existing_super_admin) { create(:user, :super_admin, email:) }
+
+      it "un-discards and promotes the RM instead of reporting email_taken" do
+        subject.call
+        existing_rm.reload
+        expect(existing_rm.regional_review_manager?).to be(true)
+        expect(existing_rm.discarded_at).to be_nil
+      end
+
+      it "does not report email_taken" do
+        service = subject.call
+        expect(service.results[:email_taken]).to be_empty
+      end
+
+      it "does not create a new user" do
+        expect { subject.call }.not_to change { User.count }
+      end
+    end
+
+    context "when the invite email differs from the stored email only by case" do
+      let(:stored_email) { "admin@example.com" }
+      let(:email) { "Admin@Example.COM" }
+      let!(:existing_rm) { create(:user, :review_manager, email: stored_email) }
+
+      it "finds and promotes the existing RM" do
+        expect { subject.call }.to change {
+          existing_rm.reload.regional_review_manager?
+        }.to(true)
+      end
+
+      it "does not create a new user" do
+        expect { subject.call }.not_to change { User.count }
+      end
+    end
+
+    context "when multiple kept RMs share the same email" do
+      let!(:older_rm) do
+        user = create(:user, :review_manager, email:)
+        user.update_column(:created_at, 2.days.ago)
+        user
+      end
+      let!(:newer_rm) do
+        user = create(:user, :review_manager, email:)
+        user.update_column(:created_at, 1.day.ago)
+        user
+      end
+
+      it "deterministically promotes the oldest kept RM" do
+        subject.call
+        expect(older_rm.reload.regional_review_manager?).to be(true)
+        expect(newer_rm.reload.review_manager?).to be(true)
+      end
+    end
+
+    context "when promotion raises an error" do
+      let!(:existing_rm) { create(:user, :review_manager, email:) }
+
+      before do
+        allow_any_instance_of(User).to receive(:update!).and_raise(
+          ActiveRecord::RecordInvalid.new(existing_rm)
+        )
+      end
+
+      it "records the error message on results[:failed]" do
+        service = subject.call
+        expect(service.results[:failed]).to include(
+          hash_including(email:, error: kind_of(String))
+        )
+      end
+
+      it "does not add the user to invited results" do
+        service = subject.call
+        expect(service.results[:invited]).not_to include(existing_rm)
       end
     end
   end


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...HUB-4814-bug-admin-user-config-unable-to-add-rrm-to-a-jurisdiction-email-taken` (merge-base range).

Admins have been hitting an intermittent "email taken" response when inviting an existing review manager as a regional review manager (RRM), even though the flow is supposed to promote the matching manager and add the new jurisdiction. `Jurisdiction::UserInviter` is the service behind this and it had several latent issues that, combined with the fact that `users.email` is not unique, made the outcome depend on the exact mix of rows that happened to share the email:

- The email lookup was case-sensitive (`where(email: email.strip)`) while Devise downcases emails on save, so any mixed-case invite payload would miss the existing manager and fall through to creating a duplicate row.
- A discarded review_manager row would be returned by the lookup (no `kept` filter), then silently fail both the "promote" and "email_taken" gates, landing in the reinvite branch and destructively wiping `confirmed_at` / replacing jurisdictions instead of performing the intended promotion.
- When only a non-manager row (super_admin / technical_support / reviewer) shared the email and no RM/RRM existed, the service reported `email_taken` even though emails aren't unique and we could legitimately create an RRM alongside.
- Queries had no `ORDER BY`, so with multiple rows of the same role/email, Postgres could return different winners across environments.
- `user.update(...)` return values were ignored in the promote path, so validation failures were reported as successes.
- `rescue StandardError` swallowed the exception, making the incident extremely hard to diagnose in production.

The refactor normalizes lookups, makes the promotion path transactional and idempotent (including un-discarding a stale RM when promotion is intended), falls through to creating a new RRM row when only non-managers share the email, and surfaces real errors both in `Rails.logger` and on `results[:failed]`.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | Fixes [HUB-4814](https://hous-bssb.atlassian.net/browse/HUB-4814) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- `find_existing_invited_user` now normalizes the incoming email with `strip.downcase` and queries with `LOWER(email) = ?`, matching Devise's `case_insensitive_keys` normalization so mixed-case invites no longer miss existing managers.
- For RRM invites the lookup preference is now explicit and deterministic: kept review_manager → kept regional_review_manager → discarded RM/RRM (with `ORDER BY created_at`), and it deliberately does not fall back to a non-manager row.
- When only a non-manager row (super_admin / technical_support / reviewer) shares the email and no RM/RRM exists, the service falls through to `invite_new_user` and creates a brand-new RRM row alongside the existing user instead of reporting `email_taken`.
- `should_promote_to_regional_rm?` no longer blocks on `discarded?`; `promote_to_regional_rm` un-discards the user when needed so a stale soft-deleted RM is revived and promoted instead of being silently reinvited through the wrong branch.
- `promote_to_regional_rm` is now wrapped in a single `ActiveRecord::Base.transaction`, uses `update!` and `find_or_create_by!`, iterates `Array(jurisdiction_id)` (fixing a latent bug where an array of jurisdiction IDs was being passed as-is to `find_or_create_by`), and only fires `PermitHubMailer.new_jurisdiction_membership` when a membership was actually created and the user is confirmed.
- The top-level `rescue StandardError` now logs class/message and the first 10 backtrace lines, and attaches `error: e.message` to `results[:failed]` so incident debugging is possible going forward.
- Spec coverage added for: case-only mismatch between invite and stored email, discarded-RM + kept-super_admin revive-and-promote, create-new-RRM-alongside-super_admin, deterministic oldest-kept-RM selection when multiple match, and failure-path reporting on `results[:failed]`.

---

## 🧪 Steps to QA

> Provide clear, reproducible steps for the reviewer/QA engineer to verify the changes.

1. Log in as a super admin.
2. **Case-sensitivity fix** — Ensure an existing review manager exists with email `rm@example.com` (lowercase). Go to the admin user config and invite `RM@Example.COM` as a regional review manager for a new jurisdiction. Verify the existing RM is promoted to RRM and the new jurisdiction is added; no duplicate user row is created and the response does not say "email taken".
3. **Intermittent "email taken" fix** — Find (or seed) a case where the email has both a confirmed super_admin / technical_support / reviewer and a kept review_manager. Invite that email as regional review manager. Verify the RM is promoted and a membership is added to the new jurisdiction; the response does not report "email taken".
4. **Discarded RM revive** — Archive (soft-delete) a review manager, then invite that email as a regional review manager for a new jurisdiction. Verify the archived user is restored (no longer archived), role is updated to regional review manager, and the new jurisdiction membership is added.
5. **Create-alongside** — Take an email that only has a super_admin account (no RM/RRM) and invite it as a regional review manager for a jurisdiction. Verify a new regional review manager user is created and the existing super_admin is unchanged.
6. **Existing behavior preserved** — Re-run the normal flows (inviting a brand-new reviewer, re-inviting an unconfirmed reviewer, re-inviting a discarded reviewer) and confirm they still behave as before.
7. **Error visibility** — If you trigger a genuine validation failure during invite (e.g. via the backend), confirm the response's `failed` entry now includes an `error` message and that the server log has the "UserInviter failed for ..." line with a class and backtrace.

**Expected Behaviour:**
> Inviting an email that has an existing review manager / regional review manager as a regional review manager always finds that existing user and promotes / adds the jurisdiction, regardless of case or archived status of the RM. Non-manager rows sharing the email no longer block the invite. "email taken" is only returned when we genuinely cannot create or promote anyone.

**Before this change:**
> Admin sometimes saw "email taken" when trying to add an existing review manager to a new jurisdiction as a regional review manager. A discarded RM could be silently resurrected through the reinvite path instead of being promoted. Mixed-case email invites created duplicate user rows.

**After this change:**
> Promotion reliably finds the existing manager (case-insensitive, ordered, kept-first, discarded-fallback). Discarded managers are explicitly revived as part of promotion. Non-manager rows with the same email no longer block invite. Failures are surfaced with a real error message.

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4814]: https://hous-bssb.atlassian.net/browse/HUB-4814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ