### PR TITLE
Vibe POC for reusable questions

### DIFF
--- a/app/blueprints/requirement_blueprint.rb
+++ b/app/blueprints/requirement_blueprint.rb
@@ -3,10 +3,7 @@
 class RequirementBlueprint < Blueprinter::Base
   identifier :id
   fields :requirement_code,
-         :label,
-         :input_type,
-         :hint,
-         :instructions,
+         :requirement_question_id,
          :required,
          :related_content,
          :required_for_in_person_hint,
@@ -15,18 +12,34 @@ class RequirementBlueprint < Blueprinter::Base
          :updated_at,
          :created_at
 
+  association :requirement_question, blueprint: RequirementQuestionBlueprint
+
+  field :label do |requirement|
+    requirement.effective_label
+  end
+
+  field :input_type do |requirement|
+    requirement.effective_input_type
+  end
+
+  field :hint do |requirement|
+    requirement.effective_hint
+  end
+
+  field :instructions do |requirement|
+    requirement.effective_instructions
+  end
+
   field :form_json do |requirement|
     requirement.to_form_json
   end
 
   field :input_options do |requirement|
-    unless requirement
-             .input_options
-             .dig("computed_compliance", "options_map")
-             .is_a?(Hash)
-      requirement.input_options
+    input_options = requirement.effective_input_options
+    unless input_options.dig("computed_compliance", "options_map").is_a?(Hash)
+      input_options
     else
-      input_options_dup = requirement.input_options.deep_dup
+      input_options_dup = input_options.deep_dup
 
       # this needs to be done to prevent camelizing the computed compliance options map keys
       # as conversion results in unexpected behaviour

--- a/app/blueprints/requirement_question_blueprint.rb
+++ b/app/blueprints/requirement_question_blueprint.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class RequirementQuestionBlueprint < Blueprinter::Base
+  identifier :id
+
+  fields :requirement_code,
+         :label,
+         :input_type,
+         :hint,
+         :instructions,
+         :shared,
+         :discarded_at,
+         :created_at,
+         :updated_at
+
+  field :input_options do |requirement_question|
+    input_options = requirement_question.input_options
+    unless input_options.dig("computed_compliance", "options_map").is_a?(Hash)
+      input_options
+    else
+      input_options_dup = input_options.deep_dup
+      input_options_dup["computed_compliance"][
+        "options_map"
+      ] = input_options_dup["computed_compliance"][
+        "options_map"
+      ].transform_keys { |key| "compliance-options-map-prefix-#{key}" }
+      input_options_dup
+    end
+  end
+
+  field :usage_count do |requirement_question|
+    requirement_question.usage_count
+  end
+end

--- a/app/controllers/api/requirement_blocks_controller.rb
+++ b/app/controllers/api/requirement_blocks_controller.rb
@@ -117,6 +117,7 @@ class Api::RequirementBlocksController < Api::ApplicationController
       ],
       requirements_attributes: [
         :id,
+        :requirement_question_id,
         :requirement_code,
         :label,
         :input_type,

--- a/app/controllers/api/requirement_questions_controller.rb
+++ b/app/controllers/api/requirement_questions_controller.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+class Api::RequirementQuestionsController < Api::ApplicationController
+  before_action :set_requirement_question, only: %i[show update destroy restore]
+  skip_after_action :verify_policy_scoped, only: [:index]
+
+  def index
+    authorize RequirementQuestion
+
+    questions =
+      policy_scope(RequirementQuestion).includes(:requirements).where(
+        shared: shared_filter
+      )
+    questions = questions.where(discarded_at: nil) unless show_archived?
+    questions = questions.where("label ILIKE ?", "%#{query}%") if query.present?
+    questions = questions.order(updated_at: :desc)
+
+    paginated_questions =
+      if params[:page].present?
+        questions.page(params[:page]).per(per_page)
+      else
+        questions
+      end
+
+    render_success paginated_questions,
+                   nil,
+                   {
+                     meta:
+                       (
+                         if params[:page].present?
+                           page_meta(paginated_questions)
+                         else
+                           {}
+                         end
+                       ),
+                     blueprint: RequirementQuestionBlueprint
+                   }
+  end
+
+  def show
+    authorize @requirement_question
+
+    render_success @requirement_question,
+                   nil,
+                   { blueprint: RequirementQuestionBlueprint }
+  end
+
+  def create
+    @requirement_question =
+      RequirementQuestion.new(requirement_question_params.merge(shared: true))
+    authorize @requirement_question
+
+    if @requirement_question.save
+      render_success @requirement_question,
+                     "requirement_question.create_success",
+                     { blueprint: RequirementQuestionBlueprint }
+    else
+      render_error "requirement_question.create_error",
+                   message_opts: {
+                     error_message:
+                       @requirement_question.errors.full_messages.join(", ")
+                   }
+    end
+  end
+
+  def update
+    authorize @requirement_question
+
+    if @requirement_question.update(requirement_question_params)
+      render_success @requirement_question,
+                     nil,
+                     { blueprint: RequirementQuestionBlueprint }
+    else
+      render_error "requirement_question.update_error",
+                   message_opts: {
+                     error_message:
+                       @requirement_question.errors.full_messages.join(", ")
+                   }
+    end
+  end
+
+  def destroy
+    authorize @requirement_question
+
+    if @requirement_question.discard
+      render_success @requirement_question,
+                     "requirement_question.destroy_success",
+                     { blueprint: RequirementQuestionBlueprint }
+    else
+      render_error "requirement_question.destroy_error",
+                   message_opts: {
+                     error_message:
+                       @requirement_question.errors.full_messages.join(", ")
+                   }
+    end
+  end
+
+  def restore
+    authorize @requirement_question
+
+    if @requirement_question.undiscard
+      render_success @requirement_question,
+                     "requirement_question.restore_success",
+                     { blueprint: RequirementQuestionBlueprint }
+    else
+      render_error "requirement_question.restore_error",
+                   message_opts: {
+                     error_message:
+                       @requirement_question.errors.full_messages.join(", ")
+                   }
+    end
+  end
+
+  private
+
+  def set_requirement_question
+    @requirement_question = RequirementQuestion.find(params[:id])
+  end
+
+  def requirement_question_params
+    params.require(:requirement_question).permit(
+      :requirement_code,
+      :label,
+      :input_type,
+      :hint,
+      :instructions,
+      :shared,
+      input_options: [
+        :number_unit,
+        :can_add_multiple_contacts,
+        :energy_step_code,
+        :multiple,
+        { headers: %i[first_column a quantity ab] },
+        { rows: %i[name a] },
+        value_options: [%i[value label]],
+        computed_compliance: [:value, :module, options_map: {}],
+        data_validation: %i[operation value error_message]
+      ]
+    )
+  end
+
+  def query
+    params[:query].presence
+  end
+
+  def show_archived?
+    ActiveModel::Type::Boolean.new.cast(params[:show_archived] || false)
+  end
+
+  def shared_filter
+    if params.key?(:shared)
+      ActiveModel::Type::Boolean.new.cast(params[:shared])
+    else
+      true
+    end
+  end
+
+  def per_page
+    params[:per_page] || Kaminari.config.default_per_page
+  end
+end

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react"
-import { CaretDown, Warning, X } from "@phosphor-icons/react"
+import { CaretDown, LinkBreak, ShareNetwork, Warning, X } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React, { useEffect } from "react"
 import { useTranslation } from "react-i18next"
@@ -26,6 +26,11 @@ export interface IRequirementOptionsMenu {
   index: number
   disabledOptions?: Array<"remove" | "conditional">
   requirementType?: ERequirementType
+  onMakeReusable?: () => void
+  onUpdateSharedQuestion?: () => void
+  onDetachSharedQuestion?: () => void
+  isSharedQuestion?: boolean
+  canMakeReusable?: boolean
 }
 
 export const OptionsMenu = observer(function OptionsMenu({
@@ -35,6 +40,11 @@ export const OptionsMenu = observer(function OptionsMenu({
   emitOpenState,
   index,
   requirementType,
+  onMakeReusable,
+  onUpdateSharedQuestion,
+  onDetachSharedQuestion,
+  isSharedQuestion,
+  canMakeReusable,
 }: IRequirementOptionsMenu) {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -84,6 +94,31 @@ export const OptionsMenu = observer(function OptionsMenu({
           }}
         />
         <ComputedComplianceSetupModal requirementIndex={index} />
+
+        <MenuDivider />
+        {isSharedQuestion ? (
+          <>
+            <MenuItem color={"text.primary"} onClick={onUpdateSharedQuestion}>
+              <HStack spacing={2} fontSize={"sm"}>
+                <ShareNetwork />
+                <Text as={"span"}>{t("requirementsLibrary.sharedQuestions.updateSharedQuestion")}</Text>
+              </HStack>
+            </MenuItem>
+            <MenuItem color={"text.primary"} onClick={onDetachSharedQuestion}>
+              <HStack spacing={2} fontSize={"sm"}>
+                <LinkBreak />
+                <Text as={"span"}>{t("requirementsLibrary.sharedQuestions.detach")}</Text>
+              </HStack>
+            </MenuItem>
+          </>
+        ) : (
+          <MenuItem color={"text.primary"} onClick={onMakeReusable} isDisabled={!canMakeReusable}>
+            <HStack spacing={2} fontSize={"sm"}>
+              <ShareNetwork />
+              <Text as={"span"}>{t("requirementsLibrary.sharedQuestions.makeReusable")}</Text>
+            </HStack>
+          </MenuItem>
+        )}
 
         <MenuDivider />
         <MenuItem color={"semantic.error"} onClick={onRemove} isDisabled={disabledOptions.includes("remove")}>

--- a/app/frontend/components/domains/requirements-library/requirement-questions-library-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-questions-library-drawer.tsx
@@ -1,0 +1,65 @@
+import {
+  Button,
+  ButtonProps,
+  Drawer,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerOverlay,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { LinkSimple } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React, { Ref, useRef } from "react"
+import { useTranslation } from "react-i18next"
+import { IRequirementQuestion } from "../../../models/requirement-question"
+import { RequirementQuestionsTable } from "./requirement-questions-table"
+
+interface IProps {
+  defaultButtonProps?: Partial<ButtonProps>
+  renderTriggerButton?: (props: ButtonProps & { ref: Ref<HTMLElement> }) => JSX.Element
+  onUse?: (requirementQuestion: IRequirementQuestion, closeDrawer?: () => void) => void
+}
+
+export const RequirementQuestionsLibraryDrawer = observer(function RequirementQuestionsLibraryDrawer({
+  defaultButtonProps,
+  renderTriggerButton,
+  onUse,
+}: IProps) {
+  const { t } = useTranslation()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const btnRef = useRef<HTMLButtonElement>()
+
+  return (
+    <>
+      {renderTriggerButton?.({ onClick: onOpen, ref: btnRef }) ?? (
+        <Button
+          leftIcon={<LinkSimple size={12} />}
+          variant={"secondary"}
+          onClick={onOpen}
+          aria-label={"use shared question"}
+          {...defaultButtonProps}
+        >
+          {t("requirementsLibrary.sharedQuestions.useSharedQuestion")}
+        </Button>
+      )}
+      <Drawer
+        id="add-shared-question-drawer"
+        isOpen={isOpen}
+        onClose={onClose}
+        finalFocusRef={btnRef}
+        placement={"right"}
+      >
+        <DrawerOverlay />
+        <DrawerContent display={"flex"} flexDir={"column"} maxW={"80%"} h={"full"} p={8}>
+          <DrawerCloseButton fontSize={"xs"} />
+          <RequirementQuestionsTable
+            h={"calc(100% - 120px)"}
+            flex={1}
+            p={0}
+            onUse={(question) => onUse?.(question, onClose)}
+          />
+        </DrawerContent>
+      </Drawer>
+    </>
+  )
+})

--- a/app/frontend/components/domains/requirements-library/requirement-questions-table.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-questions-table.tsx
@@ -1,0 +1,98 @@
+import { Box, Button, Flex, StackProps, Text, VStack } from "@chakra-ui/react"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { useSearch } from "../../../hooks/use-search"
+import { ISearch } from "../../../lib/create-search-model"
+import { IRequirementQuestion } from "../../../models/requirement-question"
+import { useMst } from "../../../setup/root"
+import { Paginator } from "../../shared/base/inputs/paginator"
+import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
+import { SharedSpinner } from "../../shared/base/shared-spinner"
+import { SearchGrid } from "../../shared/grid/search-grid"
+import { SearchGridItem } from "../../shared/grid/search-grid-item"
+import { RequirementTypeTag } from "../../shared/requirement-type-tag"
+
+interface IProps extends Partial<StackProps> {
+  onUse?: (question: IRequirementQuestion) => void
+}
+
+const ROW_CLASS_NAME = "requirement-questions-grid-row"
+
+export const RequirementQuestionsTable = observer(function RequirementQuestionsTable({
+  onUse,
+  ...containerProps
+}: IProps) {
+  const { t } = useTranslation()
+  const { requirementQuestionStore } = useMst()
+  const searchModel = requirementQuestionStore
+  const {
+    tableRequirementQuestions,
+    currentPage,
+    totalPages,
+    totalCount,
+    countPerPage,
+    handleCountPerPageChange,
+    handlePageChange,
+    isSearching,
+    showArchived,
+  } = searchModel
+
+  useSearch(searchModel as ISearch, [showArchived])
+
+  return (
+    <VStack as={"article"} spacing={5} {...containerProps}>
+      <SearchGrid gridRowClassName={ROW_CLASS_NAME} templateColumns="repeat(4, 1fr)" pos={"relative"}>
+        <SearchGridItem fontWeight={700}>{t("requirementsLibrary.sharedQuestions.question")}</SearchGridItem>
+        <SearchGridItem fontWeight={700}>{t("requirementsLibrary.sharedQuestions.type")}</SearchGridItem>
+        <SearchGridItem fontWeight={700}>{t("requirementsLibrary.sharedQuestions.usedBy")}</SearchGridItem>
+        <SearchGridItem fontWeight={700}>{t("requirementsLibrary.sharedQuestions.actions")}</SearchGridItem>
+
+        {isSearching ? (
+          <Flex py={50} gridColumn={"span 4"}>
+            <SharedSpinner />
+          </Flex>
+        ) : (
+          tableRequirementQuestions.map((question) => (
+            <Box key={question.id} className={ROW_CLASS_NAME} role={"row"} display={"contents"}>
+              <SearchGridItem minW="250px">
+                <Flex direction="column" overflow="hidden">
+                  <Text as={"span"} fontWeight={700} noOfLines={2} title={question.label}>
+                    {question.label}
+                  </Text>
+                  <Text as={"span"} color={"text.secondary"} fontSize={"xs"} noOfLines={1}>
+                    {question.requirementCode}
+                  </Text>
+                </Flex>
+              </SearchGridItem>
+              <SearchGridItem>
+                <RequirementTypeTag type={question.inputType} />
+              </SearchGridItem>
+              <SearchGridItem>{question.usageCount}</SearchGridItem>
+              <SearchGridItem justifyContent={"center"}>
+                <Button size="sm" variant="primary" onClick={() => onUse?.(question)}>
+                  {t("ui.use")}
+                </Button>
+              </SearchGridItem>
+            </Box>
+          ))
+        )}
+      </SearchGrid>
+      <Flex w={"full"} justifyContent={"space-between"}>
+        <PerPageSelect
+          handleCountPerPageChange={handleCountPerPageChange}
+          countPerPage={countPerPage}
+          totalCount={totalCount}
+        />
+        <Paginator
+          current={currentPage}
+          total={totalCount}
+          totalPages={totalPages}
+          pageSize={countPerPage}
+          handlePageChange={handlePageChange}
+          showLessItems={true}
+        />
+      </Flex>
+    </VStack>
+  )
+})

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
@@ -23,6 +23,11 @@ interface IProps {
   computedCompliance?: TComputedCompliance
   dataValidation?: IDataValidation
   index: number
+  onMakeReusable?: IRequirementOptionsMenu["onMakeReusable"]
+  onUpdateSharedQuestion?: IRequirementOptionsMenu["onUpdateSharedQuestion"]
+  onDetachSharedQuestion?: IRequirementOptionsMenu["onDetachSharedQuestion"]
+  isSharedQuestion?: boolean
+  canMakeReusable?: boolean
 }
 
 export function FieldControlsHeader({
@@ -37,6 +42,11 @@ export function FieldControlsHeader({
   onRemove,
   index,
   requirementCode,
+  onMakeReusable,
+  onUpdateSharedQuestion,
+  onDetachSharedQuestion,
+  isSharedQuestion,
+  canMakeReusable,
 }: IProps) {
   const { t } = useTranslation()
 
@@ -53,6 +63,11 @@ export function FieldControlsHeader({
             disabledOptions={disabledMenuOptions}
             index={index}
             requirementType={requirementType}
+            onMakeReusable={onMakeReusable}
+            onUpdateSharedQuestion={onUpdateSharedQuestion}
+            onDetachSharedQuestion={onDetachSharedQuestion}
+            isSharedQuestion={isSharedQuestion}
+            canMakeReusable={canMakeReusable}
           />
         )}
       <HStack className={"requirement-edit-controls-container"} p={2}>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -13,6 +13,7 @@ import { CustomMessageBox } from "../../../shared/base/custom-message-box"
 import { EditableInputWithControls } from "../../../shared/editable-input-with-controls"
 import { EditorWithPreview } from "../../../shared/editor/custom-extensions/editor-with-preview"
 import { FieldsSetupDrawer } from "../fields-setup-drawer"
+import { RequirementQuestionsLibraryDrawer } from "../requirement-questions-library-drawer"
 import { IRequirementBlockForm } from "./index"
 import { ReorderList } from "./reorder-list"
 import { RequirementFieldRow } from "./requirement-field-row"
@@ -53,12 +54,13 @@ export const FieldsSetup = observer(function FieldsSetup({
     setRequirementIdsToEdit((pastState) => ({ ...pastState, [requirementId]: !pastState[requirementId] }))
   }
 
-  const { onUseRequirement, onRemoveRequirement, disabledRequirementTypeOptions } = useRequirementLogic({
-    append,
-    remove,
-    watchedRequirements: watchedRequirements as IRequirementAttributes[],
-    requirementBlock,
-  })
+  const { onUseRequirement, onUseSharedQuestion, onRemoveRequirement, disabledRequirementTypeOptions } =
+    useRequirementLogic({
+      append,
+      remove,
+      watchedRequirements: watchedRequirements as IRequirementAttributes[],
+      requirementBlock,
+    })
 
   const hasFields = fields.length > 0
 
@@ -128,10 +130,18 @@ export const FieldsSetup = observer(function FieldsSetup({
             {!hasFields && (
               <Flex w={"full"} justifyContent={"space-between"} px={6}>
                 <Text>{t("requirementsLibrary.modals.noFormFieldsAdded")}</Text>
-                <FieldsSetupDrawer
-                  disabledRequirementTypeOptions={disabledRequirementTypeOptions}
-                  onUse={onUseRequirement}
-                />
+                <HStack>
+                  <RequirementQuestionsLibraryDrawer
+                    onUse={(question, closeDrawer) => {
+                      onUseSharedQuestion(question)
+                      closeDrawer?.()
+                    }}
+                  />
+                  <FieldsSetupDrawer
+                    disabledRequirementTypeOptions={disabledRequirementTypeOptions}
+                    onUse={onUseRequirement}
+                  />
+                </HStack>
               </Flex>
             )}
             {isInReorderMode ? (
@@ -151,14 +161,18 @@ export const FieldsSetup = observer(function FieldsSetup({
                   )
                 })}
                 {hasFields && (
-                  <FieldsSetupDrawer
-                    disabledRequirementTypeOptions={disabledRequirementTypeOptions}
-                    onUse={onUseRequirement}
-                    defaultButtonProps={{
-                      alignSelf: "flex-end",
-                      mr: 3,
-                    }}
-                  />
+                  <HStack alignSelf="flex-end" mr={3}>
+                    <RequirementQuestionsLibraryDrawer
+                      onUse={(question, closeDrawer) => {
+                        onUseSharedQuestion(question)
+                        closeDrawer?.()
+                      }}
+                    />
+                    <FieldsSetupDrawer
+                      disabledRequirementTypeOptions={disabledRequirementTypeOptions}
+                      onUse={onUseRequirement}
+                    />
+                  </HStack>
                 )}
               </VStack>
             )}

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
@@ -98,14 +98,15 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
         // remove dummy id to prevent backend from trying to update a non-existent record
         ra.id = undefined
       }
-      if (!ra?.inputOptions) return ra
+      const requirementAttributes = R.omit(["requirementQuestion"], ra) as IRequirementAttributes
+      if (!requirementAttributes?.inputOptions) return requirementAttributes
 
-      const { conditional, ...restOfInputOptions } = ra?.inputOptions
+      const { conditional, ...restOfInputOptions } = requirementAttributes?.inputOptions
 
       const formConditional = conditional as IFormConditional
 
       const processedRequirementAttributes = {
-        ...ra,
+        ...requirementAttributes,
         inputOptions: {
           ...restOfInputOptions,
         } as any,

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/requirement-field-row.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/requirement-field-row.tsx
@@ -1,8 +1,9 @@
-import { Box, Text } from "@chakra-ui/react"
+import { Box, Tag, Text } from "@chakra-ui/react"
 import { ErrorMessage } from "@hookform/error-message"
 import React from "react"
 import { useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
+import { useMst } from "../../../../setup/root"
 import { IFormConditional, IRequirementAttributes } from "../../../../types/api-request"
 import { EEnergyStepCodeDependencyRequirementCode, ENumberUnit, ERequirementType } from "../../../../types/enums"
 import {
@@ -60,6 +61,7 @@ const getRequirementFieldState = (requirementCode: string | undefined, inputType
 
 export const RequirementFieldRow = ({ index, field, isEditing, toggleEdit, onRemove }: RequirementFieldRowProps) => {
   const { t } = useTranslation()
+  const { requirementQuestionStore } = useMst()
   const {
     setValue,
     control,
@@ -75,8 +77,49 @@ export const RequirementFieldRow = ({ index, field, isEditing, toggleEdit, onRem
   const watchedRequirementCode = watch(`requirementsAttributes.${index}.requirementCode`)
   const watchedComputedCompliance = watch(`requirementsAttributes.${index}.inputOptions.computedCompliance`)
   const watchedDataValidation = watch(`requirementsAttributes.${index}.inputOptions.dataValidation`)
+  const watchedRequirementQuestionId = watch(`requirementsAttributes.${index}.requirementQuestionId`)
+  const watchedRequirementQuestion = watch(`requirementsAttributes.${index}.requirementQuestion`)
+  const isSharedQuestion = !!watchedRequirementQuestion?.shared
+  const canMakeReusable = !!watchedRequirementQuestionId
 
   const { disabledMenuOptions, showEditControls } = getRequirementFieldState(watchedRequirementCode, requirementType)
+
+  const handleMakeReusable = async () => {
+    if (!watchedRequirementQuestionId) return
+
+    const isSuccess = await updateLinkedQuestion({ shared: true })
+
+    if (isSuccess) {
+      setValue(`requirementsAttributes.${index}.requirementQuestion.shared` as any, true)
+    }
+  }
+
+  const handleUpdateSharedQuestion = async () => {
+    await updateLinkedQuestion()
+  }
+
+  const updateLinkedQuestion = async (overrides = {}) => {
+    if (!watchedRequirementQuestionId) return false
+
+    const questionInputOptions = { ...(watch(`requirementsAttributes.${index}.inputOptions`) ?? {}) }
+    delete questionInputOptions.conditional
+
+    return await requirementQuestionStore.updateRequirementQuestion(watchedRequirementQuestionId, {
+      shared: true,
+      requirementCode: watchedRequirementCode,
+      label: watch(`requirementsAttributes.${index}.label`),
+      inputType: requirementType,
+      hint: watchedHint,
+      instructions: watch(`requirementsAttributes.${index}.instructions`),
+      inputOptions: questionInputOptions,
+      ...overrides,
+    })
+  }
+
+  const handleDetachSharedQuestion = () => {
+    setValue(`requirementsAttributes.${index}.requirementQuestionId` as any, null)
+    setValue(`requirementsAttributes.${index}.requirementQuestion` as any, null)
+  }
 
   return (
     <Box
@@ -106,6 +149,11 @@ export const RequirementFieldRow = ({ index, field, isEditing, toggleEdit, onRem
       pos={"relative"}
       bg={isEditing ? "greys.grey04" : "transparent"}
     >
+      {isSharedQuestion && (
+        <Tag size="sm" bg="semantic.infoLight" color="text.primary" mb={2}>
+          {t("requirementsLibrary.sharedQuestions.sharedQuestion")}
+        </Tag>
+      )}
       <ErrorMessage
         errors={errors}
         name={`requirementsAttributes.${index}.label`}
@@ -245,6 +293,11 @@ export const RequirementFieldRow = ({ index, field, isEditing, toggleEdit, onRem
         requirementType={requirementType}
         index={index}
         disabledMenuOptions={disabledMenuOptions}
+        isSharedQuestion={isSharedQuestion}
+        canMakeReusable={canMakeReusable}
+        onMakeReusable={handleMakeReusable}
+        onUpdateSharedQuestion={handleUpdateSharedQuestion}
+        onDetachSharedQuestion={handleDetachSharedQuestion}
       />
     </Box>
   )

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/use-requirement-logic.ts
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/use-requirement-logic.ts
@@ -5,6 +5,7 @@ import {
   getEnergyStepCodeRequirementRequiredSchema,
 } from "../../../../constants"
 import { IRequirementBlock } from "../../../../models/requirement-block"
+import { IRequirementQuestion } from "../../../../models/requirement-question"
 import { IRequirementAttributes } from "../../../../types/api-request"
 import {
   EEnergyStepCodeDependencyRequirementCode,
@@ -31,6 +32,26 @@ export const useRequirementLogic = ({
   requirementBlock,
 }: UseRequirementLogicProps) => {
   const { t } = useTranslation()
+  const onUseSharedQuestion = (question: IRequirementQuestion) => {
+    const requirementCodeAlreadyUsed = watchedRequirements?.some(
+      (requirement) => requirement.requirementCode === question.requirementCode
+    )
+
+    append({
+      id: `dummy-${uuidv4()}`,
+      requirementQuestionId: question.id,
+      requirementQuestion: question,
+      requirementCode: requirementCodeAlreadyUsed ? `dummy-${uuidv4()}` : question.requirementCode,
+      inputType: question.inputType,
+      label: question.label,
+      hint: question.hint ?? "",
+      instructions: question.instructions ?? "",
+      required: true,
+      elective: false,
+      inputOptions: question.inputOptions ?? {},
+    })
+  }
+
   const onUseRequirement = (requirementType: ERequirementType) => {
     // Architectural drawing is a single requirement with pre-configured defaults
     if (requirementType === ERequirementType.architecturalDrawing) {
@@ -192,6 +213,7 @@ export const useRequirementLogic = ({
 
   return {
     onUseRequirement,
+    onUseSharedQuestion,
     onRemoveRequirement,
     disabledRequirementTypeOptions,
   }

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1879,6 +1879,17 @@ Thank you,
             useButton: "Use",
             dummyOption: "Option",
           },
+          sharedQuestions: {
+            actions: "Actions",
+            question: "Question",
+            sharedQuestion: "Shared question",
+            detach: "Detach and edit locally",
+            makeReusable: "Make reusable",
+            updateSharedQuestion: "Update shared question",
+            type: "Type",
+            usedBy: "Used by",
+            useSharedQuestion: "Use shared question",
+          },
           modals: {
             unsavedChanges: {
               title: "Unsaved changes",

--- a/app/frontend/models/requirement-question.ts
+++ b/app/frontend/models/requirement-question.ts
@@ -1,0 +1,20 @@
+import { Instance, types } from "mobx-state-tree"
+import { ERequirementType } from "../types/enums"
+import { IRequirementOptions } from "../types/types"
+
+export const RequirementQuestionModel = types.model("RequirementQuestionModel", {
+  id: types.identifier,
+  requirementCode: types.string,
+  label: types.string,
+  inputType: types.enumeration<ERequirementType[]>(Object.values(ERequirementType)),
+  inputOptions: types.frozen<IRequirementOptions>({}),
+  hint: types.maybeNull(types.string),
+  instructions: types.maybeNull(types.string),
+  shared: types.optional(types.boolean, false),
+  discardedAt: types.maybeNull(types.Date),
+  usageCount: types.optional(types.number, 0),
+  createdAt: types.Date,
+  updatedAt: types.Date,
+})
+
+export interface IRequirementQuestion extends Instance<typeof RequirementQuestionModel> {}

--- a/app/frontend/models/requirement.ts
+++ b/app/frontend/models/requirement.ts
@@ -1,10 +1,13 @@
 import { Instance, types } from "mobx-state-tree"
 import { ENumberUnit, ERequirementType } from "../types/enums"
 import { IFormIORequirement, IOption, IRequirementOptions, TComputedCompliance, TConditional } from "../types/types"
+import { RequirementQuestionModel } from "./requirement-question"
 
 export const RequirementModel = types
   .model("RequirementModel", {
     id: types.identifier,
+    requirementQuestionId: types.maybeNull(types.string),
+    requirementQuestion: types.maybeNull(RequirementQuestionModel),
     label: types.string,
     requirementCode: types.string,
     hint: types.maybeNull(types.string),

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -18,6 +18,7 @@ import { IPermitCollaboration } from "../../models/permit-collaboration"
 import { IPermitProject } from "../../models/permit-project"
 import { IPreCheck } from "../../models/pre-check"
 import { IProjectAudit } from "../../models/project-audit"
+import { IRequirementQuestion } from "../../models/requirement-question"
 import { IRequirementTemplate } from "../../models/requirement-template"
 import { ITemplateVersion } from "../../models/template-version"
 import { ITemplateVersionPreview } from "../../models/template-version-preview"
@@ -29,6 +30,7 @@ import {
   IIntegrationMappingUpdateParams,
   IPermitProjectUpdateParams,
   IRequirementBlockParams,
+  IRequirementQuestionParams,
   IRequirementTemplateUpdateParams,
   ITagSearchParams,
 } from "../../types/api-request"
@@ -42,6 +44,7 @@ import {
   IOptionResponse,
   IPageMeta,
   IRequirementBlockResponse,
+  IRequirementQuestionResponse,
   IRequirementTemplateResponse,
   IUsersResponse,
 } from "../../types/api-responses"
@@ -254,6 +257,34 @@ export class Api {
 
   async fetchRequirementBlocks(params?: TSearchParams<ERequirementLibrarySortFields>) {
     return this.client.post<IRequirementBlockResponse>("/requirement_blocks/search", params)
+  }
+
+  async fetchRequirementQuestions(params?: TSearchParams<ERequirementLibrarySortFields>) {
+    return this.client.post<IRequirementQuestionResponse>("/requirement_questions/search", params)
+  }
+
+  async fetchRequirementQuestion(id: string) {
+    return this.client.get<ApiResponse<IRequirementQuestion>>(`/requirement_questions/${id}`)
+  }
+
+  async createRequirementQuestion(params: IRequirementQuestionParams) {
+    return this.client.post<ApiResponse<IRequirementQuestion>>("/requirement_questions", {
+      requirementQuestion: params,
+    })
+  }
+
+  async updateRequirementQuestion(id: string, params: Partial<IRequirementQuestionParams>) {
+    return this.client.patch<ApiResponse<IRequirementQuestion>>(`/requirement_questions/${id}`, {
+      requirementQuestion: params,
+    })
+  }
+
+  async archiveRequirementQuestion(id: string) {
+    return this.client.delete<ApiResponse<IRequirementQuestion>>(`/requirement_questions/${id}`)
+  }
+
+  async restoreRequirementQuestion(id: string) {
+    return this.client.post<ApiResponse<IRequirementQuestion>>(`/requirement_questions/${id}/restore`)
   }
 
   async fetchJurisdictionUsers(jurisdictionId, params?: TSearchParams<EUserSortFields>) {

--- a/app/frontend/stores/requirement-block-store.ts
+++ b/app/frontend/stores/requirement-block-store.ts
@@ -184,7 +184,10 @@ export const RequirementBlockStoreModel = types
       const clonedParams: IRequirementBlockParams = {
         ...copyableRequirementsAttributes,
         requirementsAttributes: requirementBlock.requirements?.map((attr) => {
-          const { id, ...rest } = attr
+          const { id, requirementQuestion, requirementQuestionId, ...rest } = attr
+          if (requirementQuestion?.shared) {
+            return { ...rest, requirementQuestionId }
+          }
           return rest
         }),
         name: requirementBlock.name,

--- a/app/frontend/stores/requirement-question-store.ts
+++ b/app/frontend/stores/requirement-question-store.ts
@@ -1,0 +1,89 @@
+import { Instance, cast, flow, toGenerator, types } from "mobx-state-tree"
+import { createSearchModel } from "../lib/create-search-model"
+import { withEnvironment } from "../lib/with-environment"
+import { withMerge } from "../lib/with-merge"
+import { RequirementQuestionModel } from "../models/requirement-question"
+import { IRequirementQuestionParams } from "../types/api-request"
+import { ERequirementLibrarySortFields } from "../types/enums"
+
+export const RequirementQuestionStoreModel = types
+  .compose(
+    types.model("RequirementQuestionStoreModel").props({
+      requirementQuestionMap: types.map(RequirementQuestionModel),
+      tableRequirementQuestions: types.array(types.safeReference(RequirementQuestionModel)),
+    }),
+    createSearchModel<ERequirementLibrarySortFields>("fetchRequirementQuestions")
+  )
+  .extend(withEnvironment())
+  .extend(withMerge())
+  .views((self) => ({
+    getRequirementQuestionById(id: string) {
+      return self.requirementQuestionMap.get(id)
+    },
+  }))
+  .actions((self) => ({
+    fetchRequirementQuestions: flow(function* (opts?: { reset?: boolean; page?: number; countPerPage?: number }) {
+      if (opts?.reset) {
+        self.resetPages()
+      }
+
+      const response = yield* toGenerator(
+        self.environment.api.fetchRequirementQuestions({
+          query: self.query,
+          sort: self.sort,
+          page: opts?.page ?? self.currentPage,
+          showArchived: self.showArchived,
+          perPage: opts?.countPerPage ?? self.countPerPage,
+        })
+      )
+
+      if (response.ok) {
+        self.mergeUpdateAll(response.data.data, "requirementQuestionMap")
+        self.tableRequirementQuestions = cast(response.data.data.map((question) => question.id))
+        self.setPageFields(response.data.meta, opts)
+      }
+      return response.ok
+    }),
+    createRequirementQuestion: flow(function* (params: IRequirementQuestionParams) {
+      const response = yield* toGenerator(self.environment.api.createRequirementQuestion(params))
+
+      if (response.ok) {
+        self.requirementQuestionMap.put(response.data.data)
+        yield self.fetchRequirementQuestions()
+      }
+
+      return response.ok
+    }),
+    updateRequirementQuestion: flow(function* (id: string, params: Partial<IRequirementQuestionParams>) {
+      const response = yield* toGenerator(self.environment.api.updateRequirementQuestion(id, params))
+
+      if (response.ok) {
+        self.requirementQuestionMap.put(response.data.data)
+        yield self.fetchRequirementQuestions()
+      }
+
+      return response.ok
+    }),
+    archiveRequirementQuestion: flow(function* (id: string) {
+      const response = yield* toGenerator(self.environment.api.archiveRequirementQuestion(id))
+
+      if (response.ok) {
+        self.requirementQuestionMap.put(response.data.data)
+        yield self.fetchRequirementQuestions()
+      }
+
+      return response.ok
+    }),
+    restoreRequirementQuestion: flow(function* (id: string) {
+      const response = yield* toGenerator(self.environment.api.restoreRequirementQuestion(id))
+
+      if (response.ok) {
+        self.requirementQuestionMap.put(response.data.data)
+        yield self.fetchRequirementQuestions()
+      }
+
+      return response.ok
+    }),
+  }))
+
+export interface IRequirementQuestionStoreModel extends Instance<typeof RequirementQuestionStoreModel> {}

--- a/app/frontend/stores/root-store.ts
+++ b/app/frontend/stores/root-store.ts
@@ -15,6 +15,7 @@ import { IPermitProjectStore, PermitProjectStoreModel } from "./permit-project-s
 import { IPreCheckStore, PreCheckStoreModel } from "./pre-check-store"
 import { IProjectAuditStore, ProjectAuditStoreModel } from "./project-audit-store"
 import { IRequirementBlockStoreModel, RequirementBlockStoreModel } from "./requirement-block-store"
+import { IRequirementQuestionStoreModel, RequirementQuestionStoreModel } from "./requirement-question-store"
 import { IRequirementTemplateStoreModel, RequirementTemplateStoreModel } from "./requirement-template-store"
 import { ISandboxStore, SandboxStoreModel } from "./sandbox-store"
 import { ISessionStore, SessionStoreModel } from "./session-store"
@@ -39,6 +40,7 @@ export const RootStoreModel = types
     overheatingCodeStore: types.optional(OverheatingCodeStoreModel, {}),
     jurisdictionStore: types.optional(JurisdictionStoreModel, {}),
     requirementBlockStore: types.optional(RequirementBlockStoreModel, {}),
+    requirementQuestionStore: types.optional(RequirementQuestionStoreModel, {}),
     requirementTemplateStore: types.optional(RequirementTemplateStoreModel, {}),
     digitalSealValidatorStore: types.optional(DigitalSealValidatorStoreModel, {}),
     templateVersionPreviewStore: types.optional(TemplateVersionPreviewStoreModel, {}),
@@ -124,6 +126,7 @@ export interface IRootStore extends IStateTreeNode {
   jurisdictionStore: IJurisdictionStore
   userStore: IUserStore
   requirementBlockStore: IRequirementBlockStoreModel
+  requirementQuestionStore: IRequirementQuestionStoreModel
   requirementTemplateStore: IRequirementTemplateStoreModel
   digitalSealValidatorStore: IDigitalSealValidatorStore
   templateVersionPreviewStore: ITemplateVersionPreviewStoreModel

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -42,6 +42,8 @@ export interface IDataValidation {
 
 export interface IRequirementAttributes {
   id?: string
+  requirementQuestionId?: string
+  requirementQuestion?: IRequirementQuestionParams
   label?: string
   inputType?: ERequirementType
   hint?: string
@@ -60,6 +62,17 @@ export interface IRequirementAttributes {
     dataValidation?: IDataValidation
   }
   position?: number
+}
+
+export interface IRequirementQuestionParams {
+  id?: string
+  requirementCode: string
+  label: string
+  inputType: ERequirementType
+  hint?: string
+  instructions?: string
+  shared?: boolean
+  inputOptions?: IRequirementAttributes["inputOptions"]
 }
 
 export interface IRequirementBlockParams {

--- a/app/frontend/types/api-responses.ts
+++ b/app/frontend/types/api-responses.ts
@@ -3,6 +3,7 @@ import { IJurisdiction } from "../models/jurisdiction"
 import { IPermitApplication } from "../models/permit-application"
 import { IPreCheck } from "../models/pre-check"
 import { IRequirementBlock } from "../models/requirement-block"
+import { IRequirementQuestion } from "../models/requirement-question"
 import { IRequirementTemplate } from "../models/requirement-template"
 import { IUser } from "../models/user"
 import { INotification, IOption, ITemplateVersionDiff } from "./types"
@@ -21,6 +22,8 @@ export interface IPageMeta {
 export interface IUserResponse extends IApiResponse<IUser, {}> {}
 
 export interface IRequirementBlockResponse extends IApiResponse<IRequirementBlock[], IPageMeta> {}
+
+export interface IRequirementQuestionResponse extends IApiResponse<IRequirementQuestion[], IPageMeta> {}
 
 export interface IRequirementTemplateResponse extends IApiResponse<IRequirementTemplate[], IPageMeta> {}
 

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -216,6 +216,7 @@ export interface ISubmissionData {
 
 export interface IDenormalizedRequirement {
   id: string
+  requirementQuestionId?: string
   label: string
   inputType: ERequirementType
   inputOptions: IRequirementOptions

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -5,6 +5,7 @@ class Requirement < ApplicationRecord
   scope :electives, -> { where(elective: true) }
 
   belongs_to :requirement_block, touch: true
+  belongs_to :requirement_question, optional: true, autosave: true
 
   acts_as_list scope: :requirement_block, top_of_list: 0
 
@@ -36,6 +37,8 @@ class Requirement < ApplicationRecord
 
   # This needs to run before validation because we have validations related to the requirement_code
   before_validation :set_requirement_code
+  before_validation :ensure_requirement_question
+  before_validation :sync_private_requirement_question_definition
   before_validation :merge_computed_compliance_default_settings
 
   before_validation :convert_value_options,
@@ -195,23 +198,52 @@ class Requirement < ApplicationRecord
     ARCHITECTURAL_DRAWING_DEPENDENCY_REQUIRED_SCHEMA.keys.map(&:to_s).freeze
 
   def value_options
-    return nil if input_options.blank? || input_options["value_options"].blank?
-
-    input_options["value_options"]
-  end
-
-  def number_unit
-    return nil if input_options.blank? || input_options["number_unit"].blank?
-
-    input_options["number_unit"]
-  end
-
-  def computed_compliance
-    if input_options.blank? || input_options["computed_compliance"].blank?
+    if effective_input_options.blank? ||
+         effective_input_options["value_options"].blank?
       return nil
     end
 
-    input_options["computed_compliance"]
+    effective_input_options["value_options"]
+  end
+
+  def number_unit
+    if effective_input_options.blank? ||
+         effective_input_options["number_unit"].blank?
+      return nil
+    end
+
+    effective_input_options["number_unit"]
+  end
+
+  def computed_compliance
+    if effective_input_options.blank? ||
+         effective_input_options["computed_compliance"].blank?
+      return nil
+    end
+
+    effective_input_options["computed_compliance"]
+  end
+
+  def effective_label
+    requirement_question&.label || read_attribute(:label)
+  end
+
+  def effective_hint
+    requirement_question&.hint || read_attribute(:hint)
+  end
+
+  def effective_instructions
+    requirement_question&.instructions || read_attribute(:instructions)
+  end
+
+  def effective_input_type
+    requirement_question&.input_type || input_type
+  end
+
+  def effective_input_options
+    question_options = requirement_question&.input_options || {}
+    placement_options = read_attribute(:input_options) || {}
+    question_options.deep_merge(placement_options)
   end
 
   def key(requirement_block_key)
@@ -225,15 +257,15 @@ class Requirement < ApplicationRecord
   end
 
   def computed_compliance?
-    input_options["computed_compliance"].present?
+    effective_input_options["computed_compliance"].present?
   end
 
   def has_conditional?
-    input_options["conditional"].present?
+    effective_input_options["conditional"].present?
   end
 
   def has_data_validation?
-    input_options["data_validation"].present?
+    effective_input_options["data_validation"].present?
   end
 
   def self.extract_requirement_id_from_submission_key(key)
@@ -249,6 +281,34 @@ class Requirement < ApplicationRecord
   def merge_computed_compliance_default_settings
     configuration_service = AutomatedComplianceConfigurationService.new(self)
     configuration_service.merge_default_settings!
+  end
+
+  def ensure_requirement_question
+    return if requirement_question.present?
+    return if label.blank? || input_type.blank?
+
+    self.requirement_question =
+      RequirementQuestion.new(requirement_question_definition_attributes)
+  end
+
+  def sync_private_requirement_question_definition
+    return unless requirement_question.present?
+    return if requirement_question.shared?
+
+    requirement_question.assign_attributes(
+      requirement_question_definition_attributes
+    )
+  end
+
+  def requirement_question_definition_attributes
+    {
+      requirement_code: requirement_code,
+      label: read_attribute(:label),
+      input_type: read_attribute(:input_type),
+      input_options: read_attribute(:input_options) || {},
+      hint: read_attribute(:hint),
+      instructions: read_attribute(:instructions)
+    }
   end
 
   def validate_architectural_drawing_file

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -14,6 +14,7 @@ class RequirementBlock < ApplicationRecord
   sanitizable :display_description
 
   has_many :requirements, -> { order(position: :asc) }, dependent: :destroy
+  has_many :requirement_questions, through: :requirements
   has_many :requirement_documents,
            dependent: :destroy,
            inverse_of: :requirement_block
@@ -52,7 +53,8 @@ class RequirementBlock < ApplicationRecord
     {
       updated_at: updated_at,
       name: name,
-      requirement_labels: requirements.pluck(:label),
+      requirement_labels:
+        requirements.includes(:requirement_question).map(&:effective_label),
       associations: association_list,
       configurations: configurations_search_list,
       discarded: discarded_at.present?,

--- a/app/models/requirement_question.rb
+++ b/app/models/requirement_question.rb
@@ -1,0 +1,161 @@
+class RequirementQuestion < ApplicationRecord
+  include HtmlSanitizeAttributes
+  include Discard::Model
+
+  sanitizable :hint, :instructions
+
+  has_many :requirements, dependent: :restrict_with_error
+  has_many :requirement_blocks, through: :requirements
+
+  enum :input_type,
+       {
+         text: 0,
+         number: 1,
+         checkbox: 2,
+         select: 3,
+         multi_option_select: 4,
+         date: 5,
+         textarea: 6,
+         file: 7,
+         phone: 10,
+         email: 11,
+         radio: 12,
+         address: 13,
+         bcaddress: 14,
+         signature: 15,
+         energy_step_code: 16,
+         general_contact: 17,
+         professional_contact: 18,
+         pid_info: 19,
+         energy_step_code_part_3: 20,
+         multiply_sum_grid: 21,
+         architectural_drawing: 22
+       },
+       prefix: true
+
+  before_validation :set_requirement_code
+  before_validation :merge_computed_compliance_default_settings
+  before_validation :convert_value_options,
+                    if:
+                      Proc.new { |question|
+                        Requirement::TYPES_WITH_VALUE_OPTIONS.include?(
+                          question.input_type.to_s
+                        )
+                      }
+
+  validates :label, presence: true
+  validates :input_type, presence: true
+  validates :requirement_code, presence: true
+  validate :validate_value_options,
+           if:
+             Proc.new { |question|
+               Requirement::TYPES_WITH_VALUE_OPTIONS.include?(
+                 question.input_type.to_s
+               )
+             }
+  validate :validate_unit_for_number_inputs
+  validate :validate_can_add_multiple_contacts
+  validate :validate_computed_compliance
+
+  def value_options
+    return nil if input_options.blank? || input_options["value_options"].blank?
+
+    input_options["value_options"]
+  end
+
+  def number_unit
+    return nil if input_options.blank? || input_options["number_unit"].blank?
+
+    input_options["number_unit"]
+  end
+
+  def computed_compliance
+    if input_options.blank? || input_options["computed_compliance"].blank?
+      return nil
+    end
+
+    input_options["computed_compliance"]
+  end
+
+  def computed_compliance?
+    input_options["computed_compliance"].present?
+  end
+
+  def usage_count
+    requirements.count
+  end
+
+  private
+
+  def set_requirement_code
+    return if requirement_code.present?
+    return if label.blank?
+
+    self.requirement_code = label.parameterize(separator: "_")
+  end
+
+  def merge_computed_compliance_default_settings
+    configuration_service = AutomatedComplianceConfigurationService.new(self)
+    configuration_service.merge_default_settings!
+  end
+
+  def validate_value_options
+    if input_options.blank? || input_options["value_options"].blank? ||
+         !input_options["value_options"].is_a?(Array) ||
+         !input_options["value_options"].all? { |option|
+           option.is_a?(Hash) &&
+             (option.key?("label") && option["label"].is_a?(String)) &&
+             (option.key?("value") && option["value"].is_a?(String))
+         }
+      errors.add(:input_options, "must have value options defined")
+    end
+  end
+
+  def validate_unit_for_number_inputs
+    unless input_options.present? && input_options["number_unit"].present?
+      return
+    end
+
+    return if input_type_number?
+
+    errors.add(:input_options, "number_unit is only allowed for number inputs")
+  end
+
+  def validate_can_add_multiple_contacts
+    unless input_options.present? &&
+             input_options["can_add_multiple_contacts"].present?
+      return
+    end
+
+    return if Requirement::CONTACT_TYPES.include?(input_type.to_s)
+
+    errors.add(
+      :input_options,
+      "can_add_multiple_contacts is only allowed for contact inputs"
+    )
+  end
+
+  def validate_computed_compliance
+    configuration_service = AutomatedComplianceConfigurationService.new(self)
+    config_validation = configuration_service.validate_configuration
+
+    error = config_validation[:error]
+    errors.add(:input_options, error) if error.present?
+  end
+
+  def convert_value_options
+    return unless attribute_changed?(:input_options)
+
+    input_options["value_options"] = input_options[
+      "value_options"
+    ].map do |option_json|
+      unless option_json.is_a?(Hash) && option_json["value"].is_a?(String)
+        next option_json
+      end
+
+      value = option_json["value"]
+      words = value.split(" ").map(&:capitalize)
+      option_json.merge("value" => words.join("").strip.camelize(:lower))
+    end
+  end
+end

--- a/app/policies/requirement_question_policy.rb
+++ b/app/policies/requirement_question_policy.rb
@@ -1,0 +1,2 @@
+class RequirementQuestionPolicy < RequirementBlockPolicy
+end

--- a/app/services/infrastructure/template_export_service.rb
+++ b/app/services/infrastructure/template_export_service.rb
@@ -11,6 +11,7 @@ module Infrastructure
         filename: "requirement_template_sections.ndjson"
       },
       { model: RequirementBlock, filename: "requirement_blocks.ndjson" },
+      { model: RequirementQuestion, filename: "requirement_questions.ndjson" },
       {
         model: TemplateSectionBlock,
         filename: "template_section_blocks.ndjson"

--- a/app/services/infrastructure/template_import_service.rb
+++ b/app/services/infrastructure/template_import_service.rb
@@ -4,6 +4,7 @@ module Infrastructure
   class TemplateImportService
     IMPORT_ORDER = [
       { model: RequirementBlock, filename: "requirement_blocks.ndjson" },
+      { model: RequirementQuestion, filename: "requirement_questions.ndjson" },
       {
         model: RequirementTemplate,
         filename: "requirement_templates.ndjson",
@@ -88,6 +89,7 @@ module Infrastructure
       RequirementDocument.destroy_all
       TemplateVersion.destroy_all
       Requirement.destroy_all
+      RequirementQuestion.destroy_all
       TemplateSectionBlock.destroy_all
       RequirementTemplateSection.destroy_all
       RequirementTemplate.destroy_all
@@ -213,6 +215,12 @@ module Infrastructure
         # Check parent requirement block existence
         unless RequirementBlock.exists?(attributes["requirement_block_id"])
           Rails.logger.warn "Skipping Requirement #{attributes["id"]} - Block #{attributes["requirement_block_id"]} missing"
+          return nil
+        end
+
+        if attributes["requirement_question_id"].present? &&
+             !RequirementQuestion.exists?(attributes["requirement_question_id"])
+          Rails.logger.warn "Skipping Requirement #{attributes["id"]} - RequirementQuestion #{attributes["requirement_question_id"]} missing"
           return nil
         end
       end

--- a/app/services/requirement_form_json_service.rb
+++ b/app/services/requirement_form_json_service.rb
@@ -250,38 +250,37 @@ class RequirementFormJsonService
   end
 
   def to_form_json(requirement_block_key = requirement&.requirement_block&.key)
-    return nil unless requirement&.input_type.present?
+    return nil unless effective_input_type.present?
     json =
-      if requirement.input_type_general_contact? ||
-           requirement.input_type_professional_contact?
+      if input_type?(:general_contact) || input_type?(:professional_contact)
         get_contact_form_json(requirement_block_key)
-      elsif requirement.input_type_pid_info?
+      elsif input_type?(:pid_info)
         get_pid_info_components(requirement_block_key, requirement.required)
-      elsif requirement.input_type_multiply_sum_grid?
+      elsif input_type?(:multiply_sum_grid)
         get_multiply_sum_grid_form_json(requirement_block_key)
       else
         {
           id: requirement.id,
           key: requirement.key(requirement_block_key),
-          type: requirement.input_type,
-          requirementInputType: requirement.input_type,
+          type: effective_input_type,
+          requirementInputType: effective_input_type,
           input: true,
-          label: requirement.label,
+          label: effective_label,
           widget: {
             type: "input"
           }
         }.merge!(formio_type_options)
       end
 
-    json.merge!({ description: requirement.hint }) if requirement.hint
-    if requirement.instructions
-      json.merge!({ instructions: requirement.instructions })
+    json.merge!({ description: effective_hint }) if effective_hint
+    if effective_instructions
+      json.merge!({ instructions: effective_instructions })
     end
 
     json.merge!({ validate: { required: true } }) if requirement.required
 
-    if requirement.input_options["data_validation"].present?
-      data_validation = requirement.input_options["data_validation"]
+    if effective_input_options["data_validation"].present?
+      data_validation = effective_input_options["data_validation"]
       validate_json = json[:validate] || {}
 
       if data_validation["operation"] == "min"
@@ -327,20 +326,19 @@ class RequirementFormJsonService
     # assume all electives use a customConditional that defaults to false.  The customConditional works in tandem with the conditionals
     json.merge!({ elective: requirement.elective }) if requirement.elective
 
-    if requirement.input_type_select?
+    if input_type?(:select)
       json.merge!(
-        { data: { values: requirement.input_options["value_options"] } }
+        { data: { values: effective_input_options["value_options"] } }
       )
     end
 
-    if requirement.input_type_multi_option_select? ||
-         requirement.input_type_radio?
-      json.merge!({ values: requirement.input_options["value_options"] })
+    if input_type?(:multi_option_select) || input_type?(:radio)
+      json.merge!({ values: effective_input_options["value_options"] })
     end
 
     if requirement.computed_compliance?
       json.merge!(
-        { computedCompliance: requirement.input_options["computed_compliance"] }
+        { computedCompliance: effective_input_options["computed_compliance"] }
       )
 
       unless json[:tooltip].present?
@@ -350,21 +348,21 @@ class RequirementFormJsonService
       end
     end
 
-    if requirement.input_type.to_sym == :energy_step_code
+    if input_type?(:energy_step_code)
       json.merge!(
-        { energyStepCode: requirement.input_options["energy_step_code"] }
+        { energyStepCode: effective_input_options["energy_step_code"] }
       )
       # Inject the requirement key into the link below the primary button
       inject_step_code_existing_link!(json, "Part9StepCode", json[:key])
     end
 
-    if requirement.input_type.to_sym == :energy_step_code_part_3
+    if input_type?(:energy_step_code_part_3)
       # Inject the requirement key into the link below the primary button
       inject_step_code_existing_link!(json, "Part3StepCode", json[:key])
     end
 
-    if requirement.input_options["conditional"].present?
-      conditional = requirement.input_options["conditional"].clone
+    if effective_input_options["conditional"].present?
+      conditional = effective_input_options["conditional"].clone
       section = PermitApplication.section_from_key(requirement_block_key)
       component_path =
         if conditional["when"].present?
@@ -390,9 +388,9 @@ class RequirementFormJsonService
     end
 
     # indicates code-based conditionals.  Always merge elective show = false to end.
-    if requirement.input_options["customConditional"].present?
+    if effective_input_options["customConditional"].present?
       json.merge!(
-        { customConditional: requirement.input_options["customConditional"] }
+        { customConditional: effective_input_options["customConditional"] }
       )
     end
     if requirement.elective
@@ -406,18 +404,41 @@ class RequirementFormJsonService
 
   private
 
+  def effective_label
+    requirement.effective_label
+  end
+
+  def effective_hint
+    requirement.effective_hint
+  end
+
+  def effective_instructions
+    requirement.effective_instructions
+  end
+
+  def effective_input_type
+    requirement.effective_input_type
+  end
+
+  def effective_input_options
+    requirement.effective_input_options
+  end
+
+  def input_type?(type)
+    effective_input_type.to_s == type.to_s
+  end
+
   def get_contact_form_json(
     requirement_block_key = requirement&.requirement_block&.key
   )
-    unless requirement.input_type_general_contact? ||
-             requirement.input_type_professional_contact?
+    unless input_type?(:general_contact) || input_type?(:professional_contact)
       return {}
     end
 
-    if requirement.input_options["can_add_multiple_contacts"].blank?
+    if effective_input_options["can_add_multiple_contacts"].blank?
       return(
         get_contact_field_set_form_json(
-          "#{requirement.key(requirement_block_key)}|#{requirement.input_type}",
+          "#{requirement.key(requirement_block_key)}|#{effective_input_type}",
           false
         )
       )
@@ -479,14 +500,13 @@ class RequirementFormJsonService
   end
 
   def get_contact_field_set_form_json(key, is_multi)
-    unless requirement.input_type_general_contact? ||
-             requirement.input_type_professional_contact?
+    unless input_type?(:general_contact) || input_type?(:professional_contact)
       return {}
     end
 
     contact_components =
       (
-        if requirement.input_type_general_contact?
+        if input_type?(:general_contact)
           get_general_contact_field_components(key)
         else
           get_professional_contact_field_components(key)
@@ -494,11 +514,11 @@ class RequirementFormJsonService
       )
 
     form_json = {
-      legend: requirement.label,
+      legend: effective_label,
       key: key,
       type: "fieldset",
       custom_class: "contact-field-set",
-      label: requirement.label,
+      label: effective_label,
       hideLabel: true,
       input: false,
       tableView: false,
@@ -508,7 +528,7 @@ class RequirementFormJsonService
         )
     }
 
-    form_json[:id] = requirement.id if requirement.input_options[
+    form_json[:id] = requirement.id if effective_input_options[
       "can_add_multiple_contacts"
     ].blank?
 
@@ -601,14 +621,13 @@ class RequirementFormJsonService
   def get_multi_contact_datagrid_form_json(
     requirement_block_key = requirement&.requirement_block&.key
   )
-    unless requirement.input_type_general_contact? ||
-             requirement.input_type_professional_contact?
+    unless input_type?(:general_contact) || input_type?(:professional_contact)
       return {}
     end
 
     key = "#{requirement.key(requirement_block_key)}|multi_contact"
     {
-      label: requirement.label,
+      label: effective_label,
       id: requirement.id,
       reorder: false,
       addAnother: I18n.t("formio.requirement.contact.add_person_button"),
@@ -623,10 +642,7 @@ class RequirementFormJsonService
       type: "datagrid",
       input: false,
       components: [
-        get_contact_field_set_form_json(
-          "#{key}|#{requirement.input_type}",
-          true
-        )
+        get_contact_field_set_form_json("#{key}|#{effective_input_type}", true)
       ]
     }
   end
@@ -690,15 +706,15 @@ class RequirementFormJsonService
     requirement_block_key = requirement&.requirement_block&.key,
     required = false
   )
-    return {} unless requirement.input_type_pid_info?
+    return {} unless input_type?(:pid_info)
 
     key = "#{requirement.key(requirement_block_key)}|additional_pid_info"
     component = {
-      legend: requirement.label,
+      legend: effective_label,
       key: key,
       type: "fieldset",
       custom_class: "multi-field-set",
-      label: requirement.label,
+      label: effective_label,
       hideLabel: true,
       input: false,
       tableView: false,
@@ -712,7 +728,7 @@ class RequirementFormJsonService
               "PID",
               required,
               nil,
-              requirement.input_options["computed_compliance"]
+              effective_input_options["computed_compliance"]
             ),
             get_nested_info_component(
               :folio_number,
@@ -731,13 +747,13 @@ class RequirementFormJsonService
         )
       ]
     }
-    multi_data_grid_form_json(key, component, true, "Add #{requirement.label}")
+    multi_data_grid_form_json(key, component, true, "Add #{effective_label}")
   end
 
   def get_multiply_sum_grid_form_json(
     requirement_block_key = requirement&.requirement_block&.key
   )
-    return {} unless requirement.input_type_multiply_sum_grid?
+    return {} unless input_type?(:multiply_sum_grid)
 
     grid_key = "#{requirement.key(requirement_block_key)}|grid"
     total_key = "#{requirement.key(requirement_block_key)}|totalLoad"
@@ -747,7 +763,7 @@ class RequirementFormJsonService
 
     # Allow rows to be provided via input_options["rows"]. Each row should
     # be a hash with { name: String, : Number }.
-    configured_rows = requirement.input_options["rows"]
+    configured_rows = effective_input_options["rows"]
     # Do not force defaults; rows are fully configurable from the editor UI
     default_rows = []
     rows =
@@ -762,7 +778,7 @@ class RequirementFormJsonService
     datagrid_default_value =
       rows.map { |r| { "name" => r["name"], "a" => r["a"] } }
 
-    headers = requirement.input_options["headers"] || {}
+    headers = effective_input_options["headers"] || {}
     first_col_label = headers["first_column"].presence || "Item name"
     a_col_label = "#{headers["a"].presence} (A)"
     quantity_col_label = "#{headers["quantity"].presence} (B)"
@@ -789,7 +805,7 @@ class RequirementFormJsonService
     end
 
     datagrid_component = {
-      label: requirement.label,
+      label: effective_label,
       id: requirement.id,
       reorder: false,
       layoutFixed: false,
@@ -888,9 +904,9 @@ class RequirementFormJsonService
       id: requirement.id,
       key: requirement.key(requirement_block_key),
       type: "fieldset",
-      legend: requirement.label,
+      legend: effective_label,
       custom_class: "multiply-sum-grid",
-      label: requirement.label,
+      label: effective_label,
       hideLabel: true,
       input: false,
       tableView: false,
@@ -910,7 +926,7 @@ class RequirementFormJsonService
     addMoreText = I18n.t("formio.requirement.multi_grid.default_add")
   )
     {
-      label: requirement.label,
+      label: effective_label,
       id: requirement.id,
       reorder: false,
       addAnother: addMoreText,
@@ -929,10 +945,10 @@ class RequirementFormJsonService
   end
 
   def formio_type_options
-    return {} unless requirement.input_type.present?
+    return {} unless effective_input_type.present?
 
-    input_type = requirement.input_type
-    input_options = requirement.input_options
+    input_type = effective_input_type
+    input_options = effective_input_options
 
     if input_options["value_options"].is_a?(Array)
       input_options["value_options"].select! do |option|

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -358,13 +358,22 @@ class TemplateVersioningService
         requirement = canonical_block.requirements.find_by(id: draft_req["id"])
         next if requirement.blank?
 
-        # Update mutable fields from the draft snapshot
+        # Update placement fields locally and definition fields through the
+        # linked question source so future snapshots see the shared wording.
         requirement.update(
+          required: draft_req["required"],
+          elective: draft_req["elective"]
+        )
+
+        next unless requirement.requirement_question.present?
+
+        requirement.requirement_question.update(
           label: draft_req["label"],
           input_type: draft_req["input_type"],
           hint: draft_req["hint"],
-          required: draft_req["required"],
-          elective: draft_req["elective"]
+          instructions: draft_req["instructions"],
+          input_options:
+            draft_req["input_options"] || requirement.effective_input_options
         )
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,11 @@ Rails.application.routes.draw do
           to: "requirement_blocks#auto_compliance_module_configurations"
     end
 
+    resources :requirement_questions, only: %i[create show update destroy] do
+      post "restore", on: :member, to: "requirement_questions#restore"
+      post "search", on: :collection, to: "requirement_questions#index"
+    end
+
     resources :notifications, only: %i[index] do
       post "reset_last_read",
            on: :collection,

--- a/db/data/20260602030500_backfill_requirement_questions.rb
+++ b/db/data/20260602030500_backfill_requirement_questions.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class BackfillRequirementQuestions < ActiveRecord::Migration[7.2]
+  def up
+    unless table_exists?(:requirement_questions) &&
+             column_exists?(:requirements, :requirement_question_id)
+      say "Skipping BackfillRequirementQuestions: schema prerequisites are missing."
+      return
+    end
+
+    backfill_missing_requirement_questions
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def backfill_missing_requirement_questions
+    requirements = execute(<<~SQL.squish).to_a
+        SELECT id, requirement_code, label, input_type, input_options, hint, instructions
+        FROM requirements
+        WHERE requirement_question_id IS NULL
+      SQL
+
+    requirements.each { |requirement| create_private_question_for(requirement) }
+
+    remaining = execute(<<~SQL.squish).first["count"].to_i
+        SELECT COUNT(*) AS count
+        FROM requirements
+        WHERE requirement_question_id IS NULL
+      SQL
+
+    say "BackfillRequirementQuestions complete. #{remaining} requirements still need requirement_question_id."
+  end
+
+  def create_private_question_for(requirement)
+    question_id = SecureRandom.uuid
+    quoted_question_id = quote(question_id)
+    quoted_requirement_id = quote(requirement["id"])
+
+    execute(<<~SQL.squish)
+      INSERT INTO requirement_questions (
+        id,
+        requirement_code,
+        label,
+        input_type,
+        input_options,
+        hint,
+        instructions,
+        shared,
+        created_at,
+        updated_at
+      ) VALUES (
+        #{quoted_question_id},
+        #{quote(requirement["requirement_code"])},
+        #{quote(requirement["label"])},
+        #{requirement["input_type"].to_i},
+        #{quote_json(requirement["input_options"])},
+        #{quote(requirement["hint"])},
+        #{quote(requirement["instructions"])},
+        FALSE,
+        NOW(),
+        NOW()
+      )
+    SQL
+
+    execute(<<~SQL.squish)
+      UPDATE requirements
+      SET requirement_question_id = #{quoted_question_id},
+          updated_at = NOW()
+      WHERE id = #{quoted_requirement_id}
+        AND requirement_question_id IS NULL
+    SQL
+  end
+
+  def quote(value)
+    ActiveRecord::Base.connection.quote(value)
+  end
+
+  def quote_json(value)
+    quote(value.is_a?(String) ? value : value.to_json)
+  end
+end

--- a/db/migrate/20260602030000_create_requirement_questions.rb
+++ b/db/migrate/20260602030000_create_requirement_questions.rb
@@ -1,0 +1,26 @@
+class CreateRequirementQuestions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :requirement_questions, id: :uuid do |t|
+      t.string :requirement_code, null: false
+      t.string :label
+      t.integer :input_type, null: false
+      t.jsonb :input_options, default: {}, null: false
+      t.string :hint
+      t.text :instructions
+      t.boolean :shared, default: false, null: false
+      t.datetime :discarded_at
+
+      t.timestamps
+    end
+
+    add_index :requirement_questions, :discarded_at
+    add_index :requirement_questions, :shared
+    add_index :requirement_questions, :requirement_code
+
+    add_reference :requirements,
+                  :requirement_question,
+                  null: true,
+                  foreign_key: true,
+                  type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_19_235200) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_02_030000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -338,7 +338,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_19_235200) do
     t.string "website_url"
     t.boolean "hide_from_search", default: false, null: false
     t.boolean "project_meetings_enabled", default: false, null: false
-    t.jsonb "project_meeting_notification_recipient_emails", default: [], null: false
     t.index ["ltsa_matcher"], name: "index_jurisdictions_on_ltsa_matcher"
     t.index ["prefix"], name: "index_jurisdictions_on_prefix", unique: true
     t.index ["regional_district_id"], name: "index_jurisdictions_on_regional_district_id"
@@ -734,10 +733,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_19_235200) do
     t.boolean "enable_email_unmapped_api_notification", default: true
     t.boolean "enable_in_app_resource_reminder_notification", default: true
     t.boolean "enable_email_resource_reminder_notification", default: true
-    t.boolean "enable_in_app_project_meeting_submitted_notification", default: true
-    t.boolean "enable_email_project_meeting_submitted_notification", default: true
     t.boolean "enable_in_app_project_meeting_request_received_notification", default: true
     t.boolean "enable_email_project_meeting_request_received_notification", default: true
+    t.boolean "enable_in_app_project_meeting_submitted_notification", default: true
+    t.boolean "enable_email_project_meeting_submitted_notification", default: true
     t.index ["user_id"], name: "index_preferences_on_user_id"
   end
 
@@ -764,14 +763,41 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_19_235200) do
     t.boolean "request_property_information"
     t.datetime "submitted_at"
     t.datetime "confirmed_date"
+    t.datetime "scheduled_at"
+    t.datetime "completed_at"
+    t.datetime "closed_at"
     t.string "meeting_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["closed_at"], name: "index_project_meetings_on_closed_at"
+    t.index ["completed_at"], name: "index_project_meetings_on_completed_at"
+    t.index ["permit_project_id"], name: "index_project_meetings_on_active_permit_project", unique: true, where: "(status = ANY (ARRAY[0, 1]))"
     t.index ["permit_project_id"], name: "index_project_meetings_on_permit_project_id"
     t.index ["requested_by_id"], name: "index_project_meetings_on_requested_by_id"
     t.index ["requester_relationship"], name: "index_project_meetings_on_requester_relationship"
+    t.index ["scheduled_at"], name: "index_project_meetings_on_scheduled_at"
     t.index ["status"], name: "index_project_meetings_on_status"
     t.index ["submitted_at"], name: "index_project_meetings_on_submitted_at"
+  end
+
+  create_table "question_definitions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "label", null: false
+    t.string "hint"
+    t.text "instructions"
+    t.integer "input_type", null: false
+    t.jsonb "input_options", default: {}, null: false
+    t.string "requirement_code"
+    t.integer "review_state", default: 0, null: false
+    t.uuid "owner_id"
+    t.uuid "forked_from_id"
+    t.datetime "discarded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["discarded_at"], name: "index_question_definitions_on_discarded_at"
+    t.index ["forked_from_id"], name: "index_question_definitions_on_forked_from_id"
+    t.index ["owner_id"], name: "index_question_definitions_on_owner_id"
+    t.index ["requirement_code"], name: "index_question_definitions_on_requirement_code"
+    t.index ["review_state"], name: "index_question_definitions_on_review_state"
   end
 
   create_table "report_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -811,6 +837,22 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_19_235200) do
     t.index ["scan_status"], name: "index_requirement_documents_on_scan_status"
   end
 
+  create_table "requirement_questions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "requirement_code", null: false
+    t.string "label"
+    t.integer "input_type", null: false
+    t.jsonb "input_options", default: {}, null: false
+    t.string "hint"
+    t.text "instructions"
+    t.boolean "shared", default: false, null: false
+    t.datetime "discarded_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["discarded_at"], name: "index_requirement_questions_on_discarded_at"
+    t.index ["requirement_code"], name: "index_requirement_questions_on_requirement_code"
+    t.index ["shared"], name: "index_requirement_questions_on_shared"
+  end
+
   create_table "requirement_template_sections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.uuid "requirement_template_id", null: false
@@ -831,6 +873,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_19_235200) do
     t.datetime "fetched_at"
     t.uuid "copied_from_id"
     t.boolean "available_globally"
+    t.datetime "question_bank_drift_pending_at"
     t.index ["copied_from_id"], name: "index_requirement_templates_on_copied_from_id"
     t.index ["discarded_at"], name: "index_requirement_templates_on_discarded_at"
   end
@@ -851,7 +894,12 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_19_235200) do
     t.integer "position"
     t.boolean "elective", default: false
     t.text "instructions"
+    t.uuid "question_definition_id"
+    t.jsonb "local_overrides", default: {}, null: false
+    t.uuid "requirement_question_id"
+    t.index ["question_definition_id"], name: "index_requirements_on_question_definition_id"
     t.index ["requirement_block_id"], name: "index_requirements_on_requirement_block_id"
+    t.index ["requirement_question_id"], name: "index_requirements_on_requirement_question_id"
   end
 
   create_table "resource_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1039,7 +1087,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_19_235200) do
     t.boolean "default", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["jurisdiction_id", "email"], name: "index_submission_contacts_on_jurisdiction_id_and_email", unique: true
+    t.string "type", default: "ApplicationSubmissionContact", null: false
+    t.index ["jurisdiction_id", "email", "type"], name: "idx_submission_contacts_on_jurisdiction_email_sti_type", unique: true
     t.index ["jurisdiction_id"], name: "index_submission_contacts_on_jurisdiction_id"
   end
 
@@ -1295,11 +1344,15 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_19_235200) do
   add_foreign_key "project_documents", "permit_projects"
   add_foreign_key "project_meetings", "permit_projects"
   add_foreign_key "project_meetings", "users", column: "requested_by_id"
+  add_foreign_key "question_definitions", "question_definitions", column: "forked_from_id", on_delete: :nullify
+  add_foreign_key "question_definitions", "users", column: "owner_id", on_delete: :nullify
   add_foreign_key "requirement_documents", "requirement_blocks"
   add_foreign_key "requirement_template_sections", "requirement_template_sections", column: "copied_from_id"
   add_foreign_key "requirement_template_sections", "requirement_templates"
   add_foreign_key "requirement_templates", "requirement_templates", column: "copied_from_id"
+  add_foreign_key "requirements", "question_definitions", on_delete: :nullify
   add_foreign_key "requirements", "requirement_blocks"
+  add_foreign_key "requirements", "requirement_questions"
   add_foreign_key "resource_documents", "resources"
   add_foreign_key "resources", "jurisdictions"
   add_foreign_key "revision_reasons", "site_configurations"


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...poc/requirement-question` (merge-base range).

Adds shared requirement questions as a reusable definition layer for the Requirements Library while keeping `Requirement` as the block-local placement record. This lets admins link the same question definition across multiple requirement blocks without breaking block-level structure, conditionals, documents, instructions, form keys, or published template snapshots.

The implementation includes additive schema/data migrations, backend model/API/serialization support, import/export updates, and block editor UI for finding, using, promoting, updating, and detaching shared questions.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                         |
| -------------------- | ---------------------------- |
| 🗂️ Jira Story / Task | [HUB-XXXX](https://yourorg.atlassian.net/browse/HUB-XXXX) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->          |
| 📑 Design / Figma    | <!-- Paste link -->          |
| 📚 Documentation     | <!-- Paste link -->          |

---

## ✨ Features / Changes Introduced

- Adds `RequirementQuestion` as a reusable/private question definition model, with `Requirement` remaining the block-local placement record.
- Adds schema and data migrations to create private 1:1 question definitions for existing requirements without mutating historical template snapshots.
- Updates requirement serialization and form JSON generation to merge placement fields with linked question definition fields.
- Adds `requirement_questions` API endpoints, policy, blueprint, routes, and import/export support.
- Adds block editor UI for using shared questions, showing shared badges, making a question reusable, updating a shared question, and detaching a shared question back to local editing.
- Adds frontend model/store/API/types/i18n support for shared question search and lifecycle actions.

---

## 🧪 Steps to QA

1. Navigate to the Requirements Library and open an existing requirement block.
2. Confirm existing block fields still display and edit as before.
3. Use the new “Use shared question” action from the block editor.
4. Select a shared question from the drawer and confirm it is added to the block with a “Shared question” badge.
5. Edit placement-specific settings such as required/elective/conditional logic and confirm they remain local to the block.
6. Use “Make reusable” on a local question and confirm it becomes available in the shared question picker.
7. Use “Update shared question” on a linked question and confirm other linked placements reflect the updated wording/configuration in future block/template renders.
8. Use “Detach and edit locally” and confirm the field keeps its current wording but no longer behaves as a shared question.
9. Publish or preview a template containing linked shared questions and confirm generated form JSON still uses the block-local `requirement_code` keys.
10. Verify existing published template versions and submitted applications remain unchanged.

**Expected Behaviour:**

Admins can reuse individual question definitions across multiple requirement blocks while preserving block-level instructions, documents, conditionals, required/elective settings, and template snapshot behaviour.

**Before this change:**

Individual questions duplicated across multiple blocks had to be manually updated in each block when wording or shared configuration changed.

**After this change:**

Questions can be promoted to shared definitions and linked into other blocks, reducing duplicate editing while keeping block composition intact.

---

## ♿ UI Accessibility Checklist

- [ ] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [ ] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [ ] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others