### PR TITLE
HUB-5004 show error box on sandbox mismatch

### DIFF
--- a/app/frontend/components/domains/permit-project/new-permit-project-screen.tsx
+++ b/app/frontend/components/domains/permit-project/new-permit-project-screen.tsx
@@ -6,7 +6,9 @@ import React, { useEffect } from "react"
 import { Controller, FormProvider, useForm } from "react-hook-form"
 import { useNavigate } from "react-router-dom"
 import { useMst } from "../../../setup/root"
+import { EFlashMessageStatus } from "../../../types/enums"
 import { IOption } from "../../../types/types"
+import { CustomMessageBox } from "../../shared/base/custom-message-box"
 import { BackButton } from "../../shared/buttons/back-button"
 import { TextFormControl } from "../../shared/form/input-form-control"
 import { RouterLinkButton } from "../../shared/navigation/router-link-button"
@@ -33,14 +35,18 @@ export const NewPermitProjectScreen = observer(() => {
     },
   })
 
-  const { handleSubmit, formState, control, register, watch } = formMethods
-  const { isSubmitting, errors, isValid } = formState
+  const { handleSubmit, formState, control, watch } = formMethods
+  const { isSubmitting } = formState
   const navigate = useNavigate()
-  const { permitProjectStore, jurisdictionStore } = useMst()
+  const { permitProjectStore, jurisdictionStore, sandboxStore, userStore } = useMst()
+  const { isSandboxActive } = sandboxStore
 
   const jurisdictionId = watch("jurisdictionId")
   const selectedJurisdiction = jurisdictionId ? jurisdictionStore.getJurisdictionById(jurisdictionId) : null
   const sandboxOptions = selectedJurisdiction?.sandboxOptions ?? []
+  const currentUserJurisdictionId = userStore.currentUser?.jurisdiction?.id
+  const showOutsideTrainingJurisdictionError =
+    isSandboxActive && !!jurisdictionId && !!currentUserJurisdictionId && jurisdictionId !== currentUserJurisdictionId
 
   useEffect(() => {
     if (jurisdictionId) {
@@ -72,6 +78,14 @@ export const NewPermitProjectScreen = observer(() => {
       <FormProvider {...formMethods}>
         <Box as="form" onSubmit={handleSubmit(onSubmit)}>
           <VStack spacing={8} align="stretch">
+            {showOutsideTrainingJurisdictionError && (
+              <CustomMessageBox
+                status={EFlashMessageStatus.error}
+                title={t("permitProject.new.sandboxJurisdictionMismatchTitle")}
+                description={t("permitProject.new.sandboxJurisdictionMismatchDescription")}
+              />
+            )}
+
             <Flex direction="column" gap={2} w={{ base: "full", md: "50%" }}>
               <Heading as="h2" variant="yellowline">
                 {t("permitProject.new.nameHeading")}
@@ -134,7 +148,12 @@ export const NewPermitProjectScreen = observer(() => {
 
             <HStack>
               <BackButton>{t("ui.back")}</BackButton>
-              <Button variant="primary" isLoading={isSubmitting} type="submit">
+              <Button
+                variant="primary"
+                isLoading={isSubmitting}
+                type="submit"
+                isDisabled={showOutsideTrainingJurisdictionError}
+              >
                 {t("permitProject.new.createButton")}
               </Button>
             </HStack>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1542,6 +1542,9 @@ Thank you,
             nameHeading: "Name your project",
             nameDescription:
               "Give your project a name so it’s easy to find later. The name is private to you and anyone you invite to collaborate. For example: “My new house”, “1st Avenue laneway home”, or “Smith residence addition.”",
+            sandboxJurisdictionMismatchTitle: "This address is outside your jurisdiction",
+            sandboxJurisdictionMismatchDescription:
+              "While training mode is turned on, you can only create projects within your own jurisdiction.",
             nameLabel: "Project name",
             descriptionLabel: "Description",
             fullAddressHeading: "Enter your project location",


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...HUB-5004-bug-rm-training-mode-500-error-on-create-project-in-a-different-jurisdiction` (merge-base range).

Review managers in **training mode** could create a new permit project with a site address in a **different jurisdiction** than their own. Submitting that form triggered a **500** because the API attaches `current_sandbox` to the new project while the selected jurisdiction did not match the user’s training sandbox jurisdiction.

This PR adds client-side validation on the new project screen: when training mode is active and the resolved site jurisdiction differs from the current user’s jurisdiction, show an error message and disable **Create project** so the invalid request is not sent.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5004](https://hous-bssb.atlassian.net/browse/HUB-5004) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Detect jurisdiction mismatch on **Create project** when `isSandboxActive` and the site’s `jurisdictionId` ≠ the current user’s jurisdiction
- Show `CustomMessageBox` with new i18n copy explaining training-mode restriction
- Disable **Create project** while the mismatch is present (prevents 500 on submit)
- Add `sandboxJurisdictionMismatchTitle` / `sandboxJurisdictionMismatchDescription` strings

---

## 🧪 Steps to QA

1. Sign in as a **review manager** assigned to a jurisdiction (e.g. City of Vancouver).
2. Turn on **training mode** (sandbox) for that jurisdiction.
3. Go to **Create project** (`/projects/new` or equivalent new-project route).
4. Enter a project name and pick a **site address in a different jurisdiction** (e.g. an address in another municipality).
5. Confirm an **error message box** appears: title “This address is outside your jurisdiction” and description about training mode.
6. Confirm **Create project** is disabled.
7. Change the address to one **within your jurisdiction** and confirm the error disappears and **Create project** is enabled.
8. Create the project and confirm it succeeds (no 500).
9. Repeat with **training mode off**: selecting an out-of-jurisdiction address should **not** show this error (existing behaviour for non-training users).

**Expected behaviour:** Mismatch in training mode → inline error + disabled submit; in-jurisdiction address → normal create flow.

**Before this change:** Out-of-jurisdiction address in training mode → submit → **500** error.

**After this change:** Out-of-jurisdiction address in training mode → inline error, submit blocked; in-jurisdiction address works as before.

_Add before/after screenshots of the error state if helpful for reviewers._

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (existing form + `CustomMessageBox` pattern)
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order** (disabled submit still focusable; error announced via message box component)
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning (title + description text)
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5004]: https://hous-bssb.atlassian.net/browse/HUB-5004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ