### PR TITLE
HUB-4215 all users receive notifications when release notes published

### DIFF
--- a/app/blueprints/preference_blueprint.rb
+++ b/app/blueprints/preference_blueprint.rb
@@ -14,6 +14,7 @@ class PreferenceBlueprint < Blueprinter::Base
          :enable_email_unmapped_api_notification,
          :enable_in_app_resource_reminder_notification,
          :enable_email_resource_reminder_notification,
+         :enable_in_app_release_note_publish_notification,
          :created_at,
          :updated_at
 end

--- a/app/controllers/api/release_notes_controller.rb
+++ b/app/controllers/api/release_notes_controller.rb
@@ -64,6 +64,7 @@ class Api::ReleaseNotesController < Api::ApplicationController
   def publish
     authorize @release_note
     if @release_note.update(release_note_params.merge(status: :published))
+      NotificationService.publish_release_note_publish_event(@release_note)
       render_success @release_note,
                      "release_note.publish_success",
                      {

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -245,6 +245,7 @@ class Api::UsersController < Api::ApplicationController
         enable_email_unmapped_api_notification
         enable_in_app_resource_reminder_notification
         enable_email_resource_reminder_notification
+        enable_in_app_release_note_publish_notification
       ]
     )
   end

--- a/app/frontend/components/domains/navigation/sub-nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/sub-nav-bar.tsx
@@ -68,6 +68,7 @@ const DynamicBreadcrumb = observer(({ path }: IDynamicBreadcrumbProps) => {
       const currentResourceMap = {
         jurisdictions: rootStore.jurisdictionStore.currentJurisdiction?.name,
         "permit-applications": rootStore.permitApplicationStore.currentPermitApplication?.number,
+        "release-notes": rootStore.releaseNoteStore.currentReleaseNote?.version,
       }
 
       const title = resourceNeeded
@@ -79,7 +80,12 @@ const DynamicBreadcrumb = observer(({ path }: IDynamicBreadcrumbProps) => {
     })
 
     setBreadcrumbs(breadcrumbSegments)
-  }, [path, rootStore.jurisdictionStore.currentJurisdiction])
+  }, [
+    path,
+    rootStore.jurisdictionStore.currentJurisdiction,
+    rootStore.permitApplicationStore.currentPermitApplication,
+    rootStore.releaseNoteStore.currentReleaseNote,
+  ])
 
   return <SiteBreadcrumbs breadcrumbs={breadcrumbs} />
 })

--- a/app/frontend/components/domains/super-admin/site-configuration-management/release-note-form-screen.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/release-note-form-screen.tsx
@@ -114,7 +114,14 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
   const location = useLocation()
   const { releaseNoteId } = useParams<{ releaseNoteId: string }>()
   const { releaseNoteStore } = useMst()
-  const { fetchReleaseNote, createReleaseNote, updateReleaseNote, publishReleaseNote } = releaseNoteStore
+  const {
+    fetchReleaseNote,
+    createReleaseNote,
+    updateReleaseNote,
+    publishReleaseNote,
+    resetCurrentReleaseNote,
+    setCurrentReleaseNote,
+  } = releaseNoteStore
 
   const isCreate = Boolean(matchPath({ path: "/release-notes/new", end: true }, location.pathname))
 
@@ -141,6 +148,7 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
     if (isCreate) {
       setShowIssuesSection(false)
       setIsLoading(false)
+      resetCurrentReleaseNote()
       return
     }
 
@@ -148,13 +156,20 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
     if (!id) {
       setLoadError(true)
       setIsLoading(false)
+      resetCurrentReleaseNote()
       return
     }
 
+    if (releaseNoteStore.releaseNoteMap.has(id)) {
+      setCurrentReleaseNote(id)
+    } else {
+      setCurrentReleaseNote(null)
+    }
     let cancelled = false
     fetchReleaseNote(id).then((note) => {
       if (cancelled) return
       if (note) {
+        setCurrentReleaseNote(id)
         const issuesHtml = note.issues ?? ""
         reset({
           version: note.version,
@@ -166,6 +181,7 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
         setShowIssuesSection(!isTipTapEmpty(issuesHtml))
         setLoadError(false)
       } else {
+        resetCurrentReleaseNote()
         setLoadError(true)
       }
       setIsLoading(false)
@@ -173,8 +189,9 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
 
     return () => {
       cancelled = true
+      resetCurrentReleaseNote()
     }
-  }, [fetchReleaseNote, isCreate, releaseNoteId, reset])
+  }, [fetchReleaseNote, isCreate, releaseNoteId, reset, resetCurrentReleaseNote, setCurrentReleaseNote])
 
   const saveDraft = async (data: TReleaseNoteFormData) => {
     const result = isCreate ? await createReleaseNote(data) : await updateReleaseNote(releaseNoteId as string, data)

--- a/app/frontend/components/domains/super-admin/site-configuration-management/release-notes-screen.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/release-notes-screen.tsx
@@ -3,7 +3,7 @@ import { Pencil } from "@phosphor-icons/react"
 import { format } from "date-fns"
 import { t } from "i18next"
 import { observer } from "mobx-react-lite"
-import React from "react"
+import React, { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { Link as ReactRouterLink } from "react-router-dom"
 import { useSearch } from "../../../../hooks/use-search"
@@ -53,9 +53,14 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
     handlePageChange,
     isSearching,
     tableReleaseNotes,
+    resetCurrentReleaseNote,
   } = releaseNoteStore
 
   useSearch(releaseNoteStore, [])
+
+  useEffect(() => {
+    resetCurrentReleaseNote()
+  }, [resetCurrentReleaseNote])
 
   return (
     <Container maxW="container.lg" px={8} pt={6} pb={20} flexGrow={1}>

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -203,6 +203,18 @@ export const NotificationStoreModel = types
             href: `/jurisdictions/${jurisdictionId}/configuration-management/resources`,
           },
         ]
+      } else if (notification.actionType === ENotificationActionType.releaseNotePublish) {
+        const data = notification.objectData as { releaseNoteId?: string }
+        const releaseNoteId = data?.releaseNoteId
+        if (!releaseNoteId) {
+          return []
+        }
+        return [
+          {
+            text: t("ui.show"),
+            href: `/release-notes/${releaseNoteId}`,
+          },
+        ]
       }
     },
   }))

--- a/app/frontend/stores/release-note-store.ts
+++ b/app/frontend/stores/release-note-store.ts
@@ -13,6 +13,7 @@ export const ReleaseNoteStoreModel = types
     types.model("ReleaseNoteStoreModel", {
       releaseNoteMap: types.map(ReleaseNoteModel),
       tableReleaseNotes: types.array(types.reference(ReleaseNoteModel)),
+      currentReleaseNote: types.maybeNull(types.reference(ReleaseNoteModel)),
     }),
     createSearchModel<EReleaseNoteSortFields>("searchReleaseNotes")
   )
@@ -27,6 +28,12 @@ export const ReleaseNoteStoreModel = types
   .actions((self) => ({
     setTableReleaseNotes(releaseNotes: IReleaseNote[]) {
       self.tableReleaseNotes = cast(releaseNotes.map((r) => r.id))
+    },
+    setCurrentReleaseNote(releaseNoteId) {
+      self.currentReleaseNote = releaseNoteId
+    },
+    resetCurrentReleaseNote() {
+      self.currentReleaseNote = null
     },
   }))
   .actions((self) => ({

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -455,6 +455,7 @@ export enum ENotificationActionType {
   resourceReminder = "resource_reminder",
   projectReviewCollaborationAssignment = "project_review_collaboration_assignment",
   projectReviewCollaborationUnassignment = "project_review_collaboration_unassignment",
+  releaseNotePublish = "release_note_publish",
 }
 
 export enum ECollaboratorableType {

--- a/app/models/release_note.rb
+++ b/app/models/release_note.rb
@@ -19,6 +19,22 @@ class ReleaseNote < ApplicationRecord
 
   scope :published, -> { where(status: :published) }
 
+  def publish_event_notification_data
+    {
+      "id" => SecureRandom.uuid,
+      "action_type" => Constants::NotificationActionTypes::RELEASE_NOTE_PUBLISH,
+      "action_text" =>
+        I18n.t(
+          "notification.release_note.publish_notification",
+          version: version
+        ),
+      "object_data" => {
+        "release_note_id" => id,
+        "version" => version
+      }
+    }
+  end
+
   private
 
   def version_unchanged_once_published

--- a/app/services/constants/notification_action_types.rb
+++ b/app/services/constants/notification_action_types.rb
@@ -24,5 +24,6 @@ module Constants
       "project_review_collaboration_assignment"
     PROJECT_REVIEW_COLLABORATION_UNASSIGNMENT =
       "project_review_collaboration_unassignment"
+    RELEASE_NOTE_PUBLISH = "release_note_publish"
   end
 end

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -630,6 +630,32 @@ class NotificationService
     end
   end
 
+  def self.publish_release_note_publish_event(release_note)
+    return unless release_note&.published?
+
+    recipient_ids =
+      User
+        .kept
+        .joins(:preference)
+        .where(
+          preferences: {
+            enable_in_app_release_note_publish_notification: true
+          }
+        )
+        .pluck(:id)
+
+    return if recipient_ids.blank?
+
+    notification_data = release_note.publish_event_notification_data
+
+    notification_user_hash =
+      recipient_ids.each_with_object({}) do |user_id, hash|
+        hash[user_id] = notification_data
+      end
+
+    NotificationPushJob.perform_async(notification_user_hash)
+  end
+
   def self.publish_resource_reminder_event(jurisdiction, resource_ids)
     all_managers = jurisdiction.managers
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1096,6 +1096,8 @@ en:
       status_ready_no_user: 'Requirement “%{requirement_block_name}” status set to "ready" for permit application %{number}'
     resource:
       reminder: "Reminder: Review your jurisdiction resources"
+    release_note:
+      publish_notification: "Version %{version} is now available. See what's new."
     integration_mapping:
       published_template_missing_requirements_mapping: "Missing API mapping: A new version of “%{template_label}” has been published on %{version_date}"
       scheduled_template_missing_requirements_mapping: "Missing API Mapping: A new version of “%{template_label}” has been scheduled for %{version_date}, 01:00hrs PST."

--- a/db/migrate/20260512163028_add_release_note_notification_to_preference.rb
+++ b/db/migrate/20260512163028_add_release_note_notification_to_preference.rb
@@ -1,0 +1,8 @@
+class AddReleaseNoteNotificationToPreference < ActiveRecord::Migration[7.2]
+  def change
+    add_column :preferences,
+               :enable_in_app_release_note_publish_notification,
+               :boolean,
+               default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_12_163028) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -680,6 +680,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.boolean "enable_email_unmapped_api_notification", default: true
     t.boolean "enable_in_app_resource_reminder_notification", default: true
     t.boolean "enable_email_resource_reminder_notification", default: true
+    t.boolean "enable_in_app_release_note_publish_notification", default: true
     t.index ["user_id"], name: "index_preferences_on_user_id"
   end
 

--- a/spec/models/release_note_spec.rb
+++ b/spec/models/release_note_spec.rb
@@ -65,4 +65,22 @@ RSpec.describe ReleaseNote, type: :model do
       expect(ReleaseNote.published).not_to include(draft_release_note)
     end
   end
+
+  describe "#publish_event_notification_data" do
+    it "returns notification payload referencing the release note" do
+      release_note = create(:release_note, status: :published)
+
+      data = release_note.publish_event_notification_data
+
+      expect(data).to include(
+        "action_type" =>
+          Constants::NotificationActionTypes::RELEASE_NOTE_PUBLISH
+      )
+      expect(data["action_text"]).to include(release_note.version)
+      expect(data["object_data"]).to include(
+        "release_note_id" => release_note.id,
+        "version" => release_note.version
+      )
+    end
+  end
 end

--- a/spec/requests/release_notes_spec.rb
+++ b/spec/requests/release_notes_spec.rb
@@ -141,6 +141,17 @@ RSpec.describe "ReleaseNotes", type: :request do
       expect(subject).to include("status" => "published")
     end
 
+    it "triggers a publish notification" do
+      setup
+      expect(NotificationService).to receive(
+        :publish_release_note_publish_event
+      ).with(an_instance_of(ReleaseNote))
+
+      patch publish_release_note_path(@release_note.id)
+
+      expect(response).to have_http_status(:success)
+    end
+
     it_behaves_like AN_INVALID_PAYLOAD_RESPONSE, publish_with_payload
     it_behaves_like A_NOT_FOUND_RESPONSE, publish_with_payload
   end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -400,6 +400,53 @@ RSpec.describe NotificationService do
     end
   end
 
+  describe ".publish_release_note_publish_event" do
+    it "no-ops when the release note is not published" do
+      release_note = instance_double("ReleaseNote", published?: false)
+      allow(NotificationPushJob).to receive(:perform_async)
+
+      described_class.publish_release_note_publish_event(release_note)
+
+      expect(NotificationPushJob).not_to have_received(:perform_async)
+    end
+
+    it "pushes notifications to every kept user with the preference enabled" do
+      opted_in_a = create(:user, :submitter)
+      opted_in_b = create(:user, :review_manager)
+      opted_out = create(:user, :submitter)
+      opted_out.preference.update!(
+        enable_in_app_release_note_publish_notification: false
+      )
+      discarded = create(:user, :submitter)
+      discarded.discard
+
+      release_note = create(:release_note, status: :published)
+      payload = release_note.publish_event_notification_data
+
+      allow(NotificationPushJob).to receive(:perform_async)
+
+      described_class.publish_release_note_publish_event(release_note)
+
+      expect(NotificationPushJob).to have_received(:perform_async) do |hash|
+        expect(hash.keys).to match_array([opted_in_a.id, opted_in_b.id])
+        expect(hash.values).to all(eq(payload))
+      end
+    end
+
+    it "does not enqueue a job when no users opted in" do
+      user = create(:user, :submitter)
+      user.preference.update!(
+        enable_in_app_release_note_publish_notification: false
+      )
+      release_note = create(:release_note, status: :published)
+      allow(NotificationPushJob).to receive(:perform_async)
+
+      described_class.publish_release_note_publish_event(release_note)
+
+      expect(NotificationPushJob).not_to have_received(:perform_async)
+    end
+  end
+
   describe ".publish_application_submission_event / .publish_application_revisions_request_event" do
     it "creates correct in-app and email notifications for submitters and collaborators" do
       submitter_pref =

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -420,16 +420,26 @@ RSpec.describe NotificationService do
       discarded = create(:user, :submitter)
       discarded.discard
 
-      release_note = create(:release_note, status: :published)
-      payload = release_note.publish_event_notification_data
+      release_note = create(:release_note, status: :published, version: "9.9.9")
 
       allow(NotificationPushJob).to receive(:perform_async)
 
       described_class.publish_release_note_publish_event(release_note)
 
+      expected_payload =
+        include(
+          "action_type" =>
+            Constants::NotificationActionTypes::RELEASE_NOTE_PUBLISH,
+          "action_text" => include("9.9.9"),
+          "object_data" =>
+            include("release_note_id" => release_note.id, "version" => "9.9.9")
+        )
+
       expect(NotificationPushJob).to have_received(:perform_async) do |hash|
         expect(hash.keys).to match_array([opted_in_a.id, opted_in_b.id])
-        expect(hash.values).to all(eq(payload))
+        expect(hash.values).to all(match(expected_payload))
+        # All recipients should receive the exact same payload object.
+        expect(hash.values.uniq.size).to eq(1)
       end
     end
 


### PR DESCRIPTION
## 📋 Description

In-app release note publish notifications for users & use version instead of id in breadcrumb

---

## 🔖 What type of PR is this? _(check all that apply)_

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

[HUB-4215](https://hous-bssb.atlassian.net/browse/HUB-4215)

---

## ✨ Features / Changes Introduced

> List the key changes, features, or fixes introduced in this PR.

- Publish notifications for users that have them enabled in their preferences
- Replace id with version in breadcrumbs; similar to how jurisdictions work

## 🧪 Steps to QA

Test acceptance criteria in [HUB-4215](https://hous-bssb.atlassian.net/browse/HUB-4215)

---

## ♿ UI Accessibility Checklist

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [X] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [X] Additional context added through `aria-roles` and `aria-labels` where needed?
- [X] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [X] Usable with a **keyboard** and navigable in a **logical order**?
- [X] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [X] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [X] No content relies on **colour alone** to convey meaning?
- [X] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [X] ✅ Tests written and passing for all changes where relevant
- [X] 📝 Commit messages are descriptive and follow the project convention
- [X] 📗 Related documentation updated; relevant screenshots included
- [X] 📱 For UI changes: responsive design verified across multiple screen sizes
- [X] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [X] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [X] 👀 Self-reviewed this PR before requesting others


[HUB-4215]: https://hous-bssb.atlassian.net/browse/HUB-4215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HUB-4215]: https://hous-bssb.atlassian.net/browse/HUB-4215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ