### PR TITLE
pass through all path params when regenerating url for changed rrm ju…

### DIFF
--- a/app/frontend/hooks/resources/use-jurisdiction.ts
+++ b/app/frontend/hooks/resources/use-jurisdiction.ts
@@ -32,11 +32,11 @@ export const useJurisdiction = () => {
     "/jurisdictions/:jurisdictionId/api-settings",
   ]
 
-  const findMatchingPathTemplate = (pathname) => {
+  const findMatchingPathMatch = (pathname) => {
     for (let route of jursidictionRoutes) {
       const match = matchPath(route, pathname)
       if (match) {
-        return route
+        return { route, params: match.params }
       }
     }
     return null
@@ -45,15 +45,22 @@ export const useJurisdiction = () => {
   // check if this is a jurisdiction specific route
   // if it is and if the user's jurisdiction changes, navigate to the same route for the new jurisdiction
   useEffect(() => {
-    if (currentUser?.isRegionalReviewManager && currentUser?.jurisdiction?.id != jurisdictionId) {
-      const originalPath = findMatchingPathTemplate(pathname)
-      if (!originalPath) return
+    const currentUserJurisdiction = currentUser?.jurisdiction
+    const isCurrentUserJurisdiction =
+      currentUserJurisdiction?.id === jurisdictionId || currentUserJurisdiction?.slug === jurisdictionId
+
+    if (currentUser?.isRegionalReviewManager && currentUserJurisdiction && !isCurrentUserJurisdiction) {
+      const pathMatch = findMatchingPathMatch(pathname)
+      if (!pathMatch) return
 
       // Get the existing query params
       const existingQuery = window.location.search
 
       // Generate the new path
-      const path = generatePath(originalPath, { jurisdictionId: currentUser.jurisdiction.slug })
+      const path = generatePath(pathMatch.route, {
+        ...pathMatch.params,
+        jurisdictionId: currentUserJurisdiction.slug,
+      })
 
       // Append the existing query params to the new path
       const newPathWithQuery = `${path}${existingQuery}`


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff stable...bugfix/missing-occupancy-key` (merge-base range).

This PR fixes an intermittent crash on jurisdiction Energy Step Code Part 3 occupancy detail pages. The root cause was the regional review manager jurisdiction redirect regenerating matched jurisdiction routes with only `jurisdictionId`, which dropped dynamic route params like `occupancyKey` and caused React Router to throw `Missing ":occupancyKey" param`.

The redirect now preserves all matched route params when regenerating the URL, while still replacing the jurisdiction with the current user's jurisdiction slug. It also treats both jurisdiction IDs and slugs as valid matches to avoid unnecessary redirects when the URL already points at the current jurisdiction by slug.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-XXXX](https://hous-bssb.atlassian.net/browse/HUB-XXXX) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Preserves all matched route params when regenerating jurisdiction-specific URLs for regional review managers.
- Fixes crashes on nested jurisdiction routes that require params beyond `jurisdictionId`, such as Part 3 occupancy detail pages requiring `occupancyKey`.
- Avoids unnecessary regional review manager redirects when the current jurisdiction is already represented in the URL by slug instead of UUID.

---

## 🧪 Steps to QA

1. Sign in as a regional review manager with access to the District of Squamish jurisdiction.
2. Navigate to `/jurisdictions/district-of-squamish/configuration-management/energy-step/part-3/schools_other_than_colleges`.
3. Verify the Part 3 occupancy detail page loads without a router crash.
4. Navigate between the Part 3 occupancy overview and multiple occupancy detail rows.
5. Verify browser refresh on an occupancy detail URL keeps the same occupancy page loaded.
6. Verify query params, if present, are preserved during the jurisdiction redirect.

**Expected Behaviour:**
The page loads normally and keeps the `occupancyKey` segment in the URL.

**Before this change:**
The redirect could call `generatePath` without `occupancyKey`, causing React Router to throw `Missing ":occupancyKey" param`.

**After this change:**
The redirect passes through matched route params and only replaces `jurisdictionId`, so nested jurisdiction routes are regenerated successfully.

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others