### PR TITLE
allow finalize when no designated

### DIFF
--- a/app/frontend/components/domains/permit-application/designated-reviewer-modal.tsx
+++ b/app/frontend/components/domains/permit-application/designated-reviewer-modal.tsx
@@ -28,6 +28,8 @@ export const DesignatedReviewerModal = observer(({ isOpen, onClose, designatedRe
   const name = user?.name
   const organization = user?.organization
 
+  if (!user) return null
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="lg" isCentered>
       <ModalOverlay />

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -601,7 +601,7 @@ export const PermitApplicationModel = types.snapshotProcessor(
           return false
         }
 
-        return featureEnabled ? !designatedReviewerExists : designatedReviewerExists
+        return featureEnabled && designatedReviewerExists
       },
     }))
     .actions((self) => ({

--- a/app/policies/permit_application_policy.rb
+++ b/app/policies/permit_application_policy.rb
@@ -95,7 +95,10 @@ class PermitApplicationPolicy < ApplicationPolicy
 
     return true unless feature_enabled
 
-    record.permit_collaborations.review.exists?(collaborator_id: user.id)
+    designated_reviewer = record.permit_collaborations.review.delegatee.first
+    return true if designated_reviewer.nil?
+
+    designated_reviewer.collaborator.user_id == user.id
   end
 
   def create_permit_collaboration?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -705,3 +705,6 @@ end
 
 PermitApplication.reindex
 PermitProject.reindex
+
+puts "Running pending data migrations..."
+DataMigrate::DatabaseTasks.migrate


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...HUB-4905-story-unauthorized-access-when-no-designated-reviewer` (merge-base range).

Review staff could not send revision requests back to submitters when the designated-reviewer feature was enabled but no designated reviewer had been assigned to the application. Two bugs conspired to block this flow:

1. **Frontend (`shouldShowDesignatedReviewerModal`)** — the ternary `featureEnabled ? !designatedReviewerExists : designatedReviewerExists` was inverted, popping up the "contact the designated reviewer" modal even when nobody was assigned.
2. **Backend (`finalize_revision_requests?` policy)** — the authorization check `permit_collaborations.review.exists?(collaborator_id: user.id)` compared a user UUID against `collaborator_id` (a FK to `collaborators`, not `users`), and additionally denied *all* review staff whenever the feature was enabled but no designated reviewer existed, resulting in a 403.

The fix aligns both sides: the modal only appears when a designated reviewer is actually assigned and the current user isn't them; the policy allows any `review_staff` to finalize when no designated reviewer is assigned, and otherwise restricts to the designated reviewer via the correct join (`collaborator.user_id`).

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-4905](https://hous-bssb.atlassian.net/browse/HUB-4905) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Fix inverted logic in `PermitApplication#shouldShowDesignatedReviewerModal` so the modal only appears when a designated reviewer is actually assigned (and the current user is not them).
- Harden `DesignatedReviewerModal` to render nothing when no user is present, preventing a broken empty "DESIGNATED REVIEWER" label rendering as a disabled-input-looking box.
- Fix `PermitApplicationPolicy#finalize_revision_requests?`: use the correct association (`collaborator.user_id`) instead of comparing a user UUID against the `collaborator_id` FK, and allow any review staff to finalize when the feature is enabled but no designated reviewer has been assigned.
- Seed: run pending data migrations at the end of `db/seeds.rb`.

---

## 🧪 Steps to QA

**Scenario A — Feature on, no designated reviewer assigned**

1. Ensure the site-wide and jurisdiction-level "Designated Reviewer" feature is enabled.
2. Sign in as a review manager in a jurisdiction with the feature enabled.
3. Open a submitted application that has **no designated reviewer** assigned.
4. Open "Request Revisions", add one or more revision requests, then click **Send to submitter**.
5. Verify the "Trying to send this revision request…" modal does **not** appear.
6. Confirm the standard "Send this list of revisions to the submitter?" dialog appears.
7. Confirm the send, and verify the request succeeds (no 403) and the application transitions to Revisions Requested.

**Scenario B — Feature on, designated reviewer assigned (you are NOT them)**

1. Assign a different user as the designated reviewer on a submitted application.
2. Sign in as a different review staff user.
3. Attempt to send revisions back to the submitter.
4. Verify the "Trying to send this revision request…" modal appears, listing the designated reviewer's name (and organization if present) inside a bordered box.
5. Verify submission is blocked from the backend as well.

**Scenario C — Feature on, you ARE the designated reviewer**

1. Assign yourself as the designated reviewer on a submitted application.
2. Create revision requests and send to submitter.
3. Verify no blocking modal, and the request succeeds.

**Scenario D — Feature off**

1. Disable the feature at site or jurisdiction level.
2. Verify any review staff can finalize revision requests as before.

**Expected Behaviour:**
> Review staff can send revision requests unless the designated-reviewer feature is enabled *and* a specific designated reviewer has been assigned to that application — in which case only that person can finalize.

**Before this change:**
> Review staff saw a "contact the designated reviewer" modal (with an empty bordered box since no reviewer existed) and, if they bypassed it, got a 403 from the backend. See screenshot of the broken empty modal in the ticket.

**After this change:**
> Modal only appears when there's someone to contact; backend permits any review staff to finalize when no designated reviewer has been assigned.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML**
- [x] Additional context added through `aria-roles` and `aria-labels` where needed (Chakra Modal provides these)
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors
- [x] Usable with a **keyboard** and navigable in a **logical order**
- [ ] Usable with a **screen reader**
- [x] **Colour contrast** meets minimum AA ratio
- [x] No content relies on **colour alone** to convey meaning
- [x] All images have meaningful **alt text** (no new images)

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x

[HUB-4905]: https://hous-bssb.atlassian.net/browse/HUB-4905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ