### PR TITLE
move inputs into env in deploy

### DIFF
--- a/.github/actions/openshift-deploy/action.yml
+++ b/.github/actions/openshift-deploy/action.yml
@@ -66,8 +66,11 @@ runs:
     - name: Confirm branch and SHA to deploy
       id: confirm-deploy-target
       shell: bash
+      env:
+        DEPLOY_BRANCH: ${{ inputs.branch }}
+        ENVIRONMENT_LABEL: ${{ inputs.environment_label }}
       run: |
-        echo "Deploying branch: ${{ inputs.branch }} @ ${{ env.GITHUB_SHA }} to ${{ inputs.environment_label }}"
+        echo "Deploying branch: ${DEPLOY_BRANCH} @ ${GITHUB_SHA} to ${ENVIRONMENT_LABEL}"
 
     - name: Build Docker Image
       id: build-image


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...chore/address-ghas-inputbranch` (merge-base range).

This PR addresses a GitHub Advanced Security script-injection warning in the reusable OpenShift deploy action. The deploy confirmation log step now passes workflow inputs through step-level environment variables before referencing them from Bash, so user-provided `branch` and `environment_label` values are treated as data instead of being interpolated directly into the shell script.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-XXXX](https://hous-bssb.atlassian.net/browse/HUB-XXXX) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | N/A |
| 📚 Documentation | N/A |

---

## ✨ Features / Changes Introduced

- Moves `branch` and `environment_label` workflow inputs into step-level environment variables before shell usage.
- Updates the deploy confirmation log command to reference Bash environment variables instead of direct GitHub expression interpolation.
- Reduces GitHub Actions script-injection alert noise while preserving the existing deploy log output.

---

## 🧪 Steps to QA

1. Open the GitHub Actions workflow for a non-production OpenShift deploy environment.
2. Manually dispatch the workflow with a normal branch value.
3. Confirm the deploy action reaches the `Confirm branch and SHA to deploy` step successfully.
4. Confirm the log still prints the selected branch, resolved SHA, and target environment.
5. Confirm GitHub Advanced Security no longer reports script injection for `inputs.branch` or `inputs.environment_label` in this step.

**Expected Behaviour:**
The deployment workflow continues to log the selected deploy target, and GHAS no longer flags direct user-controlled input interpolation in the Bash `run` block.

**Before this change:**
The deploy confirmation step interpolated `${{ inputs.branch }}` and `${{ inputs.environment_label }}` directly into a shell command, triggering GHAS script-injection warnings.

**After this change:**
The inputs are assigned to environment variables first, and the shell script references those variables instead.

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [x] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others