### PR TITLE
add updates for template builder and versions sidebar

### DIFF
--- a/app/frontend/components/domains/requirement-template/create-early-access-version-modal.tsx
+++ b/app/frontend/components/domains/requirement-template/create-early-access-version-modal.tsx
@@ -1,0 +1,72 @@
+import {
+  Button,
+  ButtonProps,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { observer } from "mobx-react-lite"
+import React, { useState } from "react"
+import { useTranslation } from "react-i18next"
+
+interface ICreateEarlyAccessVersionModalProps {
+  onCreateEarlyAccessVersion?: () => Promise<void> | void
+  triggerButtonProps?: Partial<ButtonProps>
+  renderTrigger?: (onOpen: () => void) => React.ReactNode
+}
+
+export const CreateEarlyAccessVersionModal = observer(function CreateEarlyAccessVersionModal({
+  onCreateEarlyAccessVersion,
+  triggerButtonProps,
+  renderTrigger,
+}: ICreateEarlyAccessVersionModalProps) {
+  const { t } = useTranslation()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const [isCreating, setIsCreating] = useState(false)
+
+  const onConfirm = async () => {
+    setIsCreating(true)
+    try {
+      await onCreateEarlyAccessVersion?.()
+      onClose()
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  return (
+    <>
+      {renderTrigger ? (
+        renderTrigger(onOpen)
+      ) : (
+        <Button variant="secondary" onClick={onOpen} {...triggerButtonProps}>
+          {t("requirementTemplate.edit.createEarlyAccessVersion")}
+        </Button>
+      )}
+      <Modal isOpen={isOpen} onClose={onClose} autoFocus={false}>
+        <ModalOverlay />
+        <ModalContent w="full" maxW="436px" mx={4}>
+          <ModalHeader fontSize={"2xl"} mt={2}>
+            {t("requirementTemplate.edit.earlyAccessModalTitle")}
+          </ModalHeader>
+          <ModalBody>
+            <Text>{t("requirementTemplate.edit.earlyAccessModalBody")}</Text>
+          </ModalBody>
+          <ModalFooter justifyContent={"flex-start"} mt={4} gap={3}>
+            <Button variant={"primary"} onClick={onConfirm} isLoading={isCreating}>
+              {t("ui.confirm")}
+            </Button>
+            <Button variant={"secondary"} onClick={onClose} isDisabled={isCreating}>
+              {t("ui.neverMind")}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+})

--- a/app/frontend/components/domains/requirement-template/publish-schedule-modal.tsx
+++ b/app/frontend/components/domains/requirement-template/publish-schedule-modal.tsx
@@ -37,8 +37,8 @@ export interface IPublishScheduleModalProps {
   minDate?: Date
   onScheduleConfirm?: (date: Date) => void
   onForcePublishNow?: () => void
-  onCreateDraft?: () => void
   triggerButtonProps?: Partial<ButtonProps>
+  renderTrigger?: (onOpen: () => void) => React.ReactNode
   requirementTemplate?: IRequirementTemplate
   onSaveDraft?: () => void
   /**
@@ -62,8 +62,8 @@ export const PublishScheduleModal = observer(function PublishScheduleModal({
   minDate,
   onScheduleConfirm,
   triggerButtonProps,
+  renderTrigger,
   onForcePublishNow,
-  onCreateDraft,
   requirementTemplate,
   scheduledConflicts,
   translationNamespace = "requirementTemplate.edit",
@@ -132,9 +132,13 @@ export const PublishScheduleModal = observer(function PublishScheduleModal({
           {t("requirementTemplate.access.title", "Manage access")}
         </Button>
       )}
-      <Button variant={"primary"} rightIcon={<CaretRight />} onClick={onOpen} {...triggerButtonProps}>
-        {triggerLabel ?? t("ui.publish")}
-      </Button>
+      {renderTrigger ? (
+        renderTrigger(onOpen)
+      ) : (
+        <Button variant={"primary"} rightIcon={<CaretRight />} onClick={onOpen} {...triggerButtonProps}>
+          {triggerLabel ?? t("ui.publish")}
+        </Button>
+      )}
       {requirementTemplate && (
         <TemplateAccessSidebar
           requirementTemplate={requirementTemplate}
@@ -144,7 +148,7 @@ export const PublishScheduleModal = observer(function PublishScheduleModal({
       )}
       <Modal isOpen={isOpen} onClose={onClose} autoFocus={false}>
         <ModalOverlay />
-        <ModalContent w="full" maxW={onForcePublishNow || onCreateDraft ? "680px" : "436px"} mx={4}>
+        <ModalContent w="full" maxW={onForcePublishNow ? "680px" : "436px"} mx={4}>
           <ModalHeader fontSize={"2xl"} mt={2}>
             {t(nk("scheduleModalTitle"))}
           </ModalHeader>
@@ -213,11 +217,6 @@ export const PublishScheduleModal = observer(function PublishScheduleModal({
             <Button variant={"secondary"} onClick={onCancel}>
               {t("ui.neverMind")}
             </Button>
-            {onCreateDraft && (
-              <Button variant={"secondary"} onClick={onCreateDraft}>
-                Create draft version
-              </Button>
-            )}
             {onForcePublishNow && (
               <Button
                 variant={"secondary"}

--- a/app/frontend/components/domains/requirement-template/screens/base-edit-requirement-template-screen/builder-header.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/base-edit-requirement-template-screen/builder-header.tsx
@@ -1,8 +1,9 @@
-import { Container, Heading, HStack, Text, VStack } from "@chakra-ui/react"
-import { CaretRight } from "@phosphor-icons/react"
+import { Button, Container, Heading, HStack, Text, VStack } from "@chakra-ui/react"
+import { CaretLeft, CaretRight } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
+import { useLocation, useNavigate } from "react-router-dom"
 import { ETemplateVersionStatus } from "../../../../../types/enums"
 import { IDenormalizedTemplate } from "../../../../../types/types"
 import { RouterLinkButton } from "../../../../shared/navigation/router-link-button"
@@ -17,11 +18,13 @@ interface IProps {
   requirementTemplate: Pick<IDenormalizedTemplate, "id" | "description" | "tags" | "nickname">
   renderDescription?: () => JSX.Element
   renderHeading?: () => JSX.Element
+  renderTags?: () => JSX.Element
   status?: TTemplateStatusTagStatus
   versionDate?: Date
   breadCrumbs?: { href: string; title: string }[]
   latestVersionId?: string
   forEdit?: boolean
+  showBackButton?: boolean
 }
 
 export const BuilderHeader = observer(function BuilderHeader({
@@ -30,11 +33,24 @@ export const BuilderHeader = observer(function BuilderHeader({
   versionDate,
   renderDescription,
   renderHeading,
+  renderTags,
   breadCrumbs = [],
   latestVersionId,
   forEdit = false,
+  showBackButton = false,
 }: IProps) {
   const { t } = useTranslation()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const handleBack = () => {
+    if (location.key === "default") {
+      navigate("/requirement-templates")
+    } else {
+      navigate(-1)
+    }
+  }
+
   return (
     <Container as={"header"} maxW={"container.lg"} px={8}>
       <HStack justifyContent={"space-between"}>
@@ -50,32 +66,49 @@ export const BuilderHeader = observer(function BuilderHeader({
         </Text>
       </HStack>
       <VStack spacing={2} w={"full"} alignItems={"flex-start"} py={5}>
+        {showBackButton && (
+          <Button variant="link" onClick={handleBack} leftIcon={<CaretLeft size={20} />} textDecoration="none">
+            {t("ui.back")}
+          </Button>
+        )}
         {renderHeading ? renderHeading() : <Heading as="h1">{requirementTemplate.nickname}</Heading>}
         <HStack>
           <Text fontWeight={700}>{t("requirementTemplate.fields.description")}:</Text>
           {renderDescription ? renderDescription() : <Text as="span">{requirementTemplate.description}</Text>}
         </HStack>
-        <HStack alignItems={"center"} spacing={2}>
-          <TemplateStatusTag
-            status={status}
-            scheduledFor={status === ETemplateVersionStatus.scheduled && versionDate ? versionDate : undefined}
-          />
-          {status === ETemplateVersionStatus.deprecated && (
-            <RouterLinkButton
-              to={
-                forEdit ? `/digital-building-permits/${latestVersionId}/edit` : `/template-versions/${latestVersionId}`
-              }
-              variant="secondary"
-              size="xs"
-              p={3}
-              rightIcon={<CaretRight />}
-            >
-              {t("requirementTemplate.edit.goToLatest")}
-            </RouterLinkButton>
-          )}
+        {renderTags && (
+          <HStack alignItems={"flex-start"}>
+            <Text fontWeight={700} pt={2}>
+              {t("requirementTemplate.fields.tags")}:
+            </Text>
+            {renderTags()}
+          </HStack>
+        )}
+        {status && (
+          <HStack alignItems={"center"} spacing={2}>
+            <TemplateStatusTag
+              status={status}
+              scheduledFor={status === ETemplateVersionStatus.scheduled && versionDate ? versionDate : undefined}
+            />
+            {status === ETemplateVersionStatus.deprecated && (
+              <RouterLinkButton
+                to={
+                  forEdit
+                    ? `/digital-building-permits/${latestVersionId}/edit`
+                    : `/template-versions/${latestVersionId}`
+                }
+                variant="secondary"
+                size="xs"
+                p={3}
+                rightIcon={<CaretRight />}
+              >
+                {t("requirementTemplate.edit.goToLatest")}
+              </RouterLinkButton>
+            )}
 
-          {status === ETemplateVersionStatus.published && versionDate && <VersionTag versionDate={versionDate} />}
-        </HStack>
+            {status === ETemplateVersionStatus.published && versionDate && <VersionTag versionDate={versionDate} />}
+          </HStack>
+        )}
       </VStack>
     </Container>
   )

--- a/app/frontend/components/domains/requirement-template/screens/base-edit-requirement-template-screen/controls-header.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/base-edit-requirement-template-screen/controls-header.tsx
@@ -4,7 +4,6 @@ import { observer } from "mobx-react-lite"
 import React from "react"
 import { useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { useNavigate } from "react-router-dom"
 import { IRequirementTemplate } from "../../../../../models/requirement-template"
 import { BrowserSearchPrompt } from "../../../../shared/permit-applications/browser-search-prompt"
 import { IEditRequirementActionsProps, IEditRequirementOptionsProps, IRequirementTemplateForm } from "./index"
@@ -32,15 +31,10 @@ export const ControlsHeader = observer(function ControlsHeader({
   renderOptionsMenu,
   renderActions,
 }: IProps) {
-  const navigate = useNavigate()
   const { t } = useTranslation()
   const {
     formState: { isSubmitting, isValid },
   } = useFormContext<IRequirementTemplateForm>()
-  const onClose = () => {
-    const parentPath = location.pathname.split("/").slice(0, -2).join("/") || "/"
-    window.history.state && window.history.state.idx > 0 ? navigate(-1) : navigate(parentPath)
-  }
   const isSubmitDisabled = hasStepCodeDependencyError || !!requirementTemplate.discardedAt || isSubmitting || !isValid
 
   return (
@@ -82,10 +76,6 @@ export const ControlsHeader = observer(function ControlsHeader({
           })}
         <Button variant={"secondary"} isDisabled={isSubmitDisabled} isLoading={isSubmitting} onClick={onSaveDraft}>
           {t("requirementTemplate.edit.saveTemplate")}
-        </Button>
-
-        <Button variant={"secondary"} isDisabled={isSubmitting} onClick={onClose}>
-          {t("requirementTemplate.edit.closeEditor")}
         </Button>
       </HStack>
     </HStack>

--- a/app/frontend/components/domains/requirement-template/screens/base-edit-requirement-template-screen/editable-builder-header.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/base-edit-requirement-template-screen/editable-builder-header.tsx
@@ -1,9 +1,11 @@
 import { observer } from "mobx-react-lite"
 import React from "react"
-import { useController, useFormContext } from "react-hook-form"
+import { Controller, useController, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { IRequirementTemplate } from "../../../../../models/requirement-template"
+import { useMst } from "../../../../../setup/root"
 import { EditableInputWithControls } from "../../../../shared/editable-input-with-controls"
+import { TagsSelect } from "../../../../shared/select/selectors/tags-select"
 import { BuilderHeader } from "./builder-header"
 import { IRequirementTemplateForm } from "./index"
 
@@ -13,7 +15,10 @@ interface IProps {
 
 export const EditableBuilderHeader = observer(function EditableBuilderHeader({ requirementTemplate }: IProps) {
   const { t } = useTranslation()
-  const { control, register, watch, setValue } = useFormContext<IRequirementTemplateForm>()
+  const {
+    requirementTemplateStore: { searchTagOptions },
+  } = useMst()
+  const { control, register } = useFormContext<IRequirementTemplateForm>()
   const {
     field: { value: description, onChange: onDescriptionChange },
   } = useController({ control, name: "description" })
@@ -37,7 +42,6 @@ export const EditableBuilderHeader = observer(function EditableBuilderHeader({ r
     <BuilderHeader
       breadCrumbs={breadCrumbs}
       requirementTemplate={requirementTemplate}
-      status={"builder"}
       renderHeading={() => (
         <EditableInputWithControls
           w="full"
@@ -84,7 +88,27 @@ export const EditableBuilderHeader = observer(function EditableBuilderHeader({ r
           onCancel={onDescriptionChange}
         />
       )}
+      renderTags={() => (
+        <Controller
+          name="tags"
+          control={control}
+          render={({ field: { onChange, value } }) => (
+            <TagsSelect
+              onChange={(options) => onChange(options.map((o) => o.value))}
+              fetchOptions={(query) => searchTagOptions(query)}
+              placeholder={t("requirementTemplate.fields.tags")}
+              selectedOptions={(value ?? []).map((tag) => ({ value: tag, label: tag }))}
+              styles={{
+                container: (css) => ({ ...css, minWidth: "20rem" }),
+                menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+              }}
+              menuPortalTarget={document.body}
+            />
+          )}
+        />
+      )}
       forEdit
+      showBackButton
     />
   )
 })

--- a/app/frontend/components/domains/requirement-template/screens/base-edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/base-edit-requirement-template-screen/index.tsx
@@ -488,6 +488,7 @@ function formFormDefaults(requirementTemplate?: IRequirementTemplate): IRequirem
     return {
       description: "",
       nickname: "",
+      tags: [],
       requirementTemplateSectionsAttributes: [],
     }
   }
@@ -507,6 +508,7 @@ function formFormDefaults(requirementTemplate?: IRequirementTemplate): IRequirem
   return {
     description: requirementTemplate.description,
     nickname: requirementTemplate.nickname,
+    tags: [...(requirementTemplate.tags ?? [])],
     requirementTemplateSectionsAttributes,
   }
 }

--- a/app/frontend/components/domains/requirement-template/screens/base-edit-requirement-template-screen/sections-display.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/base-edit-requirement-template-screen/sections-display.tsx
@@ -33,7 +33,6 @@ export const SectionsDisplay = observer(function SectionsDisplay(props: IProps) 
       w={"full"}
       alignItems={"flex-start"}
       spacing={16}
-      mt="8"
       mb="20"
       mx="auto"
       pl="8"

--- a/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/edit-requirement-template-screen/index.tsx
@@ -1,6 +1,12 @@
+import { Button, Menu, MenuButton, MenuItem, MenuList, useDisclosure } from "@chakra-ui/react"
+import { CaretDown, ClockCounterClockwise } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
+import { useTranslation } from "react-i18next"
+import { CreateEarlyAccessVersionModal } from "../../create-early-access-version-modal"
 import { PublishScheduleModal } from "../../publish-schedule-modal"
+import { TemplateAccessSidebar } from "../../template-access-sidebar"
+import { TemplateVersionsSidebar } from "../../template-versions-sidebar"
 import {
   BaseEditRequirementTemplateScreen,
   IEditRequirementActionsProps,
@@ -9,5 +15,71 @@ import {
 export interface IEditRequirementTemplateScreenRenderActionProps extends Partial<IEditRequirementActionsProps> {}
 
 export const EditRequirementTemplateScreen = observer(function EditRequirementTemplateScreen() {
-  return <BaseEditRequirementTemplateScreen renderActions={(props) => <PublishScheduleModal {...props} />} />
+  return (
+    <BaseEditRequirementTemplateScreen
+      renderActions={({ onCreateDraft, ...publishScheduleProps }) => (
+        <EditRequirementTemplateActions onCreateDraft={onCreateDraft} {...publishScheduleProps} />
+      )}
+    />
+  )
+})
+
+const EditRequirementTemplateActions = observer(function EditRequirementTemplateActions({
+  onCreateDraft,
+  ...publishScheduleProps
+}: IEditRequirementActionsProps) {
+  const { t } = useTranslation()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const { isOpen: isVersionsOpen, onOpen: onVersionsOpen, onClose: onVersionsClose } = useDisclosure()
+
+  return (
+    <>
+      <Button variant="secondary" leftIcon={<ClockCounterClockwise size={20} />} onClick={onVersionsOpen}>
+        {t("requirementTemplate.versions", "Versions")}
+      </Button>
+      <Button variant="secondary" onClick={onOpen}>
+        {t("requirementTemplate.access.title", "Manage access")}
+      </Button>
+      {publishScheduleProps.requirementTemplate && (
+        <>
+          <TemplateVersionsSidebar
+            requirementTemplate={publishScheduleProps.requirementTemplate}
+            isOpen={isVersionsOpen}
+            onClose={onVersionsClose}
+            isInBuilder
+          />
+          <TemplateAccessSidebar
+            requirementTemplate={publishScheduleProps.requirementTemplate}
+            isOpen={isOpen}
+            onClose={onClose}
+          />
+        </>
+      )}
+      <Menu>
+        <MenuButton
+          as={Button}
+          variant={"primary"}
+          rightIcon={<CaretDown />}
+          {...publishScheduleProps.triggerButtonProps}
+        >
+          {t("requirementTemplate.edit.createVersion")}
+        </MenuButton>
+        <MenuList>
+          {onCreateDraft && (
+            <CreateEarlyAccessVersionModal
+              onCreateEarlyAccessVersion={onCreateDraft}
+              renderTrigger={(onOpen) => <MenuItem onClick={onOpen}>{t("requirementTemplate.status.draft")}</MenuItem>}
+            />
+          )}
+          <PublishScheduleModal
+            {...publishScheduleProps}
+            hideManageAccessButton
+            renderTrigger={(onOpen) => (
+              <MenuItem onClick={onOpen}>{t("requirementTemplate.versionSidebar.listTitles.scheduled")}</MenuItem>
+            )}
+          />
+        </MenuList>
+      </Menu>
+    </>
+  )
 })

--- a/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
@@ -181,6 +181,7 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
                   onScheduleConfirm={onScheduleConfirm}
                   onForcePublishNow={onForcePublishNow}
                   translationNamespace="templateVersionPreview.schedulePublish"
+                  triggerLabel={t("templateVersionPreview.schedulePublish.triggerButton")}
                   hideManageAccessButton
                 />
               )}

--- a/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
@@ -185,6 +185,11 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
                   hideManageAccessButton
                 />
               )}
+              {isSuperAdmin && requirementTemplateId && (
+                <RouterLinkButton to={`/requirement-templates/${requirementTemplateId}/edit`} variant="secondary">
+                  {t("templateVersionPreview.goToBuilder")}
+                </RouterLinkButton>
+              )}
               <RouterLinkButton to={`/template-versions/${templateVersion.id}/preview`} variant="secondary">
                 {t("ui.view")}
               </RouterLinkButton>

--- a/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
+++ b/app/frontend/components/domains/requirement-template/template-versions-sidebar.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  ButtonGroup,
   Drawer,
   DrawerBody,
   DrawerCloseButton,
@@ -39,12 +38,15 @@ interface IProps {
   requirementTemplate: IRequirementTemplate
   isOpen?: boolean
   onClose?: () => void
+  /** Hide "Open builder" in the drawer when the user is already on the template builder. */
+  isInBuilder?: boolean
 }
 
 export const TemplateVersionsSidebar = observer(function TemplateVersionsSidebar({
   requirementTemplate,
   isOpen: externalIsOpen,
   onClose: externalOnClose,
+  isInBuilder = false,
 }: IProps) {
   const { isOpen: internalIsOpen, onOpen: internalOnOpen, onClose: internalOnClose } = useDisclosure()
   const btnRef = React.useRef()
@@ -77,51 +79,15 @@ export const TemplateVersionsSidebar = observer(function TemplateVersionsSidebar
 
           <DrawerBody py={10} px={8}>
             <Stack spacing={10}>
-              <Box w="full">
-                <VersionsList
-                  type={ETemplateVersionStatus.published}
-                  templateVersions={
-                    requirementTemplate.publishedTemplateVersion ? [requirementTemplate.publishedTemplateVersion] : []
-                  }
-                />
-              </Box>
               {!requirementTemplate.isDiscarded && (
-                <Box>
-                  <Text as="h3" fontSize={"xl"} fontWeight={700} mb={2}>
-                    {t("requirementTemplate.versionSidebar.listTitles.templateBuilder")}
-                  </Text>
-
-                  <VersionCard
-                    viewRoute={`/requirement-templates/${requirementTemplate.id}/edit`}
-                    status={"builder"}
-                    updatedAt={requirementTemplate.updatedAt}
-                  />
-                </Box>
-              )}
-              {requirementTemplate.draftTemplateVersion && (
-                <Box>
-                  <Text as="h3" fontSize={"xl"} fontWeight={700} mb={2}>
-                    {t("requirementTemplate.versionSidebar.listTitles.draft")}
-                  </Text>
-
-                  <Box border="1px solid" borderColor="border.light" borderRadius="sm" overflow="hidden">
-                    <VersionCard
-                      viewRoute={`/template-versions/${requirementTemplate.draftTemplateVersion.id}`}
-                      status={ETemplateVersionStatus.draft}
-                      updatedAt={requirementTemplate.draftTemplateVersion.updatedAt}
-                      borderRadius="none"
-                      border="none"
-                    />
-                    <SharePreviewAccordion draftTemplateVersion={requirementTemplate.draftTemplateVersion} />
-                  </Box>
-                </Box>
+                <BuilderPanel
+                  viewRoute={`/requirement-templates/${requirementTemplate.id}/edit`}
+                  updatedAt={requirementTemplate.updatedAt}
+                  hideOpenBuilderButton={isInBuilder}
+                />
               )}
 
-              <VersionsList
-                type={ETemplateVersionStatus.scheduled}
-                templateVersions={requirementTemplate.scheduledTemplateVersions}
-                onUnschedule={requirementTemplate.unscheduleTemplateVersion}
-              />
+              <VersionFlow requirementTemplate={requirementTemplate} />
 
               <VersionsList
                 type={ETemplateVersionStatus.deprecated}
@@ -151,6 +117,177 @@ export const TemplateVersionsSidebar = observer(function TemplateVersionsSidebar
   )
 })
 
+const BuilderPanel = ({
+  viewRoute,
+  updatedAt,
+  hideOpenBuilderButton = false,
+}: {
+  viewRoute: string
+  updatedAt: Date
+  hideOpenBuilderButton?: boolean
+}) => {
+  const { t } = useTranslation()
+
+  return (
+    <Box>
+      <Text as="h3" fontSize={"xl"} fontWeight={700} mb={2}>
+        {t("requirementTemplate.versionSidebar.listTitles.templateBuilder")}
+      </Text>
+      <Flex
+        p={4}
+        border={"1px solid"}
+        borderColor={"border.light"}
+        borderRadius={"sm"}
+        bg={"greys.grey04"}
+        w="full"
+        justifyContent={hideOpenBuilderButton ? "flex-start" : "space-between"}
+        alignItems={"center"}
+        gap={4}
+      >
+        <HStack spacing={4}>
+          <Flex
+            border={"1px solid"}
+            borderColor={"border.base"}
+            borderRadius={"sm"}
+            bg={"greys.white"}
+            p={2}
+            color={"text.primary"}
+          >
+            <Pencil />
+          </Flex>
+          <Box>
+            <Text fontWeight={700}>{t("requirementTemplate.versionSidebar.builderTitle")}</Text>
+            <Text color={"text.secondary"} fontSize={"sm"}>
+              {t("requirementTemplate.versionSidebar.lastUpdated")} {format(updatedAt, "MMM dd, yyyy")}
+            </Text>
+          </Box>
+        </HStack>
+        {!hideOpenBuilderButton && (
+          <Button as={RouterLink} to={viewRoute} variant={"primary"} size="sm" leftIcon={<Pencil />}>
+            {t("translation:requirementTemplate.versionSidebar.openBuilderButton")}
+          </Button>
+        )}
+      </Flex>
+    </Box>
+  )
+}
+
+const VersionFlow = observer(function VersionFlow({
+  requirementTemplate,
+}: {
+  requirementTemplate: IRequirementTemplate
+}) {
+  const { t } = useTranslation()
+  const publishedTemplateVersions = requirementTemplate.publishedTemplateVersion
+    ? [requirementTemplate.publishedTemplateVersion]
+    : []
+
+  return (
+    <Box>
+      <Text as="h3" fontSize={"xl"} fontWeight={700} mb={2}>
+        {t("requirementTemplate.versionSidebar.flowTitle")}
+      </Text>
+      <Text color={"text.secondary"} fontSize={"sm"} mb={4}>
+        {t("requirementTemplate.versionSidebar.flowDescription")}
+      </Text>
+
+      <Stack spacing={0}>
+        <VersionFlowStep
+          label={t("requirementTemplate.versionSidebar.listTitles.draft")}
+          emptyLabel={t("requirementTemplate.versionSidebar.noEarlyAccessVersion")}
+          hasContent={!!requirementTemplate.draftTemplateVersion}
+        >
+          {requirementTemplate.draftTemplateVersion && (
+            <Box border="1px solid" borderColor="border.light" borderRadius="sm" overflow="hidden">
+              <VersionCard
+                viewRoute={`/template-versions/${requirementTemplate.draftTemplateVersion.id}`}
+                status={ETemplateVersionStatus.draft}
+                updatedAt={requirementTemplate.draftTemplateVersion.updatedAt}
+                borderRadius="none"
+                border="none"
+              />
+              <SharePreviewAccordion draftTemplateVersion={requirementTemplate.draftTemplateVersion} />
+            </Box>
+          )}
+        </VersionFlowStep>
+
+        <VersionFlowStep
+          label={t("requirementTemplate.versionSidebar.listTitles.scheduled")}
+          emptyLabel={t("requirementTemplate.versionSidebar.noScheduledVersion")}
+          hasContent={requirementTemplate.scheduledTemplateVersions.length > 0}
+        >
+          {requirementTemplate.scheduledTemplateVersions.map((templateVersion, index) => (
+            <VersionCard
+              key={templateVersion.id}
+              viewRoute={`/template-versions/${templateVersion.id}`}
+              status={ETemplateVersionStatus.scheduled}
+              versionDate={templateVersion.versionDate}
+              borderTop={index !== 0 ? "none" : undefined}
+              borderTopRadius={index === 0 ? "sm" : undefined}
+              borderBottomRadius={index === requirementTemplate.scheduledTemplateVersions.length - 1 ? "sm" : undefined}
+              borderRadius={"none"}
+              onUnschedule={() => requirementTemplate.unscheduleTemplateVersion(templateVersion.id)}
+            />
+          ))}
+        </VersionFlowStep>
+
+        <VersionFlowStep
+          label={t("requirementTemplate.versionSidebar.listTitles.published")}
+          emptyLabel={t("requirementTemplate.versionSidebar.noPublishedVersion")}
+          hasContent={publishedTemplateVersions.length > 0}
+          isLast
+        >
+          {publishedTemplateVersions.map((templateVersion) => (
+            <VersionCard
+              key={templateVersion.id}
+              viewRoute={`/template-versions/${templateVersion.id}`}
+              status={ETemplateVersionStatus.published}
+              versionDate={templateVersion.versionDate}
+            />
+          ))}
+        </VersionFlowStep>
+      </Stack>
+    </Box>
+  )
+})
+
+const VersionFlowStep = ({
+  label,
+  emptyLabel,
+  hasContent,
+  isLast,
+  children,
+}: {
+  label: string
+  emptyLabel: string
+  hasContent: boolean
+  isLast?: boolean
+  children?: React.ReactNode
+}) => {
+  return (
+    <Flex align="stretch">
+      <Flex direction="column" align="center" mr={4} pt={2}>
+        <Box w={3} h={3} borderRadius="full" bg="theme.blue" />
+        {!isLast && <Box flex={1} borderLeft="1px solid" borderColor="border.base" my={2} />}
+      </Flex>
+      <Box flex={1} pb={isLast ? 0 : 5}>
+        <Text fontWeight={700} mb={2}>
+          {label}
+        </Text>
+        {hasContent ? (
+          children
+        ) : (
+          <Flex p={4} border={"1px dashed"} borderColor={"border.base"} borderRadius={"sm"} bg={"greys.grey04"}>
+            <Text color={"text.secondary"} fontSize={"sm"}>
+              {emptyLabel}
+            </Text>
+          </Flex>
+        )}
+      </Box>
+    </Flex>
+  )
+}
+
 const VersionsList = observer(function VersionsList({
   type,
   templateVersions,
@@ -178,7 +315,7 @@ const VersionsList = observer(function VersionsList({
           borderTopRadius={index === 0 ? "sm" : undefined}
           borderBottomRadius={index === templateVersions.length - 1 ? "sm" : undefined}
           borderRadius={"none"}
-          onUnschedule={() => onUnschedule(templateVersion.id)}
+          onUnschedule={onUnschedule ? () => onUnschedule(templateVersion.id) : undefined}
           deprecationReasonLabel={templateVersion.deprecationReasonLabel}
         />
       ))}
@@ -194,7 +331,7 @@ type TVersionCardProps = Partial<FlexProps> & { viewRoute: string; onUnschedule?
         deprecationReasonLabel?: string
       }
     | {
-        status: "builder" | ETemplateVersionStatus.draft
+        status: ETemplateVersionStatus.draft
         versionDate?: never
         updatedAt: Date
         deprecationReasonLabel?: never
@@ -216,27 +353,18 @@ const VersionCard = observer(function VersionCard({
     if (status === ETemplateVersionStatus.published || status === ETemplateVersionStatus.deprecated) {
       return (
         <Button as={RouterLink} to={viewRoute} variant={"primary"} size="sm">
-          {t("requirementTemplate.versionSidebar.viewTemplateButton")}
-        </Button>
-      )
-    } else if (status === "builder") {
-      return (
-        <Button as={RouterLink} to={viewRoute} variant={"primary"} size="sm" leftIcon={<Pencil />}>
-          {t("translation:requirementTemplate.versionSidebar.openBuilderButton")}
+          {t("ui.view")}
         </Button>
       )
     } else if (status === ETemplateVersionStatus.draft) {
       return (
         <Button as={RouterLink} to={viewRoute} variant={"primary"} size="sm">
-          {t("requirementTemplate.versionSidebar.viewDraftButton")}
+          {t("ui.view")}
         </Button>
       )
     } else {
       return (
-        <ButtonGroup spacing={4}>
-          <Button as={RouterLink} to={viewRoute} variant={"primary"} size="sm">
-            {t("ui.preview")}
-          </Button>
+        <>
           <RemoveConfirmationModal
             title={t("requirementTemplate.versionSidebar.unscheduleWarning.title")}
             body={t("requirementTemplate.versionSidebar.unscheduleWarning.body")}
@@ -250,7 +378,10 @@ const VersionCard = observer(function VersionCard({
             onRemove={onUnschedule}
             triggerText={t("translation:requirementTemplate.versionSidebar.unscheduleButton")}
           />
-        </ButtonGroup>
+          <Button as={RouterLink} to={viewRoute} variant={"primary"} size="sm" ml="auto">
+            {t("ui.view")}
+          </Button>
+        </>
       )
     }
   }
@@ -262,6 +393,8 @@ const VersionCard = observer(function VersionCard({
       borderRadius={"sm"}
       w="full"
       justifyContent={"space-between"}
+      alignItems={"center"}
+      gap={4}
       {...containerProps}
     >
       <HStack spacing={16}>
@@ -270,7 +403,7 @@ const VersionCard = observer(function VersionCard({
           scheduledFor={status === ETemplateVersionStatus.scheduled && versionDate ? versionDate : undefined}
           subText={status === ETemplateVersionStatus.deprecated ? deprecationReasonLabel : undefined}
         />
-        {status === "builder" || status === ETemplateVersionStatus.draft ? (
+        {status === ETemplateVersionStatus.draft ? (
           <Text>
             {t("requirementTemplate.versionSidebar.lastUpdated")}
             <br />

--- a/app/frontend/components/shared/requirement-template/requirement-template-grid.tsx
+++ b/app/frontend/components/shared/requirement-template/requirement-template-grid.tsx
@@ -36,7 +36,7 @@ export const RequirementTemplateGrid: React.FC<RequirementTemplateGridProps> = o
 
   return (
     <VStack alignItems={"flex-start"} spacing={5} w={"full"} h={"full"}>
-      <SearchGrid templateColumns="1.5fr 1.5fr 2fr 1.5fr 1fr 1fr">
+      <SearchGrid templateColumns="1.5fr 1.5fr 2fr 1.5fr 1.5fr 1fr 1fr">
         <GridHeaders />
 
         {isSearching ? (
@@ -61,6 +61,11 @@ export const RequirementTemplateGrid: React.FC<RequirementTemplateGridProps> = o
                 {rt.publishedTemplateVersion?.versionDate ? (
                   <VersionTag versionDate={rt.publishedTemplateVersion.versionDate} />
                 ) : null}
+              </SearchGridItem>
+              <SearchGridItem>
+                {rt.draftTemplateVersion?.versionDate && (
+                  <VersionTag versionDate={rt.draftTemplateVersion.versionDate} />
+                )}
               </SearchGridItem>
               <SearchGridItem>{rt.availableIn}</SearchGridItem>
               <SearchGridItem>{renderActions(rt)}</SearchGridItem>
@@ -111,21 +116,30 @@ const GridHeaders = observer(function GridHeaders() {
       </Box>
       <Box display={"contents"} role={"row"}>
         {Object.values(ERequirementTemplateSortFields).map((field) => (
-          <GridHeader key={field} role={"columnheader"}>
-            <Flex
-              w={"full"}
-              as={"button"}
-              justifyContent={"space-between"}
-              cursor="pointer"
-              onClick={() => toggleSort(field)}
-              borderRight={"1px solid"}
-              borderColor={"border.light"}
-              px={4}
-            >
-              <Text>{getSortColumnHeader(field)}</Text>
-              <SortIcon<ERequirementTemplateSortFields> field={field} currentSort={sort} />
-            </Flex>
-          </GridHeader>
+          <React.Fragment key={field}>
+            <GridHeader role={"columnheader"}>
+              <Flex
+                w={"full"}
+                as={"button"}
+                justifyContent={"space-between"}
+                cursor="pointer"
+                onClick={() => toggleSort(field)}
+                borderRight={"1px solid"}
+                borderColor={"border.light"}
+                px={4}
+              >
+                <Text>{getSortColumnHeader(field)}</Text>
+                <SortIcon<ERequirementTemplateSortFields> field={field} currentSort={sort} />
+              </Flex>
+            </GridHeader>
+            {field === ERequirementTemplateSortFields.currentVersion && (
+              <GridHeader role={"columnheader"}>
+                <Flex w={"full"} borderRight={"1px solid"} borderColor={"border.light"} px={4}>
+                  <Text>{t("requirementTemplate.status.draft")}</Text>
+                </Flex>
+              </GridHeader>
+            )}
+          </React.Fragment>
         ))}
         <GridHeader role={"columnheader"} />
       </Box>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4186,6 +4186,7 @@ Thank you,
           earlyAccessTitle: "Early access – submissions not yet enabled",
           earlyAccessDescription:
             "This permit is available for early access to help your team get familiar with the application process. You can view and edit your application, but submission is currently disabled. Submissions will be enabled once this permit type is officially launched in your jurisdiction.",
+          goToBuilder: "Go to builder",
           schedulePublish: {
             triggerButton: "Promote",
             scheduleModalTitle: "Promote early access version?",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4187,12 +4187,13 @@ Thank you,
           earlyAccessDescription:
             "This permit is available for early access to help your team get familiar with the application process. You can view and edit your application, but submission is currently disabled. Submissions will be enabled once this permit type is officially launched in your jurisdiction.",
           schedulePublish: {
-            scheduleModalTitle: "Publish early access version?",
+            triggerButton: "Promote",
+            scheduleModalTitle: "Promote early access version?",
             scheduleModalBody:
-              "Publishing this early access version will replace the currently-published version. Local jurisdictions and submitters will be able to see and use this new version of the form. <br><br><1>Notifications will only be sent out to those jurisdictions you have set available, which is currently: {{count}}</1>",
-            scheduleModalHelperText: "Schedule to <1>publish</1> (at midnight 00:01 PST)",
-            scheduleModalCancelMessage: "Changes were not scheduled.",
-            forcePublishNow: "Force publish now",
+              "Promoting this early access version will create a scheduled or published version from the current early access snapshot. The early access version will remain available for preview. Once the promoted version is published, local jurisdictions and submitters will be able to see and use it. <br><br><1>Notifications will only be sent out to those jurisdictions you have set available, which is currently: {{count}}</1>",
+            scheduleModalHelperText: "Schedule to <1>promote</1> (at midnight 00:01 PST)",
+            scheduleModalCancelMessage: "Promotion was not scheduled.",
+            forcePublishNow: "Force promote now",
             conflictWarning:
               "Another version is already scheduled for <1>{{dates}}</1>. Confirming this date will auto-unschedule that version.",
             laterScheduledWarning:
@@ -4398,7 +4399,7 @@ Thank you,
               published: "Published",
               templateBuilder: "Template builder",
               draft: "Early access versions",
-              scheduled: "Scheduled",
+              scheduled: "Schedule publish",
               deprecated: "Deprecated (last 3)",
             },
             unscheduleWarning: {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -189,9 +189,9 @@ const options = {
           reviewMaterials: "Review materials",
           underDevelopmentTitle: "Share your feedback on permit applications under development",
           underDevelopmentBody:
-            "We’re co-developing standard permit classifications with local governments and First Nations across BC. These drafts are available for review and discussion as we continue this work together.",
+            "We’re co-developing standard permit classifications with local governments and First Nations across BC. These early access versions are available for review and discussion as we continue this work together.",
           listedDrafts:
-            " The listed drafts are open for review. These permit applications are drafts; do not use for permit intake.",
+            " The listed early access versions are open for review. These permit applications are early access versions; do not use for permit intake.",
           shareFeedbackBody:
             "We’re looking for your input. <1>Email us your feedback at:</1> <2>digital.codes.permits@gov.bc.ca</2>",
           ssmuHousingTitle: "Small-scale / multi-unit housing permits",
@@ -209,7 +209,7 @@ const options = {
             description1:
               "Building Permit Hub is working with BC communities to bring more clarity and consistency to building permit application materials.",
             description2:
-              "We are developing shared forms and guidance that communities can choose to adopt. Feedback from local governments and First Nations helps shape these materials so they meet local needs. Published and draft versions are available for review.",
+              "We are developing shared forms and guidance that communities can choose to adopt. Feedback from local governments and First Nations helps shape these materials so they meet local needs. Published and early access versions are available for review.",
           },
           resources: {
             title: "Creating shared, common permitting resources",
@@ -277,7 +277,7 @@ const options = {
           explore: {
             title: "Explore standard permit application forms",
             description:
-              "You are invited to review and provide feedback on the draft forms, requirements, and guidance for the permit types currently available in Building Permit Hub.",
+              "You are invited to review and provide feedback on the early access forms, requirements, and guidance for the permit types currently available in Building Permit Hub.",
             smallScale: {
               title: "Small-scale projects only",
               description:
@@ -1818,7 +1818,7 @@ Thank you,
             published: 'Training mode: "Published"',
             scheduled: 'Training mode: "Upcoming"',
             deprecated: "Deprecated",
-            draft: "Draft",
+            draft: "Early access",
           },
           scopeDescriptions: {
             published: "Copies of live permit templates available only in Training Mode for testing",
@@ -1903,7 +1903,7 @@ Thank you,
               copy: "Copy this block",
               removeConfirmationModal: {
                 title: "Confirm you want to archive this requirement block.",
-                body: "Archiving this requirement blocks will remove it from all draft templates. This action cannot be undone.",
+                body: "Archiving this requirement blocks will remove it from all early access templates. This action cannot be undone.",
               },
             },
             clickToWriteDisplayName: "Click to write display name",
@@ -1985,9 +1985,9 @@ Thank you,
             },
             addOptionButton: "Add another option",
             templateEditWarning:
-              "Any changes made here will be reflected in all unsaved preview drafts that use this requirement block.",
+              "Any changes made here will be reflected in all unsaved early access previews that use this requirement block.",
             previewEditWarning:
-              "Any changes made here will be reflected in all in-progress template drafts that use this requirement block.",
+              "Any changes made here will be reflected in all in-progress early access versions that use this requirement block.",
             templates: "templates",
             previews: "previews",
             stepCodeDependencies: {
@@ -4183,13 +4183,13 @@ Thank you,
           department: "Department",
         },
         templateVersionPreview: {
-          earlyAccessTitle: "Early Access – Submissions Not Yet Enabled",
+          earlyAccessTitle: "Early access – submissions not yet enabled",
           earlyAccessDescription:
             "This permit is available for early access to help your team get familiar with the application process. You can view and edit your application, but submission is currently disabled. Submissions will be enabled once this permit type is officially launched in your jurisdiction.",
           schedulePublish: {
-            scheduleModalTitle: "Publish draft?",
+            scheduleModalTitle: "Publish early access version?",
             scheduleModalBody:
-              "Publishing this draft will replace the currently-published version. Local jurisdictions and submitters will be able to see and use this new version of the form. <br><br><1>Notifications will only be sent out to those jurisdictions you have set available, which is currently: {{count}}</1>",
+              "Publishing this early access version will replace the currently-published version. Local jurisdictions and submitters will be able to see and use this new version of the form. <br><br><1>Notifications will only be sent out to those jurisdictions you have set available, which is currently: {{count}}</1>",
             scheduleModalHelperText: "Schedule to <1>publish</1> (at midnight 00:01 PST)",
             scheduleModalCancelMessage: "Changes were not scheduled.",
             forcePublishNow: "Force publish now",
@@ -4215,13 +4215,13 @@ Thank you,
             confirmation: {
               revokeTitle: "Are you sure you want to revoke access for {{ name }}?",
               revokeBody:
-                "Revoking access will immediately prevent this user from accessing the draft preview content. This may be undone.",
+                "Revoking access will immediately prevent this user from accessing the early access version preview content. This may be undone.",
               extendTitle: "Extend Access Duration for {{ name }}",
               extendBody:
-                "Extending access will give the user 60 additional days to interact with the draft preview content. Do you want to proceed?",
+                "Extending access will give the user 60 additional days to interact with the early access version preview content. Do you want to proceed?",
               unrevokeTitle: "Restore Access for {{ name }}",
               unrevokeBody:
-                "Restoring access will allow the user to access the draft preview content again. Are you sure you want to proceed?",
+                "Restoring access will allow the user to access the early access version preview content again. Are you sure you want to proceed?",
             },
           },
         },
@@ -4325,6 +4325,11 @@ Thank you,
               "Once you publish, local jurisdictions and submitters will be able to see and use this new version of the form. <br><br><1>Notifications will only be sent out to those jurisdictions you have set available, which is currently: {{count}}</1>",
             scheduleModalHelperText: "Schedule to <1>publish</1> (at midnight 00:01 PST)",
             scheduleModalCancelMessage: "Changes were not scheduled.",
+            createVersion: "Create version",
+            createEarlyAccessVersion: "Create early access version",
+            earlyAccessModalTitle: "Create early access version?",
+            earlyAccessModalBody:
+              "This will save your current template changes and create an early access version that can be shared for preview before it is scheduled or published.",
             forcePublishNow: "Force publish!",
             pleaseReview: "Please review the following:",
             errorsBox: {
@@ -4353,7 +4358,7 @@ Thank you,
           status: {
             published: "Published",
             scheduled: "Upcoming",
-            draft: "Draft",
+            draft: "Early access",
             deprecated: "Deprecated",
             builder: "Editing",
           },
@@ -4379,14 +4384,20 @@ Thank you,
             title: "Template versions",
             subtitlePrefix: "For:",
             viewTemplateButton: "View template",
-            viewDraftButton: "View draft",
-            shareDraftButton: "Share draft",
+            viewDraftButton: "View early access version",
+            shareDraftButton: "Share early access version",
             openBuilderButton: "Open builder",
             unscheduleButton: "Unschedule",
+            builderTitle: "Template builder",
+            flowTitle: "Version flow",
+            flowDescription: "Versions can move from the builder into early access or scheduled release.",
+            noEarlyAccessVersion: "No early access version",
+            noScheduledVersion: "No scheduled version",
+            noPublishedVersion: "No published version",
             listTitles: {
               published: "Published",
-              templateBuilder: "Template Builder",
-              draft: "Drafts",
+              templateBuilder: "Template builder",
+              draft: "Early access versions",
               scheduled: "Scheduled",
               deprecated: "Deprecated (last 3)",
             },

--- a/app/frontend/models/template-section-block.ts
+++ b/app/frontend/models/template-section-block.ts
@@ -6,7 +6,7 @@ const BlockConditionalModel = types.model("BlockConditionalModel", {
   whenBlockId: types.string,
   whenRequirementCode: types.string,
   operator: types.optional(types.string, EConditionalOperator.isEqual),
-  eq: types.optional(types.string, ""),
+  eq: types.optional(types.union(types.string, types.boolean), ""),
   show: types.maybe(types.boolean),
   hide: types.maybe(types.boolean),
 })

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -79,6 +79,17 @@ import {
 import { camelizeResponse, decamelizeRequest } from "../../utils"
 import { getCsrfToken } from "../../utils/utility-functions"
 
+interface ITemplateVersionFeedback {
+  id: string
+  sentiment: string
+  body: string
+  resolved: boolean
+  createdAt: Date
+  updatedAt: Date
+  user?: IUser
+  resolvedBy?: IUser | null
+}
+
 export class Api {
   client: ApisauceInstance
 
@@ -546,8 +557,9 @@ export class Api {
   }
 
   async createRequirementTemplate(params: TCreateRequirementTemplateFormData) {
+    const requirementTemplateParams = { ...params, tagList: params.tags }
     return this.client.post<ApiResponse<IRequirementTemplate>>(`/requirement_templates`, {
-      requirementTemplate: params,
+      requirementTemplate: requirementTemplateParams,
     })
   }
 
@@ -565,8 +577,10 @@ export class Api {
   }
 
   async updateRequirementTemplate(templateId: string, params: IRequirementTemplateUpdateParams) {
+    const { tags, ...rest } = params
+    const requirementTemplateParams = tags ? { ...rest, tagList: tags } : rest
     return this.client.put<ApiResponse<IRequirementTemplate>>(`/requirement_templates/${templateId}`, {
-      requirementTemplate: params,
+      requirementTemplate: requirementTemplateParams,
     })
   }
 
@@ -581,17 +595,25 @@ export class Api {
       versionDate: string
     }
   ) {
+    const { tags, ...rest } = requirementTemplate ?? {}
+    const requirementTemplateParams = requirementTemplate
+      ? tags
+        ? { ...rest, tagList: tags }
+        : rest
+      : requirementTemplate
     return this.client.post<ApiResponse<IRequirementTemplate>>(`/requirement_templates/${templateId}/schedule`, {
-      requirementTemplate,
+      requirementTemplate: requirementTemplateParams,
       versionDate,
     })
   }
 
   async forcePublishRequirementTemplate(templateId: string, requirementTemplate: IRequirementTemplateUpdateParams) {
+    const { tags, ...rest } = requirementTemplate
+    const requirementTemplateParams = tags ? { ...rest, tagList: tags } : rest
     return this.client.post<ApiResponse<IRequirementTemplate>>(
       `/requirement_templates/${templateId}/force_publish_now`,
       {
-        requirementTemplate,
+        requirementTemplate: requirementTemplateParams,
       }
     )
   }

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -82,7 +82,7 @@ export interface IBlockConditional {
   whenBlockId: string
   whenRequirementCode: string
   operator: string
-  eq: string
+  eq: string | boolean
   show?: boolean
   hide?: boolean
 }
@@ -119,6 +119,7 @@ export interface IRevisionReasonsAttributes {
 export interface IRequirementTemplateUpdateParams {
   description?: string | null
   nickname?: string | null
+  tags?: string[]
   assigneeId?: string | null
   requirementTemplateSectionsAttributes?: IRequirementTemplateSectionAttributes[]
   availableGlobally?: boolean | null

--- a/app/models/template_version.rb
+++ b/app/models/template_version.rb
@@ -225,7 +225,10 @@ class TemplateVersion < ApplicationRecord
         .where.not(id: id)
 
     if existing_draft.exists?
-      errors.add(:status, "only one draft version is allowed per template")
+      errors.add(
+        :status,
+        "only one early access version is allowed per template"
+      )
     end
   end
 end

--- a/app/models/template_version_feedback.rb
+++ b/app/models/template_version_feedback.rb
@@ -32,7 +32,7 @@ class TemplateVersionFeedback < ApplicationRecord
     unless template_version.draft?
       errors.add(
         :template_version,
-        "must be a draft version to receive feedback"
+        "must be an early access version to receive feedback"
       )
     end
   end

--- a/app/services/template_version_feedback_service.rb
+++ b/app/services/template_version_feedback_service.rb
@@ -4,7 +4,7 @@ class TemplateVersionFeedbackService
   def self.create_feedback!(template_version, user:, body:, sentiment: :comment)
     unless template_version.draft?
       raise TemplateVersionDraftError,
-            "Feedback can only be added to draft versions"
+            "Feedback can only be added to early access versions"
     end
 
     feedback =

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -137,7 +137,7 @@ class TemplateVersioningService
   def self.create_draft!(requirement_template, assignee: nil)
     if requirement_template.draft_template_version.present?
       raise TemplateVersionDraftError,
-            "A draft version already exists for this template. Discard or promote it first."
+            "An early access version already exists for this template. Discard or promote it first."
     end
 
     template_version =
@@ -169,13 +169,13 @@ class TemplateVersioningService
   def self.update_draft_block!(draft_version, block_id, block_data)
     unless draft_version.draft?
       raise TemplateVersionDraftError,
-            "Can only update blocks on a draft version"
+            "Can only update blocks on an early access version"
     end
 
     blocks_json = draft_version.requirement_blocks_json.deep_dup
     unless blocks_json.key?(block_id)
       raise TemplateVersionDraftError,
-            "Block #{block_id} not found in this draft version"
+            "Block #{block_id} not found in this early access version"
     end
 
     blocks_json[block_id] = blocks_json[block_id].merge(block_data)
@@ -192,7 +192,8 @@ class TemplateVersioningService
   # keep any draft-specific block edits.
   def self.refresh_draft_snapshot!(draft_version)
     unless draft_version.draft?
-      raise TemplateVersionDraftError, "Can only refresh a draft version"
+      raise TemplateVersionDraftError,
+            "Can only refresh an early access version"
     end
 
     requirement_template = draft_version.requirement_template
@@ -234,7 +235,8 @@ class TemplateVersioningService
     current_user: nil
   )
     unless draft_version.draft?
-      raise TemplateVersionDraftError, "Can only promote a draft version"
+      raise TemplateVersionDraftError,
+            "Can only promote an early access version"
     end
 
     requirement_template = draft_version.requirement_template
@@ -363,7 +365,8 @@ class TemplateVersioningService
   # Discards a draft version (sets to deprecated).
   def self.discard_draft!(draft_version)
     unless draft_version.draft?
-      raise TemplateVersionDraftError, "Can only discard a draft version"
+      raise TemplateVersionDraftError,
+            "Can only discard an early access version"
     end
 
     draft_version.update!(

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -218,14 +218,15 @@ class TemplateVersioningService
     draft_version
   end
 
-  # Promotes a draft to scheduled status with a future version_date. The draft's
-  # JSON snapshot becomes the scheduled version's snapshot. Any sibling scheduled
-  # versions whose version_date is on or before the incoming date are auto-
-  # unscheduled (deprecated with reason :unscheduled) so the newly-scheduled
-  # draft becomes the canonical next version. Pass skip_date_check: true (gated
-  # on ENABLE_TEMPLATE_FORCE_PUBLISH) to force-publish the draft inline with
-  # today's version_date; in that case publish_version! handles deprecation of
-  # existing published/scheduled versions via deprecate_versions_before_template.
+  # Promotes a copy of a draft to scheduled status with a future version_date.
+  # The original draft remains available for early access and public preview.
+  # Any sibling scheduled versions whose version_date is on or before the
+  # incoming date are auto-unscheduled (deprecated with reason :unscheduled) so
+  # the promoted copy becomes the canonical next version. Pass skip_date_check:
+  # true (gated on ENABLE_TEMPLATE_FORCE_PUBLISH) to publish the promoted copy
+  # inline with today's version_date; in that case publish_version! handles
+  # deprecation of existing published/scheduled versions via
+  # deprecate_versions_before_template.
   def self.promote_draft_to_scheduled!(
     draft_version,
     version_date,
@@ -270,33 +271,40 @@ class TemplateVersioningService
         )
       end
 
-      draft_version.assign_attributes(
-        status: "scheduled",
-        version_date: version_date,
-        version_diff: compute_version_diff(draft_version),
-        change_notes: change_notes,
-        change_significance: change_significance
-      )
+      promoted_version =
+        requirement_template.template_versions.build(
+          denormalized_template_json:
+            draft_version.denormalized_template_json.deep_dup,
+          form_json: draft_version.form_json.deep_dup,
+          requirement_blocks_json:
+            draft_version.requirement_blocks_json.deep_dup,
+          status: "scheduled",
+          version_date: version_date,
+          change_notes: change_notes,
+          change_significance: change_significance
+        )
 
-      unless draft_version.save
+      promoted_version.version_diff = compute_version_diff(promoted_version)
+
+      unless promoted_version.save
         raise TemplateVersionScheduleError.new(
-                draft_version.errors.full_messages.join(", ")
+                promoted_version.errors.full_messages.join(", ")
               )
       end
 
       if skip_date_check
-        publish_version!(draft_version, true)
+        publish_version!(promoted_version, true)
 
         WebsocketBroadcaster.push_update_to_relevant_users(
           User.super_admin.kept.all.pluck(:id),
           Constants::Websockets::Events::TemplateVersion::DOMAIN,
           Constants::Websockets::Events::TemplateVersion::TYPES[:update],
-          TemplateVersionBlueprint.render_as_hash(draft_version)
+          TemplateVersionBlueprint.render_as_hash(promoted_version)
         )
       end
-    end
 
-    draft_version
+      promoted_version
+    end
   end
 
   # Deprecates sibling scheduled TemplateVersions whose version_date is on or

--- a/app/views/permit_hub_mailer/notify_new_or_unconfirmed_template_version_preview.erb
+++ b/app/views/permit_hub_mailer/notify_new_or_unconfirmed_template_version_preview.erb
@@ -11,7 +11,7 @@
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">Dear <%= @user.email %>
             ,</p>
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
-            You’ve been selected to preview a draft building permit template in the BC Building Permit Hub!
+            You’ve been selected to preview an early access building permit template in the BC Building Permit Hub!
             This exclusive opportunity allows you to review and provide feedback on proposed updates to permit application requirements.
           </p>
 
@@ -31,11 +31,11 @@
           <h2 style="color: #292929; font-family: 'Open Sans', sans-serif; font-weight: 700; line-height: 1.4; margin-top: 24px; margin-bottom: 16px; text-align: left; font-size: 22px;">Action
             Required #2</h2>
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
-            Once your account is set up, you can view the draft preview using the link below.
+            Once your account is set up, you can view the early access preview using the link below.
             This link will guide you
             directly to the template where you can view proposed requirements.
           </p>
-          <a href="<%= @template_version_preview.frontend_url %>" target="_blank" rel="noopener">View Draft Preview</a>.
+          <a href="<%= @template_version_preview.frontend_url %>" target="_blank" rel="noopener">View early access preview</a>.
           <% if !@user.confirmed? %>
             <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; min-width: 100%; box-sizing: border-box; width: 100%; margin: 12px auto;" width="100%">
               <tbody>

--- a/app/views/permit_hub_mailer/notify_template_version_preview.erb
+++ b/app/views/permit_hub_mailer/notify_template_version_preview.erb
@@ -10,16 +10,16 @@
           </h1>
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">Dear <%= @user.name %>,</p>
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
-            You’ve been selected to preview a draft building permit template in the BC Building Permit Hub!
+            You’ve been selected to preview an early access building permit template in the BC Building Permit Hub!
             This exclusive opportunity allows you to review and provide feedback on proposed updates to permit application requirements.
           </p>
 
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 24px;">
-            You can view the draft preview using the link below.
+            You can view the early access preview using the link below.
             This link will guide you
             directly to the template where you can view proposed requirements.
           </p>
-          <a href="<%= @template_version_preview.frontend_url %>" target="_blank" rel="noopener">View Draft Preview</a>
+          <a href="<%= @template_version_preview.frontend_url %>" target="_blank" rel="noopener">View early access preview</a>
 
           <br>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -492,25 +492,25 @@ en:
         message: "%{error_message}"
       create_draft_success:
         title: ""
-        message: "Draft version created successfully"
+        message: "Early access version created successfully"
       create_draft_error:
         title: Error
         message: "%{error_message}"
       discard_draft_success:
         title: ""
-        message: "Draft version discarded"
+        message: "Early access version discarded"
       discard_draft_error:
         title: Error
         message: "%{error_message}"
       promote_draft_success:
         title: ""
-        message: "Draft promoted to scheduled version"
+        message: "Early access version promoted to scheduled version"
       promote_draft_error:
         title: Error
         message: "%{error_message}"
       no_draft_error:
         title: Error
-        message: "No draft version exists for this template"
+        message: "No early access version exists for this template"
       delete_error:
         title: Error
         message: "%{error_message}"
@@ -847,28 +847,28 @@ en:
     template_version:
       update_draft_block_success:
         title: ""
-        message: "Draft block updated"
+        message: "Early access version block updated"
       update_draft_block_error:
         title: Error
         message: "%{error_message}"
       refresh_draft_success:
         title: ""
-        message: "Draft refreshed from current template"
+        message: "Early access version refreshed from current template"
       refresh_draft_error:
         title: Error
         message: "%{error_message}"
       share_draft_success:
         title: ""
-        message: "Draft shared with %{count} previewer(s)"
+        message: "Early access version shared with %{count} previewer(s)"
       no_previewers_error:
         title: Error
-        message: "No previewers are invited to this draft yet. Invite previewers first."
+        message: "No previewers are invited to this early access version yet. Invite previewers first."
       not_draft_error:
         title: Error
-        message: "This version is not a draft"
+        message: "This version is not an early access version"
       invite_previewers_success:
         title: ""
-        message: "Previewers invited to draft"
+        message: "Previewers invited to early access version"
       invite_previewers_error:
         title: Error
         message: "Could not invite previewers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_15_165400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -98,6 +98,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.uuid "contactable_id"
     t.string "contact_type"
     t.index ["contactable_type", "contactable_id"], name: "index_contacts_on_contactable"
+  end
+
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "design_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -273,7 +276,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.text "checklist_html"
     t.text "look_out_html"
     t.text "contact_summary_html"
-    t.jsonb "map_position"
+    t.jsonb "map_position", default: [0.0, 0.0]
     t.string "prefix", null: false
     t.string "slug"
     t.integer "map_zoom"
@@ -288,7 +291,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.jsonb "boundary_points", default: []
     t.string "weather_location"
     t.decimal "design_summer_temp", precision: 5, scale: 1
-    t.boolean "hide_from_search", default: false, null: false
     t.text "processing_time_html"
     t.text "key_stages_html"
     t.text "timeline_and_deliverables_html"
@@ -297,6 +299,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.string "office_telephone"
     t.string "office_email"
     t.string "website_url"
+    t.boolean "hide_from_search", default: false, null: false
     t.index ["ltsa_matcher"], name: "index_jurisdictions_on_ltsa_matcher"
     t.index ["prefix"], name: "index_jurisdictions_on_prefix", unique: true
     t.index ["regional_district_id"], name: "index_jurisdictions_on_regional_district_id"
@@ -749,14 +752,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.string "nickname"
     t.datetime "fetched_at"
     t.uuid "copied_from_id"
-    t.uuid "assignee_id"
-    t.boolean "public", default: false
-    t.uuid "site_configuration_id"
     t.boolean "available_globally"
-    t.index ["assignee_id"], name: "index_requirement_templates_on_assignee_id"
     t.index ["copied_from_id"], name: "index_requirement_templates_on_copied_from_id"
     t.index ["discarded_at"], name: "index_requirement_templates_on_discarded_at"
-    t.index ["site_configuration_id"], name: "index_requirement_templates_on_site_configuration_id"
   end
 
   create_table "requirements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -852,6 +850,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.boolean "allow_designated_reviewer", default: false, null: false
     t.boolean "code_compliance_enabled", default: false, null: false
     t.boolean "archistar_enabled_for_all_jurisdictions", default: false, null: false
+    t.boolean "qa_tools_enabled", default: false, null: false
   end
 
   create_table "step_code_building_characteristics_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1048,14 +1047,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
   end
 
   create_table "template_version_previews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "early_access_requirement_template_id", null: false
     t.uuid "previewer_id", null: false
     t.datetime "expires_at", null: false
     t.datetime "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "template_version_id"
-    t.index ["early_access_requirement_template_id", "previewer_id"], name: "index_early_access_previews_on_template_id_and_previewer_id", unique: true
+    t.uuid "template_version_id", null: false
     t.index ["previewer_id"], name: "index_template_version_previews_on_previewer_id"
     t.index ["template_version_id", "previewer_id"], name: "index_tv_previews_on_tv_id_and_previewer_id", unique: true
     t.index ["template_version_id"], name: "index_template_version_previews_on_template_version_id"
@@ -1217,8 +1214,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
   add_foreign_key "requirement_template_sections", "requirement_template_sections", column: "copied_from_id"
   add_foreign_key "requirement_template_sections", "requirement_templates"
   add_foreign_key "requirement_templates", "requirement_templates", column: "copied_from_id"
-  add_foreign_key "requirement_templates", "site_configurations"
-  add_foreign_key "requirement_templates", "users", column: "assignee_id"
   add_foreign_key "requirements", "requirement_blocks"
   add_foreign_key "resource_documents", "resources"
   add_foreign_key "resources", "jurisdictions"

--- a/spec/controllers/requirement_templates_controller_spec.rb
+++ b/spec/controllers/requirement_templates_controller_spec.rb
@@ -188,17 +188,28 @@ RSpec.describe Api::RequirementTemplatesController,
     context "as a super admin" do
       before { sign_in super_admin }
 
-      it "promotes the draft to scheduled for a future date" do
-        post :promote_draft,
-             params: {
-               id: requirement_template.id,
-               version_date: Date.tomorrow.to_s
-             }
+      it "creates a scheduled version from the draft for a future date" do
+        expect {
+          post :promote_draft,
+               params: {
+                 id: requirement_template.id,
+                 version_date: Date.tomorrow.to_s
+               }
+        }.to change { requirement_template.template_versions.count }.by(1)
 
         expect(response).to have_http_status(:success)
         draft_version.reload
-        expect(draft_version.status).to eq("scheduled")
-        expect(draft_version.version_date).to eq(Date.tomorrow)
+        promoted_version =
+          requirement_template
+            .template_versions
+            .where(status: :scheduled)
+            .where.not(id: draft_version.id)
+            .order(created_at: :desc)
+            .first
+
+        expect(draft_version.status).to eq("draft")
+        expect(promoted_version.id).not_to eq(draft_version.id)
+        expect(promoted_version.version_date).to eq(Date.tomorrow)
       end
 
       it "auto-unschedules sibling scheduled versions with earlier dates" do
@@ -265,17 +276,28 @@ RSpec.describe Api::RequirementTemplatesController,
             )
           end
 
-          it "publishes the draft inline with today's date" do
-            post :promote_draft,
-                 params: {
-                   id: requirement_template.id,
-                   skip_date_check: true
-                 }
+          it "publishes a copy inline with today's date and keeps the draft" do
+            expect {
+              post :promote_draft,
+                   params: {
+                     id: requirement_template.id,
+                     skip_date_check: true
+                   }
+            }.to change { requirement_template.template_versions.count }.by(1)
 
             expect(response).to have_http_status(:success)
             draft_version.reload
-            expect(draft_version.status).to eq("published")
-            expect(draft_version.version_date).to eq(Date.current)
+            promoted_version =
+              requirement_template
+                .template_versions
+                .where(status: :published)
+                .where.not(id: draft_version.id)
+                .order(created_at: :desc)
+                .first
+
+            expect(draft_version.status).to eq("draft")
+            expect(promoted_version.id).not_to eq(draft_version.id)
+            expect(promoted_version.version_date).to eq(Date.current)
           end
         end
       end

--- a/spec/services/template_versioning_service_spec.rb
+++ b/spec/services/template_versioning_service_spec.rb
@@ -289,19 +289,44 @@ RSpec.describe TemplateVersioningService, type: :service, search: true do
     end
 
     context "when the version date is valid" do
-      it "promotes the draft to a scheduled version" do
+      it "creates a scheduled version from the draft and keeps the draft" do
         version_date = Date.tomorrow
+        promoted = nil
 
+        draft_version
+
+        expect {
+          promoted =
+            TemplateVersioningService.promote_draft_to_scheduled!(
+              draft_version,
+              version_date,
+              current_user: super_admin
+            )
+        }.to change { requirement_template.template_versions.count }.by(1)
+
+        draft_version.reload
+
+        expect(promoted.id).not_to eq(draft_version.id)
+        expect(draft_version.status).to eq("draft")
+        expect(promoted.status).to eq("scheduled")
+        expect(promoted.version_date).to eq(version_date)
+      end
+
+      it "copies the draft snapshot onto the scheduled version" do
         promoted =
           TemplateVersioningService.promote_draft_to_scheduled!(
             draft_version,
-            version_date,
+            Date.tomorrow,
             current_user: super_admin
           )
 
-        expect(promoted.id).to eq(draft_version.id)
-        expect(promoted.status).to eq("scheduled")
-        expect(promoted.version_date).to eq(version_date)
+        expect(promoted.denormalized_template_json).to eq(
+          draft_version.denormalized_template_json
+        )
+        expect(promoted.form_json).to eq(draft_version.form_json)
+        expect(promoted.requirement_blocks_json).to eq(
+          draft_version.requirement_blocks_json
+        )
       end
 
       it "unschedules sibling scheduled versions on or before the incoming date" do
@@ -415,7 +440,7 @@ RSpec.describe TemplateVersioningService, type: :service, search: true do
           allow(WebsocketBroadcaster).to receive(:push_update_to_relevant_users)
         end
 
-        it "publishes the draft inline with today's version_date" do
+        it "publishes a copy inline with today's version_date and keeps the draft" do
           promoted =
             TemplateVersioningService.promote_draft_to_scheduled!(
               draft_version,
@@ -424,6 +449,9 @@ RSpec.describe TemplateVersioningService, type: :service, search: true do
               current_user: super_admin
             )
 
+          draft_version.reload
+          expect(promoted.id).not_to eq(draft_version.id)
+          expect(draft_version.status).to eq("draft")
           expect(promoted.status).to eq("published")
           expect(promoted.version_date).to eq(Date.current)
         end

--- a/spec/services/template_versioning_service_spec.rb
+++ b/spec/services/template_versioning_service_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe TemplateVersioningService, type: :service, search: true do
           )
         }.to raise_error(
           TemplateVersionDraftError,
-          /Can only promote a draft version/
+          /Can only promote an early access version/
         )
       end
     end


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5043-bug-admin-early-access-fixes` (merge-base range).

Renames user-facing “draft” wording to **early access** across admin template tooling, API flash copy, validations, and preview emails so language matches the early-access product story. Improves the **template builder** actions: dedicated **Versions** and **Manage access** entry points, a **Create version** menu that splits **early access** (with confirmation modal) from **scheduled** publish flow, and a reorganized **versions** drawer (builder panel, version flow, hide “open builder” when already in the builder). **Tags** are editable in the builder header with `tagList` sent on create/update/schedule/force-publish. Requirement template **search grid** adds a column for early-access version date. Small fix: block conditional `eq` accepts boolean in MST/types.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5043](https://hous-bssb.atlassian.net/browse/HUB-5043) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Early access terminology: i18n (`i18n.ts`, `en.yml`), mailers, `TemplateVersion` / `TemplateVersionFeedback` validation copy, `TemplateVersioningService` / `TemplateVersionFeedbackService` errors, toast strings.
- `CreateEarlyAccessVersionModal` + `EditRequirementTemplateActions` menu wiring; `PublishScheduleModal` supports custom `renderTrigger` and drops inline “create draft” footer path.
- `TemplateVersionsSidebar`: `BuilderPanel`, `VersionFlow`, `isInBuilder`; version card copy tweaks for builder vs draft.
- Builder header: optional back navigation, optional tags row; `EditableBuilderHeader` uses `TagsSelect` and form `tags`; form defaults include tags; `ControlsHeader` removes separate close control.
- API: map `tags` → `tagList` for requirement template create/update/schedule/force publish; `IRequirementTemplateUpdateParams.tags`; conditional `ITemplateVersionFeedback` typing in API module.
- `template-section-block` / `IBlockConditional`: `eq` as `string | boolean`.
- `requirement-template-grid`: extra column for early-access (draft) version date next to current published column.
- Spec: `template_versioning_service_spec` expectation updated for new error message.

---

## 🧪 Steps to QA

1. As an admin (or role that can edit requirement templates), open **Requirement templates** and open a template in the **builder** (`/requirement-templates/:id/edit` or your usual builder route).
2. Confirm **Back** in the header navigates sensibly (browser back when history exists, otherwise templates list).
3. In the header, add/remove **tags**, save draft, reload builder — tags should persist.
4. Use **Versions** — drawer shows builder panel, version flow, and **Open builder** is hidden while already in builder; published / scheduled / deprecated sections still behave.
5. Use **Manage access** — still opens access sidebar as before.
6. **Create version** menu:
   - **Early access** path opens confirmation modal; confirming runs create flow and strings say “early access” where relevant.
   - **Scheduled** path opens publish/schedule modal (no duplicate manage-access affordance where `hideManageAccessButton` applies).
7. From **Requirement templates** search/grid, confirm new **Early access** column shows version date when an early-access version exists; headers align with sorting on **Current version**.
8. Trigger or spot-check **preview invitation** emails (if staging supports): copy uses “early access” not “draft”.
9. Optional: create second early-access version when one exists — error/validation should refer to early access, not “draft”.

**Expected Behaviour:** Consistent “early access” language; builder actions match new layout; tags save via `tagList`; grid shows early-access dates; no duplicate or broken publish/draft flows.

**Before this change:** “Draft” labels and mixed controls (e.g. publish modal footers); tags not in builder header; versions drawer layout differed; no dedicated early-access column in grid.

**After this change:** Early-access naming; streamlined menus/sidebars; tags in header; grid column for early-access version date.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

- [ ] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [ ] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

_Add before/after screenshots for builder header, Create version menu, and versions drawer._

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [ ] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5043]: https://hous-bssb.atlassian.net/browse/HUB-5043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ