### PR TITLE
HUB-4744 reviewer can see a chronological record of reviewer initiated actions taken on a project or application submissions index via unified multi view workspace

### DIFF
--- a/app/models/application_audit.rb
+++ b/app/models/application_audit.rb
@@ -2,20 +2,34 @@ class ApplicationAudit < Audited::Audit
   include ActivityFeedPreloader
   include AuditRoleFilter
 
+  # Hide read/unread noise when viewed_at was refreshed but stayed "read".
+  REDUNDANT_VIEWED_AT_TRANSITION_SQL = <<~SQL.squish
+    auditable_type IN ('PermitProject', 'SubmissionVersion')
+    AND audited_changes ? 'viewed_at'
+    AND NULLIF(audited_changes #>> '{viewed_at,0}', '') IS NOT NULL
+    AND NULLIF(audited_changes #>> '{viewed_at,1}', '') IS NOT NULL
+  SQL
+
+  scope :excluding_redundant_viewed_at_audits,
+        -> { where.not(REDUNDANT_VIEWED_AT_TRANSITION_SQL) }
+
   scope :for_permit_project,
         ->(project_id) do
           pa_subquery =
             PermitApplication.where(permit_project_id: project_id).select(:id)
-          where(
+          excluding_redundant_viewed_at_audits.where(
             "(auditable_type = ? AND auditable_id = ?) OR " \
               "(auditable_type = ? AND auditable_id IN (?)) OR " \
-              "(associated_type = ? AND associated_id IN (?))",
+              "(associated_type = ? AND associated_id IN (?)) OR " \
+              "(associated_type = ? AND associated_id = ?)",
             "PermitProject",
             project_id,
             "PermitApplication",
             pa_subquery,
             "PermitApplication",
-            pa_subquery
+            pa_subquery,
+            "PermitProject",
+            project_id
           )
         end
 end

--- a/app/models/concerns/activity_feed_preloader.rb
+++ b/app/models/concerns/activity_feed_preloader.rb
@@ -5,6 +5,8 @@ module ActivityFeedPreloader
     def preload_activity_feed(audits)
       preload_permit_collaborations(audits)
       preload_permit_block_statuses(audits)
+      preload_permit_project_collaborations(audits)
+      preload_submission_versions(audits)
     end
 
     private
@@ -22,6 +24,39 @@ module ActivityFeedPreloader
         associations: {
           collaborator: :user,
           permit_application: %i[template_version]
+        }
+      ).call
+    end
+
+    def preload_permit_project_collaborations(audits)
+      records =
+        audits
+          .select { |a| a.auditable_type == "PermitProjectCollaboration" }
+          .map(&:auditable)
+          .compact
+      return if records.empty?
+
+      ActiveRecord::Associations::Preloader.new(
+        records: records,
+        associations: {
+          collaborator: :user,
+          permit_project: :jurisdiction
+        }
+      ).call
+    end
+
+    def preload_submission_versions(audits)
+      records =
+        audits
+          .select { |a| a.auditable_type == "SubmissionVersion" }
+          .map(&:auditable)
+          .compact
+      return if records.empty?
+
+      ActiveRecord::Associations::Preloader.new(
+        records: records,
+        associations: {
+          permit_application: :jurisdiction
         }
       ).call
     end

--- a/app/models/concerns/audit_role_filter.rb
+++ b/app/models/concerns/audit_role_filter.rb
@@ -1,18 +1,34 @@
 module AuditRoleFilter
   extend ActiveSupport::Concern
 
+  # Reviewer-only activity types (submitters retain access to the feed but not these rows).
+  SUBMITTER_HIDDEN_AUDITABLE_TYPES = %w[
+    PermitProjectCollaboration
+    SubmissionVersion
+  ].freeze
+
+  SUBMITTER_HIDDEN_PERMIT_PROJECT_CHANGES = <<~SQL.squish
+    auditable_type = 'PermitProject'
+    AND action = 'update'
+    AND (audited_changes ? 'state' OR audited_changes ? 'viewed_at')
+  SQL
+
   class_methods do
     # Filters an audit relation to only include records visible to the given user's role.
-    #   - Submitters: hide review collaborations
+    #   - Submitters: hide review collaborations and reviewer-only project *updates*
+    #     (state, read/unread marks), plus project reviewer / application read-unread audits
     #   - Review staff: hide block status audits, hide non-delegatee submission collaborations
     #   - Others: hide block status audits, review collaborations, non-delegatee submission collaborations
     def visible_to_role(relation, user)
       if user.submitter?
-        relation.where.not(
-          auditable_type: "PermitCollaboration",
-          auditable_id:
-            PermitCollaboration.where(collaboration_type: :review).select(:id)
-        )
+        relation
+          .where.not(
+            auditable_type: "PermitCollaboration",
+            auditable_id:
+              PermitCollaboration.where(collaboration_type: :review).select(:id)
+          )
+          .where.not(auditable_type: SUBMITTER_HIDDEN_AUDITABLE_TYPES)
+          .where.not(SUBMITTER_HIDDEN_PERMIT_PROJECT_CHANGES)
       elsif user.review_staff?
         relation
           .where.not(

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -349,16 +349,18 @@ class PermitApplication < ApplicationRecord
   end
 
   def update_viewed_at
-    return unless latest_submission_version.present?
+    version = latest_submission_version
+    return unless version.present?
 
-    latest_submission_version.update(viewed_at: Time.current)
+    version.reload.mark_read!
     reindex
   end
 
   def mark_as_unviewed
-    return unless latest_submission_version.present?
+    version = latest_submission_version
+    return unless version.present?
 
-    latest_submission_version.update(viewed_at: nil)
+    version.reload.clear_read!
     reindex
   end
 

--- a/app/models/permit_project.rb
+++ b/app/models/permit_project.rb
@@ -128,11 +128,15 @@ class PermitProject < ApplicationRecord
   end
 
   def update_viewed_at
-    update(viewed_at: Time.current)
+    return if viewed_at.present?
+
+    update!(viewed_at: Time.current)
   end
 
   def mark_as_unviewed
-    update(viewed_at: nil)
+    return if viewed_at.blank?
+
+    update!(viewed_at: nil)
   end
 
   def broadcast_jurisdiction_projects_count_update

--- a/app/models/permit_project.rb
+++ b/app/models/permit_project.rb
@@ -1,7 +1,7 @@
 class PermitProject < ApplicationRecord
   # searchkick must be declared before Discard::Model to ensure auto-callbacks register correctly
   searchkick word_middle: %i[title full_address pid pin number owner_name]
-  audited on: %i[create update], only: %i[title full_address]
+  audited on: %i[create update], only: %i[title full_address state viewed_at]
   has_associated_audits
 
   include Discard::Model

--- a/app/models/permit_project_collaboration.rb
+++ b/app/models/permit_project_collaboration.rb
@@ -1,6 +1,8 @@
 class PermitProjectCollaboration < ApplicationRecord
   include Discard::Model
 
+  audited on: %i[create update], associated_with: :permit_project
+
   belongs_to :permit_project, touch: true
   belongs_to :collaborator
 

--- a/app/models/submission_version.rb
+++ b/app/models/submission_version.rb
@@ -1,4 +1,8 @@
 class SubmissionVersion < ApplicationRecord
+  audited on: %i[update],
+          only: %i[viewed_at],
+          associated_with: :permit_application
+
   belongs_to :permit_application
   has_many :revision_requests, dependent: :destroy
   has_many :supporting_documents, dependent: :destroy

--- a/app/models/submission_version.rb
+++ b/app/models/submission_version.rb
@@ -9,6 +9,18 @@ class SubmissionVersion < ApplicationRecord
 
   accepts_nested_attributes_for :revision_requests, allow_destroy: true
 
+  def mark_read!
+    return if viewed_at.present?
+
+    update!(viewed_at: Time.current)
+  end
+
+  def clear_read!
+    return if viewed_at.blank?
+
+    update!(viewed_at: nil)
+  end
+
   delegate :sandbox, to: :permit_application
 
   scope :sandboxed,

--- a/app/presenters/project_audit_formatters/base_formatter.rb
+++ b/app/presenters/project_audit_formatters/base_formatter.rb
@@ -1,5 +1,7 @@
 module ProjectAuditFormatters
   class BaseFormatter
+    include ChangesHelper
+
     attr_reader :audit, :viewer
 
     def initialize(audit, viewer)

--- a/app/presenters/project_audit_formatters/changes_helper.rb
+++ b/app/presenters/project_audit_formatters/changes_helper.rb
@@ -1,0 +1,51 @@
+module ProjectAuditFormatters
+  module ChangesHelper
+    private
+
+    def enum_change_labels(enum_hash, label_prefix, old_value, new_value)
+      [
+        enum_label(enum_hash, label_prefix, old_value),
+        enum_label(enum_hash, label_prefix, new_value)
+      ]
+    end
+
+    def enum_label(enum_hash, label_prefix, value)
+      return I18n.t("project_audit.values.unknown") if value.nil?
+
+      key = (value.is_a?(Integer) ? enum_hash.key(value) : value.to_s)
+
+      return I18n.t("project_audit.values.unknown") if key.blank?
+
+      I18n.t(
+        "project_audit.values.#{label_prefix}.#{key}",
+        default: key.humanize
+      )
+    end
+
+    def viewed_at_marked_read?(key = "viewed_at")
+      old_value, new_value = Array(changes[key])
+      old_value.blank? && new_value.present?
+    end
+
+    def viewed_at_marked_unread?(key = "viewed_at")
+      old_value, new_value = Array(changes[key])
+      old_value.present? && new_value.blank?
+    end
+
+    def format_enum_change(action_key, enum_hash, label_prefix, attribute_key)
+      old_value, new_value = Array(changes[attribute_key])
+      from_label, to_label =
+        enum_change_labels(enum_hash, label_prefix, old_value, new_value)
+
+      I18n.t(action_key, user: user_display, from: from_label, to: to_label)
+    end
+
+    def format_viewed_at_change(read_key, unread_key)
+      if viewed_at_marked_read?
+        I18n.t(read_key, user: user_display)
+      elsif viewed_at_marked_unread?
+        I18n.t(unread_key, user: user_display)
+      end
+    end
+  end
+end

--- a/app/presenters/project_audit_formatters/permit_application_formatter.rb
+++ b/app/presenters/project_audit_formatters/permit_application_formatter.rb
@@ -41,38 +41,74 @@ module ProjectAuditFormatters
     private
 
     def format_status_change
-      new_status = Array(changes["status"]).last
-      format_status_change_for(new_status)
+      format_status_change_for(new_status_from_changes)
     end
 
     def format_status_change_from_inferred_status
       format_status_change_for(permit_application&.status)
     end
 
-    def format_status_change_for(status_value)
-      status_str = status_value.to_s
+    # Audited may store status as [old, new], a single value, or a scalar integer.
+    def new_status_from_changes
+      values = Array.wrap(changes["status"])
+      return values.last if values.size >= 2
 
-      case status_str
-      when PermitApplication.statuses["new_draft"].to_s
+      values.first
+    end
+
+    def format_status_change_for(status_value)
+      case status_enum_key(status_value)
+      when "new_draft"
         "#{user_display} created the application"
-      when PermitApplication.statuses["newly_submitted"].to_s
+      when "newly_submitted"
         "#{user_display} submitted the application"
-      when PermitApplication.statuses["in_review"].to_s
+      when "in_review"
         "#{user_display} marked the application as in review"
-      when PermitApplication.statuses["revisions_requested"].to_s
+      when "revisions_requested"
         "Revisions requested — sent to submitter"
-      when PermitApplication.statuses["resubmitted"].to_s
+      when "resubmitted"
         submitter_name = audit.auditable&.submitter&.name || user_display
         "#{submitter_name} resubmitted the application"
-      when PermitApplication.statuses["approved"].to_s
+      when "approved"
         "#{user_display} approved the application"
-      when PermitApplication.statuses["issued"].to_s
+      when "issued"
         "#{user_display} issued the permit"
-      when PermitApplication.statuses["withdrawn"].to_s
+      when "withdrawn"
         "#{user_display} withdrew the application"
       else
-        "#{user_display} changed the application status on the application"
+        format_unrecognized_status_change
       end
+    end
+
+    def status_enum_key(status_value)
+      return nil if status_value.nil?
+
+      if status_value.is_a?(Integer) || status_value.to_s.match?(/\A\d+\z/)
+        int_value =
+          status_value.is_a?(Integer) ? status_value : status_value.to_i
+        return PermitApplication.statuses.key(int_value)
+      end
+
+      key = status_value.to_s
+      return key if PermitApplication.statuses.key?(key)
+
+      nil
+    end
+
+    def format_unrecognized_status_change
+      values = Array.wrap(changes["status"])
+      if values.size >= 2
+        return(
+          format_enum_change(
+            "project_audit.actions.changed_application_status",
+            PermitApplication.statuses,
+            "permit_application/status",
+            "status"
+          )
+        )
+      end
+
+      "#{user_display} changed the application status on the application"
     end
   end
 end

--- a/app/presenters/project_audit_formatters/permit_collaboration_formatter.rb
+++ b/app/presenters/project_audit_formatters/permit_collaboration_formatter.rb
@@ -50,6 +50,12 @@ module ProjectAuditFormatters
         else
           "#{collaborator_name} assigned to #{block_name}"
         end
+      elsif collab.review? && collab.delegatee?
+        I18n.t(
+          "project_audit.actions.assigned_application_reviewer",
+          user: user_display,
+          reviewer: collaborator_name
+        )
       elsif collab.review?
         "#{collaborator_name} assigned to application"
       else
@@ -65,6 +71,12 @@ module ProjectAuditFormatters
           else
             "#{collaborator_name} unassigned from #{block_name}"
           end
+        elsif collab.review? && collab.delegatee?
+          I18n.t(
+            "project_audit.actions.removed_application_reviewer",
+            user: user_display,
+            reviewer: collaborator_name
+          )
         elsif collab.review?
           "#{collaborator_name} unassigned from application"
         else

--- a/app/presenters/project_audit_formatters/permit_project_collaboration_formatter.rb
+++ b/app/presenters/project_audit_formatters/permit_project_collaboration_formatter.rb
@@ -1,0 +1,44 @@
+module ProjectAuditFormatters
+  class PermitProjectCollaborationFormatter < BaseFormatter
+    def description
+      collaboration = audit.auditable
+      reviewer_name = collaboration&.collaborator&.user&.name || "reviewer"
+
+      case audit.action
+      when "create"
+        I18n.t(
+          "project_audit.actions.assigned_project_reviewer",
+          user: user_display,
+          reviewer: reviewer_name
+        )
+      when "update"
+        if discard?
+          I18n.t(
+            "project_audit.actions.removed_project_reviewer",
+            user: user_display,
+            reviewer: reviewer_name
+          )
+        else
+          I18n.t(
+            "project_audit.fallback.collaborator_change",
+            user: user_display
+          )
+        end
+      else
+        I18n.t("project_audit.fallback.collaborator_change", user: user_display)
+      end
+    end
+
+    def permit_application
+      nil
+    end
+
+    def permit_application_id
+      nil
+    end
+
+    def jurisdiction
+      audit.auditable&.permit_project&.jurisdiction
+    end
+  end
+end

--- a/app/presenters/project_audit_formatters/permit_project_formatter.rb
+++ b/app/presenters/project_audit_formatters/permit_project_formatter.rb
@@ -5,16 +5,34 @@ module ProjectAuditFormatters
       when "create"
         "#{user_display} created this project"
       when "update"
-        if changes.key?("full_address")
+        if changes.key?("state")
+          format_enum_change(
+            "project_audit.actions.changed_project_state",
+            PermitProject.states,
+            "permit_project/state",
+            "state"
+          )
+        elsif changes.key?("viewed_at")
+          format_viewed_at_change(
+            "project_audit.actions.marked_project_read",
+            "project_audit.actions.marked_project_unread"
+          ) || default_update_message
+        elsif changes.key?("full_address")
           "#{user_display} changed the project address"
         elsif changes.key?("title")
           "#{user_display} changed the project name"
         else
-          "#{user_display} updated the project"
+          default_update_message
         end
       else
         I18n.t("project_audit.fallback.generic_change", user: user_display)
       end
+    end
+
+    private
+
+    def default_update_message
+      "#{user_display} updated the project"
     end
   end
 end

--- a/app/presenters/project_audit_formatters/submission_version_formatter.rb
+++ b/app/presenters/project_audit_formatters/submission_version_formatter.rb
@@ -1,0 +1,38 @@
+module ProjectAuditFormatters
+  class SubmissionVersionFormatter < BaseFormatter
+    def description
+      case audit.action
+      when "update"
+        if changes.key?("viewed_at")
+          format_viewed_at_change(
+            "project_audit.actions.marked_application_read",
+            "project_audit.actions.marked_application_unread"
+          ) ||
+            I18n.t(
+              "project_audit.fallback.application_change",
+              user: user_display
+            )
+        else
+          I18n.t(
+            "project_audit.fallback.application_change",
+            user: user_display
+          )
+        end
+      else
+        I18n.t("project_audit.fallback.application_change", user: user_display)
+      end
+    end
+
+    def permit_application
+      audit.auditable&.permit_application
+    end
+
+    def permit_application_id
+      permit_application&.id
+    end
+
+    def jurisdiction
+      permit_application&.jurisdiction
+    end
+  end
+end

--- a/app/presenters/project_audit_presenter.rb
+++ b/app/presenters/project_audit_presenter.rb
@@ -4,7 +4,10 @@ class ProjectAuditPresenter
     "PermitApplication" => ProjectAuditFormatters::PermitApplicationFormatter,
     "PermitCollaboration" =>
       ProjectAuditFormatters::PermitCollaborationFormatter,
-    "PermitBlockStatus" => ProjectAuditFormatters::PermitBlockStatusFormatter
+    "PermitBlockStatus" => ProjectAuditFormatters::PermitBlockStatusFormatter,
+    "PermitProjectCollaboration" =>
+      ProjectAuditFormatters::PermitProjectCollaborationFormatter,
+    "SubmissionVersion" => ProjectAuditFormatters::SubmissionVersionFormatter
   }.freeze
 
   attr_reader :audit, :viewer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,38 @@ en:
       collaborator_change: "%{user} made a change to the collaborators"
       block_change: "%{user} made a change to %{block_name}"
       application_change: "%{user} made a change to the application"
+    actions:
+      changed_project_state: "%{user} changed project state from %{from} to %{to}"
+      changed_application_status: "%{user} changed status from %{from} to %{to}"
+      marked_project_read: "%{user} marked the project as read"
+      marked_project_unread: "%{user} marked the project as unread"
+      marked_application_read: "%{user} marked the application as read"
+      marked_application_unread: "%{user} marked the application as unread"
+      assigned_project_reviewer: "%{user} assigned %{reviewer} as project reviewer"
+      removed_project_reviewer: "%{user} removed %{reviewer} as project reviewer"
+      assigned_application_reviewer: "%{user} assigned %{reviewer} as reviewer"
+      removed_application_reviewer: "%{user} removed %{reviewer} as reviewer"
+    values:
+      unknown: "Unknown"
+      permit_project/state:
+        draft: "Draft"
+        queued: "Queued"
+        waiting: "Waiting"
+        in_progress: "In Progress"
+        ready: "Ready"
+        permit_issued: "Permit Issued"
+        active: "Active"
+        complete: "Complete"
+        closed: "Closed"
+      permit_application/status:
+        new_draft: "New draft"
+        newly_submitted: "Submitted"
+        in_review: "In review"
+        revisions_requested: "Revisions requested"
+        resubmitted: "Resubmitted"
+        approved: "Approved"
+        issued: "Issued"
+        withdrawn: "Withdrawn"
   activerecord:
     attributes:
       contact:

--- a/spec/models/concerns/audit_role_filter_spec.rb
+++ b/spec/models/concerns/audit_role_filter_spec.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AuditRoleFilter do
+  let(:jurisdiction) { create(:sub_district) }
+  let(:owner) { create(:user, :submitter) }
+  let(:reviewer) { create(:user, :review_manager, jurisdiction: jurisdiction) }
+  let(:project) do
+    create(
+      :permit_project,
+      owner: owner,
+      jurisdiction: jurisdiction,
+      state: :queued
+    )
+  end
+  let(:base_scope) { ApplicationAudit.for_permit_project(project.id) }
+
+  before do
+    SiteConfiguration.instance.update!(allow_designated_reviewer: true)
+    jurisdiction.update!(allow_designated_reviewer: true)
+  end
+
+  def visible_audits_for(user)
+    ApplicationAudit.visible_to_role(base_scope, user)
+  end
+
+  describe ".visible_to_role for submitters" do
+    it "excludes project state and read/unread changes" do
+      Audited.audit_class.as_user(reviewer) { project.begin_progress! }
+      Audited.audit_class.as_user(reviewer) { project.update_viewed_at }
+
+      state_audit =
+        ApplicationAudit
+          .where(
+            auditable_type: "PermitProject",
+            auditable_id: project.id,
+            action: "update"
+          )
+          .where("audited_changes ? 'state'")
+          .last
+      read_audit =
+        ApplicationAudit
+          .where(
+            auditable_type: "PermitProject",
+            auditable_id: project.id,
+            action: "update"
+          )
+          .where("audited_changes ? 'viewed_at'")
+          .last
+
+      result = visible_audits_for(owner)
+
+      expect(state_audit).to be_present
+      expect(read_audit).to be_present
+      expect(result).not_to include(state_audit, read_audit)
+    end
+
+    it "still includes permit project create audits that snapshot state and viewed_at" do
+      create_audit =
+        ApplicationAudit.find_by(
+          auditable_type: "PermitProject",
+          auditable_id: project.id,
+          action: "create"
+        )
+
+      expect(create_audit).to be_present
+      expect(create_audit.audited_changes).to include("state", "viewed_at")
+      expect(visible_audits_for(owner)).to include(create_audit)
+    end
+
+    it "still includes other permit project updates" do
+      Audited
+        .audit_class
+        .as_user(owner) { project.update!(title: "Renamed project") }
+
+      title_audit =
+        ApplicationAudit
+          .where(auditable_type: "PermitProject", auditable_id: project.id)
+          .where("audited_changes ? 'title'")
+          .last
+
+      expect(visible_audits_for(owner)).to include(title_audit)
+    end
+
+    it "excludes project reviewer assignment audits" do
+      review_collaborator = jurisdiction.collaborators.find_by!(user: reviewer)
+      collaboration = nil
+
+      Audited
+        .audit_class
+        .as_user(reviewer) do
+          collaboration =
+            project.assign_project_review_collaborator!(review_collaborator.id)
+        end
+
+      assign_audit =
+        ApplicationAudit.find_by(
+          auditable_type: "PermitProjectCollaboration",
+          auditable_id: collaboration.id
+        )
+
+      expect(assign_audit).to be_present
+      expect(visible_audits_for(owner)).not_to include(assign_audit)
+    end
+
+    it "excludes application read/unread audits" do
+      permit_application =
+        create(
+          :permit_application,
+          :newly_submitted,
+          permit_project: project,
+          submitter: owner,
+          jurisdiction: jurisdiction
+        )
+
+      Audited
+        .audit_class
+        .as_user(reviewer) { permit_application.update_viewed_at }
+
+      read_audit =
+        ApplicationAudit.find_by(
+          auditable_type: "SubmissionVersion",
+          action: "update"
+        )
+
+      expect(read_audit).to be_present
+      expect(visible_audits_for(owner)).not_to include(read_audit)
+    end
+  end
+
+  describe "excluding_redundant_viewed_at_audits" do
+    it "hides viewed_at audits where both before and after are timestamps" do
+      audit =
+        ApplicationAudit.create!(
+          auditable: project,
+          auditable_type: "PermitProject",
+          action: "update",
+          audited_changes: {
+            "viewed_at" => [1.hour.ago.iso8601, Time.current.iso8601]
+          }
+        )
+
+      expect(ApplicationAudit.for_permit_project(project.id)).not_to include(
+        audit
+      )
+    end
+
+    it "keeps viewed_at audits for nil to timestamp transitions" do
+      audit =
+        ApplicationAudit.create!(
+          auditable: project,
+          auditable_type: "PermitProject",
+          action: "update",
+          audited_changes: {
+            "viewed_at" => [nil, Time.current.iso8601]
+          }
+        )
+
+      expect(ApplicationAudit.for_permit_project(project.id)).to include(audit)
+    end
+
+    it "keeps viewed_at audits for timestamp to nil transitions" do
+      audit =
+        ApplicationAudit.create!(
+          auditable: project,
+          auditable_type: "PermitProject",
+          action: "update",
+          audited_changes: {
+            "viewed_at" => [1.hour.ago.iso8601, nil]
+          }
+        )
+
+      expect(ApplicationAudit.for_permit_project(project.id)).to include(audit)
+    end
+  end
+
+  describe ".visible_to_role for review staff" do
+    it "includes reviewer-only activity" do
+      Audited.audit_class.as_user(reviewer) { project.begin_progress! }
+
+      state_audit =
+        ApplicationAudit
+          .where(auditable_type: "PermitProject", auditable_id: project.id)
+          .where("audited_changes ? 'state'")
+          .last
+
+      expect(visible_audits_for(reviewer)).to include(state_audit)
+    end
+  end
+end

--- a/spec/models/project_activity_auditing_spec.rb
+++ b/spec/models/project_activity_auditing_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Project activity auditing", type: :model do
+  let(:jurisdiction) { create(:sub_district) }
+  let(:reviewer) { create(:user, :review_manager, jurisdiction: jurisdiction) }
+  let(:owner) { create(:user, :submitter) }
+  let!(:project) do
+    create(
+      :permit_project,
+      owner: owner,
+      jurisdiction: jurisdiction,
+      state: :queued
+    )
+  end
+  let(:review_collaborator) do
+    jurisdiction.collaborators.find_by!(user: reviewer)
+  end
+
+  before do
+    SiteConfiguration.instance.update!(allow_designated_reviewer: true)
+    jurisdiction.update!(allow_designated_reviewer: true)
+  end
+
+  def project_audits
+    ApplicationAudit.for_permit_project(project.id)
+  end
+
+  def permit_project_viewed_at_update_audits
+    ApplicationAudit
+      .where(
+        auditable_type: "PermitProject",
+        auditable_id: project.id,
+        action: "update"
+      )
+      .where("audited_changes ? 'viewed_at'")
+      .order(:created_at)
+  end
+
+  it "records project state changes" do
+    Audited.audit_class.as_user(reviewer) { project.begin_progress! }
+
+    audit =
+      project_audits
+        .where(
+          auditable_type: "PermitProject",
+          auditable_id: project.id,
+          action: "update"
+        )
+        .where("audited_changes ? 'state'")
+        .last
+
+    expect(audit.audited_changes["state"]).to eq(
+      [PermitProject.states["queued"], PermitProject.states["in_progress"]]
+    )
+    expect(
+      ProjectAuditFormatters::PermitProjectFormatter.new(
+        audit,
+        reviewer
+      ).description
+    ).to include("changed project state from Queued to In Progress")
+  end
+
+  it "records project reviewer assignment and removal" do
+    collaboration = nil
+
+    Audited
+      .audit_class
+      .as_user(reviewer) do
+        collaboration =
+          project.assign_project_review_collaborator!(review_collaborator.id)
+      end
+
+    assign_audit =
+      project_audits.find_by(
+        auditable_type: "PermitProjectCollaboration",
+        auditable_id: collaboration.id,
+        action: "create"
+      )
+    expect(assign_audit).to be_present
+
+    Audited
+      .audit_class
+      .as_user(reviewer) do
+        project.unassign_project_review_collaborator!(review_collaborator.id)
+      end
+
+    unassign_audit =
+      project_audits.find_by(
+        auditable_type: "PermitProjectCollaboration",
+        auditable_id: collaboration.id,
+        action: "update"
+      )
+    expect(unassign_audit.audited_changes).to have_key("discarded_at")
+  end
+
+  it "records project read and unread transitions" do
+    Audited.audit_class.as_user(reviewer) { project.update_viewed_at }
+
+    read_audit = permit_project_viewed_at_update_audits.last
+    expect(read_audit.audited_changes["viewed_at"].first).to be_nil
+    expect(read_audit.audited_changes["viewed_at"].last).to be_present
+    expect(project_audits).to include(read_audit)
+
+    project.reload
+    expect do
+      Audited.audit_class.as_user(reviewer) { project.mark_as_unviewed }
+    end.to change { permit_project_viewed_at_update_audits.count }.by(1)
+
+    unread_audit = permit_project_viewed_at_update_audits.last
+    expect(unread_audit.audited_changes["viewed_at"].first).to be_present
+    expect(unread_audit.audited_changes["viewed_at"].last).to be_nil
+    expect(project_audits).to include(unread_audit)
+  end
+
+  it "does not record an audit when marking an already-read project read again" do
+    Audited.audit_class.as_user(reviewer) { project.update_viewed_at }
+
+    read_count = permit_project_viewed_at_update_audits.count
+
+    Audited.audit_class.as_user(reviewer) { project.update_viewed_at }
+
+    expect(permit_project_viewed_at_update_audits.count).to eq(read_count)
+  end
+
+  context "with a submitted permit application" do
+    let!(:permit_application) do
+      create(
+        :permit_application,
+        :newly_submitted,
+        permit_project: project,
+        submitter: owner,
+        jurisdiction: jurisdiction
+      )
+    end
+    let(:submission_version) { permit_application.latest_submission_version }
+
+    def submission_version_viewed_at_audits
+      ApplicationAudit
+        .where(
+          auditable_type: "SubmissionVersion",
+          auditable_id: submission_version.id,
+          action: "update"
+        )
+        .where("audited_changes ? 'viewed_at'")
+        .order(:created_at)
+    end
+
+    it "records application status changes" do
+      Audited.audit_class.as_user(reviewer) { permit_application.start_review! }
+
+      audit =
+        ApplicationAudit.find_by(
+          auditable_type: "PermitApplication",
+          auditable_id: permit_application.id,
+          action: "update"
+        )
+
+      expect(audit.audited_changes["status"]).to eq(
+        [
+          PermitApplication.statuses["newly_submitted"],
+          PermitApplication.statuses["in_review"]
+        ]
+      )
+    end
+
+    it "records application read and unread transitions" do
+      Audited
+        .audit_class
+        .as_user(reviewer) { permit_application.update_viewed_at }
+
+      read_audit = submission_version_viewed_at_audits.last
+      expect(read_audit.audited_changes["viewed_at"].first).to be_nil
+      expect(read_audit.audited_changes["viewed_at"].last).to be_present
+      expect(project_audits).to include(read_audit)
+
+      expect do
+        Audited
+          .audit_class
+          .as_user(reviewer) { permit_application.mark_as_unviewed }
+      end.to change { submission_version_viewed_at_audits.count }.by(1)
+
+      unread_audit = submission_version_viewed_at_audits.last
+      expect(unread_audit.audited_changes["viewed_at"].first).to be_present
+      expect(unread_audit.audited_changes["viewed_at"].last).to be_nil
+      expect(project_audits).to include(unread_audit)
+    end
+
+    it "does not record an audit when marking an already-read application read again" do
+      Audited
+        .audit_class
+        .as_user(reviewer) { permit_application.update_viewed_at }
+
+      read_count = submission_version_viewed_at_audits.count
+
+      Audited
+        .audit_class
+        .as_user(reviewer) { permit_application.update_viewed_at }
+
+      expect(submission_version_viewed_at_audits.count).to eq(read_count)
+    end
+
+    it "records application reviewer assignment and removal" do
+      collaboration = nil
+
+      Audited
+        .audit_class
+        .as_user(reviewer) do
+          collaboration =
+            create(
+              :permit_collaboration,
+              :review,
+              :delegatee,
+              permit_application: permit_application,
+              collaborator: review_collaborator
+            )
+        end
+
+      expect(
+        ApplicationAudit.find_by(
+          auditable_type: "PermitCollaboration",
+          auditable_id: collaboration.id,
+          action: "create"
+        )
+      ).to be_present
+
+      Audited.audit_class.as_user(reviewer) { collaboration.discard }
+
+      expect(
+        ApplicationAudit.find_by(
+          auditable_type: "PermitCollaboration",
+          auditable_id: collaboration.id,
+          action: "update"
+        )
+      ).to be_present
+    end
+  end
+end

--- a/spec/presenters/project_audit_formatters/permit_application_formatter_spec.rb
+++ b/spec/presenters/project_audit_formatters/permit_application_formatter_spec.rb
@@ -54,6 +54,24 @@ RSpec.describe ProjectAuditFormatters::PermitApplicationFormatter do
       end
     end
 
+    context 'when action is "create" with a scalar status (legacy audits)' do
+      let(:audit) do
+        build_audit_double(
+          user: user,
+          auditable: auditable,
+          auditable_type: "PermitApplication",
+          action: "create",
+          audited_changes: {
+            "status" => PermitApplication.statuses["new_draft"]
+          }
+        )
+      end
+
+      it "returns created the application message" do
+        expect(formatter.description).to eq("Alice created the application")
+      end
+    end
+
     context 'when action is "create" and auditable is nil' do
       let(:audit) do
         build_audit_double(
@@ -159,9 +177,9 @@ RSpec.describe ProjectAuditFormatters::PermitApplicationFormatter do
           )
         end
 
-        it "returns generic status change message" do
+        it "returns from/to status change message" do
           expect(formatter.description).to eq(
-            "Alice changed the application status on the application"
+            "Alice changed status from New draft to Unknown"
           )
         end
       end

--- a/spec/presenters/project_audit_formatters/permit_collaboration_formatter_spec.rb
+++ b/spec/presenters/project_audit_formatters/permit_collaboration_formatter_spec.rb
@@ -121,6 +121,35 @@ RSpec.describe ProjectAuditFormatters::PermitCollaborationFormatter do
         end
       end
 
+      context "review delegatee collaboration" do
+        let(:collab) do
+          instance_double(
+            PermitCollaboration,
+            blank?: false,
+            submission?: false,
+            delegatee?: true,
+            review?: true,
+            collaborator_name: "Dave",
+            assigned_requirement_block_name: "",
+            permit_application: permit_application,
+            permit_application_id: "pa-1",
+            assigned_requirement_block_id: nil
+          )
+        end
+        let(:audit) do
+          build_audit_double(
+            user: user,
+            auditable: collab,
+            auditable_type: "PermitCollaboration",
+            action: "create"
+          )
+        end
+
+        it "returns reviewer assignment message" do
+          expect(formatter.description).to eq("Alice assigned Dave as reviewer")
+        end
+      end
+
       context "review collaboration" do
         let(:collab) do
           instance_double(
@@ -248,6 +277,38 @@ RSpec.describe ProjectAuditFormatters::PermitCollaborationFormatter do
           expect(formatter.description).to eq(
             "Carol unassigned from Foundation"
           )
+        end
+      end
+
+      context "review delegatee discard" do
+        let(:collab) do
+          instance_double(
+            PermitCollaboration,
+            blank?: false,
+            submission?: false,
+            delegatee?: true,
+            review?: true,
+            collaborator_name: "Dave",
+            assigned_requirement_block_name: "",
+            permit_application: permit_application,
+            permit_application_id: "pa-1",
+            assigned_requirement_block_id: nil
+          )
+        end
+        let(:audit) do
+          build_audit_double(
+            user: user,
+            auditable: collab,
+            auditable_type: "PermitCollaboration",
+            action: "update",
+            audited_changes: {
+              "discarded_at" => [nil, "2026-01-01"]
+            }
+          )
+        end
+
+        it "returns reviewer removal message" do
+          expect(formatter.description).to eq("Alice removed Dave as reviewer")
         end
       end
 

--- a/spec/presenters/project_audit_formatters/permit_project_collaboration_formatter_spec.rb
+++ b/spec/presenters/project_audit_formatters/permit_project_collaboration_formatter_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe ProjectAuditFormatters::PermitProjectCollaborationFormatter do
+  let(:user) { instance_double(User, name: "Alice", blank?: false) }
+  let(:reviewer_user) { instance_double(User, name: "Bob Reviewer") }
+  let(:collaborator) { instance_double(Collaborator, user: reviewer_user) }
+  let(:permit_project) { instance_double(PermitProject, jurisdiction: nil) }
+  let(:collaboration) do
+    instance_double(
+      PermitProjectCollaboration,
+      collaborator: collaborator,
+      permit_project: permit_project
+    )
+  end
+
+  subject(:formatter) { described_class.new(audit, nil) }
+
+  describe "#description" do
+    context 'when action is "create"' do
+      let(:audit) do
+        build_audit_double(
+          user: user,
+          auditable: collaboration,
+          auditable_type: "PermitProjectCollaboration",
+          action: "create"
+        )
+      end
+
+      it "returns assignment message" do
+        expect(formatter.description).to eq(
+          "Alice assigned Bob Reviewer as project reviewer"
+        )
+      end
+    end
+
+    context 'when action is "update" with discard' do
+      let(:audit) do
+        build_audit_double(
+          user: user,
+          auditable: collaboration,
+          auditable_type: "PermitProjectCollaboration",
+          action: "update",
+          audited_changes: {
+            "discarded_at" => [nil, Time.current]
+          }
+        )
+      end
+
+      it "returns removal message" do
+        expect(formatter.description).to eq(
+          "Alice removed Bob Reviewer as project reviewer"
+        )
+      end
+    end
+  end
+end

--- a/spec/presenters/project_audit_formatters/permit_project_formatter_spec.rb
+++ b/spec/presenters/project_audit_formatters/permit_project_formatter_spec.rb
@@ -62,6 +62,69 @@ RSpec.describe ProjectAuditFormatters::PermitProjectFormatter do
         end
       end
 
+      context "with state change" do
+        let(:audit) do
+          build_audit_double(
+            user: user,
+            auditable: auditable,
+            auditable_type: "PermitProject",
+            action: "update",
+            audited_changes: {
+              "state" => [
+                PermitProject.states["queued"],
+                PermitProject.states["in_progress"]
+              ]
+            }
+          )
+        end
+
+        it "returns state change message with old and new labels" do
+          expect(formatter.description).to eq(
+            "Alice changed project state from Queued to In Progress"
+          )
+        end
+      end
+
+      context "when marked as read" do
+        let(:audit) do
+          build_audit_double(
+            user: user,
+            auditable: auditable,
+            auditable_type: "PermitProject",
+            action: "update",
+            audited_changes: {
+              "viewed_at" => [nil, Time.current]
+            }
+          )
+        end
+
+        it "returns marked as read message" do
+          expect(formatter.description).to eq(
+            "Alice marked the project as read"
+          )
+        end
+      end
+
+      context "when marked as unread" do
+        let(:audit) do
+          build_audit_double(
+            user: user,
+            auditable: auditable,
+            auditable_type: "PermitProject",
+            action: "update",
+            audited_changes: {
+              "viewed_at" => [Time.current, nil]
+            }
+          )
+        end
+
+        it "returns marked as unread message" do
+          expect(formatter.description).to eq(
+            "Alice marked the project as unread"
+          )
+        end
+      end
+
       context "with other changes" do
         let(:audit) do
           build_audit_double(

--- a/spec/presenters/project_audit_formatters/submission_version_formatter_spec.rb
+++ b/spec/presenters/project_audit_formatters/submission_version_formatter_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe ProjectAuditFormatters::SubmissionVersionFormatter do
+  let(:user) { instance_double(User, name: "Alice", blank?: false) }
+  let(:permit_application) do
+    instance_double(PermitApplication, jurisdiction: nil, id: "pa-1")
+  end
+  let(:submission_version) do
+    instance_double(SubmissionVersion, permit_application: permit_application)
+  end
+
+  subject(:formatter) { described_class.new(audit, nil) }
+
+  describe "#description" do
+    context "when marked as read" do
+      let(:audit) do
+        build_audit_double(
+          user: user,
+          auditable: submission_version,
+          auditable_type: "SubmissionVersion",
+          action: "update",
+          audited_changes: {
+            "viewed_at" => [nil, Time.current]
+          }
+        )
+      end
+
+      it "returns marked as read message" do
+        expect(formatter.description).to eq(
+          "Alice marked the application as read"
+        )
+      end
+    end
+
+    context "when marked as unread" do
+      let(:audit) do
+        build_audit_double(
+          user: user,
+          auditable: submission_version,
+          auditable_type: "SubmissionVersion",
+          action: "update",
+          audited_changes: {
+            "viewed_at" => [Time.current, nil]
+          }
+        )
+      end
+
+      it "returns marked as unread message" do
+        expect(formatter.description).to eq(
+          "Alice marked the application as unread"
+        )
+      end
+    end
+  end
+end

--- a/spec/presenters/project_audit_presenter_spec.rb
+++ b/spec/presenters/project_audit_presenter_spec.rb
@@ -65,7 +65,10 @@ RSpec.describe ProjectAuditPresenter do
       "PermitApplication" => ProjectAuditFormatters::PermitApplicationFormatter,
       "PermitCollaboration" =>
         ProjectAuditFormatters::PermitCollaborationFormatter,
-      "PermitBlockStatus" => ProjectAuditFormatters::PermitBlockStatusFormatter
+      "PermitBlockStatus" => ProjectAuditFormatters::PermitBlockStatusFormatter,
+      "PermitProjectCollaboration" =>
+        ProjectAuditFormatters::PermitProjectCollaborationFormatter,
+      "SubmissionVersion" => ProjectAuditFormatters::SubmissionVersionFormatter
     }.each do |type, formatter_class|
       context "when auditable_type is #{type}" do
         let(:auditable_type) { type }


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-4744-reviewer-can-see-a-chronological-record-of-reviewer-initiated-actions-taken-on-a-project-or-application-submissions-index-via-unified-multi-view-workspace` (merge-base range).

Reviewers need a chronological project activity feed that reflects reviewer-initiated work (state changes, read/unread, reviewer assignments) without flooding the feed with noise or exposing that detail to submitters. This PR extends auditing, query scoping, role-based filtering, and audit formatters so the existing Activity tab shows those events with clear, localized descriptions.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-4744](https://yourorg.atlassian.net/browse/HUB-4744) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                        |
| 📑 Design / Figma    | <!-- Paste link -->                                        |
| 📚 Documentation     | <!-- Paste link -->                                        |

---

## ✨ Features / Changes Introduced

- Audit **permit project** `state` and `viewed_at` updates, with human-readable formatter messages (e.g. state transitions, marked read/unread).
- Audit **permit project collaborations** (assign/remove project reviewer) and **submission version** `viewed_at` changes (application read/unread), associated to the project feed.
- Add formatters for `PermitProjectCollaboration` and `SubmissionVersion`, plus shared `ChangesHelper` for enum and read/unread copy.
- Improve **permit application** status change formatting (scalar/legacy audits, from/to labels for unrecognized transitions).
- Add clearer **application reviewer** assign/remove messages for delegatee review collaborations.
- **Role filter:** submitters no longer see reviewer-only rows (project state/read-unread updates, project reviewer audits, submission read/unread audits); review staff still do.
- **Feed noise control:** skip no-op read updates at the model layer; exclude redundant `viewed_at` audits (timestamp → timestamp) from `for_permit_project`; include associated `PermitProject` audits in the project scope.
- **Preload** collaborations and submission versions for activity feed performance.
- Add locale strings for new audit actions and enum value labels.
- Add model and presenter specs covering auditing, filtering, and formatter output.

---

## 🧪 Steps to QA

1. Sign in as **review staff** with access to a permit project that has at least one submitted application (designated reviewer enabled if testing reviewer assignment).
2. Open the project from the **unified multi-view / submission inbox** workspace and go to the **Activity** tab.
3. As the reviewer, perform several actions on the project and an application:
   - Change project state (e.g. begin progress).
   - Mark the project read, then unread.
   - Assign and remove a **project reviewer** (if configured).
   - Mark an application read, then unread.
   - Assign and remove an **application reviewer** (delegatee).
   - Move an application through a status change (e.g. start review).
4. Refresh or revisit the Activity tab and confirm new entries appear in **chronological order** with descriptions such as state changes, read/unread, and reviewer assign/remove (not generic “updated the project” where a specific message applies).
5. Repeat mark-as-read on an already-read project/application and confirm **no duplicate read** entries appear.
6. Sign in as the **submitter (project owner)** and open the same project Activity tab.
7. Confirm submitter-visible activity still includes normal project updates (e.g. title change) and **does not** show reviewer-only items from step 3 (state, read/unread, reviewer assignments, application read/unread).

**Expected behaviour:**

- Review staff see a complete, readable timeline of reviewer-initiated project and application actions.
- Submitters see a filtered feed without reviewer-internal activity.
- Re-marking read does not add spurious activity rows.

**Before this change:**

- Many reviewer actions were not audited or not formatted for the activity feed; read/unread could create noisy or missing entries.

**After this change:**

- Reviewer actions appear with specific copy; redundant read transitions are suppressed; submitters do not see reviewer-only audit rows.

_Add before/after screenshots of the Activity tab if helpful for review._

---

## ♿ UI Accessibility Checklist

> No UI component changes in this PR. Activity tab markup is unchanged; only backend audit content/descriptions may differ. Skip detailed accessibility re-check unless copy changes affect screen reader context in testing.

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4744]: https://hous-bssb.atlassian.net/browse/HUB-4744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ