### PR TITLE
HUB-4960 undefined meui bug

### DIFF
--- a/app/services/step_code/compliance/check_requirements/energy/meui.rb
+++ b/app/services/step_code/compliance/check_requirements/energy/meui.rb
@@ -47,7 +47,8 @@ class StepCode::Compliance::CheckRequirements::Energy::MEUI < StepCode::Complian
   end
 
   def meui_percent_improvement
-    return nil if ref_energy_target == 0 || checklist.step_code?
+    return 0 if ref_energy_target == 0 || checklist.step_code?
+
     @meui_improvement_percentage ||=
       ((ref_energy_target - energy_consumption) / ref_energy_target * 100)
   end

--- a/spec/services/step_code/compliance/check_requirements/energy/meui_spec.rb
+++ b/spec/services/step_code/compliance/check_requirements/energy/meui_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe StepCode::Compliance::CheckRequirements::Energy::MEUI do
   end
 
   context "when neither meui nor percent improvement meets energy step requirement" do
+    let(:ref_aec) { 72.92 }
+
     let(:data_entries_attributes) do
       [
         {
@@ -70,11 +72,37 @@ RSpec.describe StepCode::Compliance::CheckRequirements::Energy::MEUI do
           design_cooling_load: 2189.98,
           air_heat_pump_cooling_capacity: 9,
           building_volume: 624.9,
-          ref_aec: 72.92
+          ref_aec:
         }
       ]
     end
 
-    it_behaves_like FAILED_STEP_CODE
+    context "where the reference energy target is specified and compliance path is not 9.36.5" do
+      it_behaves_like FAILED_STEP_CODE
+    end
+
+    context "where the reference energy target is not specified" do
+      let(:ref_aec) { 25.62 }
+
+      it "sets meui_percent_improvement to zero" do
+        expect(subject.meui_percent_improvement).to eq 0
+      end
+
+      it_behaves_like FAILED_STEP_CODE
+    end
+
+    context "where the compliance path is 9.36.5" do
+      before :each do
+        allow(step_code.pre_construction_checklist).to receive(
+          :step_code?
+        ).and_return(true)
+      end
+
+      it "sets meui_percent_improvement to zero" do
+        expect(subject.meui_percent_improvement).to eq 0
+      end
+
+      it_behaves_like FAILED_STEP_CODE
+    end
   end
 end


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-4960-story-undefined-meui-bug` (merge-base range).

Fixes a checklist crash in MEUI compliance evaluation. The MEUI percent improvement path returned `nil` when the reference energy target was zero or when the checklist used the 9.36.5 Step Code compliance path, but `requirements_met?` still compared that value with `>=`, causing a `NoMethodError`.

This PR treats unavailable MEUI percent improvement as `0`, matching the existing TEDI behavior, and adds regression coverage for both affected cases.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-4960](https://hous-bssb.atlassian.net/browse/HUB-4960) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Prevents `NoMethodError` when MEUI percent improvement is unavailable.
- Returns `0` for unavailable MEUI percent improvement, consistent with TEDI compliance checks.
- Adds specs covering zero reference energy target and 9.36.5 Step Code compliance path behavior.

---

## 🧪 Steps to QA

1. Open a Part 9 Step Code checklist that previously triggered the MEUI error.
2. View the checklist details page.
3. Verify the page loads without a 500 error.
4. Verify MEUI compliance shows as not passing when MEUI does not meet the direct requirement and percent improvement is unavailable.
5. Verify non-9.36.5 checklists with a valid reference energy target still evaluate MEUI percent improvement normally.

**Expected Behaviour:**
The checklist page loads successfully, and unavailable MEUI percent improvement is treated as `0` instead of crashing.

**Before this change:**
Checklist show could fail with `undefined method >= for nil:NilClass` in `MEUI#requirements_met?`.

**After this change:**
MEUI compliance evaluation completes and returns `false` when neither the direct MEUI requirement nor percent improvement requirement is met.

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-4960]: https://hous-bssb.atlassian.net/browse/HUB-4960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ