### PR TITLE
only notify users applying to relevant jurisdiction of customization …

### DIFF
--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -319,11 +319,13 @@ class NotificationService
 
   def self.publish_customization_update_event(customization)
     template_version = customization.template_version
+    jurisdiction_id = customization.jurisdiction_id
     relevant_submitter_ids =
       PermitApplication
         .kept
         .joins(:template_version)
         .joins(submitter: :preference)
+        .left_joins(:permit_project)
         .where(
           template_versions: {
             requirement_template_id: template_version.requirement_template_id
@@ -334,6 +336,12 @@ class NotificationService
               enable_in_app_customization_update_notification: true
             }
           }
+        )
+        .where(
+          Arel.sql(
+            "COALESCE(permit_projects.jurisdiction_id, permit_applications.jurisdiction_id) = ?"
+          ),
+          jurisdiction_id
         )
         .pluck(:submitter_id)
         .uniq

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -651,4 +651,47 @@ RSpec.describe NotificationService do
       )
     end
   end
+
+  describe ".publish_customization_update_event" do
+    it "notifies only submitters with drafts in the customizing jurisdiction" do
+      allow(NotificationPushJob).to receive(:perform_async)
+
+      requirement_template = create(:requirement_template)
+      template_version =
+        create(:template_version, requirement_template: requirement_template)
+
+      jurisdiction_customized = create(:sub_district)
+      jurisdiction_other = create(:sub_district)
+
+      customization =
+        create(
+          :jurisdiction_template_version_customization,
+          jurisdiction: jurisdiction_customized,
+          template_version: template_version
+        )
+
+      matching_submitter = create(:user, :submitter)
+      other_submitter = create(:user, :submitter)
+
+      create(
+        :permit_application,
+        submitter: matching_submitter,
+        template_version: template_version,
+        jurisdiction: jurisdiction_customized
+      )
+
+      create(
+        :permit_application,
+        submitter: other_submitter,
+        template_version: template_version,
+        jurisdiction: jurisdiction_other
+      )
+
+      described_class.publish_customization_update_event(customization)
+
+      expect(NotificationPushJob).to have_received(:perform_async) do |payload|
+        expect(payload.keys).to contain_exactly(matching_submitter.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HEAD` (merge-base range on branch `HUB-5046-bug-production-notifications-r-ms-receiving-notifications-for-other-jurisdictions`).

Customization update notifications were sent to every submitter with a qualifying draft **anywhere** who shared the same `requirement_template_id`, because `NotificationService.publish_customization_update_event` did not scope by jurisdiction. That produced misleading alerts (e.g. mentioning Powell River) for users whose drafts belonged to other municipalities.

This change restricts recipients to submitters whose permit application’s effective jurisdiction matches the **customization’s** `jurisdiction_id`. Effective jurisdiction matches `ProjectItem`: `COALESCE(permit_projects.jurisdiction_id, permit_applications.jurisdiction_id)`, with `left_joins(:permit_project)` so rows without a project still resolve correctly.

Adds an RSpec example that asserts only the submitter in the customizing jurisdiction receives the push payload.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5046](https://hous-bssb.atlassian.net/browse/HUB-5046) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- N/A --> |
| 📚 Documentation | <!-- N/A --> |

---

## ✨ Features / Changes Introduced

- Scope `publish_customization_update_event` to permit applications whose resolved jurisdiction equals the updated customization’s jurisdiction.
- Use `left_joins(:permit_project)` and `COALESCE(permit_projects.jurisdiction_id, permit_applications.jurisdiction_id)` for consistent jurisdiction resolution with `PermitApplication` / `ProjectItem`.
- Add `NotificationService.publish_customization_update_event` example proving submitters in another jurisdiction are not notified.

---

## 🧪 Steps to QA

> Backend-only change; validate behavior via in-app notifications after a customization save.

1. **Staging:** Identify two jurisdictions **A** and **B**, and a requirement template **T** enabled in both (same `requirement_template_id`).
2. As **User 1**, create or use a **draft** (or revisions-requested draft) permit application under jurisdiction **B** for template **T**; ensure in-app customization notifications are enabled in profile/preferences.
3. As staff for jurisdiction **A**, update and save **jurisdiction template customizations** for template **T** (published row as used in prod).
4. **Expected:** User 1 **does not** receive an in-app notification claiming jurisdiction **A** changed requirements for **T**.
5. Repeat with **User 2** holding a draft under jurisdiction **A** for template **T**; save customization again for **A**.
6. **Expected:** User 2 **does** receive the customization-update notification for **A**.

**Expected Behaviour:** Customization-update notifications only reach submitters with qualifying drafts in the **same jurisdiction** as the customization that was updated.

**Before this change:** Submitters with drafts in other jurisdictions could receive notifications when any jurisdiction updated customizations for the shared requirement template.

**After this change:** Notifications are limited to drafts tied to that customization’s jurisdiction (resolved via project first, then permit application).

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [ ] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [ ] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5046]: https://hous-bssb.atlassian.net/browse/HUB-5046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ