### PR TITLE
HUB 5010 suppress inbox links to new draft applications

### DIFF
--- a/app/frontend/components/domains/permit-project/activity-list-item.tsx
+++ b/app/frontend/components/domains/permit-project/activity-list-item.tsx
@@ -1,9 +1,11 @@
-import { Flex, HStack, Text } from "@chakra-ui/react"
+import { Flex, HStack, Text, Tooltip } from "@chakra-ui/react"
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React from "react"
+import { useTranslation } from "react-i18next"
 import { datefnsTableDateTimeFormat } from "../../../constants"
 import { IProjectAudit } from "../../../models/project-audit"
+import { EPermitApplicationStatus } from "../../../types/enums"
 import { RouterLink } from "../../shared/navigation/router-link"
 
 interface IActivityListItemProps {
@@ -12,16 +14,27 @@ interface IActivityListItemProps {
 }
 
 export const ActivityListItem = observer(({ projectAudit, fromInbox = false }: IActivityListItemProps) => {
-  const { createdAt, description, permitName, permitApplicationId } = projectAudit
+  const { createdAt, description, permitName, permitApplicationId, permitApplicationStatus } = projectAudit
+  const { t } = useTranslation()
   const permitApplicationPath =
     permitApplicationId &&
     (fromInbox ? `/permit-applications/${permitApplicationId}` : `/permit-applications/${permitApplicationId}/edit`)
+  const suppressPermitApplicationLink = fromInbox && permitApplicationStatus === EPermitApplicationStatus.newDraft
 
   return (
     <Flex align="center" justify="space-between" py={3} px={4} gap={4} minH={20}>
       <HStack align="center" spacing={1} flex={1} minW={0}>
         <Text>{description}</Text>
-        {permitName && <RouterLink to={permitApplicationPath ?? undefined}>{permitName}</RouterLink>}
+        {permitName &&
+          (suppressPermitApplicationLink ? (
+            <Tooltip label={t("permitProject.activity.unsubmittedPermitApplication")} hasArrow>
+              <Text as="span" color="text.secondary" cursor="not-allowed">
+                {permitName}
+              </Text>
+            </Tooltip>
+          ) : (
+            <RouterLink to={permitApplicationPath ?? undefined}>{permitName}</RouterLink>
+          ))}
       </HStack>
       <Text variant="secondary">{format(createdAt, datefnsTableDateTimeFormat)}</Text>
     </Flex>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1366,6 +1366,7 @@ Thank you,
             toFilter: "To date",
             empty: "No activity found",
             description: "What’s happened on this project and its permit applications.",
+            unsubmittedPermitApplication: "This application has not been submitted yet.",
           },
           permits: {
             title: "Applications",

--- a/app/frontend/models/project-audit.ts
+++ b/app/frontend/models/project-audit.ts
@@ -1,4 +1,5 @@
 import { Instance, types } from "mobx-state-tree"
+import { EPermitApplicationStatus } from "../types/enums"
 
 export const ProjectAuditModel = types.model("ProjectAuditModel", {
   id: types.identifier,
@@ -6,6 +7,7 @@ export const ProjectAuditModel = types.model("ProjectAuditModel", {
   createdAt: types.Date,
   permitApplicationId: types.maybeNull(types.string),
   permitName: types.maybeNull(types.string),
+  permitApplicationStatus: types.maybeNull(types.enumeration(Object.values(EPermitApplicationStatus))),
 })
 
 export interface IProjectAudit extends Instance<typeof ProjectAuditModel> {}


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff stable...HUB-5010-bug-rm-submissions-project-overview-activity-application-links-in-activity-display-submitter-view-causes-403-supress` (merge-base range).

This fixes confusing inbox activity links for review staff. When a linked permit application is still a `new_draft`, reviewers cannot access it by policy, so the inbox now suppresses that link and shows the permit name as disabled text with a tooltip explaining that the application has not been submitted yet.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5010](https://hous-bssb.atlassian.net/browse/HUB-5010) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Adds permit application status to the project audit frontend model.
- Suppresses inbox activity links when the linked permit application is still `new_draft`.
- Shows disabled permit text with tooltip copy: “This application has not been submitted yet.”
- Keeps existing link behavior for submitted applications and non-inbox activity views.

---

## 🧪 Steps to QA

1. Sign in as review staff with access to a jurisdiction inbox.
2. Open a project activity feed from the submission inbox that includes an activity linked to an unsubmitted permit application.
3. Verify the permit application name is visible but not clickable.
4. Hover or focus around the disabled permit name and verify the tooltip explains that the application has not been submitted yet.
5. Confirm submitted permit application activity links still navigate to the review permit application page.

**Expected Behaviour:**
Review staff can see activity context, but unsubmitted permit applications do not appear as usable links from the inbox.

**Before this change:**
Review staff could click an inbox activity link to an unsubmitted application and land on an error/unauthorized screen.

**After this change:**
The unsubmitted application name is disabled with explanatory tooltip text, preventing confusing navigation.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [x] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [ ] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5010]: https://hous-bssb.atlassian.net/browse/HUB-5010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ