### PR TITLE
HUB-4866 only navigate if user is on the current pre-check edit flow

### DIFF
--- a/app/frontend/components/domains/pre-check/form-section/confirm-submission.tsx
+++ b/app/frontend/components/domains/pre-check/form-section/confirm-submission.tsx
@@ -29,8 +29,13 @@ export const ConfirmSubmission = observer(function ConfirmSubmission() {
 
       if (result.ok) {
         closeModal()
-        // Navigate to results
-        navigateToNext()
+        const isStillOnCurrentPreCheckEditFlow = window.location.pathname.startsWith(
+          `/pre-checks/${currentPreCheck.id}/edit`
+        )
+
+        if (isStillOnCurrentPreCheckEditFlow) {
+          navigateToNext()
+        }
       } else {
         // Handle error - could show a toast notification
         console.error("Failed to submit pre-check:", result.error)


### PR DESCRIPTION
## 📋 Description

Pre-checks were navigating to the results summary regardless of where the user was on the app.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

[HUB-4866](https://hous-bssb.atlassian.net/browse/HUB-4866)

---

## ✨ Features / Changes Introduced

- Check the current URL to see if the user is editing the same pre-check before navigating

---

## 🧪 Steps to QA

Follow steps described in HUB-4866

**Expected Behaviour:**
User is navigated to precheck results summary only if they're editing the same precheck

**Before this change:**
User is navigated to precheck results summary regardless of current location

**After this change:**
User is navigated to precheck results summary only if they're editing the same precheck

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [X] ✅ Tests written and passing for all changes where relevant
- [X] 📝 Commit messages are descriptive and follow the project convention
- [X] 📗 Related documentation updated; relevant screenshots included
- [X] 📱 For UI changes: responsive design verified across multiple screen sizes
- [X] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [X] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [X] 👀 Self-reviewed this PR before requesting others


[HUB-4866]: https://hous-bssb.atlassian.net/browse/HUB-4866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ