### PR TITLE
HUB-4722 revert search grid item padding change

### DIFF
--- a/app/frontend/components/shared/grid/search-grid-item.tsx
+++ b/app/frontend/components/shared/grid/search-grid-item.tsx
@@ -8,8 +8,7 @@ interface ISearchGridItemProps extends GridItemProps {
 export const SearchGridItem = ({ children, ...rest }: ISearchGridItemProps) => {
   return (
     <GridItem
-      px={4}
-      py={2}
+      p={4}
       display="flex"
       justifyContent="flex-start"
       alignItems="center"


### PR DESCRIPTION
## 📋 Description

Revert a change that modified padding of search grid items

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

[HUB-4722](https://hous-bssb.atlassian.net/browse/HUB-4722)

---

## ✨ Features / Changes Introduced

- Switch SearchGridItem padding back to 16px on left, top, right, and bottom.

---

## 🧪 Steps to QA

1. Open the Jurisdictions page and observe padding

**Expected Behaviour:**
Padding is 16px on all sides

**Before this change:**
Padding was 8px on the vertical axis

**After this change:**
Padding is 16px on all sides

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [x] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [x] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others


[HUB-4722]: https://hous-bssb.atlassian.net/browse/HUB-4722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ