### PR TITLE
HUB-4950 make date filtering in project audits to include full calend…

### DIFF
--- a/app/controllers/api/concerns/search/project_audits.rb
+++ b/app/controllers/api/concerns/search/project_audits.rb
@@ -45,8 +45,8 @@ module Api::Concerns::Search::ProjectAudits
       (
         project_audit_search_params[:filters].to_h || {}
       ).deep_symbolize_keys.compact_blank
-    from = parsed_datetime(search_filters[:from])
-    to = parsed_datetime(search_filters[:to])
+    from = parsed_datetime(search_filters[:from])&.beginning_of_day
+    to = parsed_datetime(search_filters[:to])&.end_of_day
     relation = relation.where("created_at >= ?", from) if from.present?
     relation = relation.where("created_at <= ?", to) if to.present?
     relation

--- a/spec/requests/api/project_audits_spec.rb
+++ b/spec/requests/api/project_audits_spec.rb
@@ -189,6 +189,35 @@ RSpec.describe "Api::ProjectAudits (project activities)", type: :request do
           end
         expect(timestamps).to eq(timestamps.sort)
       end
+
+      it "includes activities on a calendar day when from and to are the same date" do
+        create(
+          :permit_application,
+          permit_project: permit_project,
+          submitter: owner,
+          jurisdiction: jurisdiction
+        )
+        audit =
+          ApplicationAudit
+            .for_permit_project(permit_project.id)
+            .order(:id)
+            .first
+        audit.update_column(:created_at, Time.zone.parse("2026-04-29 14:30:00"))
+
+        post "/api/permit_projects/#{permit_project.id}/activities",
+             params: {
+               filters: {
+                 from: "2026/04/29",
+                 to: "2026/04/29"
+               }
+             },
+             headers: headers,
+             as: :json
+
+        expect(response).to have_http_status(:ok)
+        ids = json_response["data"].map { |row| row["id"] }
+        expect(ids).to include(audit.id)
+      end
     end
 
     context "with sandbox scoping" do


### PR DESCRIPTION
## 📋 Description

Dates were parsing to midnight, so filtering on the same day would not include any results

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

[HUB-4950](https://hous-bssb.atlassian.net/browse/HUB-4950)

---

## ✨ Features / Changes Introduced

> List the key changes, features, or fixes introduced in this PR.

- Use beginning of day for "from" date and end of day for "to" date

---

## 🧪 Steps to QA

> Provide clear, reproducible steps for the reviewer/QA engineer to verify the changes.

1. Open a project
2. Open activity
3. Select the same to and from date in the date picker

**Expected Behaviour:**
Results from that date are displayed

**Before this change:**
No results from that date were displayed

**After this change:**
Results from that date are displayed

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [X] ✅ Tests written and passing for all changes where relevant
- [X] 📝 Commit messages are descriptive and follow the project convention
- [X] 📗 Related documentation updated; relevant screenshots included
- [X] 📱 For UI changes: responsive design verified across multiple screen sizes
- [X] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [X] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [X] 👀 Self-reviewed this PR before requesting others


[HUB-4950]: https://hous-bssb.atlassian.net/browse/HUB-4950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ