### PR TITLE
prevent losing tempfiles before completion of zipper job

### DIFF
--- a/app/services/supporting_documents_zipper.rb
+++ b/app/services/supporting_documents_zipper.rb
@@ -95,7 +95,7 @@ class SupportingDocumentsZipper
       end
     end
     temp_file.close
-    temp_files << temp_file.path
+    temp_files << temp_file
     temp_file.path
   rescue => e
     Rails.logger.error(
@@ -107,7 +107,14 @@ class SupportingDocumentsZipper
   end
 
   def cleanup_temp_files
-    temp_files.each { |file| FileUtils.rm_f(file) }
+    temp_files.each do |file|
+      if file.is_a?(Tempfile)
+        file.close unless file.closed?
+        file.unlink
+      else
+        FileUtils.rm_f(file)
+      end
+    end
     FileUtils.rm_f(file_path)
   end
 end

--- a/spec/services/supporting_documents_zipper_spec.rb
+++ b/spec/services/supporting_documents_zipper_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe SupportingDocumentsZipper do
 
       expect(path).to be_present
       expect(File.exist?(path)).to eq(true)
-      expect(zipper.temp_files).to include(path)
+      expect(zipper.temp_files.map(&:path)).to include(path)
     end
 
     it "returns nil and logs when download fails" do


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-4781-bug-rm-review-permit-application-downloaded-files-are-renamed-by-bph-missingfile` (merge-base range).

`SupportingDocumentsZipper` downloaded each supporting document into a `Tempfile`, closed it, and only kept the path string in `@temp_files`. With nothing retaining the `Tempfile` object, Ruby’s GC could finalize it and unlink the path before Rubyzip read the file during `Zip::File.open`. That produced intermittent `Errno::ENOENT` on paths like `/tmp/download…` in Sidekiq (remote workers often differ in GC timing from local/dev).

This change stores the `Tempfile` instances so they stay alive until zip creation finishes, then closes and unlinks them explicitly in `cleanup_temp_files`. String paths (e.g. the uploaded zip file handle path) still use `FileUtils.rm_f`.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-4781](https://yourorg.atlassian.net/browse/HUB-4781) <!-- replace org URL if needed --> |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                        |
| 📑 Design / Figma    | <!-- N/A -->                                               |
| 📚 Documentation     | <!-- N/A -->                                               |

---

## ✨ Features / Changes Introduced

- Retain downloaded supporting-document `Tempfile` objects until after the zip is built, avoiding premature unlink/GC races.
- Cleanup now closes and `unlink`s `Tempfile` entries; non-temp paths still removed with `FileUtils.rm_f`.
- Spec expectation updated so `@temp_files` is asserted via tempfile paths.

---

## 🧪 Steps to QA

1. In an environment where Sidekiq runs the `file_processing` queue (e.g. staging), use a permit application that has multiple supporting documents across submission versions.
2. Trigger supporting-documents zip generation (same flow as production—e.g. submit or whatever action enqueues `ZipfileJob`).
3. Confirm the job completes without `Errno::ENOENT` on `/tmp/download…` in worker logs.
4. Download/open the generated zip from the app and confirm expected files are present and readable.

**Expected Behaviour:** Zip job succeeds reliably; archive contains the expected documents.

**Before this change:** Intermittent Sidekiq failures with `No such file or directory @ rb_sysopen - /tmp/download…` during `SupportingDocumentsZipper#create_zip_file`.

**After this change:** Temp download files remain on disk until Rubyzip finishes adding entries.

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [ ] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [ ] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4781]: https://hous-bssb.atlassian.net/browse/HUB-4781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ