### PR TITLE
fix failing specs on large classification and draftrefactors

### DIFF
--- a/app/services/template_version_preview/management_service.rb
+++ b/app/services/template_version_preview/management_service.rb
@@ -68,6 +68,12 @@ class TemplateVersionPreview::ManagementService
       template_version
         .template_version_previews
         .find_or_create_by!(previewer: previewer) do |p|
+          # TODO: Remove after early-access preview cleanup runs in all envs.
+          # db/schema.rb still has this legacy NOT NULL column until final cleanup.
+          if p.has_attribute?(:early_access_requirement_template_id)
+            p.early_access_requirement_template_id =
+              template_version.requirement_template_id
+          end
           p.expires_at = expires_at
         end
 

--- a/spec/requests/api/qa_tools_spec.rb
+++ b/spec/requests/api/qa_tools_spec.rb
@@ -76,14 +76,6 @@ RSpec.describe "Api::QaTools", type: :request do
   end
 
   before do
-    requirement_template.permit_type.update!(enabled: true)
-    requirement_template.activity.update!(enabled: true)
-
-    create(
-      :permit_type_submission_contact,
-      jurisdiction: jurisdiction,
-      permit_type: requirement_template.permit_type
-    )
     allow(TemplateVersion).to receive(:cached_published_ids).and_return(
       [template_version.id]
     )
@@ -184,8 +176,6 @@ RSpec.describe "Api::QaTools", type: :request do
         :permit_application,
         submitter: submitter,
         jurisdiction: jurisdiction,
-        permit_type: requirement_template.permit_type,
-        activity: requirement_template.activity,
         template_version: template_version
       )
     end

--- a/spec/services/qa/permit_application_autofill_service_spec.rb
+++ b/spec/services/qa/permit_application_autofill_service_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe Qa::PermitApplicationAutofillService do
   let(:user) { instance_double("User", review_staff?: false) }
   let(:permit_application) do
-    instance_double("PermitApplication", reload: true, submitter: user)
-  end
-  let(:submission_data_service) do
     instance_double(
-      PermitApplication::SubmissionDataService,
-      update_with_submission_data_merge: true
+      "PermitApplication",
+      reload: true,
+      submitter: user,
+      submission_data: nil,
+      update: true
     )
   end
 
@@ -23,12 +23,14 @@ RSpec.describe Qa::PermitApplicationAutofillService do
                 {
                   "key" =>
                     "section-a.formSubmissionDataRSTsection-a|RBblock-1|text",
-                  "type" => "textfield"
+                  "type" => "textfield",
+                  "input" => true
                 },
                 {
                   "key" =>
                     "section-a.formSubmissionDataRSTsection-a|RBblock-1|count",
-                  "type" => "number"
+                  "type" => "number",
+                  "input" => true
                 }
               ]
             }
@@ -42,9 +44,6 @@ RSpec.describe Qa::PermitApplicationAutofillService do
     allow(permit_application).to receive(:form_json).with(
       current_user: user
     ).and_return(form_json)
-    allow(PermitApplication::SubmissionDataService).to receive(:new).with(
-      permit_application
-    ).and_return(submission_data_service)
   end
 
   it "generates sectioned submission data for fillable form components" do
@@ -53,13 +52,9 @@ RSpec.describe Qa::PermitApplicationAutofillService do
       current_user: user
     ).call
 
-    expect(submission_data_service).to have_received(
-      :update_with_submission_data_merge
-    ) do |args|
-      expect(args[:current_user]).to eq(user)
+    expect(permit_application).to have_received(:update) do |args|
       expect(
         args.dig(
-          :permit_application_params,
           :submission_data,
           "data",
           "section-a",
@@ -68,7 +63,6 @@ RSpec.describe Qa::PermitApplicationAutofillService do
       ).to eq("QA test value")
       expect(
         args.dig(
-          :permit_application_params,
           :submission_data,
           "data",
           "section-a",

--- a/spec/services/seeded_requirement_template_service_spec.rb
+++ b/spec/services/seeded_requirement_template_service_spec.rb
@@ -28,10 +28,8 @@ RSpec.describe SeededRequirementTemplateService, type: :service do
     it "keeps Part 9 and Part 3 step code requirements separated" do
       described_class.seed!
 
-      part_9_input_types =
-        requirement_input_types("Sandbox - Large Part 9 Template")
-      part_3_input_types =
-        requirement_input_types("Sandbox - Large Part 3 Template")
+      part_9_input_types = requirement_input_types("Large Part 9 Template")
+      part_3_input_types = requirement_input_types("Large Part 3 Template")
 
       expect(part_9_input_types).to include("energy_step_code")
       expect(part_9_input_types).not_to include("energy_step_code_part_3")
@@ -42,10 +40,7 @@ RSpec.describe SeededRequirementTemplateService, type: :service do
     it "includes requirement-level and block-level conditionals in snapshots" do
       described_class.seed!
 
-      template =
-        RequirementTemplate.find_by!(
-          nickname: "Sandbox - Large Part 9 Template"
-        )
+      template = RequirementTemplate.find_by!(nickname: "Large Part 9 Template")
       version = template.published_template_version
 
       requirements = version.form_json_requirements

--- a/spec/services/template_version_preview/management_service_spec.rb
+++ b/spec/services/template_version_preview/management_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe TemplateVersionPreview::ManagementService,
   end
 
   describe "#invite_previewers!" do
-    subject { service.invite_previewers!(emails) }
+    subject(:result) { service.invite_previewers!(emails) }
 
     let(:emails) { [] }
 
@@ -29,18 +29,17 @@ RSpec.describe TemplateVersionPreview::ManagementService,
       let(:emails) { %w[user1@example.com user2@example.com] }
 
       it "creates template version previews for existing users" do
-        expect { subject }.to change(TemplateVersionPreview, :count).by(2)
+        expect { result }.to change(TemplateVersionPreview, :count).by(2)
 
-        expect(subject[:previews].map(&:previewer_id)).to contain_exactly(
+        expect(result[:previews].map(&:previewer_id)).to contain_exactly(
           user1.id,
           user2.id
         )
-        expect(subject[:failed_emails]).to be_empty
+        expect(result[:failed_emails]).to be_empty
       end
 
       it "sends notification emails to confirmed and active users" do
-        subject
-        previews = subject[:previews]
+        previews = result[:previews]
 
         expect(PermitHubMailer).to have_received(
           :notify_template_version_preview
@@ -57,7 +56,7 @@ RSpec.describe TemplateVersionPreview::ManagementService,
       let(:emails) { ["new_user@example.com"] }
 
       it "creates new users and template version previews" do
-        expect { subject }.to change(User, :count).by(1).and change(
+        expect { result }.to change(User, :count).by(1).and change(
                 TemplateVersionPreview,
                 :count
               ).by(1)
@@ -68,13 +67,12 @@ RSpec.describe TemplateVersionPreview::ManagementService,
         expect(new_user.last_name).to eq("User")
         expect(new_user.role).to eq("submitter")
 
-        expect(subject[:previews].first.previewer).to eq(new_user)
-        expect(subject[:failed_emails]).to be_empty
+        expect(result[:previews].first.previewer).to eq(new_user)
+        expect(result[:failed_emails]).to be_empty
       end
 
       it "sends notification emails to newly created users" do
-        subject
-        preview = subject[:previews].first
+        preview = result[:previews].first
         expect(PermitHubMailer).to have_received(
           :notify_new_or_unconfirmed_template_version_preview
         ).with(template_version_preview: preview, user: preview.previewer).once
@@ -85,12 +83,13 @@ RSpec.describe TemplateVersionPreview::ManagementService,
       let(:emails) { %w[invalid_email another_invalid] }
 
       it "does not create template version previews and returns failed emails" do
-        expect { subject }.not_to change(TemplateVersionPreview, :count)
-        expect { subject }.not_to change(User, :count)
+        expect { result }.to change(TemplateVersionPreview, :count).by(
+          0
+        ).and change(User, :count).by(0)
 
-        expect(subject[:previews]).to be_empty
+        expect(result[:previews]).to be_empty
 
-        expect(subject[:failed_emails]).to match(
+        expect(result[:failed_emails]).to match(
           [
             { email: "invalid_email", error: "Invalid email format" },
             { email: "another_invalid", error: "Invalid email format" }
@@ -99,7 +98,7 @@ RSpec.describe TemplateVersionPreview::ManagementService,
       end
 
       it "does not send any emails" do
-        subject
+        result
         expect(PermitHubMailer).not_to have_received(
           :notify_new_or_unconfirmed_template_version_preview
         )
@@ -114,17 +113,18 @@ RSpec.describe TemplateVersionPreview::ManagementService,
       let(:emails) { %w[user@example.com invalid_email] }
 
       it "creates template version previews for valid emails and reports failures" do
-        expect { subject }.to change(TemplateVersionPreview, :count).by(1)
-        expect { subject }.not_to change(User, :count)
+        expect { result }.to change(TemplateVersionPreview, :count).by(
+          1
+        ).and change(User, :count).by(0)
 
-        expect(subject[:previews].first.previewer).to eq(user)
-        expect(subject[:failed_emails]).to match(
+        expect(result[:previews].first.previewer).to eq(user)
+        expect(result[:failed_emails]).to match(
           [{ email: "invalid_email", error: "Invalid email format" }]
         )
       end
 
       it "sends notification emails only for valid previews" do
-        subject
+        result
         expect(PermitHubMailer).to have_received(
           :notify_template_version_preview
         ).once
@@ -140,14 +140,14 @@ RSpec.describe TemplateVersionPreview::ManagementService,
 
       it "does not create a duplicate preview and returns the existing one twice" do
         # First invite creates the preview; second iteration should find the existing one.
-        expect { subject }.to change(TemplateVersionPreview, :count).by(1)
+        expect { result }.to change(TemplateVersionPreview, :count).by(1)
 
-        expect(subject[:failed_emails]).to be_empty
-        expect(subject[:previews].map(&:id).uniq.length).to eq(1)
+        expect(result[:failed_emails]).to be_empty
+        expect(result[:previews].map(&:id).uniq.length).to eq(1)
       end
 
       it "re-sends the notification email on every invite" do
-        subject
+        result
 
         expect(PermitHubMailer).to have_received(
           :notify_template_version_preview
@@ -168,11 +168,13 @@ RSpec.describe TemplateVersionPreview::ManagementService,
       end
 
       it "reports the user creation failure" do
-        expect { subject }.not_to change(User, :count)
-        expect { subject }.not_to change(TemplateVersionPreview, :count)
+        expect { result }.to change(User, :count).by(0).and change(
+                TemplateVersionPreview,
+                :count
+              ).by(0)
 
-        expect(subject[:previews]).to be_empty
-        expect(subject[:failed_emails]).to match(
+        expect(result[:previews]).to be_empty
+        expect(result[:failed_emails]).to match(
           [
             {
               email: "fail_user@example.com",
@@ -193,7 +195,7 @@ RSpec.describe TemplateVersionPreview::ManagementService,
       let(:emails) { %w[unconfirmed@example.com discarded@example.com] }
 
       it "sends notify_new_or_unconfirmed_template_version_preview emails" do
-        subject
+        result
 
         previews =
           TemplateVersionPreview.where(
@@ -215,7 +217,7 @@ RSpec.describe TemplateVersionPreview::ManagementService,
       let(:emails) { ["confirmed@example.com"] }
 
       it "sends notify_template_version_preview email" do
-        subject
+        result
 
         preview = TemplateVersionPreview.last
         expect(PermitHubMailer).to have_received(


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...chore/remove-permittypes-specs` (merge-base range).

This PR updates specs after the permit type/activity classification removal and draft template version refactor. It removes stale permit classification setup from QA tools specs, aligns autofill specs with the current direct `submission_data` update flow, and makes template version preview mailer specs less brittle by ensuring the invite service is only invoked once per example.

It also keeps a temporary compatibility write for `template_version_previews.early_access_requirement_template_id` while the legacy early-access preview schema remains in place.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-XXXX](https://hous-bssb.atlassian.net/browse/HUB-XXXX) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | N/A |
| 📚 Documentation | N/A |

---

## ✨ Features / Changes Introduced

- Removed stale `permit_type`, `activity`, and `permit_type_submission_contact` setup from QA tools request specs.
- Updated QA autofill service spec to assert the current direct `permit_application.update(submission_data: ...)` behavior.
- Updated seeded template specs to use current large template nicknames.
- Stabilized template version preview management specs by memoizing the service result and avoiding repeated subject execution.
- Added temporary compatibility handling for legacy `early_access_requirement_template_id` while schema cleanup is pending.

---

## 🧪 Steps to QA

1. In QA mode, create a full QA permit project for a jurisdiction.
2. Verify the project is created with permit applications based on available template versions.
3. Open a draft permit application and run QA autofill.
4. Verify supported fields are populated, including text, number, email, contact grid, and file-style fields.
5. Invite previewers to a draft template version.
6. Verify confirmed users receive the standard preview notification and unconfirmed or discarded users receive the registration/unconfirmed notification.

**Expected Behaviour:**
QA tools and draft preview invitations work without errors from removed permit classification associations or duplicate spec-side service execution.

**Before this change:**
Specs failed because they referenced removed permit type/activity relationships, expected the old autofill submission service path, and invoked preview invite logic multiple times in some examples.

**After this change:**
Specs match the current template-version-based model and preview invitation flow.

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [ ] 📝 Commit messages are descriptive and follow the project convention
- [x] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others