### PR TITLE
Hub 4742 story reviewer can assign a reviewer to any project or application directly from the submissions index submissions index via unified multi view workspace rework

### DIFF
--- a/app/blueprints/jurisdiction_blueprint.rb
+++ b/app/blueprints/jurisdiction_blueprint.rb
@@ -86,5 +86,9 @@ class JurisdictionBlueprint < Blueprinter::Base
         sandbox: options[:current_sandbox]
       )
     end
+
+    field :unviewed_projects_count do |jurisdiction, options|
+      jurisdiction.unviewed_projects_count(sandbox: options[:current_sandbox])
+    end
   end
 end

--- a/app/blueprints/permit_project_blueprint.rb
+++ b/app/blueprints/permit_project_blueprint.rb
@@ -54,13 +54,14 @@ class PermitProjectBlueprint < Blueprinter::Base
   view :jurisdiction_review_inbox do
     include_view :base
 
-    field :aggregated_review_collaborators,
-          if: ->(_field_name, permit_project, options) do
-            options[:current_user]&.review_staff_of?(
-              permit_project.jurisdiction_id
-            )
-          end do |permit_project, _options|
-      permit_project.aggregated_review_collaborators
+    association :review_delegatee,
+                blueprint: CollaboratorBlueprint,
+                if: ->(_field_name, permit_project, options) do
+                  options[:current_user]&.review_staff_of?(
+                    permit_project.jurisdiction_id
+                  )
+                end do |permit_project, _options|
+      permit_project.review_delegatee
     end
 
     association :permit_project_collaborations,

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/application-inbox-table.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/application-inbox-table.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Box,
   Circle,
   Flex,
@@ -11,12 +10,11 @@ import {
   MenuItem,
   MenuList,
   Portal,
-  Spinner,
   Text,
   Tooltip,
   VStack,
 } from "@chakra-ui/react"
-import { Info, Swap, UserPlus } from "@phosphor-icons/react"
+import { Info, Swap } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React, { useMemo } from "react"
 import { useTranslation } from "react-i18next"
@@ -41,9 +39,9 @@ import { SearchGridItem } from "../../../shared/grid/search-grid-item"
 import { SearchGridRow } from "../../../shared/grid/search-grid-row"
 import { PermitApplicationStatusTag } from "../../../shared/permit-applications/permit-application-status-tag"
 import { SortIcon } from "../../../shared/sort-icon"
-import { SharedAvatar } from "../../../shared/user/shared-avatar"
 import { DesignatedCollaboratorAssignmentPopover } from "../../permit-application/collaborator-management/designated-collaborator-assignment-popover"
 import { InboxNoMatchingEmpty } from "./inbox-no-matching-empty"
+import { renderAssignPlusIconTrigger, ReviewAssigneesRow } from "./review-assignees-row"
 import { SubmissionInboxMarkUnreadIconButton } from "./submission-inbox-mark-unread-icon-button"
 
 interface IProps {
@@ -348,7 +346,12 @@ const ApplicationBlockLevelAndDesignatedAssigneesCell = observer(
     const { t } = useTranslation()
     const { permitApplicationStore } = useMst()
 
-    const blockLevelReviewAssigneeUsers = useMemo(() => {
+    const designatedReviewerUser = application.designatedReviewer?.collaborator?.user
+    const primaryAssignee = designatedReviewerUser
+      ? { id: designatedReviewerUser.id, name: designatedReviewerUser.name, role: designatedReviewerUser.role }
+      : null
+
+    const secondaryAssignees = useMemo(() => {
       const designatedReviewerUserId = application.designatedReviewer?.collaborator?.user?.id
       const seenUserIds = new Set<string>(designatedReviewerUserId ? [designatedReviewerUserId] : [])
       const users: { id: string; name: string; role: string }[] = []
@@ -364,72 +367,22 @@ const ApplicationBlockLevelAndDesignatedAssigneesCell = observer(
       return users
     }, [application])
 
-    const visibleBlockLevelReviewAssignees = blockLevelReviewAssigneeUsers.slice(
-      0,
-      MAX_VISIBLE_BLOCK_LEVEL_REVIEW_ASSIGNEE_AVATARS
-    )
-    const blockLevelReviewAssigneesOverflowCount =
-      blockLevelReviewAssigneeUsers.length - MAX_VISIBLE_BLOCK_LEVEL_REVIEW_ASSIGNEE_AVATARS
-    const hasDesignatedReviewer = !!application.designatedReviewer
-    const hasDesignatedReviewerOrBlockLevelReviewers = hasDesignatedReviewer || blockLevelReviewAssigneeUsers.length > 0
-
     return (
-      <HStack spacing={1}>
-        {hasDesignatedReviewerOrBlockLevelReviewers ? (
-          <>
-            {visibleBlockLevelReviewAssignees.map((user) => (
-              <SharedAvatar key={user.id} size="xs" name={user.name} role={user.role} fontSize="2xs" />
-            ))}
-            {blockLevelReviewAssigneesOverflowCount > 0 && (
-              <Avatar
-                size="xs"
-                name={`+${blockLevelReviewAssigneesOverflowCount}`}
-                getInitials={(name) => name}
-                bg="gray.200"
-                color="text.primary"
-                fontSize="2xs"
-              />
-            )}
-          </>
-        ) : (
-          <Text fontSize="sm" color="text.secondary">
-            {t("ui.unassigned")}
-          </Text>
-        )}
+      <ReviewAssigneesRow
+        primaryAssignee={primaryAssignee}
+        secondaryAssignees={secondaryAssignees}
+        maxSecondaryVisible={MAX_VISIBLE_BLOCK_LEVEL_REVIEW_ASSIGNEE_AVATARS}
+        emptyText={t("ui.unassigned")}
+      >
         <DesignatedCollaboratorAssignmentPopover
           permitApplication={application}
           collaborationType={ECollaborationType.review}
           onBeforeOpen={async () => {
             await permitApplicationStore.fetchPermitApplication(application.id, true)
           }}
-          renderTrigger={({ isLoading, existingDelegateeCollaboration, onClick, isDisabled }) => (
-            <IconButton
-              aria-label={t("permitCollaboration.sidebar.title")}
-              icon={
-                isLoading ? (
-                  <Spinner size="xs" />
-                ) : existingDelegateeCollaboration ? (
-                  <SharedAvatar
-                    size="xs"
-                    name={existingDelegateeCollaboration.collaborator?.user?.name}
-                    role={existingDelegateeCollaboration.collaborator?.user?.role}
-                    fontSize="2xs"
-                    border="2px solid"
-                    borderColor="theme.blueActive"
-                  />
-                ) : (
-                  <UserPlus size={14} />
-                )
-              }
-              size="xs"
-              variant="ghost"
-              borderRadius="full"
-              onClick={onClick}
-              isDisabled={isDisabled}
-            />
-          )}
+          renderTrigger={renderAssignPlusIconTrigger({ ariaLabel: t("permitCollaboration.sidebar.title") })}
         />
-      </HStack>
+      </ReviewAssigneesRow>
     )
   }
 )

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/application-inbox-table.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/application-inbox-table.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from "react-i18next"
 import { Link, useNavigate } from "react-router-dom"
 import { IPermitApplication } from "../../../../models/permit-application"
 import { IPermitProject } from "../../../../models/permit-project"
+import { IUser } from "../../../../models/user"
 import { useMst } from "../../../../setup/root"
 import { IPermitApplicationInboxStore } from "../../../../stores/submission-inbox-store"
 import {
@@ -346,26 +347,22 @@ const ApplicationBlockLevelAndDesignatedAssigneesCell = observer(
     const { t } = useTranslation()
     const { permitApplicationStore } = useMst()
 
-    const designatedReviewerUser = application.designatedReviewer?.collaborator?.user
-    const primaryAssignee = designatedReviewerUser
-      ? { id: designatedReviewerUser.id, name: designatedReviewerUser.name, role: designatedReviewerUser.role }
-      : null
+    const primaryAssignee = application.designatedReviewer?.collaborator?.user ?? null
 
     const secondaryAssignees = useMemo(() => {
-      const designatedReviewerUserId = application.designatedReviewer?.collaborator?.user?.id
-      const seenUserIds = new Set<string>(designatedReviewerUserId ? [designatedReviewerUserId] : [])
-      const users: { id: string; name: string; role: string }[] = []
+      const seenUserIds = new Set<string>(primaryAssignee ? [primaryAssignee.id] : [])
+      const users: IUser[] = []
 
       application.getCollaborationAssignees(ECollaborationType.review).forEach((collaboration) => {
         const user = collaboration.collaborator?.user
         if (user && !seenUserIds.has(user.id)) {
           seenUserIds.add(user.id)
-          users.push({ id: user.id, name: user.name, role: user.role })
+          users.push(user)
         }
       })
 
       return users
-    }, [application])
+    }, [application, primaryAssignee])
 
     return (
       <ReviewAssigneesRow

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/application-kanban-board.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/application-kanban-board.tsx
@@ -1,18 +1,5 @@
-import {
-  Avatar,
-  Box,
-  Icon,
-  IconButton,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
-  Portal,
-  Spinner,
-  Text,
-  Tooltip,
-} from "@chakra-ui/react"
-import { Swap, UserPlus } from "@phosphor-icons/react"
+import { Box, Icon, IconButton, Menu, MenuButton, MenuItem, MenuList, Portal, Text, Tooltip } from "@chakra-ui/react"
+import { Swap } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React, { useMemo } from "react"
 import { useTranslation } from "react-i18next"
@@ -21,10 +8,10 @@ import { IPermitApplication } from "../../../../models/permit-application"
 import { useMst } from "../../../../setup/root"
 import { colors } from "../../../../styles/theme/foundations/colors"
 import { ECollaborationType, EPermitApplicationStatus } from "../../../../types/enums"
-import { SharedAvatar } from "../../../shared/user/shared-avatar"
 import { DesignatedCollaboratorAssignmentPopover } from "../../permit-application/collaborator-management/designated-collaborator-assignment-popover"
 import { EReorderDirection, IKanbanColumn, IReorderEvent, KanbanBoard } from "./kanban-board"
 import { KanbanCard } from "./kanban-card"
+import { renderAssignPlusIconTrigger, ReviewAssigneesRow } from "./review-assignees-row"
 
 interface IProps {
   applications: IPermitApplication[]
@@ -134,25 +121,20 @@ const ApplicationKanbanCard = observer(function ApplicationKanbanCard({
   const isSandbox = !!application.sandbox
   const isUnread = !application.isViewed
 
-  const designatedReviewerUserId = application.designatedReviewer?.collaborator?.user?.id
+  const designatedReviewerUser = application.designatedReviewer?.collaborator?.user
+  const primaryAssignee = designatedReviewerUser
+    ? { id: designatedReviewerUser.id, name: designatedReviewerUser.name, role: designatedReviewerUser.role }
+    : null
 
-  const blockLevelReviewCollaborations = application.getCollaborationAssignees(ECollaborationType.review)
-  const seenUserIds = new Set<string>(designatedReviewerUserId ? [designatedReviewerUserId] : [])
-  const blockLevelReviewAssigneeUsers: { name: string; id: string; role: string }[] = []
-  for (const collab of blockLevelReviewCollaborations) {
+  const secondaryAssignees: { id: string; name: string; role: string }[] = []
+  const seenUserIds = new Set<string>(designatedReviewerUser ? [designatedReviewerUser.id] : [])
+  for (const collab of application.getCollaborationAssignees(ECollaborationType.review)) {
     const user = collab.collaborator?.user
     if (user && !seenUserIds.has(user.id)) {
       seenUserIds.add(user.id)
-      blockLevelReviewAssigneeUsers.push({ name: user.name, id: user.id, role: user.role })
+      secondaryAssignees.push({ id: user.id, name: user.name, role: user.role })
     }
   }
-
-  const visibleBlockLevelReviewAssignees = blockLevelReviewAssigneeUsers.slice(
-    0,
-    MAX_VISIBLE_BLOCK_LEVEL_REVIEW_ASSIGNEE_AVATARS
-  )
-  const blockLevelReviewAssigneesOverflowCount =
-    blockLevelReviewAssigneeUsers.length - MAX_VISIBLE_BLOCK_LEVEL_REVIEW_ASSIGNEE_AVATARS
 
   return (
     <KanbanCard
@@ -164,55 +146,23 @@ const ApplicationKanbanCard = observer(function ApplicationKanbanCard({
       isLast={isLast}
       onMove={onMove}
       avatars={
-        <>
-          {visibleBlockLevelReviewAssignees.map((user) => (
-            <SharedAvatar key={user.id} size="xs" name={user.name} role={user.role} fontSize="2xs" />
-          ))}
-          {blockLevelReviewAssigneesOverflowCount > 0 && (
-            <Avatar
-              size="xs"
-              name={`+${blockLevelReviewAssigneesOverflowCount}`}
-              getInitials={(name) => name}
-              bg="gray.200"
-              color="text.primary"
-              fontSize="2xs"
-            />
-          )}
+        <ReviewAssigneesRow
+          primaryAssignee={primaryAssignee}
+          secondaryAssignees={secondaryAssignees}
+          maxSecondaryVisible={MAX_VISIBLE_BLOCK_LEVEL_REVIEW_ASSIGNEE_AVATARS}
+        >
           <DesignatedCollaboratorAssignmentPopover
             permitApplication={application}
             collaborationType={ECollaborationType.review}
             onBeforeOpen={async () => {
               await permitApplicationStore.fetchPermitApplication(application.id, true)
             }}
-            renderTrigger={({ isLoading, existingDelegateeCollaboration, onClick, isDisabled }) => (
-              <IconButton
-                aria-label={t("permitCollaboration.sidebar.title")}
-                icon={
-                  isLoading ? (
-                    <Spinner size="xs" />
-                  ) : existingDelegateeCollaboration ? (
-                    <SharedAvatar
-                      size="xs"
-                      name={existingDelegateeCollaboration.collaborator?.user?.name}
-                      role={existingDelegateeCollaboration.collaborator?.user?.role}
-                      fontSize="2xs"
-                      border="2px solid"
-                      borderColor="theme.blueActive"
-                    />
-                  ) : (
-                    <UserPlus size={16} />
-                  )
-                }
-                size="sm"
-                minW={7}
-                h={7}
-                variant="ghost"
-                onClick={onClick}
-                isDisabled={isDisabled}
-              />
-            )}
+            renderTrigger={renderAssignPlusIconTrigger({
+              ariaLabel: t("permitCollaboration.sidebar.title"),
+              size: "sm",
+            })}
           />
-        </>
+        </ReviewAssigneesRow>
       }
     >
       {isSandbox && (

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/application-kanban-board.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/application-kanban-board.tsx
@@ -5,6 +5,7 @@ import React, { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useNavigate } from "react-router-dom"
 import { IPermitApplication } from "../../../../models/permit-application"
+import { IUser } from "../../../../models/user"
 import { useMst } from "../../../../setup/root"
 import { colors } from "../../../../styles/theme/foundations/colors"
 import { ECollaborationType, EPermitApplicationStatus } from "../../../../types/enums"
@@ -121,18 +122,15 @@ const ApplicationKanbanCard = observer(function ApplicationKanbanCard({
   const isSandbox = !!application.sandbox
   const isUnread = !application.isViewed
 
-  const designatedReviewerUser = application.designatedReviewer?.collaborator?.user
-  const primaryAssignee = designatedReviewerUser
-    ? { id: designatedReviewerUser.id, name: designatedReviewerUser.name, role: designatedReviewerUser.role }
-    : null
+  const primaryAssignee = application.designatedReviewer?.collaborator?.user ?? null
 
-  const secondaryAssignees: { id: string; name: string; role: string }[] = []
-  const seenUserIds = new Set<string>(designatedReviewerUser ? [designatedReviewerUser.id] : [])
+  const secondaryAssignees: IUser[] = []
+  const seenUserIds = new Set<string>(primaryAssignee ? [primaryAssignee.id] : [])
   for (const collab of application.getCollaborationAssignees(ECollaborationType.review)) {
     const user = collab.collaborator?.user
     if (user && !seenUserIds.has(user.id)) {
       seenUserIds.add(user.id)
-      secondaryAssignees.push({ id: user.id, name: user.name, role: user.role })
+      secondaryAssignees.push(user)
     }
   }
 

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-overview-tab.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-overview-tab.tsx
@@ -145,7 +145,7 @@ export const InboxOverviewTab = observer(({ permitProject }: IProps) => {
                 ))}
             </SearchGrid>
             <Flex justify="flex-end" mt={4}>
-              <RouterLinkButton variant="tertiary" rightIcon={<CaretRight />} to="permits">
+              <RouterLinkButton variant="link" rightIcon={<CaretRight />} to="permits">
                 {t("submissionInbox.projectDetail.viewAllPermits")}
               </RouterLinkButton>
             </Flex>

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-inbox-table.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-inbox-table.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Box,
   Circle,
   Flex,
@@ -11,12 +10,11 @@ import {
   MenuItem,
   MenuList,
   Portal,
-  Spinner,
   Text,
   Tooltip,
   VStack,
 } from "@chakra-ui/react"
-import { Info, Swap, UserPlus } from "@phosphor-icons/react"
+import { Info, Swap } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
@@ -34,10 +32,10 @@ import { SearchGrid } from "../../../shared/grid/search-grid"
 import { SearchGridItem } from "../../../shared/grid/search-grid-item"
 import { ProjectStateTag } from "../../../shared/permit-projects/project-state-tag"
 import { SortIcon } from "../../../shared/sort-icon"
-import { SharedAvatar } from "../../../shared/user/shared-avatar"
 import { InboxNoMatchingEmpty } from "./inbox-no-matching-empty"
 import { ProjectReviewCollaboratorsPopover } from "./project-designated-reviewer-popover"
 import { ProjectInboxPermitApplicationsPopover } from "./project-inbox-permit-applications-popover"
+import { renderAssignPlusIconTrigger, ReviewAssigneesRow } from "./review-assignees-row"
 import { SubmissionInboxMarkUnreadIconButton } from "./submission-inbox-mark-unread-icon-button"
 
 interface IProps {
@@ -53,8 +51,6 @@ const SORT_FIELDS = [
   EPermitProjectInboxSortFields.assigned,
   EPermitProjectInboxSortFields.state,
 ]
-
-const MAX_VISIBLE_AVATARS = 3
 
 export const ProjectInboxTable = observer(function ProjectInboxTable({ searchStore, projects }: IProps) {
   const { t } = useTranslation()
@@ -294,60 +290,21 @@ const ProjectAssignedCell = observer(function ProjectAssignedCell({ project }: {
   const { t } = useTranslation()
   const { permitProjectStore } = useMst()
 
-  const allCollaborators = project.aggregatedReviewCollaborators
-  const visibleAssignees = allCollaborators.slice(0, MAX_VISIBLE_AVATARS)
-  const overflowCount = allCollaborators.length - MAX_VISIBLE_AVATARS
-  const hasAnyAssignees = allCollaborators.length > 0
+  const user = project.reviewDelegatee?.user
+  const primaryAssignee = user ? { id: user.id, name: user.name, role: user.role } : null
 
   return (
-    <HStack spacing={1}>
-      {hasAnyAssignees ? (
-        <>
-          {visibleAssignees.map((user) => (
-            <SharedAvatar key={user.id} size="xs" name={user.name} role={user.role} fontSize="2xs" />
-          ))}
-          {overflowCount > 0 && (
-            <Avatar
-              size="xs"
-              name={`+${overflowCount}`}
-              getInitials={(name) => name}
-              bg="gray.200"
-              color="text.primary"
-              fontSize="2xs"
-            />
-          )}
-        </>
-      ) : (
-        <Text fontSize="sm" color="text.secondary">
-          {t("ui.unassigned")}
-        </Text>
-      )}
+    <ReviewAssigneesRow primaryAssignee={primaryAssignee} emptyText={t("ui.unassigned")}>
       <ProjectReviewCollaboratorsPopover
         project={project}
         onBeforeOpen={async () => {
           await permitProjectStore.fetchPermitProject(project.id)
         }}
-        renderTrigger={({ isLoading, collaborationCount, onClick, isDisabled }) => (
-          <IconButton
-            aria-label={t("permitCollaboration.projectSidebar.projectReviewCollaborators")}
-            icon={
-              isLoading ? (
-                <Spinner size="xs" />
-              ) : collaborationCount > 0 ? (
-                <UserPlus size={14} />
-              ) : (
-                <UserPlus size={14} />
-              )
-            }
-            size="xs"
-            variant="ghost"
-            borderRadius="full"
-            onClick={onClick}
-            isDisabled={isDisabled}
-          />
-        )}
+        renderTrigger={renderAssignPlusIconTrigger({
+          ariaLabel: t("permitCollaboration.projectSidebar.projectReviewCollaborators"),
+        })}
       />
-    </HStack>
+    </ReviewAssigneesRow>
   )
 })
 

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-inbox-table.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-inbox-table.tsx
@@ -290,8 +290,7 @@ const ProjectAssignedCell = observer(function ProjectAssignedCell({ project }: {
   const { t } = useTranslation()
   const { permitProjectStore } = useMst()
 
-  const user = project.reviewDelegatee?.user
-  const primaryAssignee = user ? { id: user.id, name: user.name, role: user.role } : null
+  const primaryAssignee = project.reviewDelegatee?.user ?? null
 
   return (
     <ReviewAssigneesRow primaryAssignee={primaryAssignee} emptyText={t("ui.unassigned")}>

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-kanban-board.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-kanban-board.tsx
@@ -1,5 +1,5 @@
-import { Avatar, Box, HStack, Icon, IconButton, Spinner, Text } from "@chakra-ui/react"
-import { CalendarBlank, UserPlus } from "@phosphor-icons/react"
+import { Box, HStack, Icon, Text } from "@chakra-ui/react"
+import { CalendarBlank } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React, { useMemo } from "react"
 import { useTranslation } from "react-i18next"
@@ -7,12 +7,12 @@ import { Link } from "react-router-dom"
 import { IPermitProject } from "../../../../models/permit-project"
 import { useMst } from "../../../../setup/root"
 import { EProjectState } from "../../../../types/enums"
-import { SharedAvatar } from "../../../shared/user/shared-avatar"
 import { ChangeProjectStateMenu } from "./change-project-state-menu"
 import { EReorderDirection, IKanbanColumn, IReorderEvent, KanbanBoard } from "./kanban-board"
 import { KanbanCard } from "./kanban-card"
 import { ProjectReviewCollaboratorsPopover } from "./project-designated-reviewer-popover"
 import { ProjectInboxPermitApplicationsPopover } from "./project-inbox-permit-applications-popover"
+import { renderAssignPlusIconTrigger, ReviewAssigneesRow } from "./review-assignees-row"
 
 interface IProps {
   projects: IPermitProject[]
@@ -96,8 +96,6 @@ export const ProjectKanbanBoard = observer(function ProjectKanbanBoard({
   )
 })
 
-const MAX_VISIBLE_AVATARS = 3
-
 const ProjectKanbanCard = observer(function ProjectKanbanCard({
   project,
   isFirst,
@@ -116,9 +114,8 @@ const ProjectKanbanCard = observer(function ProjectKanbanCard({
   const total = project.totalPermitsCount
   const isUnread = !project.viewedAt
 
-  const allCollaborators = project.aggregatedReviewCollaborators
-  const visibleAssignees = allCollaborators.slice(0, MAX_VISIBLE_AVATARS)
-  const overflowCount = allCollaborators.length - MAX_VISIBLE_AVATARS
+  const user = project.reviewDelegatee?.user
+  const primaryAssignee = user ? { id: user.id, name: user.name, role: user.role } : null
 
   return (
     <KanbanCard
@@ -130,39 +127,18 @@ const ProjectKanbanCard = observer(function ProjectKanbanCard({
       isLast={isLast}
       onMove={onMove}
       avatars={
-        <>
-          {visibleAssignees.map((user) => (
-            <SharedAvatar key={user.id} size="xs" name={user.name} role={user.role} fontSize="2xs" />
-          ))}
-          {overflowCount > 0 && (
-            <Avatar
-              size="xs"
-              name={`+${overflowCount}`}
-              getInitials={(name) => name}
-              bg="gray.200"
-              color="text.primary"
-              fontSize="2xs"
-            />
-          )}
+        <ReviewAssigneesRow primaryAssignee={primaryAssignee}>
           <ProjectReviewCollaboratorsPopover
             project={project}
             onBeforeOpen={async () => {
               await permitProjectStore.fetchPermitProject(project.id)
             }}
-            renderTrigger={({ isLoading, collaborationCount, onClick, isDisabled }) => (
-              <IconButton
-                aria-label={t("permitCollaboration.projectSidebar.projectReviewCollaborators")}
-                icon={isLoading ? <Spinner size="xs" /> : <UserPlus size={16} />}
-                size="sm"
-                minW={7}
-                h={7}
-                variant="ghost"
-                onClick={onClick}
-                isDisabled={isDisabled}
-              />
-            )}
+            renderTrigger={renderAssignPlusIconTrigger({
+              ariaLabel: t("permitCollaboration.projectSidebar.projectReviewCollaborators"),
+              size: "sm",
+            })}
           />
-        </>
+        </ReviewAssigneesRow>
       }
     >
       <Box

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-kanban-board.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-kanban-board.tsx
@@ -114,8 +114,7 @@ const ProjectKanbanCard = observer(function ProjectKanbanCard({
   const total = project.totalPermitsCount
   const isUnread = !project.viewedAt
 
-  const user = project.reviewDelegatee?.user
-  const primaryAssignee = user ? { id: user.id, name: user.name, role: user.role } : null
+  const primaryAssignee = project.reviewDelegatee?.user ?? null
 
   return (
     <KanbanCard

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/review-assignees-row.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/review-assignees-row.tsx
@@ -2,26 +2,21 @@ import { Avatar, AvatarProps, HStack, IconButton, Spinner, Text, Tooltip } from 
 import { UserPlus } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
+import { IUser } from "../../../../models/user"
 import { SharedAvatar } from "../../../shared/user/shared-avatar"
-
-export interface IReviewAssigneeUser {
-  id: string
-  name: string
-  role: string
-}
 
 interface IReviewAssigneesRowProps {
   /**
    * The designated / delegatee reviewer. Rendered first with a blue border to
    * distinguish them from block-level reviewers.
    */
-  primaryAssignee?: IReviewAssigneeUser | null
+  primaryAssignee?: IUser | null
   /**
    * Block-level review collaborators. Only relevant for permit applications.
    * Rendered without a border, capped at `maxSecondaryVisible` with an overflow
    * counter when exceeded.
    */
-  secondaryAssignees?: IReviewAssigneeUser[]
+  secondaryAssignees?: IUser[]
   /**
    * Maximum number of secondary avatars to render before collapsing the rest
    * into a "+N" overflow avatar. Defaults to `Infinity` (no cap).

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/review-assignees-row.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/review-assignees-row.tsx
@@ -1,0 +1,141 @@
+import { Avatar, AvatarProps, HStack, IconButton, Spinner, Text, Tooltip } from "@chakra-ui/react"
+import { UserPlus } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { SharedAvatar } from "../../../shared/user/shared-avatar"
+
+export interface IReviewAssigneeUser {
+  id: string
+  name: string
+  role: string
+}
+
+interface IReviewAssigneesRowProps {
+  /**
+   * The designated / delegatee reviewer. Rendered first with a blue border to
+   * distinguish them from block-level reviewers.
+   */
+  primaryAssignee?: IReviewAssigneeUser | null
+  /**
+   * Block-level review collaborators. Only relevant for permit applications.
+   * Rendered without a border, capped at `maxSecondaryVisible` with an overflow
+   * counter when exceeded.
+   */
+  secondaryAssignees?: IReviewAssigneeUser[]
+  /**
+   * Maximum number of secondary avatars to render before collapsing the rest
+   * into a "+N" overflow avatar. Defaults to `Infinity` (no cap).
+   */
+  maxSecondaryVisible?: number
+  /**
+   * Text to render when there are no assignees. Omit to render nothing in the
+   * empty state (useful for kanban cards where the adjacent + icon carries the
+   * affordance to assign).
+   */
+  emptyText?: string
+  avatarSize?: AvatarProps["size"]
+  /**
+   * Usually the assign-collaborator popover. Rendered immediately after the
+   * avatars so the + icon trigger always sits to the right of any assigned
+   * avatars.
+   */
+  children?: React.ReactNode
+  /** Spacing between row items. Defaults to 1. */
+  spacing?: number | string
+}
+
+/**
+ * Shared row component for the submission inbox "assigned reviewer" cells and
+ * kanban card avatar strips. Renders the designated reviewer (if any), block
+ * level reviewers (for applications), an overflow counter, an optional
+ * "unassigned" label, and whatever assign trigger the consumer passes as
+ * children. Every avatar exposes the user's name on hover.
+ */
+export const ReviewAssigneesRow = observer(function ReviewAssigneesRow({
+  primaryAssignee,
+  secondaryAssignees = [],
+  maxSecondaryVisible = Infinity,
+  emptyText,
+  avatarSize = "xs",
+  spacing = 1,
+  children,
+}: IReviewAssigneesRowProps) {
+  const visibleSecondary = secondaryAssignees.slice(0, maxSecondaryVisible)
+  const overflowCount = Math.max(secondaryAssignees.length - maxSecondaryVisible, 0)
+  const hasAnyAssignee = !!primaryAssignee || secondaryAssignees.length > 0
+
+  return (
+    <HStack spacing={spacing}>
+      {hasAnyAssignee ? (
+        <>
+          {primaryAssignee && (
+            <Tooltip label={primaryAssignee.name} hasArrow placement="top" openDelay={200}>
+              <SharedAvatar
+                key={primaryAssignee.id}
+                size={avatarSize}
+                name={primaryAssignee.name}
+                role={primaryAssignee.role}
+                fontSize="2xs"
+                border="2px solid"
+                borderColor="theme.blueActive"
+              />
+            </Tooltip>
+          )}
+          {visibleSecondary.map((user) => (
+            <Tooltip key={user.id} label={user.name} hasArrow placement="top" openDelay={200}>
+              <SharedAvatar size={avatarSize} name={user.name} role={user.role} fontSize="2xs" />
+            </Tooltip>
+          ))}
+          {overflowCount > 0 && (
+            <Avatar
+              size={avatarSize}
+              name={`+${overflowCount}`}
+              getInitials={(name) => name}
+              bg="gray.200"
+              color="text.primary"
+              fontSize="2xs"
+            />
+          )}
+        </>
+      ) : emptyText ? (
+        <Text fontSize="sm" color="text.secondary">
+          {emptyText}
+        </Text>
+      ) : null}
+      {children}
+    </HStack>
+  )
+})
+
+interface IAssignPlusTriggerOpts {
+  ariaLabel: string
+  size?: "xs" | "sm"
+}
+
+interface ITriggerRenderArgs {
+  isLoading: boolean
+  onClick: (e: React.MouseEvent) => void
+  isDisabled: boolean
+}
+
+/**
+ * Shared `renderTrigger` factory producing the "+" IconButton used by the
+ * assign-collaborator popovers across the submission inbox. Consumers pass the
+ * result into either `ProjectReviewCollaboratorsPopover` or
+ * `DesignatedCollaboratorAssignmentPopover`.
+ */
+export const renderAssignPlusIconTrigger =
+  ({ ariaLabel, size = "xs" }: IAssignPlusTriggerOpts) =>
+  ({ isLoading, onClick, isDisabled }: ITriggerRenderArgs) => (
+    <IconButton
+      aria-label={ariaLabel}
+      icon={isLoading ? <Spinner size="xs" /> : <UserPlus size={size === "sm" ? 16 : 14} />}
+      size={size}
+      minW={size === "sm" ? 7 : undefined}
+      h={size === "sm" ? 7 : undefined}
+      variant="ghost"
+      borderRadius="full"
+      onClick={onClick}
+      isDisabled={isDisabled}
+    />
+  )

--- a/app/frontend/components/domains/navigation/menu-content/menu-items/submission-inbox-menu-item.tsx
+++ b/app/frontend/components/domains/navigation/menu-content/menu-items/submission-inbox-menu-item.tsx
@@ -3,13 +3,19 @@ import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
 import { useMst } from "../../../../../setup/root"
+import { EInboxViewMode } from "../../../../../types/enums"
 import { MenuLinkItem } from "../menu-link-item"
 
 export const SubmissionInboxMenuItem = observer(() => {
   const { t } = useTranslation()
-  const { userStore } = useMst()
+  const { userStore, submissionInboxStore } = useMst()
   const { currentUser } = userStore
-  const count = currentUser?.jurisdiction?.unviewedSubmissionsCount || 0
+  const { viewMode } = submissionInboxStore
+
+  const count =
+    viewMode === EInboxViewMode.projects
+      ? currentUser?.jurisdiction?.unviewedProjectsCount || 0
+      : currentUser?.jurisdiction?.unviewedSubmissionsCount || 0
 
   return (
     <MenuLinkItem

--- a/app/frontend/components/domains/permit-application/review-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/review-permit-application-screen.tsx
@@ -328,7 +328,7 @@ export const ReviewPermitApplicationScreen = observer(() => {
                   )
                 )
               }}
-              updateCollaborationAssignmentNodes={isReadOnly ? undefined : updateRequirementBlockAssignmentNode}
+              updateCollaborationAssignmentNodes={updateRequirementBlockAssignmentNode}
             />
           </Flex>
         )}
@@ -341,17 +341,16 @@ export const ReviewPermitApplicationScreen = observer(() => {
           permitApplication={currentPermitApplication}
         />
       )}
-      {!isReadOnly &&
-        requirementBlockAssignmentNodes.map((requirementBlockAssignmentNode) => {
-          return (
-            <BlockCollaboratorAssignmentManagement
-              key={requirementBlockAssignmentNode.requirementBlockId}
-              requirementBlockAssignmentNode={requirementBlockAssignmentNode}
-              permitApplication={currentPermitApplication}
-              collaborationType={ECollaborationType.review}
-            />
-          )
-        })}
+      {requirementBlockAssignmentNodes.map((requirementBlockAssignmentNode) => {
+        return (
+          <BlockCollaboratorAssignmentManagement
+            key={requirementBlockAssignmentNode.requirementBlockId}
+            requirementBlockAssignmentNode={requirementBlockAssignmentNode}
+            permitApplication={currentPermitApplication}
+            collaborationType={ECollaborationType.review}
+          />
+        )
+      })}
     </Box>
   )
 })

--- a/app/frontend/components/shared/user/shared-avatar.tsx
+++ b/app/frontend/components/shared/user/shared-avatar.tsx
@@ -25,7 +25,10 @@ interface ISharedAvatarProps extends Omit<AvatarProps, "bg" | "color"> {
   role?: string | null
 }
 
-export const SharedAvatar = ({ role, ...rest }: ISharedAvatarProps) => {
+export const SharedAvatar = React.forwardRef<HTMLSpanElement, ISharedAvatarProps>(function SharedAvatar(
+  { role, ...rest },
+  ref
+) {
   const colors = getRoleAvatarColors(role)
-  return <Avatar bg={colors.bg} color={colors.color} {...rest} />
-}
+  return <Avatar ref={ref} bg={colors.bg} color={colors.color} {...rest} />
+})

--- a/app/frontend/models/jurisdiction.ts
+++ b/app/frontend/models/jurisdiction.ts
@@ -41,6 +41,7 @@ export const JurisdictionModel = types
     reviewersSize: types.maybeNull(types.number),
     permitApplicationsSize: types.maybeNull(types.number),
     unviewedSubmissionsCount: types.maybeNull(types.number),
+    unviewedProjectsCount: types.maybeNull(types.number),
     descriptionHtml: types.maybeNull(types.string),
     checklistHtml: types.maybeNull(types.string),
     lookOutHtml: types.maybeNull(types.string),
@@ -160,6 +161,9 @@ export const JurisdictionModel = types
     },
     setUnviewedSubmissionsCount: (count: number) => {
       self.unviewedSubmissionsCount = count
+    },
+    setUnviewedProjectsCount: (count: number) => {
+      self.unviewedProjectsCount = count
     },
     update: flow(function* (params) {
       const { ok, data: response } = yield* toGenerator(self.environment.api.updateJurisdiction(self.id, params))

--- a/app/frontend/models/permit-project-collaboration.ts
+++ b/app/frontend/models/permit-project-collaboration.ts
@@ -1,0 +1,21 @@
+import { Instance, types } from "mobx-state-tree"
+import { CollaboratorModel } from "./collaborator"
+
+export const PermitProjectCollaborationModel = types.snapshotProcessor(
+  types.model("PermitProjectCollaborationModel", {
+    id: types.identifier,
+    collaborator: types.reference(types.late(() => CollaboratorModel)),
+  }),
+  {
+    preProcessor(snapshot: any) {
+      return {
+        ...snapshot,
+        collaborator: snapshot.collaborator?.id ?? snapshot.collaborator,
+      }
+    },
+  }
+)
+
+export interface IPermitProjectCollaboration extends Instance<typeof PermitProjectCollaborationModel> {
+  collaborator: any
+}

--- a/app/frontend/models/permit-project.ts
+++ b/app/frontend/models/permit-project.ts
@@ -5,22 +5,11 @@ import { withEnvironment } from "../lib/with-environment"
 import { withRootStore } from "../lib/with-root-store"
 import { EInboxDisplayMode, EPermitProjectRollupStatus, EProjectState } from "../types/enums"
 import { IParcelGeometry, IProjectAuditSummary, IProjectDocument } from "../types/types"
-import { ICollaborator } from "./collaborator"
+import { CollaboratorModel } from "./collaborator"
 import { JurisdictionModel } from "./jurisdiction"
 import { IPermitApplication, PermitApplicationModel } from "./permit-application"
+import { PermitProjectCollaborationModel } from "./permit-project-collaboration"
 import { PermitProjectInboxApplicationSearchSlice } from "./permit-project-inbox-application-search"
-
-export interface IAggregatedReviewCollaborator {
-  id: string
-  name: string
-  role: string
-  isProjectCollaborator: boolean
-}
-
-export interface IPermitProjectCollaboration {
-  id: string
-  collaborator: ICollaborator
-}
 
 const PermitProjectCoreModel = types.model("PermitProjectCore", {
   id: types.identifier,
@@ -71,9 +60,8 @@ const PermitProjectCoreModel = types.model("PermitProjectCore", {
   inboxSortOrder: types.maybeNull(types.number),
   daysInQueue: types.maybeNull(types.number),
   recentAudits: types.optional(types.array(types.frozen<IProjectAuditSummary>()), []),
-  reviewDelegatee: types.maybeNull(types.frozen<ICollaborator>()),
-  permitProjectCollaborations: types.optional(types.array(types.frozen<IPermitProjectCollaboration>()), []),
-  aggregatedReviewCollaborators: types.optional(types.array(types.frozen<IAggregatedReviewCollaborator>()), []),
+  reviewDelegatee: types.maybeNull(types.safeReference(CollaboratorModel)),
+  permitProjectCollaborations: types.optional(types.array(PermitProjectCollaborationModel), []),
   displayMode: types.optional(types.enumeration(Object.values(EInboxDisplayMode)), EInboxDisplayMode.list),
 })
 

--- a/app/frontend/stores/jurisdiction-store.ts
+++ b/app/frontend/stores/jurisdiction-store.ts
@@ -146,20 +146,29 @@ export const JurisdictionStoreModel = types
       return result
     }),
     processWebsocketChange(payload: IUserPushPayload) {
-      if (payload?.eventType === EJurisdictionSocketEventTypes.unviewedSubmissionsCountUpdated) {
-        const { jurisdictionId, sandboxId, unviewedCount } = payload.data as any
-        const currentUser = self.rootStore.userStore.currentUser
-        const currentJurisdiction = currentUser?.jurisdiction
-        const currentSandboxId = self.rootStore.sandboxStore.currentSandboxId
+      const isSubmissionsEvent = payload?.eventType === EJurisdictionSocketEventTypes.unviewedSubmissionsCountUpdated
+      const isProjectsEvent = payload?.eventType === EJurisdictionSocketEventTypes.unviewedProjectsCountUpdated
 
-        // Only update if it's for the current jurisdiction and sandbox matches
-        if (
-          currentJurisdiction?.id === jurisdictionId &&
-          sandboxId === currentSandboxId &&
-          typeof unviewedCount === "number"
-        ) {
-          currentJurisdiction.setUnviewedSubmissionsCount(unviewedCount)
-        }
+      if (!isSubmissionsEvent && !isProjectsEvent) return
+
+      const { jurisdictionId, sandboxId, unviewedCount } = payload.data as any
+      const currentUser = self.rootStore.userStore.currentUser
+      const currentJurisdiction = currentUser?.jurisdiction
+      const currentSandboxId = self.rootStore.sandboxStore.currentSandboxId
+
+      // Only update if it's for the current jurisdiction and sandbox matches
+      if (
+        currentJurisdiction?.id !== jurisdictionId ||
+        sandboxId !== currentSandboxId ||
+        typeof unviewedCount !== "number"
+      ) {
+        return
+      }
+
+      if (isSubmissionsEvent) {
+        currentJurisdiction.setUnviewedSubmissionsCount(unviewedCount)
+      } else {
+        currentJurisdiction.setUnviewedProjectsCount(unviewedCount)
       }
     },
   }))

--- a/app/frontend/stores/permit-project-store.ts
+++ b/app/frontend/stores/permit-project-store.ts
@@ -52,14 +52,14 @@ export const PermitProjectStoreModel = types
       }
 
       // Handle permit applications (inbox reviewer payloads use permitApplications for full visible list)
-      if (permitProject.permitApplications && Array.isArray(permitProject.permitApplications)) {
+      if (permitProject.permitApplications) {
         permitProject.permitApplications.forEach((app) => {
           if (typeof app === "object") {
             self.rootStore.permitApplicationStore.mergeUpdate(app, "permitApplicationMap")
           }
         })
       }
-      if (permitProject.recentPermitApplications && Array.isArray(permitProject.recentPermitApplications)) {
+      if (permitProject.recentPermitApplications) {
         permitProject.recentPermitApplications.forEach((app) => {
           if (typeof app === "object") {
             self.rootStore.permitApplicationStore.mergeUpdate(app, "permitApplicationMap")
@@ -73,8 +73,8 @@ export const PermitProjectStoreModel = types
 
       if (permitProject.permitProjectCollaborations) {
         permitProject.permitProjectCollaborations.forEach((collab: any) => {
-          if (collab?.collaborator?.user && typeof collab.collaborator.user === "object") {
-            self.rootStore.userStore.mergeUpdate(collab.collaborator.user, "usersMap")
+          if (collab?.collaborator) {
+            self.rootStore.collaboratorStore.mergeUpdate(collab.collaborator, "collaboratorMap")
           }
         })
       }
@@ -83,13 +83,23 @@ export const PermitProjectStoreModel = types
         owner: permitProject.owner?.id || null,
       }
 
+      if ("reviewDelegatee" in permitProject) {
+        const rd = permitProject.reviewDelegatee
+        if (rd) {
+          self.rootStore.collaboratorStore.mergeUpdate(rd, "collaboratorMap")
+          overrides.reviewDelegatee = rd.id
+        } else {
+          overrides.reviewDelegatee = null
+        }
+      }
+
       // Inbox extended: permit_applications -> inboxTablePermitApplications (not tablePermitApplications)
-      if (permitProject.permitApplications && Array.isArray(permitProject.permitApplications)) {
+      if (permitProject.permitApplications) {
         overrides.inboxTablePermitApplications =
           permitProject.permitApplications.map((app) => (typeof app === "object" ? app.id : app)) || []
       }
 
-      if (permitProject.recentPermitApplications && Array.isArray(permitProject.recentPermitApplications)) {
+      if (permitProject.recentPermitApplications) {
         overrides.recentPermitApplications =
           permitProject.recentPermitApplications.map((app) => (typeof app === "object" ? app.id : app)) || []
       }

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -378,6 +378,7 @@ export enum EPermitApplicationSocketEventTypes {
 
 export enum EJurisdictionSocketEventTypes {
   unviewedSubmissionsCountUpdated = "unviewed_submissions_count_updated",
+  unviewedProjectsCountUpdated = "unviewed_projects_count_updated",
 }
 
 export enum EEnabledElectiveFieldReason {

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -261,14 +261,30 @@ class Jurisdiction < ApplicationRecord
     permit_applications&.kept&.size || 0
   end
 
+  # Mirrors the semantics of
+  # Api::Concerns::Search::JurisdictionPermitApplications#jurisdiction_application_unread_count
+  # (the unread-filter badge on the submission inbox search page):
+  #   - kept (not discarded)
+  #   - status != "new_draft"
+  #   - latest submission_version.viewed_at IS NULL (same field the
+  #     PermitApplication searchkick index exposes as `viewed_at`)
+  #   - optional sandbox scope
   def unviewed_submissions_count(sandbox: nil)
+    latest_submission_version_viewed_at_sql = <<~SQL.squish
+      (
+        SELECT sv.viewed_at
+        FROM submission_versions sv
+        WHERE sv.permit_application_id = permit_applications.id
+        ORDER BY sv.created_at DESC
+        LIMIT 1
+      )
+    SQL
+
     permit_applications
       .kept
       .for_sandbox(sandbox)
-      .where(status: %i[newly_submitted resubmitted])
-      .joins(:submission_versions)
-      .where(submission_versions: { viewed_at: nil })
-      .distinct
+      .where.not(status: "new_draft")
+      .where("#{latest_submission_version_viewed_at_sql} IS NULL")
       .count
   end
 

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -288,6 +288,22 @@ class Jurisdiction < ApplicationRecord
       .count
   end
 
+  # Mirrors the semantics of
+  # Api::Concerns::Search::JurisdictionPermitProjects#jurisdiction_unread_count
+  # (the unread-filter badge on the project-inbox search page):
+  #   - kept (not discarded)
+  #   - state != "draft"
+  #   - viewed_at IS NULL
+  #   - optional sandbox scope
+  def unviewed_projects_count(sandbox: nil)
+    permit_projects
+      .kept
+      .for_sandbox(sandbox)
+      .where.not(state: PermitProject.states[:draft])
+      .where(viewed_at: nil)
+      .count
+  end
+
   def unviewed_permit_applications
     permit_applications.kept.unviewed
   end

--- a/app/models/permit_project.rb
+++ b/app/models/permit_project.rb
@@ -280,49 +280,12 @@ class PermitProject < ApplicationRecord
     audits
   end
 
-  def aggregated_review_collaborators
-    users = {}
-
-    # Include project-level review collaborators
+  # Exposed in API as +review_delegatee+ (Collaborator JSON). UI treats a single project reviewer.
+  def review_delegatee
     permit_project_collaborations
       .includes(collaborator: :user)
-      .each do |ppc|
-        user = ppc.collaborator&.user
-        next unless user
-
-        users[user.id] ||= {
-          id: user.id,
-          name: user.name,
-          role: user.role,
-          is_project_collaborator: true
-        }
-      end
-
-    # Include per-application review collaborators
-    permit_applications.each do |pa|
-      next if pa.discarded? || !pa.submitted?
-
-      pa.permit_collaborations.each do |collab|
-        next unless collab.review?
-
-        user = collab.collaborator&.user
-        next unless user
-
-        existing = users[user.id]
-        if existing
-          existing[:is_project_collaborator] ||= false
-        else
-          users[user.id] = {
-            id: user.id,
-            name: user.name,
-            role: user.role,
-            is_project_collaborator: false
-          }
-        end
-      end
-    end
-
-    users.values
+      .first
+      &.collaborator
   end
 
   def designated_reviewer_enabled?
@@ -330,23 +293,38 @@ class PermitProject < ApplicationRecord
       jurisdiction&.allow_designated_reviewer
   end
 
+  # Atomically assigns the project's single review collaborator, replacing any
+  # existing assignment. Re-picking the current collaborator is a no-op (no
+  # notification churn). Locks existing kept rows to serialize concurrent calls.
   def assign_project_review_collaborator!(collaborator_id)
     unless designated_reviewer_enabled?
       raise "Designated reviewer feature is not enabled"
     end
 
-    collaboration =
-      permit_project_collaborations.create!(collaborator_id: collaborator_id)
+    transaction do
+      existing = permit_project_collaborations.kept.lock.first
 
-    PermitHubMailer.notify_project_review_collaboration(
-      permit_project_collaboration: collaboration
-    )&.deliver_later
+      if existing&.collaborator_id == collaborator_id
+        existing
+      else
+        existing&.discard!
 
-    NotificationService.publish_project_collaboration_assignment_event(
-      collaboration
-    )
+        collaboration =
+          permit_project_collaborations.create!(
+            collaborator_id: collaborator_id
+          )
 
-    collaboration
+        PermitHubMailer.notify_project_review_collaboration(
+          permit_project_collaboration: collaboration
+        )&.deliver_later
+
+        NotificationService.publish_project_collaboration_assignment_event(
+          collaboration
+        )
+
+        collaboration
+      end
+    end
   end
 
   def unassign_project_review_collaborator!(collaborator_id)

--- a/app/models/permit_project.rb
+++ b/app/models/permit_project.rb
@@ -40,6 +40,8 @@ class PermitProject < ApplicationRecord
   delegate :name, to: :owner, prefix: true
 
   after_commit :reindex
+  after_commit :broadcast_jurisdiction_projects_count_update,
+               if: :should_broadcast_projects_count_update?
 
   scope :sandboxed, -> { where.not(sandbox_id: nil) }
   scope :live, -> { where(sandbox_id: nil) }
@@ -136,6 +138,27 @@ class PermitProject < ApplicationRecord
 
   def mark_as_unviewed
     update(viewed_at: nil)
+  end
+
+  def broadcast_jurisdiction_projects_count_update
+    return unless jurisdiction.present?
+
+    review_staff_user_ids =
+      jurisdiction.users.kept.select(&:review_staff?).map(&:id)
+    return if review_staff_user_ids.empty?
+
+    WebsocketBroadcaster.push_update_to_relevant_users(
+      review_staff_user_ids,
+      Constants::Websockets::Events::Jurisdiction::DOMAIN,
+      Constants::Websockets::Events::Jurisdiction::TYPES[
+        :unviewed_projects_count_updated
+      ],
+      {
+        jurisdiction_id: jurisdiction.id,
+        sandbox_id: sandbox_id,
+        unviewed_count: jurisdiction.unviewed_projects_count(sandbox: sandbox)
+      }
+    )
   end
 
   def search_data
@@ -334,6 +357,17 @@ class PermitProject < ApplicationRecord
   end
 
   private
+
+  # Recompute the jurisdiction-wide unviewed projects badge whenever a change
+  # could affect membership in the set counted by
+  # Jurisdiction#unviewed_projects_count:
+  #   - viewed_at transitions (mark_as_unviewed / update_viewed_at)
+  #   - state transitions in/out of "draft"
+  #   - discarded/undiscarded transitions
+  def should_broadcast_projects_count_update?
+    saved_change_to_viewed_at? || saved_change_to_state? ||
+      saved_change_to_discarded_at?
+  end
 
   def sandbox_belongs_to_jurisdiction
     return unless sandbox

--- a/app/models/permit_project_collaboration.rb
+++ b/app/models/permit_project_collaboration.rb
@@ -19,6 +19,7 @@ class PermitProjectCollaboration < ApplicationRecord
 
   validate :validate_review_staff_for_jurisdiction
   validate :validate_collaborator_is_review_type
+  validate :validate_only_one_kept_per_project
 
   def collaboration_assignment_notification_data
     {
@@ -80,6 +81,17 @@ class PermitProjectCollaboration < ApplicationRecord
     unless collaborator.collaboratorable_type == "Jurisdiction"
       errors.add(:collaborator, :must_be_review_collaborator)
     end
+  end
+
+  def validate_only_one_kept_per_project
+    return unless permit_project_id
+    return if discarded?
+
+    scope = self.class.kept.where(permit_project_id: permit_project_id)
+    scope = scope.where.not(id: id) if persisted?
+    return unless scope.exists?
+
+    errors.add(:permit_project, :only_one_review_collaborator_allowed)
   end
 
   def send_unassignment_notification

--- a/app/services/constants/websockets.rb
+++ b/app/services/constants/websockets.rb
@@ -28,7 +28,8 @@ module Constants
         DOMAIN = :jurisdiction
         TYPES = {
           unviewed_submissions_count_updated:
-            :unviewed_submissions_count_updated
+            :unviewed_submissions_count_updated,
+          unviewed_projects_count_updated: :unviewed_projects_count_updated
         }.freeze
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,10 @@ en:
               review_staff_requires_sandbox: "review staff cannot own permit projects outside of a sandbox"
             sandbox:
               incorrect_jurisdiction: "must belong to the jurisdiction. Please apply to your own jurisdiction to use this sandbox."
+        permit_project_collaboration:
+          attributes:
+            permit_project:
+              only_one_review_collaborator_allowed: "can only have one review collaborator assigned at a time"
         requirement_template:
           step_code_package_required: '"Energy step code" is required to have the Design package energy step code file'
           duplicate_energy_step_code: 'Multiple "Energy step code" requirements found. Please ensure there is only one "Energy step code" requirement in the template'

--- a/db/migrate/20260420120000_enforce_single_kept_project_review_collaborator.rb
+++ b/db/migrate/20260420120000_enforce_single_kept_project_review_collaborator.rb
@@ -1,0 +1,45 @@
+class EnforceSingleKeptProjectReviewCollaborator < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  INDEX_NAME = "index_project_collabs_unique_kept_per_project"
+
+  # Lightweight inline model so the migration doesn't depend on the app model,
+  # which may change shape over time.
+  class Collab < ActiveRecord::Base
+    self.table_name = "permit_project_collaborations"
+  end
+
+  def up
+    # Clean up any pre-existing duplicate kept collaborations before the unique
+    # partial index is built, otherwise its creation will fail. The product is
+    # early enough in development that hard-deleting extras is acceptable; we
+    # keep the oldest kept row per project as the canonical reviewer.
+    duplicate_project_ids =
+      Collab
+        .where(discarded_at: nil)
+        .group(:permit_project_id)
+        .having("COUNT(*) > 1")
+        .pluck(:permit_project_id)
+
+    duplicate_project_ids.each do |project_id|
+      Collab
+        .where(discarded_at: nil, permit_project_id: project_id)
+        .order(:created_at, :id)
+        .offset(1)
+        .each(&:delete)
+    end
+
+    add_index :permit_project_collaborations,
+              :permit_project_id,
+              unique: true,
+              where: "discarded_at IS NULL",
+              name: INDEX_NAME,
+              algorithm: :concurrently
+  end
+
+  def down
+    remove_index :permit_project_collaborations,
+                 name: INDEX_NAME,
+                 algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_16_183037) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_20_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -587,6 +587,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_16_183037) do
     t.index ["discarded_at"], name: "index_permit_project_collaborations_on_discarded_at"
     t.index ["permit_project_id", "collaborator_id"], name: "index_project_collabs_on_project_and_collaborator", unique: true, where: "(discarded_at IS NULL)"
     t.index ["permit_project_id"], name: "index_permit_project_collaborations_on_permit_project_id"
+    t.index ["permit_project_id"], name: "index_project_collabs_unique_kept_per_project", unique: true, where: "(discarded_at IS NULL)"
   end
 
   create_table "permit_projects", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/policies/permit_application_policy_spec.rb
+++ b/spec/policies/permit_application_policy_spec.rb
@@ -281,7 +281,8 @@ RSpec.describe PermitApplicationPolicy do
 
     it "finalize_revision_requests? respects designated reviewer feature" do
       reviewer = create(:user, :review_manager, jurisdiction:)
-      review_rel = double("ReviewRel", exists?: true)
+      review_rel =
+        double("ReviewRel", delegatee: double("DelegateeRel", first: nil))
       record =
         double(
           "PermitApplication",

--- a/swagger/external_api/v1/swagger.yaml
+++ b/swagger/external_api/v1/swagger.yaml
@@ -2,7 +2,7 @@
 openapi: 3.1.0
 info:
   title: Integration API V1
-  version: v1
+  version: v1.1
   description: "### API documentation overview\nThis document provides detailed information
     about the APIs available for external integrators to query and retrieve submitted
     and resubmitted permit applications.\nIt also includes specifications on webhook


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...HUB-4742-story-reviewer-can-assign-a-reviewer-to-any-project-or-application-directly-from-the-submissions-index-submissions-index-via-unified-multi-view-workspace-rework` (merge-base range).

Rework the submission-inbox assignment flow so reviewers can assign a designated reviewer to either a project or a specific permit application straight from the inbox, and fix the mega-menu "Submission Inbox" unread badge so it reflects the side (projects vs applications) the user is currently looking at.

Three coordinated changes:

1. **Unread count correctness & per-view badge.** The mega-menu `unviewedSubmissionsCount` was computed with different rules than the inbox search page's `unread_count` (different status set; "any unviewed submission_version" vs "latest version"). Rewrote `Jurisdiction#unviewed_submissions_count` to mirror the search-page semantics (kept, `status != "new_draft"`, latest `submission_version.viewed_at IS NULL`). Added a parallel `Jurisdiction#unviewed_projects_count` for the projects side, a new `unviewed_projects_count_updated` websocket event broadcast from `PermitProject` whenever `viewed_at` / `state` / `discarded_at` transitions, and a new `EInboxViewMode`-aware selector in `SubmissionInboxMenuItem` so the badge number matches whichever inbox view (`projects` or `applications`) the reviewer currently has active.

2. **Single designated reviewer per project (hard invariant).** The project-level review collaborator is now a single collaborator. Added a model validation + partial-unique index (`index_project_collabs_unique_kept_per_project`) to prevent more than one kept `PermitProjectCollaboration` per project, cleaning up any existing duplicates on migration. `assign_project_review_collaborator!` is now transactional: it locks existing kept rows, no-ops on a re-pick, and atomically discards-then-creates on a swap so we can't double-notify or leave orphans. The blueprint now returns a single `review_delegatee` association instead of the old `aggregated_review_collaborators` list; the front-end `PermitProject` model and store were updated to match.

3. **Shared assignee-row UI.** The four inbox surfaces (application + project × table + kanban) all duplicated very similar "designated reviewer + block-level reviewers with overflow + + assign trigger" avatar-row markup. Extracted a single `ReviewAssigneesRow` component (with tooltips on hover per user) and a shared `renderAssignPlusIconTrigger` factory; all four call sites now consume them. `SharedAvatar` gained `forwardRef` so Chakra's `Tooltip` can attach.

Also fixed `ReviewPermitApplicationScreen` to allow updating collaboration assignment nodes when the form is read-only (so reviewers can still reassign block-level reviewers on an in-review application).

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-4742](https://hous-bssb.atlassian.net/browse/HUB-4742) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Mega-menu "Submission Inbox" badge now reflects the active inbox view (`projects` vs `applications`) via a new `unviewedProjectsCount` field on `JurisdictionBlueprint` and a `viewMode`-aware selector in `SubmissionInboxMenuItem`.
- `Jurisdiction#unviewed_submissions_count` rewritten to match the search-page unread semantics (kept, `status != new_draft`, latest `submission_version.viewed_at IS NULL`); the menu badge and inbox unread filter can no longer disagree.
- New `Jurisdiction#unviewed_projects_count` + `unviewed_projects_count_updated` websocket event broadcast from `PermitProject` on `viewed_at` / `state` / `discarded_at` transitions so both counts stay live.
- Single-designated-reviewer-per-project enforced via new validation + partial unique index (`db/migrate/20260420120000_enforce_single_kept_project_review_collaborator.rb`); existing duplicates are cleaned up at migration time.
- `PermitProject#assign_project_review_collaborator!` is now transactional and idempotent — row-locks existing rows, no-ops on same-collaborator re-pick, atomically discards-then-creates on swap, avoiding duplicate notifications/orphans.
- `PermitProjectBlueprint` now serializes a single `review_delegatee` (Collaborator JSON) for the `jurisdiction_review_inbox` view instead of the old `aggregated_review_collaborators` list; front-end `PermitProject` MST model and store updated to consume it.
- New shared `ReviewAssigneesRow` component + `renderAssignPlusIconTrigger` factory replace duplicated avatar-row markup in the application and project inbox tables and kanban boards; every avatar now has a tooltip revealing the reviewer's name on hover.
- `SharedAvatar` converted to `forwardRef` so Chakra `Tooltip` can attach.
- `ReviewPermitApplicationScreen` no longer gates `updateCollaborationAssignmentNodes` behind `isReadOnly`, so reviewers can reassign block-level reviewers on an already-submitted application.

---

## 🧪 Steps to QA

1. Sign in as a review manager / reviewer in a jurisdiction with at least one sandbox and a mix of applications across statuses and projects across states.
2. **Mega-menu badge reflects view:**
   - Open **Submission Inbox** and toggle the top-of-page view between **Projects** and **Applications**.
   - Verify the number on the left-nav "Submission Inbox" badge changes when the view changes.
   - Verify it matches the "unread" filter count shown on the inbox search page header for the corresponding side.
3. **Live count updates:**
   - With the inbox open in one browser tab (Applications view), open an application in a second tab — the first tab's menu badge should decrement within a second or two.
   - Click "Mark as unread" on an application — the badge should increment.
   - Repeat for projects: switch to **Projects** view, open/close a project, toggle "mark as unread" on the project — badge decrements/increments.
   - Verify sandbox filtering: while scoped to a sandbox, only that sandbox's counts are reflected; non-super-admin users viewing outside their sandbox should not see changes from unrelated sandboxes.
4. **Single project reviewer invariant:**
   - On a project with the designated-reviewer feature enabled, click the **+** trigger on the project-inbox row/kanban card and assign a reviewer. Confirm the avatar appears with a blue border and shows the correct name on hover.
   - Re-open the popover and pick the **same** reviewer again — no duplicate notification email is sent and no new row is created (check Mailcatcher / server logs).
   - Pick a **different** reviewer — the old assignment is discarded, the new one takes its place, and a single notification is sent.
   - Confirm the project row/kanban card shows exactly one primary avatar at all times.
5. **Shared assignee row UI:**
   - On the application inbox: open both the table and kanban views. Verify the designated reviewer (blue border) and block-level reviewers render in the row, each with a hover tooltip showing the user's name. Verify the overflow "+N" avatar appears when there are more block-level reviewers than fit.
   - On the project inbox: same checks (designated reviewer only, no block-level).
   - Verify the **+** assign trigger sits to the right of all avatars in every surface.
6. **Review screen regression:**
   - Open an already-submitted application as a reviewer. Verify you can still reassign block-level reviewers from the form (the block-level assignment nodes are interactive even when the form body is read-only).

**Expected Behaviour:**
> The mega-menu unread badge always matches the number the user would see on the inbox search page for their current view. Assigning a designated reviewer to a project is idempotent and enforces a single reviewer at any time. All four inbox surfaces render assignees consistently with hover tooltips.

**Before this change:**
> Mega-menu badge used a different unread definition than the search page, so numbers disagreed. Projects could accumulate multiple `PermitProjectCollaboration` rows. Four near-identical avatar-row implementations existed across table/kanban × application/project. Reviewers could not reassign block-level reviewers on a read-only application form.

**After this change:**
> Single source of truth for "unread" semantics on each side, live-broadcast to subscribed review staff. One collaborator per project enforced at both app and DB layer. Single shared UI component for assignee rows. Block-level reviewer reassignment works on submitted applications.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (Chakra's `HStack`, `IconButton`, `Tooltip`, `Avatar`).
- [x] Additional context added through `aria-labels` on the assign-trigger `IconButton` (`permitCollaboration.sidebar.title`).
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors
- [x] Usable with a **keyboard** and navigable in a **logical order** (popover triggers are focusable buttons; avatars are purely presentational).
- [x] Usable with a **screen reader** — reviewer names are exposed via tooltips and avatar `name` props.
- [x] **Colour contrast** meets minimum AA ratio — primary designated reviewer uses `theme.blueActive` border on avatar; overflow avatar uses gray.200 on text.primary.
- [x] No content relies on **colour alone** to convey meaning — the designated reviewer is distinguished by border *and* position, not just colour.
- [x] Avatars have meaningful names via Chakra's `name` prop (used for initials and the tooltip label).

> ⚠️ Add before/after screenshots of the inbox table rows, kanban cards, and the mega-menu badge in each view mode.

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4742]: https://hous-bssb.atlassian.net/browse/HUB-4742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ