### PR TITLE
Hub 4214 all users can view release notes with historical navigation

### DIFF
--- a/app/blueprints/release_note_blueprint.rb
+++ b/app/blueprints/release_note_blueprint.rb
@@ -1,12 +1,10 @@
 class ReleaseNoteBlueprint < Blueprinter::Base
   identifier :id
-
-  view :base do
-    fields :version, :release_date, :release_notes_url, :status, :updated_at
-  end
-
-  view :extended do
-    include_view :base
-    fields :content, :issues
-  end
+  fields :version,
+         :release_date,
+         :release_notes_url,
+         :status,
+         :updated_at,
+         :content,
+         :issues
 end

--- a/app/controllers/api/concerns/search/release_notes.rb
+++ b/app/controllers/api/concerns/search/release_notes.rb
@@ -26,13 +26,21 @@ module Api::Concerns::Search::ReleaseNotes
   private
 
   def release_note_search_params
-    params.permit(:page, :per_page, :year, sort: %i[field direction])
+    params.permit(
+      :page,
+      :per_page,
+      :year,
+      :published_only,
+      sort: %i[field direction]
+    )
   end
 
   def release_note_where_clause
     filters = {}
 
-    filters[:status] = "published" unless current_user&.super_admin?
+    if release_note_published_only? || !current_user&.super_admin?
+      filters[:status] = "published"
+    end
 
     year = release_note_search_params[:year].presence
     return filters unless year
@@ -61,5 +69,11 @@ module Api::Concerns::Search::ReleaseNotes
     else
       { release_date: :desc, created_at: :desc }
     end
+  end
+
+  def release_note_published_only?
+    ActiveModel::Type::Boolean.new.cast(
+      release_note_search_params[:published_only]
+    )
   end
 end

--- a/app/controllers/api/concerns/search/release_notes.rb
+++ b/app/controllers/api/concerns/search/release_notes.rb
@@ -8,10 +8,19 @@ module Api::Concerns::Search::ReleaseNotes
   }.freeze
 
   def perform_release_note_search
-    relation = policy_scope(ReleaseNote)
-    relation = apply_release_note_year_filter(relation)
-    relation = apply_release_note_order(relation)
-    @release_notes = relation.page(release_note_page).per(release_note_per_page)
+    where_clause = release_note_where_clause
+    order = release_note_order
+    release_note_policy_scope = policy_scope(ReleaseNote)
+
+    @release_note_search =
+      ReleaseNote.search(
+        "*",
+        where: where_clause,
+        order: order,
+        page: release_note_page,
+        per_page: release_note_per_page,
+        scope_results: ->(_relation) { release_note_policy_scope }
+      )
   end
 
   private
@@ -20,13 +29,17 @@ module Api::Concerns::Search::ReleaseNotes
     params.permit(:page, :per_page, :year, sort: %i[field direction])
   end
 
-  def apply_release_note_year_filter(relation)
+  def release_note_where_clause
+    filters = {}
+
+    filters[:status] = "published" unless current_user&.super_admin?
+
     year = release_note_search_params[:year].presence
-    return relation unless year
+    return filters unless year
 
     start_date = Date.new(year.to_i, 1, 1)
     end_date = Date.new(year.to_i, 12, 31)
-    relation.where(release_date: start_date..end_date)
+    filters.merge(release_date: start_date..end_date)
   end
 
   def release_note_page
@@ -38,14 +51,15 @@ module Api::Concerns::Search::ReleaseNotes
       Kaminari.config.default_per_page
   end
 
-  def apply_release_note_order(relation)
+  def release_note_order
     sort = release_note_search_params[:sort]
     field = SORTABLE_COLUMNS[sort&.dig(:field).to_s]
     direction = (sort&.dig(:direction).to_s.downcase == "asc" ? :asc : :desc)
+    # Use created_at to break ties when release_date (including time) is the same
     if field
-      relation.order(field => direction, :id => direction)
+      { field => direction, :created_at => direction }
     else
-      relation.order(release_date: :desc, id: :desc)
+      { release_date: :desc, created_at: :desc }
     end
   end
 end

--- a/app/controllers/api/concerns/search/release_notes.rb
+++ b/app/controllers/api/concerns/search/release_notes.rb
@@ -9,6 +9,7 @@ module Api::Concerns::Search::ReleaseNotes
 
   def perform_release_note_search
     relation = policy_scope(ReleaseNote)
+    relation = apply_release_note_year_filter(relation)
     relation = apply_release_note_order(relation)
     @release_notes = relation.page(release_note_page).per(release_note_per_page)
   end
@@ -16,7 +17,16 @@ module Api::Concerns::Search::ReleaseNotes
   private
 
   def release_note_search_params
-    params.permit(:page, :per_page, sort: %i[field direction])
+    params.permit(:page, :per_page, :year, sort: %i[field direction])
+  end
+
+  def apply_release_note_year_filter(relation)
+    year = release_note_search_params[:year].presence
+    return relation unless year
+
+    start_date = Date.new(year.to_i, 1, 1)
+    end_date = Date.new(year.to_i, 12, 31)
+    relation.where(release_date: start_date..end_date)
   end
 
   def release_note_page

--- a/app/controllers/api/release_notes_controller.rb
+++ b/app/controllers/api/release_notes_controller.rb
@@ -13,12 +13,7 @@ class Api::ReleaseNotesController < Api::ApplicationController
     if @release_note.save
       render_success @release_note,
                      "release_note.create_success",
-                     {
-                       blueprint: ReleaseNoteBlueprint,
-                       blueprint_opts: {
-                         view: :extended
-                       }
-                     }
+                     { blueprint: ReleaseNoteBlueprint }
     else
       render_error "release_note.create_error",
                    {
@@ -47,12 +42,7 @@ class Api::ReleaseNotesController < Api::ApplicationController
     if @release_note.update(release_note_params)
       render_success @release_note,
                      "release_note.update_success",
-                     {
-                       blueprint: ReleaseNoteBlueprint,
-                       blueprint_opts: {
-                         view: :extended
-                       }
-                     }
+                     { blueprint: ReleaseNoteBlueprint }
     else
       render_error "release_note.update_error",
                    {
@@ -74,12 +64,7 @@ class Api::ReleaseNotesController < Api::ApplicationController
       end
       render_success @release_note,
                      "release_note.publish_success",
-                     {
-                       blueprint: ReleaseNoteBlueprint,
-                       blueprint_opts: {
-                         view: :extended
-                       }
-                     }
+                     { blueprint: ReleaseNoteBlueprint }
     else
       render_error "release_note.publish_error",
                    {
@@ -96,28 +81,17 @@ class Api::ReleaseNotesController < Api::ApplicationController
     perform_release_note_search
     release_note_results = @release_note_search.results
 
-    view = current_user&.super_admin? ? :base : :extended
     render_success release_note_results,
                    nil,
                    {
                      meta: page_meta(@release_note_search),
-                     blueprint: ReleaseNoteBlueprint,
-                     blueprint_opts: {
-                       view: view
-                     }
+                     blueprint: ReleaseNoteBlueprint
                    }
   end
 
   def show
     authorize @release_note
-    render_success @release_note,
-                   nil,
-                   {
-                     blueprint: ReleaseNoteBlueprint,
-                     blueprint_opts: {
-                       view: :extended
-                     }
-                   }
+    render_success @release_note, nil, { blueprint: ReleaseNoteBlueprint }
   end
 
   def viewer_context

--- a/app/controllers/api/release_notes_controller.rb
+++ b/app/controllers/api/release_notes_controller.rb
@@ -1,8 +1,8 @@
 class Api::ReleaseNotesController < Api::ApplicationController
   include Api::Concerns::Search::ReleaseNotes
 
-  skip_before_action :authenticate_user!, only: %i[index years viewer_context]
-  skip_before_action :require_confirmation, only: %i[index years viewer_context]
+  skip_before_action :authenticate_user!, only: %i[index viewer_context]
+  skip_before_action :require_confirmation, only: %i[index viewer_context]
 
   before_action :set_release_note, only: %i[update publish show viewer_context]
 
@@ -66,8 +66,12 @@ class Api::ReleaseNotesController < Api::ApplicationController
 
   def publish
     authorize @release_note
+    was_published = @release_note.published?
+
     if @release_note.update(release_note_params.merge(status: :published))
-      NotificationService.publish_release_note_publish_event(@release_note)
+      unless was_published
+        NotificationService.publish_release_note_publish_event(@release_note)
+      end
       render_success @release_note,
                      "release_note.publish_success",
                      {
@@ -87,26 +91,16 @@ class Api::ReleaseNotesController < Api::ApplicationController
     end
   end
 
-  def years
-    authorize :release_note, :index?
-    release_years =
-      policy_scope(ReleaseNote)
-        .order(release_date: :desc)
-        .pluck(:release_date)
-        .map(&:year)
-        .uniq
-
-    render json: { data: release_years, meta: default_meta(nil) }, status: :ok
-  end
-
   def index
     authorize :release_note, :index?
     perform_release_note_search
+    release_note_results = @release_note_search.results
+
     view = current_user&.super_admin? ? :base : :extended
-    render_success @release_notes,
+    render_success release_note_results,
                    nil,
                    {
-                     meta: page_meta(@release_notes),
+                     meta: page_meta(@release_note_search),
                      blueprint: ReleaseNoteBlueprint,
                      blueprint_opts: {
                        view: view

--- a/app/controllers/api/release_notes_controller.rb
+++ b/app/controllers/api/release_notes_controller.rb
@@ -1,7 +1,10 @@
 class Api::ReleaseNotesController < Api::ApplicationController
   include Api::Concerns::Search::ReleaseNotes
 
-  before_action :set_release_note, only: %i[update publish show]
+  skip_before_action :authenticate_user!, only: %i[index years viewer_context]
+  skip_before_action :require_confirmation, only: %i[index years viewer_context]
+
+  before_action :set_release_note, only: %i[update publish show viewer_context]
 
   def create
     @release_note = ReleaseNote.new(release_note_params)
@@ -84,10 +87,22 @@ class Api::ReleaseNotesController < Api::ApplicationController
     end
   end
 
+  def years
+    authorize :release_note, :index?
+    release_years =
+      policy_scope(ReleaseNote)
+        .order(release_date: :desc)
+        .pluck(:release_date)
+        .map(&:year)
+        .uniq
+
+    render json: { data: release_years, meta: default_meta(nil) }, status: :ok
+  end
+
   def index
     authorize :release_note, :index?
     perform_release_note_search
-    view = current_user.super_admin? ? :base : :extended
+    view = current_user&.super_admin? ? :base : :extended
     render_success @release_notes,
                    nil,
                    {
@@ -111,6 +126,18 @@ class Api::ReleaseNotesController < Api::ApplicationController
                    }
   end
 
+  def viewer_context
+    authorize @release_note, :viewer_context?
+    context =
+      ReleaseNoteViewerContext.call(
+        release_note: @release_note,
+        scope: policy_scope(ReleaseNote),
+        per_page: release_note_viewer_context_params[:per_page]
+      )
+
+    render json: { data: context, meta: default_meta(nil) }, status: :ok
+  end
+
   private
 
   def set_release_note
@@ -129,5 +156,9 @@ class Api::ReleaseNotesController < Api::ApplicationController
       :release_notes_url,
       :issues
     )
+  end
+
+  def release_note_viewer_context_params
+    params.permit(:per_page)
   end
 end

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -710,12 +710,6 @@ const AppRoutes = observer(() => {
   const isAllowedForReviewManagerOnly = loggedIn && !mustAcceptEula && (isReviewManager || isRegionalReviewManager)
   const isAllowedForTechnicalSupportOrManager =
     loggedIn && !mustAcceptEula && (isTechnicalSupport || isAllowedForReviewManagerOnly)
-  const releaseNotesRouteElement =
-    loggedIn && isSuperAdmin ? (
-      <RedirectScreen path="/configuration-management/release-notes" />
-    ) : (
-      <ReleaseNotesScreen />
-    )
 
   return (
     <>
@@ -868,7 +862,7 @@ const AppRoutes = observer(() => {
         {/* Public Routes */}
         <Route path="/accept-invitation" element={<AcceptInvitationScreen />} />
         <Route path="/contact" element={<ContactScreen />} />
-        <Route path="/release-notes" element={releaseNotesRouteElement} />
+        <Route path="/release-notes" element={<ReleaseNotesScreen />} />
         <Route path="/videos" element={<HelpVideosIndexScreen />} />
         <Route path="/videos/:videoId" element={<HelpVideoScreen />} />
         <Route path="/standardization-preview" element={<StandardizationPreviewScreen />} />

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -361,7 +361,7 @@ const AdminGlobalFeatureAccessScreen = lazy(() =>
   }))
 )
 
-const ReleaseNotesScreen = lazy(() =>
+const ReleaseNotesManagementScreen = lazy(() =>
   import("../super-admin/site-configuration-management/release-notes-screen").then((module) => ({
     default: module.ReleaseNotesScreen,
   }))
@@ -370,6 +370,12 @@ const ReleaseNotesScreen = lazy(() =>
 const ReleaseNoteFormScreen = lazy(() =>
   import("../super-admin/site-configuration-management/release-note-form-screen").then((module) => ({
     default: module.ReleaseNoteFormScreen,
+  }))
+)
+
+const ReleaseNotesScreen = lazy(() =>
+  import("../release-notes/release-notes-screen").then((module) => ({
+    default: module.ReleaseNotesScreen,
   }))
 )
 
@@ -523,9 +529,9 @@ const AppRoutes = observer(() => {
           Super admins toggle publicly_previewable directly on TemplateVersionScreen. */}
       <Route path="/configuration-management/users" element={<AdminUserIndexScreen />} />
       <Route path="/configuration-management/global-feature-access" element={<AdminGlobalFeatureAccessScreen />} />
-      <Route path="/release-notes/new" element={<ReleaseNoteFormScreen />} />
-      <Route path="/release-notes/:releaseNoteId/edit" element={<ReleaseNoteFormScreen />} />
-      <Route path="/release-notes" element={<ReleaseNotesScreen />} />
+      <Route path="/configuration-management/release-notes" element={<ReleaseNotesManagementScreen />} />
+      <Route path="/configuration-management/release-notes/new" element={<ReleaseNoteFormScreen />} />
+      <Route path="/configuration-management/release-notes/:releaseNoteId/edit" element={<ReleaseNoteFormScreen />} />
       <Route
         path="/configuration-management/global-feature-access/submission-inbox"
         element={<AdminSubmissionInboxScreen />}
@@ -704,6 +710,12 @@ const AppRoutes = observer(() => {
   const isAllowedForReviewManagerOnly = loggedIn && !mustAcceptEula && (isReviewManager || isRegionalReviewManager)
   const isAllowedForTechnicalSupportOrManager =
     loggedIn && !mustAcceptEula && (isTechnicalSupport || isAllowedForReviewManagerOnly)
+  const releaseNotesRouteElement =
+    loggedIn && isSuperAdmin ? (
+      <RedirectScreen path="/configuration-management/release-notes" />
+    ) : (
+      <ReleaseNotesScreen />
+    )
 
   return (
     <>
@@ -856,6 +868,7 @@ const AppRoutes = observer(() => {
         {/* Public Routes */}
         <Route path="/accept-invitation" element={<AcceptInvitationScreen />} />
         <Route path="/contact" element={<ContactScreen />} />
+        <Route path="/release-notes" element={releaseNotesRouteElement} />
         <Route path="/videos" element={<HelpVideosIndexScreen />} />
         <Route path="/videos/:videoId" element={<HelpVideoScreen />} />
         <Route path="/standardization-preview" element={<StandardizationPreviewScreen />} />

--- a/app/frontend/components/domains/release-notes/release-note-entry.tsx
+++ b/app/frontend/components/domains/release-notes/release-note-entry.tsx
@@ -1,0 +1,90 @@
+import { Box, Flex, Heading, Link, VStack } from "@chakra-ui/react"
+import { format } from "date-fns"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { IReleaseNote } from "../../../models/release-note-model"
+import { useMst } from "../../../setup/root"
+import { CopyLinkButton } from "../../shared/base/copy-link-button"
+import { SafeTipTapDisplay } from "../../shared/editor/safe-tiptap-display"
+import { ReleaseNoteVersionBadge } from "./release-note-version-badge"
+
+type ReleaseNoteEntryProps = {
+  releaseNote: IReleaseNote
+  isHighlighted?: boolean
+}
+
+export const ReleaseNoteEntry = observer(function ReleaseNoteEntry({
+  releaseNote,
+  isHighlighted = false,
+}: ReleaseNoteEntryProps) {
+  const { t } = useTranslation()
+  const { releaseNoteStore } = useMst()
+  const { getReleaseNoteAnchorId, getReleaseNoteShareUrl } = releaseNoteStore
+
+  return (
+    <VStack id={getReleaseNoteAnchorId(releaseNote.id)} align="stretch" spacing={10} w="full" scrollMarginTop={8}>
+      <Flex
+        align="center"
+        gap={4}
+        flexWrap="wrap"
+        w="full"
+        bg={isHighlighted ? "theme.yellowLight" : "transparent"}
+        borderRadius="sm"
+        transition="background-color 500ms ease"
+      >
+        <Heading as="h2" fontSize="2xl" m={0}>
+          {format(releaseNote.releaseDate, "MMMM d, yyyy")}
+        </Heading>
+        <ReleaseNoteVersionBadge version={releaseNote.version} />
+        <CopyLinkButton
+          value={getReleaseNoteShareUrl(releaseNote.id)}
+          iconOnly
+          aria-label={t("releaseNote.viewing.copyReleaseNoteLink")}
+        />
+      </Flex>
+
+      {releaseNote.content && (
+        <Box>
+          <Heading as="h3" variant="yellowline" fontSize="xl" mb={2} mt={0}>
+            {t("releaseNote.viewing.whatsNew")}
+          </Heading>
+          <SafeTipTapDisplay
+            htmlContent={releaseNote.content}
+            fontSize="lg"
+            lineHeight="1.68"
+            sx={{
+              "& a": {
+                color: "text.link",
+                textDecoration: "underline",
+              },
+            }}
+          />
+          {releaseNote.releaseNotesUrl && (
+            <Link
+              href={releaseNote.releaseNotesUrl}
+              isExternal
+              color="text.link"
+              fontSize="lg"
+              lineHeight="1.68"
+              textDecoration="underline"
+              display="inline-block"
+              mt={4}
+            >
+              {t("releaseNote.viewing.githubLink")}
+            </Link>
+          )}
+        </Box>
+      )}
+
+      {releaseNote.issues && (
+        <Box>
+          <Heading as="h3" fontSize="xl" mb={2} mt={0}>
+            {t("releaseNote.viewing.issues")}
+          </Heading>
+          <SafeTipTapDisplay htmlContent={releaseNote.issues} fontSize="lg" lineHeight="1.68" />
+        </Box>
+      )}
+    </VStack>
+  )
+})

--- a/app/frontend/components/domains/release-notes/release-note-version-badge.tsx
+++ b/app/frontend/components/domains/release-notes/release-note-version-badge.tsx
@@ -1,10 +1,10 @@
 import { Text } from "@chakra-ui/react"
 import React from "react"
 
-type ReleaseNoteVersionBadgeProps = {
+type ReleaseNoteVersionBadgeProps = Readonly<{
   version: string
   isHighlighted?: boolean
-}
+}>
 
 export function ReleaseNoteVersionBadge({ version, isHighlighted = false }: ReleaseNoteVersionBadgeProps) {
   return (

--- a/app/frontend/components/domains/release-notes/release-note-version-badge.tsx
+++ b/app/frontend/components/domains/release-notes/release-note-version-badge.tsx
@@ -1,0 +1,29 @@
+import { Text } from "@chakra-ui/react"
+import React from "react"
+
+type ReleaseNoteVersionBadgeProps = {
+  version: string
+  isHighlighted?: boolean
+}
+
+export function ReleaseNoteVersionBadge({ version, isHighlighted = false }: ReleaseNoteVersionBadgeProps) {
+  return (
+    <Text
+      as="span"
+      display="inline-block"
+      textTransform="uppercase"
+      fontSize="xs"
+      fontWeight="bold"
+      letterSpacing="0.05em"
+      px={1}
+      py={1}
+      borderRadius="sm"
+      bg={isHighlighted ? "theme.yellowLight" : "greys.grey03"}
+      color={isHighlighted ? "text.primary" : "text.secondary"}
+      boxShadow={isHighlighted ? "0 0 0 2px var(--chakra-colors-theme-yellow)" : undefined}
+      transition="background-color 200ms ease, color 200ms ease, box-shadow 200ms ease"
+    >
+      V.{version}
+    </Text>
+  )
+}

--- a/app/frontend/components/domains/release-notes/release-note-year-nav.tsx
+++ b/app/frontend/components/domains/release-notes/release-note-year-nav.tsx
@@ -1,0 +1,50 @@
+import { Box, Flex, Text, VStack } from "@chakra-ui/react"
+import { observer } from "mobx-react-lite"
+import React from "react"
+
+type ReleaseNoteYearNavProps = {
+  years: number[]
+  selectedYear: number
+  onSelectYear: (year: number) => void
+}
+
+export const ReleaseNoteYearNav = observer(function ReleaseNoteYearNav({
+  years,
+  selectedYear,
+  onSelectYear,
+}: ReleaseNoteYearNavProps) {
+  return (
+    <VStack align="stretch" spacing={0} w="180px" flexShrink={0} alignSelf="flex-start" maxH="full" overflowY="auto">
+      {years.map((year) => {
+        const isSelected = year === selectedYear
+        return (
+          <Box
+            key={year}
+            as="button"
+            type="button"
+            onClick={() => onSelectYear(year)}
+            textAlign="left"
+            w="full"
+            bg={isSelected ? "background.blueLightest" : "transparent"}
+            _hover={{ bg: isSelected ? "background.blueLightest" : "greys.grey03" }}
+          >
+            <Flex align="stretch" minH="43px">
+              <Box w="4px" flexShrink={0} bg={isSelected ? "theme.blueAlt" : "transparent"} />
+              <Text
+                flex={1}
+                px={4}
+                py={2}
+                fontSize="md"
+                lineHeight="1.68"
+                fontWeight={isSelected ? "bold" : "normal"}
+                color={isSelected ? "text.link" : "text.primary"}
+              >
+                {year}
+              </Text>
+            </Flex>
+          </Box>
+        )
+      })}
+    </VStack>
+  )
+})

--- a/app/frontend/components/domains/release-notes/release-notes-screen.tsx
+++ b/app/frontend/components/domains/release-notes/release-notes-screen.tsx
@@ -20,6 +20,7 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
   const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const highlightedHashRef = useRef<string | null>(null)
   const [availableHeight, setAvailableHeight] = useState<number | null>(null)
+  const [initializedHash, setInitializedHash] = useState<string | null>(null)
   const [highlightedReleaseNoteId, setHighlightedReleaseNoteId] = useState<string | null>(null)
   const {
     viewingReleaseNotes,
@@ -40,8 +41,18 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
   } = releaseNoteStore
 
   useEffect(() => {
-    initializeViewingPage(location.hash)
-  }, [initializeViewingPage])
+    let cancelled = false
+    const hash = location.hash
+    setInitializedHash(null)
+
+    Promise.resolve(initializeViewingPage(hash)).then(() => {
+      if (!cancelled) setInitializedHash(hash)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [initializeViewingPage, location.hash])
 
   useSearch(releaseNoteStore, [viewingYearInitialized ? selectedYear : null])
 
@@ -60,6 +71,14 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
   }, [])
 
   useEffect(() => {
+    const releaseNoteId = parseReleaseNoteIdFromHash(location.hash)
+    const targetAnchorId = releaseNoteId ? getReleaseNoteAnchorId(releaseNoteId) : null
+    const targetElement = targetAnchorId ? document.getElementById(targetAnchorId) : null
+
+    if (location.hash && initializedHash !== location.hash) {
+      return
+    }
+
     if (!location.hash) {
       highlightedHashRef.current = null
       setHighlightedReleaseNoteId(null)
@@ -67,19 +86,16 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
     }
 
     if (isSearching || highlightedHashRef.current === location.hash) {
-      setHighlightedReleaseNoteId(null)
       return
     }
 
-    const releaseNoteId = parseReleaseNoteIdFromHash(location.hash)
     if (!releaseNoteId) {
       setHighlightedReleaseNoteId(null)
       return
     }
 
-    const element = document.getElementById(getReleaseNoteAnchorId(releaseNoteId))
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "start" })
+    if (targetElement) {
+      targetElement.scrollIntoView({ behavior: "smooth", block: "start" })
       highlightedHashRef.current = location.hash
       setHighlightedReleaseNoteId(releaseNoteId)
 
@@ -98,7 +114,17 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
         highlightTimeoutRef.current = null
       }
     }
-  }, [location.hash, isSearching, viewingReleaseNotes.length, getReleaseNoteAnchorId, parseReleaseNoteIdFromHash])
+  }, [
+    location.hash,
+    initializedHash,
+    isSearching,
+    viewingReleaseNotes.length,
+    selectedYear,
+    currentPage,
+    viewingYearInitialized,
+    getReleaseNoteAnchorId,
+    parseReleaseNoteIdFromHash,
+  ])
 
   const reportIssueMailto = `mailto:${t("site.contactEmail")}`
 

--- a/app/frontend/components/domains/release-notes/release-notes-screen.tsx
+++ b/app/frontend/components/domains/release-notes/release-notes-screen.tsx
@@ -128,6 +128,19 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
 
   const reportIssueMailto = `mailto:${t("site.contactEmail")}`
 
+  const releaseNotesContent =
+    viewingReleaseNotes.length === 0 ? (
+      <Text color="text.secondary" fontSize="lg">
+        {t("releaseNote.viewing.emptyState", { year: selectedYear })}
+      </Text>
+    ) : (
+      <VStack align="stretch" spacing="87px">
+        {viewingReleaseNotes.map((note) => (
+          <ReleaseNoteEntry key={note.id} releaseNote={note} isHighlighted={note.id === highlightedReleaseNoteId} />
+        ))}
+      </VStack>
+    )
+
   return (
     <Container
       ref={containerRef}
@@ -137,7 +150,7 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
       as="main"
       display="flex"
       flexDirection="column"
-      h={availableHeight !== null ? `${availableHeight}px` : "auto"}
+      h={availableHeight === null ? "auto" : `${availableHeight}px`}
       overflow="hidden"
     >
       <VStack align="stretch" spacing={8} flex={1} minH={0} overflow="hidden">
@@ -155,23 +168,7 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
 
           <Flex direction="column" flex={1} minW={0} minH={0} overflow="hidden">
             <Box flex={1} minH={0} overflowY="auto" pr={1}>
-              {isSearching ? (
-                <SharedSpinner />
-              ) : viewingReleaseNotes.length === 0 ? (
-                <Text color="text.secondary" fontSize="lg">
-                  {t("releaseNote.viewing.emptyState", { year: selectedYear })}
-                </Text>
-              ) : (
-                <VStack align="stretch" spacing="87px">
-                  {viewingReleaseNotes.map((note) => (
-                    <ReleaseNoteEntry
-                      key={note.id}
-                      releaseNote={note}
-                      isHighlighted={note.id === highlightedReleaseNoteId}
-                    />
-                  ))}
-                </VStack>
-              )}
+              {isSearching ? <SharedSpinner /> : releaseNotesContent}
             </Box>
 
             <Flex w="full" justify="space-between" align="center" flexWrap="wrap" gap={4} flexShrink={0} pt={4} pb={1}>

--- a/app/frontend/components/domains/release-notes/release-notes-screen.tsx
+++ b/app/frontend/components/domains/release-notes/release-notes-screen.tsx
@@ -1,0 +1,171 @@
+import { Box, Button, Container, Flex, Heading, Text, VStack } from "@chakra-ui/react"
+import { Envelope } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { useLocation } from "react-router-dom"
+import { useSearch } from "../../../hooks/use-search"
+import { useMst } from "../../../setup/root"
+import { Paginator } from "../../shared/base/inputs/paginator"
+import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
+import { SharedSpinner } from "../../shared/base/shared-spinner"
+import { ReleaseNoteEntry } from "./release-note-entry"
+import { ReleaseNoteYearNav } from "./release-note-year-nav"
+
+export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
+  const location = useLocation()
+  const { releaseNoteStore } = useMst()
+  const { t } = useTranslation()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const highlightedHashRef = useRef<string | null>(null)
+  const [availableHeight, setAvailableHeight] = useState<number | null>(null)
+  const [highlightedReleaseNoteId, setHighlightedReleaseNoteId] = useState<string | null>(null)
+  const {
+    viewingReleaseNotes,
+    selectedYear,
+    currentPage,
+    totalPages,
+    totalCount,
+    countPerPage,
+    handleCountPerPageChange,
+    handlePageChange,
+    isSearching,
+    initializeViewingPage,
+    selectViewingYear,
+    viewingYearInitialized,
+    availableYears,
+    getReleaseNoteAnchorId,
+    parseReleaseNoteIdFromHash,
+  } = releaseNoteStore
+
+  useEffect(() => {
+    initializeViewingPage(location.hash)
+  }, [initializeViewingPage])
+
+  useSearch(releaseNoteStore, [viewingYearInitialized ? selectedYear : null])
+
+  useLayoutEffect(() => {
+    const updateAvailableHeight = () => {
+      if (!containerRef.current) return
+
+      const { top } = containerRef.current.getBoundingClientRect()
+      setAvailableHeight(Math.max(0, Math.floor(window.innerHeight - top)))
+    }
+
+    updateAvailableHeight()
+    window.addEventListener("resize", updateAvailableHeight)
+
+    return () => window.removeEventListener("resize", updateAvailableHeight)
+  }, [])
+
+  useEffect(() => {
+    if (!location.hash) {
+      highlightedHashRef.current = null
+      setHighlightedReleaseNoteId(null)
+      return
+    }
+
+    if (isSearching || highlightedHashRef.current === location.hash) {
+      setHighlightedReleaseNoteId(null)
+      return
+    }
+
+    const releaseNoteId = parseReleaseNoteIdFromHash(location.hash)
+    if (!releaseNoteId) {
+      setHighlightedReleaseNoteId(null)
+      return
+    }
+
+    const element = document.getElementById(getReleaseNoteAnchorId(releaseNoteId))
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" })
+      highlightedHashRef.current = location.hash
+      setHighlightedReleaseNoteId(releaseNoteId)
+
+      if (highlightTimeoutRef.current) {
+        clearTimeout(highlightTimeoutRef.current)
+      }
+      highlightTimeoutRef.current = setTimeout(() => {
+        setHighlightedReleaseNoteId(null)
+        highlightTimeoutRef.current = null
+      }, 3000)
+    }
+
+    return () => {
+      if (highlightTimeoutRef.current) {
+        clearTimeout(highlightTimeoutRef.current)
+        highlightTimeoutRef.current = null
+      }
+    }
+  }, [location.hash, isSearching, viewingReleaseNotes.length, getReleaseNoteAnchorId, parseReleaseNoteIdFromHash])
+
+  const reportIssueMailto = `mailto:${t("site.contactEmail")}`
+
+  return (
+    <Container
+      ref={containerRef}
+      maxW="container.lg"
+      py={6}
+      px={{ base: 4, md: 8 }}
+      as="main"
+      display="flex"
+      flexDirection="column"
+      h={availableHeight !== null ? `${availableHeight}px` : "auto"}
+      overflow="hidden"
+    >
+      <VStack align="stretch" spacing={8} flex={1} minH={0} overflow="hidden">
+        <Flex justify="space-between" align="flex-start" gap={4} flexWrap="wrap" flexShrink={0}>
+          <Heading as="h1" fontSize="3xl" m={0}>
+            {t("releaseNote.viewing.title")}
+          </Heading>
+          <Button as="a" href={reportIssueMailto} variant="secondary" size="sm" leftIcon={<Envelope size={14} />}>
+            {t("releaseNote.viewing.reportIssue")}
+          </Button>
+        </Flex>
+
+        <Flex align="stretch" gap={5} w="full" flex={1} minH={0} overflow="hidden">
+          <ReleaseNoteYearNav years={availableYears} selectedYear={selectedYear} onSelectYear={selectViewingYear} />
+
+          <Flex direction="column" flex={1} minW={0} minH={0} overflow="hidden">
+            <Box flex={1} minH={0} overflowY="auto" pr={1}>
+              {isSearching ? (
+                <SharedSpinner />
+              ) : viewingReleaseNotes.length === 0 ? (
+                <Text color="text.secondary" fontSize="lg">
+                  {t("releaseNote.viewing.emptyState", { year: selectedYear })}
+                </Text>
+              ) : (
+                <VStack align="stretch" spacing="87px">
+                  {viewingReleaseNotes.map((note) => (
+                    <ReleaseNoteEntry
+                      key={note.id}
+                      releaseNote={note}
+                      isHighlighted={note.id === highlightedReleaseNoteId}
+                    />
+                  ))}
+                </VStack>
+              )}
+            </Box>
+
+            <Flex w="full" justify="space-between" align="center" flexWrap="wrap" gap={4} flexShrink={0} pt={4} pb={1}>
+              <PerPageSelect
+                handleCountPerPageChange={handleCountPerPageChange}
+                countPerPage={countPerPage}
+                totalCount={totalCount ?? 0}
+              />
+              <Paginator
+                current={currentPage}
+                total={totalCount ?? 0}
+                totalPages={totalPages ?? 0}
+                pageSize={countPerPage}
+                handlePageChange={handlePageChange}
+                showLessItems
+              />
+            </Flex>
+          </Flex>
+        </Flex>
+      </VStack>
+    </Container>
+  )
+})

--- a/app/frontend/components/domains/super-admin/site-configuration-management/index.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/index.tsx
@@ -85,7 +85,7 @@ export const SiteConfigurationManagementScreen = observer(function SiteConfigura
               description={t(`${i18nPrefix}.releaseNotes.description`)}
               linkText={t("ui.edit")}
               icon={<File size="24px" color="var(--chakra-colors-text-link)" />}
-              href="/release-notes"
+              href="/configuration-management/release-notes"
               h="full"
             />
           </GridItem>

--- a/app/frontend/components/domains/super-admin/site-configuration-management/release-note-form-screen.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/release-note-form-screen.tsx
@@ -311,6 +311,8 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
                     ".react-datepicker__input-container": { w: "252px" },
                   },
                 },
+                showTimeInput: true,
+                dateFormat: "yyyy/MM/dd h:mm aa",
               }}
             />
             <UrlFormControl label={t("releaseNote.form.releaseNotesUrl")} fieldName="releaseNotesUrl" required />
@@ -371,7 +373,7 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
                 variant="primary"
                 size="sm"
                 isLoading={submittingIntent === "publish"}
-                isDisabled={submittingIntent === "saveDraft" || isAlreadyPublished}
+                isDisabled={submittingIntent === "saveDraft"}
               >
                 {t("releaseNote.form.publish")}
               </Button>

--- a/app/frontend/components/domains/super-admin/site-configuration-management/release-note-form-screen.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/release-note-form-screen.tsx
@@ -123,7 +123,9 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
     setCurrentReleaseNote,
   } = releaseNoteStore
 
-  const isCreate = Boolean(matchPath({ path: "/release-notes/new", end: true }, location.pathname))
+  const isCreate = Boolean(
+    matchPath({ path: "/configuration-management/release-notes/new", end: true }, location.pathname)
+  )
 
   const [loadError, setLoadError] = React.useState(false)
   const [isLoading, setIsLoading] = React.useState(!isCreate)
@@ -197,7 +199,7 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
     const result = isCreate ? await createReleaseNote(data) : await updateReleaseNote(releaseNoteId as string, data)
 
     if (result.ok) {
-      navigate("/release-notes")
+      navigate("/configuration-management/release-notes")
     } else {
       console.error("Failed to save release note:", result.error)
     }
@@ -218,7 +220,7 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
       const publishResult = await publishReleaseNote(createResult.data.id, data)
       if (!publishResult.ok) {
         console.error("Failed to publish release note after create:", publishResult.error)
-        navigate(`/release-notes/${createResult.data.id}/edit`, { replace: true })
+        navigate(`/configuration-management/release-notes/${createResult.data.id}/edit`, { replace: true })
         return
       }
     } else {
@@ -229,7 +231,7 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
       }
     }
 
-    navigate("/release-notes")
+    navigate("/configuration-management/release-notes")
   }
 
   const onFormSubmit = handleSubmit(async (data: TReleaseNoteFormData, event?: React.BaseSyntheticEvent) => {
@@ -269,7 +271,7 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
         <Heading size="md" mb={4}>
           {t("site.breadcrumb.notFound")}
         </Heading>
-        <RouterLinkButton to="/release-notes" variant="secondary">
+        <RouterLinkButton to="/configuration-management/release-notes" variant="secondary">
           {t("releaseNote.form.cancel")}
         </RouterLinkButton>
       </Container>
@@ -344,7 +346,7 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
               py={4}
             >
               <RouterLinkButton
-                to="/release-notes"
+                to="/configuration-management/release-notes"
                 variant="secondary"
                 size="sm"
                 isDisabled={submittingIntent !== null}

--- a/app/frontend/components/domains/super-admin/site-configuration-management/release-notes-screen.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/release-notes-screen.tsx
@@ -81,7 +81,12 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
               h="72px"
               align="center"
             >
-              <RouterLinkButton to="/release-notes/new" variant="primary" size="sm" fontSize="sm">
+              <RouterLinkButton
+                to="/configuration-management/release-notes/new"
+                variant="primary"
+                size="sm"
+                fontSize="sm"
+              >
                 {t("releaseNote.createNew")}
               </RouterLinkButton>
             </Flex>
@@ -113,7 +118,7 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
                     <ReleaseNotesGridCell py={0} justifyContent="flex-end">
                       <Button
                         as={ReactRouterLink}
-                        to={`/release-notes/${note.id}/edit`}
+                        to={`/configuration-management/release-notes/${note.id}/edit`}
                         variant="secondary"
                         size="sm"
                         h="32px"

--- a/app/frontend/components/domains/super-admin/site-configuration-management/release-notes-screen.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/release-notes-screen.tsx
@@ -54,13 +54,17 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
     isSearching,
     tableReleaseNotes,
     resetCurrentReleaseNote,
+    setApplyYearFilterInSearch,
+    setPublishedOnlyInSearch,
   } = releaseNoteStore
-
-  useSearch(releaseNoteStore, [])
 
   useEffect(() => {
     resetCurrentReleaseNote()
-  }, [resetCurrentReleaseNote])
+    setApplyYearFilterInSearch(false)
+    setPublishedOnlyInSearch(false)
+  }, [resetCurrentReleaseNote, setApplyYearFilterInSearch, setPublishedOnlyInSearch])
+
+  useSearch(releaseNoteStore, [])
 
   return (
     <Container maxW="container.lg" px={8} pt={6} pb={20} flexGrow={1}>

--- a/app/frontend/components/domains/super-admin/site-configuration-management/release-notes-screen.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/release-notes-screen.tsx
@@ -66,6 +66,40 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
 
   useSearch(releaseNoteStore, [])
 
+  const releaseNotesContent =
+    tableReleaseNotes.length === 0 ? (
+      <Flex py={16} gridColumn="1 / -1" justify="center">
+        <Text color="text.secondary">{t("releaseNote.emptyState")}</Text>
+      </Flex>
+    ) : (
+      tableReleaseNotes.map((note: IReleaseNote) => (
+        <Box key={note.id} display="contents" role="row">
+          <ReleaseNotesGridCell>{note.version}</ReleaseNotesGridCell>
+          <ReleaseNotesGridCell color="text.secondary">{format(note.releaseDate, "MMMM d, yyyy")}</ReleaseNotesGridCell>
+          <ReleaseNotesGridCell py={0}>
+            <ReleaseNoteStatusBadge status={note.status as EReleaseNoteStatus} />
+          </ReleaseNotesGridCell>
+          <ReleaseNotesGridCell color="text.secondary">
+            {format(note.updatedAt, "MMMM d, yyyy 'at' h:mm a")}
+          </ReleaseNotesGridCell>
+          <ReleaseNotesGridCell py={0} justifyContent="flex-end">
+            <Button
+              as={ReactRouterLink}
+              to={`/configuration-management/release-notes/${note.id}/edit`}
+              variant="secondary"
+              size="sm"
+              h="32px"
+              minW="32px"
+              px={3}
+              aria-label={t("ui.edit")}
+            >
+              <Pencil size={14} />
+            </Button>
+          </ReleaseNotesGridCell>
+        </Box>
+      ))
+    )
+
   return (
     <Container maxW="container.lg" px={8} pt={6} pb={20} flexGrow={1}>
       <VStack alignItems="flex-start" spacing={8} w="full" h="full">
@@ -102,39 +136,8 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
                 <Flex py={16} gridColumn="1 / -1" justify="center">
                   <SharedSpinner />
                 </Flex>
-              ) : tableReleaseNotes.length === 0 ? (
-                <Flex py={16} gridColumn="1 / -1" justify="center">
-                  <Text color="text.secondary">{t("releaseNote.emptyState")}</Text>
-                </Flex>
               ) : (
-                tableReleaseNotes.map((note: IReleaseNote) => (
-                  <Box key={note.id} display="contents" role="row">
-                    <ReleaseNotesGridCell>{note.version}</ReleaseNotesGridCell>
-                    <ReleaseNotesGridCell color="text.secondary">
-                      {format(note.releaseDate, "MMMM d, yyyy")}
-                    </ReleaseNotesGridCell>
-                    <ReleaseNotesGridCell py={0}>
-                      <ReleaseNoteStatusBadge status={note.status as EReleaseNoteStatus} />
-                    </ReleaseNotesGridCell>
-                    <ReleaseNotesGridCell color="text.secondary">
-                      {format(note.updatedAt, "MMMM d, yyyy 'at' h:mm a")}
-                    </ReleaseNotesGridCell>
-                    <ReleaseNotesGridCell py={0} justifyContent="flex-end">
-                      <Button
-                        as={ReactRouterLink}
-                        to={`/configuration-management/release-notes/${note.id}/edit`}
-                        variant="secondary"
-                        size="sm"
-                        h="32px"
-                        minW="32px"
-                        px={3}
-                        aria-label={t("ui.edit")}
-                      >
-                        <Pencil size={14} />
-                      </Button>
-                    </ReleaseNotesGridCell>
-                  </Box>
-                ))
+                releaseNotesContent
               )}
             </SearchGrid>
           </Box>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -5135,6 +5135,16 @@ Thank you,
         },
         releaseNote: {
           title: "Release notes",
+          viewing: {
+            title: "Release notes",
+            reportIssue: "Report an issue",
+            whatsNew: "What's new",
+            issues: "Issues",
+            githubLink: "Release notes on GitHub",
+            copyReleaseNoteLink: "Copy link to this release note",
+            openReleaseNotesUrl: "Open release notes link",
+            emptyState: "No release notes published for {{year}}.",
+          },
           createNew: "Create new release note",
           emptyState: "No release notes yet.",
           status: {

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -1165,10 +1165,6 @@ export class Api {
     return this.client.post<ApiResponse<IReleaseNote[]>>(`/release_notes/search`, params)
   }
 
-  async fetchReleaseNoteYears() {
-    return this.client.get<ApiResponse<number[]>>(`/release_notes/years`)
-  }
-
   async fetchReleaseNote(id: string) {
     return this.client.get<ApiResponse<IReleaseNote>>(`/release_notes/${id}`)
   }

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -79,6 +79,7 @@ import {
   TCreatePermitApplicationFormData,
   TCreateRequirementTemplateFormData,
   TReleaseNoteFormData,
+  TReleaseNoteViewerContext,
   TSearchParams,
 } from "../../types/types"
 import { camelizeResponse, decamelizeRequest } from "../../utils"
@@ -1164,8 +1165,16 @@ export class Api {
     return this.client.post<ApiResponse<IReleaseNote[]>>(`/release_notes/search`, params)
   }
 
+  async fetchReleaseNoteYears() {
+    return this.client.get<ApiResponse<number[]>>(`/release_notes/years`)
+  }
+
   async fetchReleaseNote(id: string) {
     return this.client.get<ApiResponse<IReleaseNote>>(`/release_notes/${id}`)
+  }
+
+  async fetchReleaseNoteViewerContext(id: string, params?: { perPage?: number }) {
+    return this.client.get<ApiResponse<TReleaseNoteViewerContext>>(`/release_notes/${id}/viewer_context`, params)
   }
 
   async createReleaseNote(releaseNote: TReleaseNoteFormData) {

--- a/app/frontend/stores/notification-store.ts
+++ b/app/frontend/stores/notification-store.ts
@@ -212,7 +212,7 @@ export const NotificationStoreModel = types
         return [
           {
             text: t("ui.show"),
-            href: `/release-notes/${releaseNoteId}`,
+            href: `/release-notes#release-note-${releaseNoteId}`,
           },
         ]
       }

--- a/app/frontend/stores/release-note-store.ts
+++ b/app/frontend/stores/release-note-store.ts
@@ -10,6 +10,12 @@ import { TReleaseNoteFormData, TSearchParams } from "../types/types"
 import { urlForPath } from "../utils/utility-functions"
 
 const RELEASE_NOTE_ANCHOR_PREFIX = "release-note-"
+const RELEASE_NOTE_YEAR_COUNT = 10
+
+const recentReleaseNoteYears = () => {
+  const currentYear = new Date().getFullYear()
+  return Array.from({ length: RELEASE_NOTE_YEAR_COUNT }, (_, index) => currentYear - index)
+}
 
 export const ReleaseNoteStoreModel = types
   .compose(
@@ -73,15 +79,9 @@ export const ReleaseNoteStoreModel = types
   }))
   .actions((self) => ({
     initializeViewingYear: flow(function* () {
-      const response = yield self.environment.api.fetchReleaseNoteYears()
-
-      if (response.ok && response.data?.data?.length) {
-        const years = response.data.data
-        self.setAvailableYears(years)
-        self.setSelectedYear(years[0])
-      } else {
-        self.setAvailableYears([])
-      }
+      const years = recentReleaseNoteYears()
+      self.setAvailableYears(years)
+      self.setSelectedYear(years[0])
     }),
 
     searchReleaseNotes: flow(function* (opts?: {

--- a/app/frontend/stores/release-note-store.ts
+++ b/app/frontend/stores/release-note-store.ts
@@ -26,6 +26,7 @@ export const ReleaseNoteStoreModel = types
       selectedYear: types.optional(types.number, () => new Date().getFullYear()),
       viewingYearInitialized: types.optional(types.boolean, false),
       applyYearFilterInSearch: types.optional(types.boolean, false),
+      publishedOnlyInSearch: types.optional(types.boolean, false),
       availableYears: types.array(types.number),
     }),
     createSearchModel<EReleaseNoteSortFields>("searchReleaseNotes")
@@ -68,12 +69,16 @@ export const ReleaseNoteStoreModel = types
     setApplyYearFilterInSearch(apply: boolean) {
       self.applyYearFilterInSearch = apply
     },
+    setPublishedOnlyInSearch(apply: boolean) {
+      self.publishedOnlyInSearch = apply
+    },
     setAvailableYears(years: number[]) {
       self.availableYears = cast(years)
     },
     resetViewingState() {
       self.viewingYearInitialized = false
       self.applyYearFilterInSearch = false
+      self.publishedOnlyInSearch = false
       self.availableYears = cast([])
     },
   }))
@@ -103,6 +108,10 @@ export const ReleaseNoteStoreModel = types
 
       if (self.applyYearFilterInSearch && !opts?.skipYearFilter) {
         searchParams.year = self.selectedYear
+      }
+
+      if (self.publishedOnlyInSearch) {
+        searchParams.publishedOnly = true
       }
 
       const response = yield self.environment.api.fetchReleaseNotes(searchParams)
@@ -188,6 +197,7 @@ export const ReleaseNoteStoreModel = types
       self.resetViewingState()
       self.syncWithUrl()
       self.setApplyYearFilterInSearch(true)
+      self.setPublishedOnlyInSearch(true)
       yield self.initializeViewingYear()
 
       const releaseNoteId = self.parseReleaseNoteIdFromHash(hash)

--- a/app/frontend/stores/release-note-store.ts
+++ b/app/frontend/stores/release-note-store.ts
@@ -83,11 +83,11 @@ export const ReleaseNoteStoreModel = types
     },
   }))
   .actions((self) => ({
-    initializeViewingYear: flow(function* () {
+    initializeViewingYear() {
       const years = recentReleaseNoteYears()
       self.setAvailableYears(years)
       self.setSelectedYear(years[0])
-    }),
+    },
 
     searchReleaseNotes: flow(function* (opts?: {
       reset?: boolean
@@ -198,7 +198,7 @@ export const ReleaseNoteStoreModel = types
       self.syncWithUrl()
       self.setApplyYearFilterInSearch(true)
       self.setPublishedOnlyInSearch(true)
-      yield self.initializeViewingYear()
+      self.initializeViewingYear()
 
       const releaseNoteId = self.parseReleaseNoteIdFromHash(hash)
       if (releaseNoteId) {

--- a/app/frontend/stores/release-note-store.ts
+++ b/app/frontend/stores/release-note-store.ts
@@ -202,7 +202,13 @@ export const ReleaseNoteStoreModel = types
 
       const releaseNoteId = self.parseReleaseNoteIdFromHash(hash)
       if (releaseNoteId) {
-        yield self.ensureReleaseNoteVisibleInList(releaseNoteId)
+        const ensured = yield self.ensureReleaseNoteVisibleInList(releaseNoteId)
+        if (ensured) {
+          yield self.searchReleaseNotes({
+            page: self.currentPage,
+            countPerPage: self.countPerPage,
+          })
+        }
       }
 
       self.viewingYearInitialized = true

--- a/app/frontend/stores/release-note-store.ts
+++ b/app/frontend/stores/release-note-store.ts
@@ -7,6 +7,9 @@ import { withRootStore } from "../lib/with-root-store"
 import { IReleaseNote, ReleaseNoteModel } from "../models/release-note-model"
 import { EReleaseNoteSortFields } from "../types/enums"
 import { TReleaseNoteFormData, TSearchParams } from "../types/types"
+import { urlForPath } from "../utils/utility-functions"
+
+const RELEASE_NOTE_ANCHOR_PREFIX = "release-note-"
 
 export const ReleaseNoteStoreModel = types
   .compose(
@@ -14,15 +17,33 @@ export const ReleaseNoteStoreModel = types
       releaseNoteMap: types.map(ReleaseNoteModel),
       tableReleaseNotes: types.array(types.reference(ReleaseNoteModel)),
       currentReleaseNote: types.maybeNull(types.reference(ReleaseNoteModel)),
+      selectedYear: types.optional(types.number, () => new Date().getFullYear()),
+      viewingYearInitialized: types.optional(types.boolean, false),
+      applyYearFilterInSearch: types.optional(types.boolean, false),
+      availableYears: types.array(types.number),
     }),
     createSearchModel<EReleaseNoteSortFields>("searchReleaseNotes")
   )
   .extend(withEnvironment())
   .extend(withRootStore())
   .extend(withMerge())
-  .views(() => ({
+  .views((self) => ({
     getSortColumnHeader(field: EReleaseNoteSortFields) {
       return t(`releaseNote.columns.${field}`)
+    },
+    getReleaseNoteAnchorId(id: string) {
+      return `${RELEASE_NOTE_ANCHOR_PREFIX}${id}`
+    },
+    getReleaseNoteShareUrl(id: string) {
+      return urlForPath(`/release-notes#${RELEASE_NOTE_ANCHOR_PREFIX}${id}`)
+    },
+    parseReleaseNoteIdFromHash(hash: string) {
+      const anchorId = hash.replace("#", "")
+      if (!anchorId.startsWith(RELEASE_NOTE_ANCHOR_PREFIX)) return null
+      return anchorId.slice(RELEASE_NOTE_ANCHOR_PREFIX.length)
+    },
+    get viewingReleaseNotes(): IReleaseNote[] {
+      return self.tableReleaseNotes.filter((note): note is IReleaseNote => !!note)
     },
   }))
   .actions((self) => ({
@@ -35,18 +56,53 @@ export const ReleaseNoteStoreModel = types
     resetCurrentReleaseNote() {
       self.currentReleaseNote = null
     },
+    setSelectedYear(year: number) {
+      self.selectedYear = year
+    },
+    setApplyYearFilterInSearch(apply: boolean) {
+      self.applyYearFilterInSearch = apply
+    },
+    setAvailableYears(years: number[]) {
+      self.availableYears = cast(years)
+    },
+    resetViewingState() {
+      self.viewingYearInitialized = false
+      self.applyYearFilterInSearch = false
+      self.availableYears = cast([])
+    },
   }))
   .actions((self) => ({
-    searchReleaseNotes: flow(function* (opts?: { reset?: boolean; page?: number; countPerPage?: number }) {
+    initializeViewingYear: flow(function* () {
+      const response = yield self.environment.api.fetchReleaseNoteYears()
+
+      if (response.ok && response.data?.data?.length) {
+        const years = response.data.data
+        self.setAvailableYears(years)
+        self.setSelectedYear(years[0])
+      } else {
+        self.setAvailableYears([])
+      }
+    }),
+
+    searchReleaseNotes: flow(function* (opts?: {
+      reset?: boolean
+      page?: number
+      countPerPage?: number
+      skipYearFilter?: boolean
+    }) {
       if (opts?.reset) {
         self.resetPages()
       }
 
-      const searchParams: TSearchParams<EReleaseNoteSortFields> = {
+      const searchParams: TSearchParams<EReleaseNoteSortFields> & { year?: number } = {
         query: self.query,
         sort: self.sort,
         page: opts?.page ?? self.currentPage,
         perPage: opts?.countPerPage ?? self.countPerPage,
+      }
+
+      if (self.applyYearFilterInSearch && !opts?.skipYearFilter) {
+        searchParams.year = self.selectedYear
       }
 
       const response = yield self.environment.api.fetchReleaseNotes(searchParams)
@@ -99,6 +155,47 @@ export const ReleaseNoteStoreModel = types
       }
       console.error("Failed to publish release note:", response.problem, response.data)
       return { ok: false as const, error: response.data?.errors || response.problem }
+    }),
+  }))
+  .actions((self) => ({
+    selectViewingYear: flow(function* (year: number) {
+      self.setSelectedYear(year)
+      yield self.searchReleaseNotes({ reset: true, page: 1 })
+    }),
+
+    ensureReleaseNoteVisibleInList: flow(function* (releaseNoteId: string) {
+      const contextResponse = yield self.environment.api.fetchReleaseNoteViewerContext(releaseNoteId, {
+        perPage: self.countPerPage,
+      })
+
+      if (!contextResponse.ok || !contextResponse.data?.data) {
+        return false
+      }
+
+      const { year, page } = contextResponse.data.data
+
+      if (year !== self.selectedYear) {
+        self.setSelectedYear(year)
+      }
+
+      self.setCurrentPage(page)
+
+      return true
+    }),
+  }))
+  .actions((self) => ({
+    initializeViewingPage: flow(function* (hash = "") {
+      self.resetViewingState()
+      self.syncWithUrl()
+      self.setApplyYearFilterInSearch(true)
+      yield self.initializeViewingYear()
+
+      const releaseNoteId = self.parseReleaseNoteIdFromHash(hash)
+      if (releaseNoteId) {
+        yield self.ensureReleaseNoteVisibleInList(releaseNoteId)
+      }
+
+      self.viewingYearInitialized = true
     }),
   }))
 

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -132,6 +132,7 @@ export type TSearchParams<IModelSortFields, IModelFilterFields = {}> = {
   page?: number
   perPage?: number
   showArchived?: boolean
+  publishedOnly?: boolean
   filters?: IModelFilterFields
   mode?: "list" | "kanban"
   perColumn?: number

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -742,6 +742,12 @@ export type TReleaseNoteFormData = {
   issues: string
 }
 
+export type TReleaseNoteViewerContext = {
+  releaseNoteId: string
+  year: number
+  page: number
+}
+
 export interface ICopyRequirementTemplateFormData extends Partial<TCreateRequirementTemplateFormData> {
   id?: string
 }

--- a/app/models/release_note.rb
+++ b/app/models/release_note.rb
@@ -6,6 +6,8 @@ class ReleaseNote < ApplicationRecord
     /\A(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?\z/
   enum :status, { draft: 0, published: 1 }, default: :draft
 
+  searchkick
+
   url_validatable :release_notes_url
   validates :version,
             presence: true,

--- a/app/models/release_note.rb
+++ b/app/models/release_note.rb
@@ -19,6 +19,19 @@ class ReleaseNote < ApplicationRecord
 
   scope :published, -> { where(status: :published) }
 
+  def search_data
+    {
+      id: id,
+      version: version,
+      content: content,
+      release_notes_url: release_notes_url,
+      release_date: release_date,
+      status: status,
+      created_at: created_at,
+      updated_at: updated_at
+    }
+  end
+
   def publish_event_notification_data
     {
       "id" => SecureRandom.uuid,

--- a/app/policies/release_note_policy.rb
+++ b/app/policies/release_note_policy.rb
@@ -16,12 +16,16 @@ class ReleaseNotePolicy < ApplicationPolicy
   end
 
   def show?
-    true
+    user&.super_admin?
+  end
+
+  def viewer_context?
+    record.published? || user&.super_admin?
   end
 
   class Scope < Scope
     def resolve
-      return scope.all if user.super_admin?
+      return scope.all if user&.super_admin?
 
       scope.published
     end

--- a/app/services/release_note_viewer_context.rb
+++ b/app/services/release_note_viewer_context.rb
@@ -1,0 +1,48 @@
+# Computes list-view pagination context for a release note so clients can open
+# /release-notes#release-note-{id} on the correct year and page.
+class ReleaseNoteViewerContext
+  def self.call(release_note:, scope:, per_page: nil)
+    new(release_note:, scope:, per_page:).call
+  end
+
+  def initialize(release_note:, scope:, per_page: nil)
+    @release_note = release_note
+    @scope = scope
+    @per_page = per_page
+  end
+
+  def call
+    year = @release_note.release_date.year
+    start_date = Date.new(year, 1, 1)
+    end_date = Date.new(year, 12, 31)
+
+    relation =
+      @scope.where(release_date: start_date..end_date).order(
+        release_date: :desc,
+        id: :desc
+      )
+
+    ahead_count =
+      relation.where(
+        "release_date > ? OR (release_date = ? AND id > ?)",
+        @release_note.release_date,
+        @release_note.release_date,
+        @release_note.id
+      ).count
+
+    {
+      release_note_id: @release_note.id,
+      year: year,
+      page: (ahead_count / resolved_per_page) + 1
+    }
+  end
+
+  private
+
+  def resolved_per_page
+    requested_per_page = @per_page.to_i
+    return requested_per_page if requested_per_page.positive?
+
+    Kaminari.config.default_per_page
+  end
+end

--- a/app/services/release_note_viewer_context.rb
+++ b/app/services/release_note_viewer_context.rb
@@ -19,15 +19,16 @@ class ReleaseNoteViewerContext
     relation =
       @scope.where(release_date: start_date..end_date).order(
         release_date: :desc,
-        id: :desc
+        created_at: :desc
       )
 
     ahead_count =
       relation.where(
-        "release_date > ? OR (release_date = ? AND id > ?)",
+        # Use created_at to break ties when release_date (including time)is the same
+        "release_date > ? OR (release_date = ? AND created_at > ?)",
         @release_note.release_date,
         @release_note.release_date,
-        @release_note.id
+        @release_note.created_at
       ).count
 
     {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -393,7 +393,6 @@ Rails.application.routes.draw do
     resources :digital_seal_validator, only: [:create]
 
     resources :release_notes, only: %i[index show create update] do
-      get "years", on: :collection, to: "release_notes#years"
       get "viewer_context", on: :member, to: "release_notes#viewer_context"
       patch "publish", on: :member, to: "release_notes#publish"
       post "search", on: :collection, to: "release_notes#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -393,6 +393,8 @@ Rails.application.routes.draw do
     resources :digital_seal_validator, only: [:create]
 
     resources :release_notes, only: %i[index show create update] do
+      get "years", on: :collection, to: "release_notes#years"
+      get "viewer_context", on: :member, to: "release_notes#viewer_context"
       patch "publish", on: :member, to: "release_notes#publish"
       post "search", on: :collection, to: "release_notes#index"
     end

--- a/spec/requests/release_notes_spec.rb
+++ b/spec/requests/release_notes_spec.rb
@@ -211,6 +211,15 @@ RSpec.describe "ReleaseNotes", type: :request do
       end
     end
 
+    it "returns only published release notes when requested by super admins" do
+      sign_in super_admin
+      get release_notes_path, params: { published_only: true }
+
+      expect(response).to have_http_status(:success)
+      expect(subject).to have_attributes(length: 1)
+      expect(subject.first["id"]).to eq(earliest_release_note.id)
+    end
+
     it "returns published release notes for non-super admins" do
       sign_in submitter
       get release_notes_path

--- a/spec/requests/release_notes_spec.rb
+++ b/spec/requests/release_notes_spec.rb
@@ -156,6 +156,40 @@ RSpec.describe "ReleaseNotes", type: :request do
     it_behaves_like A_NOT_FOUND_RESPONSE, publish_with_payload
   end
 
+  describe "#years" do
+    let!(:note_2024) do
+      create(
+        :release_note,
+        status: :published,
+        release_date: Date.new(2024, 6, 1)
+      )
+    end
+    let!(:note_2025) do
+      create(
+        :release_note,
+        status: :published,
+        release_date: Date.new(2025, 3, 1)
+      )
+    end
+    let!(:draft_note_2026) do
+      create(:release_note, status: :draft, release_date: Date.new(2026, 1, 1))
+    end
+
+    it "returns distinct release years for published notes only" do
+      get years_release_notes_path
+
+      expect(response).to have_http_status(:success)
+      expect(json_response.fetch("data")).to eq([2025, 2024])
+    end
+
+    it "is available to unauthenticated users" do
+      get years_release_notes_path
+
+      expect(response).to have_http_status(:success)
+      expect(json_response.fetch("data")).to include(2024, 2025)
+    end
+  end
+
   describe "#index" do
     let!(:earliest_release_note) do
       create(
@@ -195,6 +229,14 @@ RSpec.describe "ReleaseNotes", type: :request do
       expect(response).to have_http_status(:success)
       expect(subject).to have_attributes(length: 1)
       expect(subject).to all(include("issues", "content"))
+    end
+
+    it "returns published release notes for unauthenticated users" do
+      get release_notes_path
+
+      expect(response).to have_http_status(:success)
+      expect(subject).to have_attributes(length: 1)
+      expect(subject.first["id"]).to eq(earliest_release_note.id)
     end
 
     it "paginates the response" do
@@ -239,14 +281,97 @@ RSpec.describe "ReleaseNotes", type: :request do
       expect(subject).to include("version" => @release_note.version)
     end
 
-    it "returns an error if a non-admin tries to access a draft release note" do
+    it "returns an error if a non-admin tries to access a release note" do
       sign_in submitter
-      get release_note_path(create(:release_note).id)
+      get release_note_path(create(:release_note, status: :published).id)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "requires authentication" do
+      published = create(:release_note, status: :published)
+      get release_note_path(published.id)
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it_behaves_like A_NOT_FOUND_RESPONSE,
+                    ->(payload) { get release_note_path(payload[:id]) }
+  end
+
+  describe "#viewer_context" do
+    let!(:newest_in_2025) do
+      create(
+        :release_note,
+        status: :published,
+        release_date: Date.new(2025, 6, 1)
+      )
+    end
+    let!(:middle_in_2025) do
+      create(
+        :release_note,
+        status: :published,
+        release_date: Date.new(2025, 5, 1)
+      )
+    end
+    let!(:oldest_in_2025) do
+      create(
+        :release_note,
+        status: :published,
+        release_date: Date.new(2025, 4, 1)
+      )
+    end
+    let!(:published_2024) do
+      create(
+        :release_note,
+        status: :published,
+        release_date: Date.new(2024, 12, 1)
+      )
+    end
+    let!(:draft_in_2025) do
+      create(:release_note, status: :draft, release_date: Date.new(2025, 3, 1))
+    end
+
+    it "returns year and page for a published note" do
+      get viewer_context_release_note_path(oldest_in_2025.id),
+          params: {
+            per_page: 2
+          }
+
+      expect(response).to have_http_status(:success)
+      expect(json_response.fetch("data")).to include(
+        "release_note_id" => oldest_in_2025.id,
+        "year" => 2025,
+        "page" => 2
+      )
+    end
+
+    it "returns page 1 for the newest note in a year" do
+      get viewer_context_release_note_path(newest_in_2025.id)
+
+      expect(json_response.fetch("data")).to include("page" => 1)
+    end
+
+    it "is available to unauthenticated users for published notes" do
+      get viewer_context_release_note_path(middle_in_2025.id)
+
+      expect(response).to have_http_status(:success)
+      expect(json_response.fetch("data")).to include(
+        "release_note_id" => middle_in_2025.id,
+        "year" => 2025,
+        "page" => 1
+      )
+    end
+
+    it "returns not found for draft notes when unauthenticated" do
+      get viewer_context_release_note_path(draft_in_2025.id)
 
       expect(response).to have_http_status(:not_found)
     end
 
     it_behaves_like A_NOT_FOUND_RESPONSE,
-                    ->(payload) { get release_note_path(payload[:id]) }
+                    ->(payload) do
+                      get viewer_context_release_note_path(payload[:id])
+                    end
   end
 end

--- a/spec/requests/release_notes_spec.rb
+++ b/spec/requests/release_notes_spec.rb
@@ -152,42 +152,29 @@ RSpec.describe "ReleaseNotes", type: :request do
       expect(response).to have_http_status(:success)
     end
 
+    it "updates an already published release note without publishing again" do
+      setup
+      @release_note.update!(status: :published)
+      expect(NotificationService).not_to receive(
+        :publish_release_note_publish_event
+      )
+
+      patch publish_release_note_path(@release_note.id),
+            params: {
+              release_note: {
+                content: params[:content]
+              }
+            }
+
+      expect(response).to have_http_status(:success)
+      expect(subject).to include(
+        "status" => "published",
+        "content" => params[:content]
+      )
+    end
+
     it_behaves_like AN_INVALID_PAYLOAD_RESPONSE, publish_with_payload
     it_behaves_like A_NOT_FOUND_RESPONSE, publish_with_payload
-  end
-
-  describe "#years" do
-    let!(:note_2024) do
-      create(
-        :release_note,
-        status: :published,
-        release_date: Date.new(2024, 6, 1)
-      )
-    end
-    let!(:note_2025) do
-      create(
-        :release_note,
-        status: :published,
-        release_date: Date.new(2025, 3, 1)
-      )
-    end
-    let!(:draft_note_2026) do
-      create(:release_note, status: :draft, release_date: Date.new(2026, 1, 1))
-    end
-
-    it "returns distinct release years for published notes only" do
-      get years_release_notes_path
-
-      expect(response).to have_http_status(:success)
-      expect(json_response.fetch("data")).to eq([2025, 2024])
-    end
-
-    it "is available to unauthenticated users" do
-      get years_release_notes_path
-
-      expect(response).to have_http_status(:success)
-      expect(json_response.fetch("data")).to include(2024, 2025)
-    end
   end
 
   describe "#index" do
@@ -209,6 +196,8 @@ RSpec.describe "ReleaseNotes", type: :request do
         updated_at: 1.days.ago
       )
     end
+
+    before { ReleaseNote.reindex }
 
     it "returns all release notes for super admins" do
       sign_in super_admin
@@ -245,6 +234,23 @@ RSpec.describe "ReleaseNotes", type: :request do
 
       expect(response).to have_http_status(:success)
       expect(subject).to have_attributes(length: 1)
+    end
+
+    it "filters release notes by year" do
+      older_release_note =
+        create(
+          :release_note,
+          status: :published,
+          version: "0.9.0",
+          release_date: Date.new(2024, 12, 31)
+        )
+      ReleaseNote.reindex
+
+      sign_in super_admin
+      get release_notes_path, params: { year: 2024 }
+
+      expect(response).to have_http_status(:success)
+      expect(subject.pluck("id")).to contain_exactly(older_release_note.id)
     end
 
     describe "sorts", :aggregate_failures do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,6 +112,7 @@ RSpec.configure do |config|
     Contact.reindex
     PreCheck.reindex
     OverheatingCode.reindex
+    ReleaseNote.reindex
 
     # and disable callbacks
     Searchkick.disable_callbacks


### PR DESCRIPTION
## 📋 Description

This PR introduces release notes end-to-end and adds the public historical navigation experience for HUB-4214. Super admins can create, edit, publish, and manage release notes, while all users, including unauthenticated visitors, can view published release notes at `/release-notes`, browse by year, paginate through historical entries, and open shareable links that scroll to and highlight a specific release note.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                        |
| -------------------- | ----------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-4214](https://hous-bssb.atlassian.net/browse/HUB-4214) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                         |
| 📑 Design / Figma    | <!-- Paste link -->                                         |
| 📚 Documentation     | <!-- Paste link -->                                         |

---

## ✨ Features / Changes Introduced

- Adds the release note data model, API endpoints, policies, blueprints, search, sorting, pagination, year filtering, and viewer-context support.
- Adds super-admin release note management screens for listing, creating, editing, saving drafts, and publishing release notes.
- Adds the public `/release-notes` screen with year navigation, paginated historical release notes, rich content rendering, GitHub release links, issue sections, and a report-issue mail link.
- Adds shareable release note URLs using `#release-note-{id}` fragments, including logic to load the correct year/page and highlight the linked entry.
- Adds in-app publish notifications for opted-in users, with notification links that deep-link to the published release note.
- Adds request/model/service specs for release note permissions, public access, filtering, pagination context, publishing, and notification behavior.

---

## 🧪 Steps to QA

1. As a super admin, navigate to `/configuration-management/release-notes` and verify the release notes management list loads with pagination and status badges.
2. Create a new release note, save it as a draft, reopen it, edit it, and then publish it.
3. Confirm published release notes appear on `/release-notes`, while draft release notes are not visible to non-super-admin or unauthenticated users.
4. On `/release-notes`, verify the year navigation filters entries by release year and pagination/per-page controls work within the selected year.
5. Copy a release note link, open it in a new session or signed-out browser, and verify the page selects the correct year/page, scrolls to the release note, and highlights it.
6. Verify a release note publish notification appears for opted-in users and that clicking the notification opens the correct release note on `/release-notes`.

**Expected Behaviour:

[HUB-4214]: https://hous-bssb.atlassian.net/browse/HUB-4214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ