### PR TITLE
touchups for about page pr

### DIFF
--- a/app/frontend/components/domains/jurisdictions/jurisdiction-about-snippet-cards.tsx
+++ b/app/frontend/components/domains/jurisdictions/jurisdiction-about-snippet-cards.tsx
@@ -81,16 +81,12 @@ function OfficeAddressSnippetCard({
 
 export const JurisdictionAboutSnippetCards = observer(({ control, canManage }: IJurisdictionAboutSnippetCardsProps) => {
   const { t } = useTranslation()
-  const { trigger, getValues } = useFormContext()
+  const { trigger } = useFormContext()
   const [editingField, setEditingField] = useState<TEditableSnippetFieldName | null>(null)
-  const watchedSnippets = useWatch({
+  const snippetValues = useWatch({
     control,
     name: ["processingTimeHtml", "keyStagesHtml", "officeAddress"],
   })
-
-  const snippetValues = Array.isArray(watchedSnippets)
-    ? watchedSnippets
-    : [getValues("processingTimeHtml"), getValues("keyStagesHtml"), getValues("officeAddress")]
 
   const visibleFields = SNIPPET_FIELD_ORDER.filter((_, i) => {
     if (canManage) return true

--- a/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
@@ -147,6 +147,8 @@ const JurisdictionScreenBody = observer(
       </HeroBanner>
     )
 
+    const { mapPosition, mapZoom } = getDefaultJurisdictionValuesForJurisdiction(currentJurisdiction)
+
     return (
       <Flex as="main" direction="column" w="full" bg="greys.white">
         <FormProvider {...formMethods}>
@@ -175,8 +177,8 @@ const JurisdictionScreenBody = observer(
                     </GridItem>
                     <GridItem order={{ base: 1, md: 2 }} minW={0}>
                       <JurisdictionMap
-                        mapPosition={currentJurisdiction.mapPosition}
-                        mapZoom={currentJurisdiction.mapZoom}
+                        mapPosition={mapPosition}
+                        mapZoom={mapZoom}
                         linePositions={currentJurisdiction.boundaryPoints}
                       />
                     </GridItem>

--- a/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/jurisdiction-screen.tsx
@@ -131,26 +131,28 @@ const JurisdictionScreenBody = observer(
         currentJurisdiction?.officeEmail
       ) ||
       (currentJurisdiction?.contacts?.length ?? 0) > 0
+    const heroBanner = (
+      <HeroBanner containerProps={{ pl: 8, pr: { base: 18, md: 8 }, py: 16 }}>
+        <HighlightedLayout p={8} gap="18px" maxW={{ md: "calc((200% - var(--chakra-space-6)) / 3)", base: "full" }}>
+          <Heading as="h1" mb={0} fontSize="2xl">
+            {qualifiedName}
+          </Heading>
+          <Text fontSize="lg">{t("jurisdiction.heroBannerDescription", { jurisdictionName: qualifiedName })}</Text>
+          <JurisdictionHeroLgWebsiteRow
+            canManageAbout={canManageAbout}
+            jurisdictionName={qualifiedName}
+            persistedWebsiteUrl={currentJurisdiction.websiteUrl ?? ""}
+          />
+        </HighlightedLayout>
+      </HeroBanner>
+    )
+
     return (
       <Flex as="main" direction="column" w="full" bg="greys.white">
         <FormProvider {...formMethods}>
-          <HeroBanner containerProps={{ pl: 8, pr: { base: 18, md: 8 }, py: 16 }}>
-            <HighlightedLayout p={8} gap="18px" maxW={{ md: "calc((200% - var(--chakra-space-6)) / 3)", base: "full" }}>
-              <Heading as="h1" mb={0} fontSize="2xl">
-                {qualifiedName}
-              </Heading>
-              <Text fontSize="lg">{t("jurisdiction.heroBannerDescription", { jurisdictionName: qualifiedName })}</Text>
-              <JurisdictionHeroLgWebsiteRow
-                canManageAbout={canManageAbout}
-                jurisdictionName={qualifiedName}
-                persistedWebsiteUrl={currentJurisdiction.websiteUrl ?? ""}
-              />
-            </HighlightedLayout>
-          </HeroBanner>
-        </FormProvider>
-        {currentUser?.isReviewStaff || showAboutPage ? (
-          <FormProvider {...formMethods}>
-            <form onSubmit={formMethods.handleSubmit(onSubmit)} className="space-y-8 divide-y divide-gray-200">
+          {currentUser?.isReviewStaff || showAboutPage ? (
+            <form onSubmit={formMethods.handleSubmit(onSubmit)}>
+              {heroBanner}
               {(hasAboutSnippets || canManageAbout) && (
                 <Container maxW="container.lg" p={8}>
                   <JurisdictionAboutSnippetCards control={control} canManage={canManageAbout} />
@@ -418,44 +420,47 @@ const JurisdictionScreenBody = observer(
                 </Can>
               </Container>
             </form>
-          </FormProvider>
-        ) : (
-          <Container maxW="container.lg" py={{ base: 6, md: 16 }} px={8}>
-            <Box>
-              <Heading as="h2" fontSize="2xl" fontWeight="bold" mb={6}>
-                {t("jurisdiction.notUsingBPH.title")}
-              </Heading>
-              <Text fontSize="lg" mb={2}>
-                {t("jurisdiction.notUsingBPH.description")}
-              </Text>
-              <Text fontSize="lg" mb={8}>
-                {t("jurisdiction.notUsingBPH.noInfo", { jurisdictionName: qualifiedName })}
-              </Text>
-              <Box bg="theme.blueLight" borderRadius="lg" p={8} mb={8}>
-                <Heading as="h3" fontSize="xl" fontWeight="bold" mb={4}>
-                  {t("jurisdiction.notUsingBPH.wantToUse.title")}
-                </Heading>
-                <Text fontSize="md" mb={2}>
-                  {t("jurisdiction.notUsingBPH.wantToUse.description")}
-                </Text>
-                <Text fontSize="md" mb={6}>
-                  {t("jurisdiction.notUsingBPH.wantToUse.emailButtonDescription")}
-                </Text>
-                <Button
-                  as="a"
-                  href={mailtoHref}
-                  variant="primary"
-                  size="lg"
-                  rightIcon={<ArrowSquareOut />}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {t("jurisdiction.notUsingBPH.wantToUse.emailButtonText")}
-                </Button>
-              </Box>
-            </Box>
-          </Container>
-        )}
+          ) : (
+            <>
+              {heroBanner}
+              <Container maxW="container.lg" py={{ base: 6, md: 16 }} px={8}>
+                <Box>
+                  <Heading as="h2" fontSize="2xl" fontWeight="bold" mb={6}>
+                    {t("jurisdiction.notUsingBPH.title")}
+                  </Heading>
+                  <Text fontSize="lg" mb={2}>
+                    {t("jurisdiction.notUsingBPH.description")}
+                  </Text>
+                  <Text fontSize="lg" mb={8}>
+                    {t("jurisdiction.notUsingBPH.noInfo", { jurisdictionName: qualifiedName })}
+                  </Text>
+                  <Box bg="theme.blueLight" borderRadius="lg" p={8} mb={8}>
+                    <Heading as="h3" fontSize="xl" fontWeight="bold" mb={4}>
+                      {t("jurisdiction.notUsingBPH.wantToUse.title")}
+                    </Heading>
+                    <Text fontSize="md" mb={2}>
+                      {t("jurisdiction.notUsingBPH.wantToUse.description")}
+                    </Text>
+                    <Text fontSize="md" mb={6}>
+                      {t("jurisdiction.notUsingBPH.wantToUse.emailButtonDescription")}
+                    </Text>
+                    <Button
+                      as="a"
+                      href={mailtoHref}
+                      variant="primary"
+                      size="lg"
+                      rightIcon={<ArrowSquareOut />}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {t("jurisdiction.notUsingBPH.wantToUse.emailButtonText")}
+                    </Button>
+                  </Box>
+                </Box>
+              </Container>
+            </>
+          )}
+        </FormProvider>
       </Flex>
     )
   }

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -93,12 +93,26 @@ class Jurisdiction < ApplicationRecord
   validates :processing_time_html, length: { maximum: 140 }, allow_blank: true
   validates :key_stages_html, length: { maximum: 140 }, allow_blank: true
   validates :office_address, length: { maximum: 500 }, allow_blank: true
+  validates :office_hours, length: { maximum: 500 }, allow_blank: true
   validates :office_email,
             format: {
               with: URI::MailTo::EMAIL_REGEXP
             },
+            length: {
+              maximum: 255
+            },
             allow_blank: true
-  validates :office_telephone, phone: true, allow_blank: true
+  validates :office_telephone,
+            phone: true,
+            length: {
+              maximum: 128
+            },
+            allow_blank: true
+  validates :timeline_and_deliverables_html,
+            length: {
+              maximum: 10_000
+            },
+            allow_blank: true
   validate :inbox_enabled_requires_inbox_setup
   validate :no_duplicate_part3_occupancy_pathways
 


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff HUB-4770-review-manager-can-edit-all-new-about-page-content-sections...HEAD` (merge-base range).

Addresses review feedback on the about-page content-sections feature branch. Fixes a bug where the website URL hero row was rendered outside the `<form>`, making edits unpersistable via the Save button. Adds missing server-side length validations for several new jurisdiction fields to match the existing frontend caps. Removes dead code in the snippet cards component.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-4770](https://hous-bssb.atlassian.net/browse/HUB-4770) |
| 📄 Related PR(s) | <!-- parent about-page PR --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- **Fix: website URL now inside the save form** — Consolidated two sibling `<FormProvider>` instances into one. The hero banner (containing `JurisdictionHeroLgWebsiteRow`) is now rendered inside the `<form>` in the about-page branch, so editing the website URL is actually submitted when the user clicks Save. In the "not using BPH" branch the hero renders read-only within the same `FormProvider`.
- **Add missing server-side length validations** — Added `validates :office_hours, length: { maximum: 500 }`, `validates :office_email, length: { maximum: 255 }`, `validates :office_telephone, length: { maximum: 128 }`, and `validates :timeline_and_deliverables_html, length: { maximum: 10_000 }` to the Jurisdiction model, matching the frontend caps and closing a direct-API bypass.
- **Remove dead fallback branch in snippet cards** — `useWatch` with an array `name` always returns an array; removed the unreachable `Array.isArray` guard and the unused `getValues` destructure from `useFormContext`.

---

## 🧪 Steps to QA

1. Log in as a **Review Manager** for a jurisdiction with `showAboutPage` enabled.
2. Navigate to the jurisdiction's About page.
3. Click Edit on the **website URL** row in the hero banner, enter a URL, click Done.
4. Click the **Save** button at the bottom of the page.
5. Reload the page — verify the website URL persisted.
6. Try entering an invalid URL (e.g. `not a url`) and verify it shows a validation error.
7. Navigate to the **About Snippet Cards** (Processing Time, Key Stages) — verify editing and saving still works correctly.
8. Via API or console, attempt to set `office_hours` to a string >500 chars — verify the model rejects it with a validation error.
9. Repeat for `office_email` (>255 chars), `office_telephone` (>128 chars), and `timeline_and_deliverables_html` (>10,000 chars).

**Expected Behaviour:**
> Website URL edits persist after save. Server rejects overly long values for all new jurisdiction fields. Snippet cards render and filter correctly without console errors.

**Before this change:**
> The website URL field was outside the `<form>` — edits were lost on save. `office_hours`, `office_telephone`, `office_email`, and `timeline_and_deliverables_html` had no server-side length limits.

**After this change:**
> Website URL is part of the form submission. All new fields have matching server-side length caps. Dead code removed from snippet cards.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [x] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [x] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-4770]: https://hous-bssb.atlassian.net/browse/HUB-4770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ