### PR TITLE
add qa tools feature flag

### DIFF
--- a/app/blueprints/site_configuration_blueprint.rb
+++ b/app/blueprints/site_configuration_blueprint.rb
@@ -4,6 +4,7 @@ class SiteConfigurationBlueprint < Blueprinter::Base
          :inbox_enabled,
          :allow_designated_reviewer,
          :code_compliance_enabled,
+         :qa_tools_enabled,
          :archistar_enabled_for_all_jurisdictions
 
   field :help_link_items do |site_configuration, _options|

--- a/app/controllers/api/qa_tools_controller.rb
+++ b/app/controllers/api/qa_tools_controller.rb
@@ -74,7 +74,9 @@ class Api::QaToolsController < Api::ApplicationController
   private
 
   def require_qa_mode!
-    return if ENV["VITE_QA_MODE"] == "true"
+    if ENV["VITE_QA_MODE"] == "true" && SiteConfiguration.qa_tools_enabled?
+      return
+    end
 
     head :not_found
   end

--- a/app/controllers/api/site_configuration_controller.rb
+++ b/app/controllers/api/site_configuration_controller.rb
@@ -93,6 +93,7 @@ class Api::SiteConfigurationController < Api::ApplicationController
       :inbox_enabled,
       :allow_designated_reviewer,
       :code_compliance_enabled,
+      :qa_tools_enabled,
       :archistar_enabled_for_all_jurisdictions,
       help_link_items: [
         get_started_link_item: %i[href title description show],

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -366,6 +366,12 @@ const CodeComplianceSetupScreen = lazy(() =>
   }))
 )
 
+const QaToolsFeatureAccessScreen = lazy(() =>
+  import("../super-admin/site-configuration-management/qa-tools-feature-access").then((module) => ({
+    default: module.QaToolsFeatureAccessScreen,
+  }))
+)
+
 const ReportingScreen = lazy(() =>
   import("../super-admin/reporting/reporting-screen").then((module) => ({ default: module.ReportingScreen }))
 )
@@ -473,6 +479,7 @@ const AppRoutes = observer(() => {
   const eulaAccepted = currentUser ? currentUser.eulaAccepted : false
   const isSuperAdmin = currentUser ? currentUser.isSuperAdmin : false
   const isUnconfirmed = currentUser ? currentUser.isUnconfirmed : false
+  const qaModeEnabled = import.meta.env.VITE_QA_MODE === "true"
 
   const superAdminOnlyRoutes = (
     <>
@@ -502,6 +509,12 @@ const AppRoutes = observer(() => {
         path="/configuration-management/global-feature-access/code-compliance"
         element={<CodeComplianceSetupScreen />}
       />
+      {qaModeEnabled && (
+        <Route
+          path="/configuration-management/global-feature-access/qa-tools"
+          element={<QaToolsFeatureAccessScreen />}
+        />
+      )}
       <Route path="/configuration-management/users/invite" element={<AdminInviteScreen />} />
       <Route path="/reporting" element={<ReportingScreen />} />
       <Route path="/reporting/export-template-summary" element={<ExportTemplateSummaryScreen />} />

--- a/app/frontend/components/domains/navigation/qa-tools-popout.tsx
+++ b/app/frontend/components/domains/navigation/qa-tools-popout.tsx
@@ -13,7 +13,7 @@ export const QaToolsPopout = observer(() => {
   const location = useLocation()
   const navigate = useNavigate()
   const api = useServerAPI()
-  const { permitApplicationStore, sandboxStore, sessionStore, uiStore, userStore } = useMst()
+  const { permitApplicationStore, sandboxStore, sessionStore, siteConfigurationStore, uiStore, userStore } = useMst()
 
   const { currentUser } = userStore
   const [isOpen, setIsOpen] = useState(false)
@@ -28,6 +28,7 @@ export const QaToolsPopout = observer(() => {
   const isProjectsPath = location.pathname === "/projects"
   const isEligible = Boolean(
     import.meta.env.VITE_QA_MODE === "true" &&
+      siteConfigurationStore.qaToolsEnabled &&
       sessionStore.loggedIn &&
       currentUser &&
       (currentUser.isSubmitter || currentUser.isReviewStaff)

--- a/app/frontend/components/domains/super-admin/site-configuration-management/global-feature-access.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/global-feature-access.tsx
@@ -8,6 +8,7 @@ export const AdminGlobalFeatureAccessScreen = observer(() => {
   const i18nPrefix = "siteConfiguration.globalFeatureAccess"
   const { t } = useTranslation()
   const { siteConfigurationStore } = useMst()
+  const qaModeEnabled = import.meta.env.VITE_QA_MODE === "true"
 
   const features: FeatureItem[] = [
     {
@@ -25,6 +26,15 @@ export const AdminGlobalFeatureAccessScreen = observer(() => {
       enabled: siteConfigurationStore?.codeComplianceEnabled,
       route: "code-compliance",
     },
+    ...(qaModeEnabled
+      ? [
+          {
+            label: t(`${i18nPrefix}.qaTools`),
+            enabled: siteConfigurationStore?.qaToolsEnabled,
+            route: "qa-tools",
+          },
+        ]
+      : []),
     // Add more features here as needed
   ]
 

--- a/app/frontend/components/domains/super-admin/site-configuration-management/qa-tools-feature-access.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/qa-tools-feature-access.tsx
@@ -1,0 +1,54 @@
+import { Container, Flex, Heading, Text, VStack } from "@chakra-ui/react"
+import { CaretLeft } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React, { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { useMst } from "../../../../setup/root"
+import { SwitchButton } from "../../../shared/buttons/switch-button"
+import { RouterLinkButton } from "../../../shared/navigation/router-link-button"
+
+export const QaToolsFeatureAccessScreen = observer(() => {
+  const i18nPrefix = "siteConfiguration.globalFeatureAccess"
+  const { t } = useTranslation()
+  const { siteConfigurationStore } = useMst()
+  const { updateSiteConfiguration, configurationLoaded } = siteConfigurationStore
+  const [qaToolsEnabled, setQaToolsEnabled] = useState(false)
+
+  const updateQaToolsEnabled = async (e) => {
+    setQaToolsEnabled(e.target.checked)
+    await updateSiteConfiguration({
+      qaToolsEnabled: e.target.checked,
+    })
+  }
+
+  useEffect(() => {
+    if (configurationLoaded) {
+      setQaToolsEnabled(siteConfigurationStore.qaToolsEnabled || false)
+    }
+  }, [configurationLoaded])
+
+  return (
+    <Container maxW="container.lg" p={8} as={"main"}>
+      <VStack alignItems={"flex-start"} w={"full"} h={"full"} gap={6}>
+        <RouterLinkButton
+          variant={"link"}
+          to={`/configuration-management/global-feature-access/`}
+          leftIcon={<CaretLeft size={20} />}
+          textDecoration="none"
+        >
+          {t("ui.back")}
+        </RouterLinkButton>
+        <Heading as="h1" m={0} p={0}>
+          {t(`${i18nPrefix}.qaTools`)}
+        </Heading>
+        <Text color="text.secondary" m={0} mt={23}>
+          {t(`${i18nPrefix}.qaToolsDescription`)}
+        </Text>
+        <Flex pb={4} justify="space-between" w="100%" borderBottom="1px solid" borderColor="border.light">
+          <Text fontWeight="bold">{t(`${i18nPrefix}.qaTools`)}</Text>
+          <SwitchButton isChecked={qaToolsEnabled} onChange={updateQaToolsEnabled} size={"lg"} />
+        </Flex>
+      </VStack>
+    </Container>
+  )
+})

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4539,6 +4539,9 @@ Thank you,
               jurisdictionsCount_other: "{{count}} jurisdictions enabled",
               searchJurisdictions: "Search and select jurisdictions...",
             },
+            qaTools: "QA tools",
+            qaToolsDescription:
+              "Enable QA tools for users who can access test helpers. This setting only applies when QA mode is enabled for the environment.",
           },
           sitewideMessage: {
             title: "Site-wide message",

--- a/app/frontend/stores/site-configuration-store.ts
+++ b/app/frontend/stores/site-configuration-store.ts
@@ -16,6 +16,7 @@ export const SiteConfigurationStoreModel = types.snapshotProcessor(
       inboxEnabled: types.maybeNull(types.boolean),
       allowDesignatedReviewer: types.maybeNull(types.boolean),
       codeComplianceEnabled: types.maybeNull(types.boolean),
+      qaToolsEnabled: types.maybeNull(types.boolean),
       archistarEnabledForAllJurisdictions: types.maybeNull(types.boolean),
       sitewideMessage: types.maybeNull(types.string),
       helpLinkItems: types.frozen<IHelpLinkItems>(),

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -129,6 +129,7 @@ export interface ISiteConfigurationUpdateParams {
   inboxEnabled?: boolean | null
   allowDesignatedReviewer?: boolean | null
   codeComplianceEnabled?: boolean | null
+  qaToolsEnabled?: boolean | null
   archistarEnabledForAllJurisdictions?: boolean | null
   sitewideMessage?: string | null
   helpLinkItems?: IHelpLinkItems

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -36,6 +36,10 @@ class SiteConfiguration < ApplicationRecord
     instance.code_compliance_enabled
   end
 
+  def self.qa_tools_enabled?
+    instance.qa_tools_enabled
+  end
+
   def self.archistar_enabled_for_jurisdiction?(jurisdiction)
     return false unless instance.code_compliance_enabled # Global switch
     return true if instance.archistar_enabled_for_all_jurisdictions # Override

--- a/app/policies/permit_application_policy.rb
+++ b/app/policies/permit_application_policy.rb
@@ -37,6 +37,7 @@ class PermitApplicationPolicy < ApplicationPolicy
 
   def qa_autofill?
     return false unless ENV["VITE_QA_MODE"] == "true"
+    return false unless SiteConfiguration.qa_tools_enabled?
 
     is_draft = record.draft?
     update_allowed = is_draft && update?

--- a/db/migrate/20260515165400_add_qa_tools_enabled_to_site_configurations.rb
+++ b/db/migrate/20260515165400_add_qa_tools_enabled_to_site_configurations.rb
@@ -1,0 +1,17 @@
+class AddQaToolsEnabledToSiteConfigurations < ActiveRecord::Migration[7.1]
+  def up
+    unless column_exists?(:site_configurations, :qa_tools_enabled)
+      add_column :site_configurations,
+                 :qa_tools_enabled,
+                 :boolean,
+                 default: false,
+                 null: false
+    end
+  end
+
+  def down
+    if column_exists?(:site_configurations, :qa_tools_enabled)
+      remove_column :site_configurations, :qa_tools_enabled
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_15_165400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -98,6 +98,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.uuid "contactable_id"
     t.string "contact_type"
     t.index ["contactable_type", "contactable_id"], name: "index_contacts_on_contactable"
+  end
+
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "design_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -288,7 +291,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.jsonb "boundary_points", default: []
     t.string "weather_location"
     t.decimal "design_summer_temp", precision: 5, scale: 1
-    t.boolean "hide_from_search", default: false, null: false
     t.text "processing_time_html"
     t.text "key_stages_html"
     t.text "timeline_and_deliverables_html"
@@ -297,6 +299,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.string "office_telephone"
     t.string "office_email"
     t.string "website_url"
+    t.boolean "hide_from_search", default: false, null: false
     t.index ["ltsa_matcher"], name: "index_jurisdictions_on_ltsa_matcher"
     t.index ["prefix"], name: "index_jurisdictions_on_prefix", unique: true
     t.index ["regional_district_id"], name: "index_jurisdictions_on_regional_district_id"
@@ -749,14 +752,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.string "nickname"
     t.datetime "fetched_at"
     t.uuid "copied_from_id"
-    t.uuid "assignee_id"
-    t.boolean "public", default: false
-    t.uuid "site_configuration_id"
     t.boolean "available_globally"
-    t.index ["assignee_id"], name: "index_requirement_templates_on_assignee_id"
     t.index ["copied_from_id"], name: "index_requirement_templates_on_copied_from_id"
     t.index ["discarded_at"], name: "index_requirement_templates_on_discarded_at"
-    t.index ["site_configuration_id"], name: "index_requirement_templates_on_site_configuration_id"
   end
 
   create_table "requirements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -852,6 +850,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
     t.boolean "allow_designated_reviewer", default: false, null: false
     t.boolean "code_compliance_enabled", default: false, null: false
     t.boolean "archistar_enabled_for_all_jurisdictions", default: false, null: false
+    t.boolean "qa_tools_enabled", default: false, null: false
   end
 
   create_table "step_code_building_characteristics_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1048,14 +1047,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
   end
 
   create_table "template_version_previews", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "early_access_requirement_template_id", null: false
     t.uuid "previewer_id", null: false
     t.datetime "expires_at", null: false
     t.datetime "discarded_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "template_version_id"
-    t.index ["early_access_requirement_template_id", "previewer_id"], name: "index_early_access_previews_on_template_id_and_previewer_id", unique: true
+    t.uuid "template_version_id", null: false
     t.index ["previewer_id"], name: "index_template_version_previews_on_previewer_id"
     t.index ["template_version_id", "previewer_id"], name: "index_tv_previews_on_tv_id_and_previewer_id", unique: true
     t.index ["template_version_id"], name: "index_template_version_previews_on_template_version_id"
@@ -1217,8 +1214,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_07_162600) do
   add_foreign_key "requirement_template_sections", "requirement_template_sections", column: "copied_from_id"
   add_foreign_key "requirement_template_sections", "requirement_templates"
   add_foreign_key "requirement_templates", "requirement_templates", column: "copied_from_id"
-  add_foreign_key "requirement_templates", "site_configurations"
-  add_foreign_key "requirement_templates", "users", column: "assignee_id"
   add_foreign_key "requirements", "requirement_blocks"
   add_foreign_key "resource_documents", "resources"
   add_foreign_key "resources", "jurisdictions"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -364,6 +364,7 @@ if Rails.env.development?
   site_config.update(
     inbox_enabled: true,
     code_compliance_enabled: true,
+    qa_tools_enabled: true,
     allow_designated_reviewer: true
   )
 end

--- a/spec/models/site_configuration_spec.rb
+++ b/spec/models/site_configuration_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe SiteConfiguration, type: :model do
     end
   end
 
+  describe ".qa_tools_enabled?" do
+    before { SiteConfiguration.delete_all }
+
+    it "returns the global QA tools flag" do
+      described_class.create!(qa_tools_enabled: true)
+
+      expect(described_class.qa_tools_enabled?).to eq(true)
+    end
+  end
+
   describe "singleton enforcement" do
     it "prevents creating a second record" do
       SiteConfiguration.create!

--- a/spec/requests/api/qa_tools_spec.rb
+++ b/spec/requests/api/qa_tools_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe "Api::QaTools", type: :request do
   end
 
   before do
+    SiteConfiguration.instance.update!(qa_tools_enabled: true)
     allow(TemplateVersion).to receive(:cached_published_ids).and_return(
       [template_version.id]
     )
@@ -85,6 +86,24 @@ RSpec.describe "Api::QaTools", type: :request do
     it "returns not found when QA mode is disabled" do
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("VITE_QA_MODE").and_return(nil)
+      sign_in submitter
+
+      post "/api/qa_tools/permit_projects/full",
+           params: {
+             qa_full_permit_project: {
+               jurisdiction_id: jurisdiction.id
+             }
+           },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns not found when the global QA tools flag is disabled" do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with("VITE_QA_MODE").and_return("true")
+      SiteConfiguration.instance.update!(qa_tools_enabled: false)
       sign_in submitter
 
       post "/api/qa_tools/permit_projects/full",


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5060-task-dev-qa-tools-add-admin-feature-flag-for-admins-to-hide-test-feature` (merge-base range).

Adds super-admin controlled global access for QA tools so the QA popout and related actions can be turned on/off through site configuration, while still requiring QA mode in the frontend build. Also moves template version counter backfill work into a data migration and hardens permit application form JSON rendering when template form JSON has no `components` array.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5060](https://yourorg.atlassian.net/browse/HUB-5060) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                        |
| 📑 Design / Figma    | <!-- Paste link -->                                        |
| 📚 Documentation     | <!-- Paste link -->                                        |

---

## ✨ Features / Changes Introduced

- Adds `qa_tools_enabled` to site configuration responses, update params, frontend store state, and development seeds.
- Adds a “QA tools” row to global feature access and routes the setup screen under `/configuration-management/global-feature-access/qa-tools`.
- Gates the QA tools popout on both `VITE_QA_MODE === "true"` and the global `qaToolsEnabled` site configuration flag.
- Adds QA tools API client methods for creating a full QA permit project and autofilling a permit application.
- Adds `PermitApplicationPolicy#qa_autofill?` to constrain QA autofill to drafts and authorized users.
- Adds backend success/error copy for QA tools actions and frontend copy explaining the QA mode + super-admin flag behavior.
- Moves template version customization counter backfill into a data migration and removes the backfill from the schema migration.
- Prevents `PermitApplication::FormJsonService` from crashing when template `form_json["components"]` is missing.
- Adds model coverage for `SiteConfiguration.qa_tools_enabled?`.

***

## 🧪 Steps to QA

1. Sign in as a super admin.
2. Go to `/configuration-management/global-feature-access`.
3. Verify “QA tools” appears as a global feature row and shows its current On/Off state.
4. Open the QA tools setup screen and toggle the feature on and off.
5. In a QA-mode environment, sign in as an eligible user and go to `/projects`.
6. Verify the QA popout appears only when the global QA tools flag is on.
7. With QA tools enabled, create a project with all permits and verify the project is created.
8. Open a draft permit application in QA mode and verify the autofill action completes without an error.

**Expected Behaviour:**

Super admins can control QA tools globally. Eligible users only see and use QA tools when both QA mode and the global feature flag are enabled.

**Before this change:**

QA tools availability was tied only to QA-mode behavior and could not be disabled through super-admin global feature access. Some permit application rendering paths could fail when form JSON had no `components` array.

**After this change:**

QA tools are controlled by super-admin configuration, the popout copy reflects QA mode/global flag behavior, and form JSON rendering handles missing `components` safely.

---

## ♿ UI Accessibility Checklist

> UI changes are limited to adding a global feature access row/setup route and the QA popout visibility behavior. Add screenshots for the new QA tools global feature access screen before review.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5060]: https://hous-bssb.atlassian.net/browse/HUB-5060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ