### PR TITLE
add file namer service with specs

### DIFF
--- a/app/jobs/pdf_generation_job.rb
+++ b/app/jobs/pdf_generation_job.rb
@@ -35,11 +35,19 @@ class PdfGenerationJob
 
     submission_versions_data =
       submission_version_with_missing_pdfs.map do |submission_version|
-        # Convert data to JSON string
+        file_namer =
+          PermitApplicationGeneratedFileNamer.new(
+            permit_application,
+            date: submission_version.created_at
+          )
         application_filename =
-          "permit_application_#{permit_application.id}_v#{submission_version.version_number}.pdf"
+          file_namer.permit_application_pdf(
+            version_number: submission_version.version_number
+          )
         step_code_filename =
-          "step_code_checklist_#{permit_application.id}_v#{submission_version.version_number}.pdf"
+          file_namer.step_code_checklist_pdf(
+            version_number: submission_version.version_number
+          )
 
         should_permit_application_pdf_be_generated =
           submission_version.missing_permit_application_pdf?

--- a/app/models/supporting_document.rb
+++ b/app/models/supporting_document.rb
@@ -71,6 +71,10 @@ class SupportingDocument < FileUploadAttachment
     end
   end
 
+  def file_name
+    generated_document_filename || super
+  end
+
   def parse_signature(signer)
     {
       name:
@@ -94,6 +98,8 @@ class SupportingDocument < FileUploadAttachment
 
   def standardized_filename
     return "FILE REMOVED" unless file_available?
+
+    return generated_document_filename if generated_document_filename.present?
 
     name =
       "#{permit_application.number}_#{data_key.split("|").last.gsub("_file", "")}"
@@ -144,5 +150,35 @@ class SupportingDocument < FileUploadAttachment
         "#{disposition}; filename=\"#{standardized_filename}\"",
       **options
     )
+  end
+
+  private
+
+  def generated_document_filename
+    return unless STATIC_DOCUMENT_DATA_KEYS.include?(data_key)
+
+    file_namer =
+      PermitApplicationGeneratedFileNamer.new(
+        permit_application,
+        date: generated_document_date
+      )
+
+    if data_key == APPLICATION_PDF_DATA_KEY
+      file_namer.permit_application_pdf(
+        version_number: generated_document_version_number
+      )
+    elsif data_key == CHECKLIST_PDF_DATA_KEY
+      file_namer.step_code_checklist_pdf(
+        version_number: generated_document_version_number
+      )
+    end
+  end
+
+  def generated_document_date
+    submission_version&.created_at || created_at || Time.zone.today
+  end
+
+  def generated_document_version_number
+    submission_version&.version_number || 1
   end
 end

--- a/app/services/permit_application_generated_file_namer.rb
+++ b/app/services/permit_application_generated_file_namer.rb
@@ -1,0 +1,50 @@
+class PermitApplicationGeneratedFileNamer
+  DATE_FORMAT = "%Y-%m-%d"
+
+  def initialize(permit_application, date: Time.zone.today)
+    @permit_application = permit_application
+    @date = date
+  end
+
+  def permit_application_pdf(version_number:)
+    "#{base_name}_permit-application_v#{version_number}.pdf"
+  end
+
+  def step_code_checklist_pdf(version_number:)
+    "#{base_name}_step-code-checklist_v#{version_number}.pdf"
+  end
+
+  def supporting_documents_zip
+    "#{base_name}_supporting-documents.zip"
+  end
+
+  private
+
+  attr_reader :permit_application, :date
+
+  def base_name
+    [permit_application_identifier, formatted_date].map do |segment|
+        safe_segment(segment)
+      end
+      .join("_")
+  end
+
+  def permit_application_identifier
+    permit_application.number.presence || permit_application.id
+  end
+
+  def formatted_date
+    date.to_date.strftime(DATE_FORMAT)
+  end
+
+  def safe_segment(segment)
+    segment
+      .to_s
+      .strip
+      .gsub(/\s+/, "_")
+      .gsub(/[^A-Za-z0-9._-]/, "_")
+      .gsub(/_+/, "_")
+      .delete_prefix("_")
+      .delete_suffix("_")
+  end
+end

--- a/app/services/supporting_documents_zipper.rb
+++ b/app/services/supporting_documents_zipper.rb
@@ -13,11 +13,11 @@ class SupportingDocumentsZipper
     unless File.directory?(zipfiles_directory)
       FileUtils.mkdir_p(zipfiles_directory)
     end
-    submitter = @permit_application.submitter
-    @file_path =
-      zipfiles_directory.join(
-        "#{@permit_application.number}.#{submitter.first_name.first}.#{submitter.last_name}.#{Date.today.strftime("%Y.%m.%d")}.zip"
-      )
+    zip_filename =
+      PermitApplicationGeneratedFileNamer.new(
+        @permit_application
+      ).supporting_documents_zip
+    @file_path = zipfiles_directory.join(zip_filename)
   end
 
   def perform
@@ -44,7 +44,7 @@ class SupportingDocumentsZipper
   end
 
   def upload_zip_file
-    File.open(file_path, "rb") do |file|
+    File.open(file_path.to_s, "rb") do |file|
       uploader = ZipfileUploader.new(:store)
       temp_files << file.path
       uploaded_file = uploader.upload(file)

--- a/spec/jobs/pdf_generation_job_spec.rb
+++ b/spec/jobs/pdf_generation_job_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe PdfGenerationJob, type: :job do
   end
 
   it "generates and attaches PDFs when renderer succeeds" do
-    permit_application = instance_double("PermitApplication", id: "pa1")
+    permit_application =
+      instance_double("PermitApplication", id: "pa1", number: "DSQ-001-000-057")
     allow(PermitApplication).to receive(:find).with("pa1").and_return(
       permit_application
     )
@@ -43,7 +44,7 @@ RSpec.describe PdfGenerationJob, type: :job do
         },
         formatted_submission_data: {
         },
-        created_at: Time.current,
+        created_at: Time.zone.local(2026, 4, 29),
         has_step_code_checklist?: true,
         step_code_checklist_json: {
         },
@@ -73,6 +74,12 @@ RSpec.describe PdfGenerationJob, type: :job do
       # Create the files the job expects to attach.
       data = JSON.parse(File.read(json_filename))
       paths = data.fetch("meta").fetch("generationPaths")
+      expect(paths.fetch("permitApplication")).to end_with(
+        "DSQ-001-000-057_2026-04-29_permit-application_v1.pdf"
+      )
+      expect(paths.fetch("stepCodeChecklist")).to end_with(
+        "DSQ-001-000-057_2026-04-29_step-code-checklist_v1.pdf"
+      )
       paths.values.compact.each do |path|
         FileUtils.mkdir_p(File.dirname(path))
         File.write(path, "%PDF-1.4")
@@ -92,7 +99,8 @@ RSpec.describe PdfGenerationJob, type: :job do
   end
 
   it "raises and cleans up when renderer fails" do
-    permit_application = instance_double("PermitApplication", id: "pa1")
+    permit_application =
+      instance_double("PermitApplication", id: "pa1", number: "DSQ-001-000-057")
     allow(PermitApplication).to receive(:find).with("pa1").and_return(
       permit_application
     )

--- a/spec/models/supporting_document_spec.rb
+++ b/spec/models/supporting_document_spec.rb
@@ -2,4 +2,71 @@ require "rails_helper"
 
 RSpec.describe SupportingDocument, type: :model do
   it { should belong_to(:permit_application) }
+
+  describe "generated document filenames" do
+    let(:permit_application) do
+      instance_double("PermitApplication", id: "pa1", number: "DSQ-001-000-057")
+    end
+    let(:submission_version) do
+      instance_double(
+        "SubmissionVersion",
+        version_number: 1,
+        created_at: Time.zone.local(2026, 4, 29)
+      )
+    end
+
+    it "uses readable names for generated permit application PDFs" do
+      document =
+        described_class.new(
+          data_key: SupportingDocument::APPLICATION_PDF_DATA_KEY,
+          file_data: {
+            "id" => "store/generated-guid.pdf",
+            "metadata" => {
+              "filename" => "permit_application_guid_v1.pdf"
+            }
+          }
+        )
+      allow(document).to receive(:permit_application).and_return(
+        permit_application
+      )
+      allow(document).to receive(:submission_version).and_return(
+        submission_version
+      )
+      allow(document).to receive(:file_available?).and_return(true)
+
+      expect(document.file_name).to eq(
+        "DSQ-001-000-057_2026-04-29_permit-application_v1.pdf"
+      )
+      expect(document.standardized_filename).to eq(
+        "DSQ-001-000-057_2026-04-29_permit-application_v1.pdf"
+      )
+    end
+
+    it "uses readable names for generated step code checklist PDFs" do
+      document =
+        described_class.new(
+          data_key: SupportingDocument::CHECKLIST_PDF_DATA_KEY,
+          file_data: {
+            "id" => "store/generated-guid.pdf",
+            "metadata" => {
+              "filename" => "step_code_checklist_guid_v1.pdf"
+            }
+          }
+        )
+      allow(document).to receive(:permit_application).and_return(
+        permit_application
+      )
+      allow(document).to receive(:submission_version).and_return(
+        submission_version
+      )
+      allow(document).to receive(:file_available?).and_return(true)
+
+      expect(document.file_name).to eq(
+        "DSQ-001-000-057_2026-04-29_step-code-checklist_v1.pdf"
+      )
+      expect(document.standardized_filename).to eq(
+        "DSQ-001-000-057_2026-04-29_step-code-checklist_v1.pdf"
+      )
+    end
+  end
 end

--- a/spec/services/permit_application_generated_file_namer_spec.rb
+++ b/spec/services/permit_application_generated_file_namer_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe PermitApplicationGeneratedFileNamer do
+  let(:permit_application) do
+    instance_double(
+      "PermitApplication",
+      id: "10a8aab1",
+      number: "DSQ-001-000-057"
+    )
+  end
+
+  subject(:namer) do
+    described_class.new(permit_application, date: Date.new(2026, 4, 29))
+  end
+
+  it "builds no-space filenames from the permit application number and ISO date" do
+    expect(namer.permit_application_pdf(version_number: 1)).to eq(
+      "DSQ-001-000-057_2026-04-29_permit-application_v1.pdf"
+    )
+    expect(namer.step_code_checklist_pdf(version_number: 2)).to eq(
+      "DSQ-001-000-057_2026-04-29_step-code-checklist_v2.pdf"
+    )
+    expect(namer.supporting_documents_zip).to eq(
+      "DSQ-001-000-057_2026-04-29_supporting-documents.zip"
+    )
+  end
+
+  it "falls back to the permit application id when number is unavailable" do
+    allow(permit_application).to receive(:number).and_return(nil)
+
+    expect(namer.permit_application_pdf(version_number: 1)).to eq(
+      "10a8aab1_2026-04-29_permit-application_v1.pdf"
+    )
+  end
+end

--- a/spec/services/supporting_documents_zipper_spec.rb
+++ b/spec/services/supporting_documents_zipper_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe SupportingDocumentsZipper do
     let(:zip_entry_zipfile) { instance_double("Zip::File") }
 
     before do
+      allow(Time.zone).to receive(:today).and_return(Date.new(2026, 4, 29))
       allow(PermitApplication).to receive(:find).and_return(permit_application)
       allow(FileUtils).to receive(:mkdir_p)
       allow(File).to receive(:directory?).and_return(true)
@@ -88,6 +89,10 @@ RSpec.describe SupportingDocumentsZipper do
         "/tmp/f2.pdf"
       )
       expect(zipfile_uploader).to have_received(:upload)
+      expect(File).to have_received(:open).with(
+        end_with("PA-0001_2026-04-29_supporting-documents.zip"),
+        "rb"
+      )
       expect(permit_application).to have_received(:zipfile_data=).with(
         { "id" => "zip-1" }
       )


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-4997-bug-rm-rrm-view-submitted-application-download-files-bph-generated-files-include-guid-in-filename` (merge-base range).

Fixes generated permit application download filenames so reviewers no longer see long GUIDs in the submission download modal. Generated permit application PDFs, step code checklist PDFs, and supporting document ZIP files now use the permit application number when available plus an ISO-style date, with no spaces.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-4997](https://hous-bssb.atlassian.net/browse/HUB-4997) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Adds `PermitApplicationGeneratedFileNamer` to standardize generated permit application filenames.
- Updates generated permit application PDFs and step code checklist PDFs to use names like `DSQ-001-000-057-2026-04-29-permit-application-v1.pdf`.
- Updates generated ZIP files to use names like `DSQ-001-000-057-2026-04-29-supporting-documents.zip`.
- Updates generated supporting document display/download names so existing generated files no longer show GUID-based names in the modal.
- Adds specs for PDF generation paths, ZIP naming, generated document display names, and fallback behavior when permit application number is unavailable.

---

## 🧪 Steps to QA

1. Sign in as a reviewer or review manager.
2. Navigate to a submitted permit application with generated files.
3. Open the “Download application” modal.
4. Confirm generated permit application PDF and step code checklist PDF names do not include GUIDs.
5. Confirm filenames include the permit application number and date.
6. Download the ZIP and confirm the ZIP filename follows the same readable naming pattern.
7. Confirm uploaded user files still show their original filenames.

**Expected Behaviour:**
Generated files use readable, no-space filenames based on permit application number and date.

**Before this change:**
Generated files displayed names containing long permit application GUIDs.

**After this change:**
Generated files display concise filenames such as `DSQ-001-000-057-2026-04-29-permit-application-v1.pdf`.

---

## ♿ UI Accessibility Checklist

No markup or interaction changes in this PR. Existing modal behavior is unchanged; only generated filenames are updated.

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-4997]: https://hous-bssb.atlassian.net/browse/HUB-4997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ