### PR TITLE
HUB-5003 redact project title from jurisdiction staff and use template instead…

### DIFF
--- a/app/blueprints/permit_project_blueprint.rb
+++ b/app/blueprints/permit_project_blueprint.rb
@@ -2,8 +2,15 @@ class PermitProjectBlueprint < Blueprinter::Base
   identifier :id
 
   view :base do
-    fields :title,
-           :full_address,
+    field :title,
+          if: ->(_field_name, permit_project, options) do
+            PermitProjectBlueprint.show_private_title?(
+              permit_project,
+              options[:current_user]
+            )
+          end
+
+    fields :full_address,
            :pid,
            :number,
            :jurisdiction_disambiguated_name,
@@ -122,5 +129,11 @@ class PermitProjectBlueprint < Blueprinter::Base
                 view: :base do |permit_project, options|
       permit_project.recent_audits(options[:current_user])
     end
+  end
+
+  def self.show_private_title?(permit_project, current_user)
+    return false unless current_user
+
+    return true if permit_project.owner_id == current_user.id
   end
 end

--- a/app/controllers/api/permit_classifications_controller.rb
+++ b/app/controllers/api/permit_classifications_controller.rb
@@ -152,8 +152,7 @@ class Api::PermitClassificationsController < Api::ApplicationController
     rescue StandardError => e
       render_error(
         "permit_classification.destroy_error",
-        { message_opts: { error_message: e.message } },
-        e
+        { log_args: { errors: e.message } }
       )
     end
   end

--- a/app/controllers/api/permit_projects_controller.rb
+++ b/app/controllers/api/permit_projects_controller.rb
@@ -109,7 +109,7 @@ class Api::PermitProjectsController < Api::ApplicationController
   rescue => e
     render_error(
       "permit_project.assign_project_review_collaborator_error",
-      { message_opts: { error_message: e.message }, status: 422 }
+      { status: 422, log_args: { errors: e.message } }
     )
   end
 
@@ -139,10 +139,11 @@ class Api::PermitProjectsController < Api::ApplicationController
       render_error(
         "permit_project.update_error",
         {
-          message_opts: {
-            errors: @permit_project.errors.full_messages
-          },
-          status: :unprocessable_entity
+          status: :unprocessable_entity,
+          log_args: {
+            errors: @permit_project.errors.full_messages,
+            params: permit_project_params.to_h
+          }
         }
       )
     end
@@ -164,12 +165,13 @@ class Api::PermitProjectsController < Api::ApplicationController
                      }
     else
       render_error(
-        "permit_project.create_error", # Add this translation key
+        "permit_project.create_error",
         {
-          message_opts: {
-            errors: @permit_project.errors.full_messages
-          },
-          status: :unprocessable_entity
+          status: :unprocessable_entity,
+          log_args: {
+            errors: @permit_project.errors.full_messages,
+            params: permit_project_params.to_h
+          }
         }
       )
     end

--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -150,23 +150,21 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     ActiveRecord::Base.transaction do
       unless @requirement_template.update(requirement_template_params)
         render_error "requirement_template.schedule_error",
-                     message_opts: {
-                       error_message:
-                         @requirement_template.errors.full_messages.join(", ")
+                     log_args: {
+                       errors: @requirement_template.errors.full_messages
                      }
       end
       @requirement_template.touch
       begin
-        scheduled_template_version =
-          TemplateVersioningService.schedule!(
-            @requirement_template,
-            Date.parse(schedule_params)
-          )
+        TemplateVersioningService.schedule!(
+          @requirement_template,
+          Date.parse(schedule_params)
+        )
       rescue StandardError => e
         # If there is an error in TemplateVersioningService.schedule!, rollback the transaction
         render_error "requirement_template.schedule_error",
-                     message_opts: {
-                       error_message: e.message
+                     log_args: {
+                       errors: e.message
                      }
         raise ActiveRecord::Rollback
       end
@@ -226,8 +224,8 @@ class Api::RequirementTemplatesController < Api::ApplicationController
                      }
     else
       render_error "requirement_template.force_publish_now_error",
-                   message_opts: {
-                     error_message: error_message
+                   log_args: {
+                     errors: [error_message]
                    }
     end
   end
@@ -236,12 +234,11 @@ class Api::RequirementTemplatesController < Api::ApplicationController
     authorize @template_version, policy_class: RequirementTemplatePolicy
 
     begin
-      template_version =
-        TemplateVersioningService.unschedule!(@template_version, current_user)
+      TemplateVersioningService.unschedule!(@template_version, current_user)
     rescue StandardError => e
       render_error "requirement_template.template_unschedule_error",
-                   message_opts: {
-                     error_message: e.message
+                   log_args: {
+                     errors: e.message
                    }
     end
 

--- a/app/controllers/external_api/application_controller.rb
+++ b/app/controllers/external_api/application_controller.rb
@@ -38,8 +38,7 @@ class ExternalApi::ApplicationController < ActionController::API
   def external_api_key_not_authorized(exception)
     render_error(
       "misc.external_api_key_unauthorized_error",
-      { message_opts: { error_message: exception.message }, status: 403 },
-      exception
+      { status: 403, log_args: { errors: exception.message } }
     ) and return
   end
 

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/application-inbox-table.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/application-inbox-table.tsx
@@ -239,7 +239,7 @@ const ApplicationInboxRow = observer(function ApplicationInboxRow({
       <SearchGridItem>
         <VStack align="start" spacing={0}>
           <Text fontWeight={700} fontSize="sm" noOfLines={1}>
-            {application.nickname || application.permitType?.name || application.permitTypeAndActivity || "—"}
+            {application.templateNickname || "—"}
           </Text>
           <Text fontSize="xs" color="text.secondary" noOfLines={1}>
             {application.number}

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-project-detail-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-project-detail-screen.tsx
@@ -78,7 +78,7 @@ export const InboxProjectDetailScreen = observer(() => {
               mr={2}
             />
             <Heading as="h1" fontWeight={700} fontSize="3xl" flex={1} noOfLines={1} mb={0}>
-              {currentPermitProject.title}
+              {currentPermitProject.number}
             </Heading>
             {/* todo: inbox specific rollup status box? */}
             {/* <RollupStatusBox project={currentPermitProject} w="240px" /> */}

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-inbox-table.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-inbox-table.tsx
@@ -99,14 +99,9 @@ export const ProjectInboxTable = observer(function ProjectInboxTable({ searchSto
           <HStack spacing={3}>
             <Circle size="8px" bg={!project.viewedAt ? "theme.blueActive" : "transparent"} flexShrink={0} />
 
-            <VStack align="start" spacing={0}>
-              <Text fontWeight={700} fontSize="sm">
-                {project.number}
-              </Text>
-              <Text fontSize="xs" color="text.secondary" noOfLines={1}>
-                {project.title}
-              </Text>
-            </VStack>
+            <Text fontWeight={700} fontSize="sm">
+              {project.number}
+            </Text>
           </HStack>
         </SearchGridItem>
 

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-kanban-board.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-kanban-board.tsx
@@ -160,10 +160,6 @@ const ProjectKanbanCard = observer(function ProjectKanbanCard({
           </HStack>
         </Box>
 
-        <Text fontSize="xs" color="text.secondary" noOfLines={1}>
-          {project.title}
-        </Text>
-
         <Text fontSize="xs" noOfLines={1} mt={1.5}>
           {project.shortAddress}
         </Text>

--- a/app/frontend/models/permit-project.ts
+++ b/app/frontend/models/permit-project.ts
@@ -13,7 +13,7 @@ import { PermitProjectInboxApplicationSearchSlice } from "./permit-project-inbox
 
 const PermitProjectCoreModel = types.model("PermitProjectCore", {
   id: types.identifier,
-  title: types.maybe(types.string),
+  title: types.optional(types.string, "-"),
   fullAddress: types.maybeNull(types.string),
   pid: types.maybeNull(types.string),
   number: types.maybeNull(types.string),

--- a/app/frontend/models/permit-project.ts
+++ b/app/frontend/models/permit-project.ts
@@ -13,7 +13,7 @@ import { PermitProjectInboxApplicationSearchSlice } from "./permit-project-inbox
 
 const PermitProjectCoreModel = types.model("PermitProjectCore", {
   id: types.identifier,
-  title: types.string,
+  title: types.maybe(types.string),
   fullAddress: types.maybeNull(types.string),
   pid: types.maybeNull(types.string),
   number: types.maybeNull(types.string),

--- a/app/models/permit_project_collaboration.rb
+++ b/app/models/permit_project_collaboration.rb
@@ -29,13 +29,11 @@ class PermitProjectCollaboration < ApplicationRecord
       "action_text" =>
         I18n.t(
           "notification.permit_project_collaboration.assignment_notification",
-          project_number: permit_project.number,
-          project_title: permit_project.title
+          project_number: permit_project.number
         ),
       "object_data" => {
         "permit_project_id" => permit_project.id,
         "project_number" => permit_project.number,
-        "project_title" => permit_project.title,
         "jurisdiction_slug" => permit_project.jurisdiction&.slug
       }
     }
@@ -49,13 +47,11 @@ class PermitProjectCollaboration < ApplicationRecord
       "action_text" =>
         I18n.t(
           "notification.permit_project_collaboration.unassignment_notification",
-          project_number: permit_project.number,
-          project_title: permit_project.title
+          project_number: permit_project.number
         ),
       "object_data" => {
         "permit_project_id" => permit_project.id,
         "project_number" => permit_project.number,
-        "project_title" => permit_project.title,
         "jurisdiction_slug" => permit_project.jurisdiction&.slug
       }
     }

--- a/app/views/permit_hub_mailer/notify_project_review_collaboration.erb
+++ b/app/views/permit_hub_mailer/notify_project_review_collaboration.erb
@@ -23,9 +23,6 @@
                   <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Project #</dt>
                   <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 1px solid #d9d9d9;"><%= @permit_project.number %></dd>
 
-                  <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Title</dt>
-                  <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 1px solid #d9d9d9;"><%= @permit_project.title %></dd>
-
                   <% if @permit_project.full_address.present? %>
                     <dt style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; font-size: 11px; text-transform: uppercase; font-weight: bold; padding-top: 10px; padding-bottom: 8px;">Address</dt>
                     <dd style="box-sizing: border-box; padding-left: 16px; padding-right: 16px; margin: 0; padding-bottom: 10px; border-bottom: 0;"><%= @permit_project.full_address %></dd>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1015,8 +1015,8 @@ en:
       review_delegatee_collaboration_unassignment_notification: "You have been removed as a designated reviewer for permit application %{number}."
       review_assignee_collaboration_unassignment_notification: "You have been removed as a review collaborator on requirement “%{requirement_block_name}” for permit application %{number}"
     permit_project_collaboration:
-      assignment_notification: "You have been assigned as a review collaborator on project %{project_number} (%{project_title})."
-      unassignment_notification: "You have been removed as a review collaborator on project %{project_number} (%{project_title})."
+      assignment_notification: "You have been assigned as a review collaborator on project %{project_number}."
+      unassignment_notification: "You have been removed as a review collaborator on project %{project_number}."
     step_code:
       report_generated: "Your step code report is ready to download"
     pre_check:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,7 +263,7 @@ en:
         message: "There was an error updating the permit classification"
       destroy_error:
         title: Error
-        message: "%{error_message}"
+        message: "There was an error deleting the permit classification"
       in_use_error:
         title: Error
         message: "This permit classification is in use and cannot be deleted"
@@ -538,16 +538,16 @@ en:
         message: "%{error_message}"
       schedule_error:
         title: Error
-        message: "%{error_message}"
+        message: "There was an error scheduling the template"
       template_unschedule_error:
         title: Error unscheduling template
-        message: "%{error_message}"
+        message: "There was an error unscheduling the template"
       template_unschedule_success:
         title: ""
         message: "Template unscheduled successfully"
       force_publish_now_error:
         title: Error force publishing template
-        message: "%{error_message}"
+        message: "There was an error publishing the template"
       delete_error:
         title: Error
         message: "%{error_message}"
@@ -673,13 +673,13 @@ en:
         message: "Project updated successfully"
       update_error:
         title: Error
-        message: "%{error_message}"
+        message: "Project could not be updated"
       create_success:
         title: ""
         message: "Permit project created successfully"
       create_error:
         title: Error
-        message: "%{error_message}"
+        message: "Permit project could not be created"
       pin_success:
         title: ""
         message: "Permit project pinned successfully"
@@ -703,7 +703,7 @@ en:
         message: "Project review collaborator assigned successfully"
       assign_project_review_collaborator_error:
         title: Error
-        message: "%{error_message}"
+        message: "Project review collaborator could not be assigned"
       unassign_project_review_collaborator_success:
         title: ""
         message: "Project review collaborator removed successfully"
@@ -820,7 +820,7 @@ en:
         message: "The external api key is not authorized to do this action"
       external_api_key_unauthorized_error:
         title: "Unauthorized"
-        message: "%{error_message}"
+        message: "The external api key is not authorized to do this action"
       not_found_error:
         title: "Error"
         message: 404 - The requested resource could not be found


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5003-story-submission-inbox-item-name-content` (merge-base range).

Updates submission inbox item naming so jurisdiction staff see appropriate public-facing item content instead of applicant-private project titles. Project names are now removed from jurisdiction staff project inbox views, staff-facing project review notifications, and the staff project payload. Application inbox rows now use the requirement template nickname as the item name while keeping the permit application number beneath it.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5003](https://hous-bssb.atlassian.net/browse/HUB-5003) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Removes applicant-private project titles from jurisdiction staff project inbox list, kanban cards, and project detail header.
- Redacts project title from staff-facing `PermitProjectBlueprint` serialization unless the current user owns the project.
- Removes project title from project review collaborator in-app notification data and email content.
- Updates the application inbox “Permit type” column cells to show the requirement template nickname, with the permit application number still shown underneath.

---

## 🧪 Steps to QA

1. Log in as jurisdiction staff with access to the submission inbox.
2. Navigate to the submission inbox and view the Projects tab in both list and kanban modes.
3. Verify project rows/cards show project number, address, PID, counts, and status details, but do not show the applicant-entered project title.
4. Open a project detail page from the inbox and verify the page heading shows the project number instead of the project title.
5. View the Applications tab and verify the first column shows each application’s requirement template nickname, with the permit application number still displayed beneath it.
6. Assign and unassign a project review collaborator and verify staff-facing notification/email content references the project number only, not the project title.
7. Add before/after screenshots for the submission inbox list, kanban, and application table views.

**Expected Behaviour:**
Jurisdiction staff can identify inbox items using public permit/project identifiers and requirement template names without seeing applicant-private project titles.

**Before this change:**
Project inbox rows, cards, details, and some review collaborator notifications exposed project titles created by applicants.

**After this change:**
Project titles are hidden from jurisdiction staff inbox surfaces and project review collaborator notifications. Application inbox item names use requirement template nicknames.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5003]: https://hous-bssb.atlassian.net/browse/HUB-5003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ