### PR TITLE
add guard clause to re enable sandbox migration even though column mi…

### DIFF
--- a/db/data/20251119175520_move_staff_permit_applications_to_sandbox.rb
+++ b/db/data/20251119175520_move_staff_permit_applications_to_sandbox.rb
@@ -2,6 +2,11 @@
 
 class MoveStaffPermitApplicationsToSandbox < ActiveRecord::Migration[7.2]
   def up
+    unless column_exists?(:permit_applications, :sandbox_id)
+      say "Skipping #{self.class.name}: permit_applications.sandbox_id is not present (already migrated or superseded by project-level sandbox)"
+      return
+    end
+
     # Find all permit applications where submitter role is not "submitter" (role != 0)
     # Join with users table to check role
     PermitApplication


### PR DESCRIPTION
Quick PR to fix data migration when run in new order