### PR TITLE
remove project review assignee dependence on allow_designated_reviewer

### DIFF
--- a/app/controllers/api/permit_projects_controller.rb
+++ b/app/controllers/api/permit_projects_controller.rb
@@ -124,10 +124,6 @@ class Api::PermitProjectsController < Api::ApplicationController
   def assign_project_review_collaborator
     authorize @permit_project
 
-    unless @permit_project.designated_reviewer_enabled?
-      return render_error("permit_project.feature_not_enabled", { status: 422 })
-    end
-
     collaborator_id = params.require(:collaborator_id)
     @permit_project.assign_project_review_collaborator!(collaborator_id)
     render_success @permit_project.reload,

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-collaborators-sidebar.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-collaborators-sidebar.tsx
@@ -66,7 +66,7 @@ export const ProjectCollaboratorsSidebar = observer(function ProjectCollaborator
         </DrawerHeader>
 
         <DrawerBody as={Stack} spacing={8}>
-          {designatedReviewerEnabled && <ProjectReviewCollaboratorsSection project={project} />}
+          <ProjectReviewCollaboratorsSection project={project} />
 
           <Stack spacing={4}>
             <Text as="h3" fontSize="md" fontWeight={700}>

--- a/app/models/permit_project.rb
+++ b/app/models/permit_project.rb
@@ -306,19 +306,10 @@ class PermitProject < ApplicationRecord
       &.collaborator
   end
 
-  def designated_reviewer_enabled?
-    SiteConfiguration.allow_designated_reviewer? &&
-      jurisdiction&.allow_designated_reviewer
-  end
-
   # Atomically assigns the project's single review collaborator, replacing any
   # existing assignment. Re-picking the current collaborator is a no-op (no
   # notification churn). Locks existing kept rows to serialize concurrent calls.
   def assign_project_review_collaborator!(collaborator_id)
-    unless designated_reviewer_enabled?
-      raise "Designated reviewer feature is not enabled"
-    end
-
     transaction do
       existing = permit_project_collaborations.kept.lock.first
 


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...HUB-4954-bug-reviewer-workspace-submissions-422-error-when-no-designated-reviewer-for-projects` (merge-base range).

Project review collaborator assignment in the submission inbox was incorrectly gated by the `allow_designated_reviewer` site/jurisdiction feature flag. That flag is intended only for **permit application** designated reviewers (e.g. limiting who can request revisions), not for assigning a project-level review collaborator on kanban cards or in the project collaborators sidebar.

When `allow_designated_reviewer` was disabled, the UI still showed the assign affordance, but the API returned a 422 (`feature_not_enabled`), blocking assignment.

This PR removes that gate from project review collaborator assignment while leaving permit application designated reviewer behavior unchanged.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                                 |
| -------------------- | -------------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-4954](https://yourorg.atlassian.net/browse/HUB-4954)            |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                                  |
| 📑 Design / Figma    | <!-- Paste link -->                                                  |
| 📚 Documentation     | <!-- Paste link -->                                                  |

---

## ✨ Features / Changes Introduced

- Removed `designated_reviewer_enabled?` guard from `PermitProject#assign_project_review_collaborator!`
- Removed the matching 422 check in `Api::PermitProjectsController#assign_project_review_collaborator`
- Always show the project review collaborators section in the project collaborators sidebar (no longer hidden when `allow_designated_reviewer` is off)
- Permit application designated reviewer behavior is unchanged and still respects `allow_designated_reviewer`

---

## 🧪 Steps to QA

> Use a jurisdiction where **Designated Reviewer** is disabled at both site and jurisdiction level (`allow_designated_reviewer: false`).

1. Log in as review staff and open the submission inbox (project kanban or table view).
2. On a project card/row, click the **+** icon to assign a **project review collaborator**.
3. Select a collaborator and confirm the assignment succeeds (no 422 error).
4. Confirm the assigned collaborator avatar appears on the card/row.
5. Open the project collaborators sidebar for the same project and confirm the **Project review collaborators** section is visible and the assignment is reflected there.
6. Unassign the project review collaborator and confirm that also works.
7. Open a permit application’s collaborators sidebar and confirm **Designated reviewer** UI is still hidden when the feature flag is off.
8. (Optional, with flag enabled) Confirm permit application designated reviewer assignment still works as before.

**Expected Behaviour:**

- Project review collaborator assignment works regardless of `allow_designated_reviewer`.
- Permit application designated reviewer remains gated by the feature flag.

**Before this change:**

- Assigning a project review collaborator returned a 422 when `allow_designated_reviewer` was false.
- The project review collaborators section was hidden in the sidebar when the flag was off.

**After this change:**

- Project review collaborators can be assigned and unassigned normally.
- The project review collaborators section is always available in the sidebar.
- Permit application designated reviewer behavior is unchanged.

---

## ♿ UI Accessibility Checklist

> Minor UI change: an existing sidebar section is no longer conditionally hidden. No new interactive elements or markup changes.

- [x] No new UI patterns introduced; existing components unchanged aside from visibility logic

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4954]: https://hous-bssb.atlassian.net/browse/HUB-4954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ