### PR TITLE
Hub 4727 bug in app notifications bundle repetitive permit update notifications for r ms

### DIFF
--- a/app/frontend/components/domains/permit-project/new-permit-project-screen.tsx
+++ b/app/frontend/components/domains/permit-project/new-permit-project-screen.tsx
@@ -101,16 +101,6 @@ export const NewPermitProjectScreen = observer(() => {
               <Controller
                 name="site"
                 control={control}
-                rules={{
-                  validate: {
-                    hasJurisdiction: () => {
-                      const jurisdictionId = formMethods.getValues("jurisdictionId")
-                      return jurisdictionId
-                        ? true
-                        : (t("ui.isRequired", { field: t("permitProject.new.fullAddressHeading") }) as string)
-                    },
-                  },
-                }}
                 render={({ field: { onChange, value } }) => (
                   <SitesSelect
                     onChange={onChange}
@@ -118,6 +108,7 @@ export const NewPermitProjectScreen = observer(() => {
                     pidName="pid"
                     siteName="site"
                     jurisdictionIdFieldName="jurisdictionId"
+                    jurisdictionRequired
                   />
                 )}
               />

--- a/app/frontend/components/shared/select/selectors/sites-select.tsx
+++ b/app/frontend/components/shared/select/selectors/sites-select.tsx
@@ -1,10 +1,20 @@
-import { Button, Input as ChakraInput, Flex, FormControl, FormLabel, HStack, InputGroup, Text } from "@chakra-ui/react"
+import {
+  Button,
+  Input as ChakraInput,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  HStack,
+  InputGroup,
+  Text,
+} from "@chakra-ui/react"
 import { MapPin } from "@phosphor-icons/react"
 import debounce from "lodash/debounce"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
 import React, { useCallback, useEffect, useRef, useState } from "react"
-import { Controller, useFormContext } from "react-hook-form"
+import { Controller, useController, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { ControlProps, InputProps, OptionProps, components } from "react-select"
 import CreatableSelect from "react-select/creatable"
@@ -12,6 +22,7 @@ import { IJurisdiction } from "../../../../models/jurisdiction"
 import { useMst } from "../../../../setup/root"
 import { IOption } from "../../../../types/types"
 import { formatPidLabel, formatPidValue } from "../../../../utils/utility-functions"
+import { fieldArrayCompatibleErrorMessage } from "../../form/form-helpers"
 import { AsyncSelect, TAsyncSelectProps } from "../async-select"
 import { JurisdictionSelect } from "./jurisdiction-select"
 
@@ -28,6 +39,7 @@ export type TSitesSelectProps = {
   showJurisdiction?: boolean
   initialJurisdiction?: IJurisdiction | null
   isDisabled?: boolean
+  jurisdictionRequired?: boolean
 } & Partial<TAsyncSelectProps>
 
 // Please be advised that this is expected to be used within a form context!
@@ -47,6 +59,7 @@ export const SitesSelect = observer(function ({
   showJurisdiction = true,
   initialJurisdiction = null,
   isDisabled = false,
+  jurisdictionRequired = false,
   ...rest
 }: TSitesSelectProps) {
   const { t } = useTranslation()
@@ -63,7 +76,17 @@ export const SitesSelect = observer(function ({
   const { addJurisdiction, getJurisdictionById } = jurisdictionStore
   const pidSelectRef = useRef(null)
 
-  const { setValue, control, watch } = useFormContext()
+  const { setValue, control, watch, formState } = useFormContext()
+  const { field: jurisdictionField } = useController({
+    name: jurisdictionIdFieldName,
+    control,
+    rules: {
+      required: jurisdictionRequired && String(t("ui.isRequired", { field: t("permitProject.new.jurisdictionTitle") })),
+    },
+  })
+  const jurisdictionErrorMessage = fieldArrayCompatibleErrorMessage(jurisdictionIdFieldName, formState.errors) as
+    | string
+    | undefined
 
   const pidWatch = watch(pidName)
   const siteWatch = watch(siteName)
@@ -133,14 +156,14 @@ export const SitesSelect = observer(function ({
         if (!isActive) return
         if (matchedJurisdiction) {
           addJurisdiction(matchedJurisdiction)
-          setValue(jurisdictionIdFieldName, matchedJurisdiction.id)
+          setValue(jurisdictionIdFieldName, matchedJurisdiction.id, { shouldValidate: true })
           setJurisdiction(matchedJurisdiction)
         } else {
-          setValue(jurisdictionIdFieldName, null)
+          setValue(jurisdictionIdFieldName, null, { shouldValidate: true })
           setJurisdiction(null)
         }
       } catch (_e) {
-        setValue(jurisdictionIdFieldName, null)
+        setValue(jurisdictionIdFieldName, null, { shouldValidate: true })
         setJurisdiction(null)
         if (onLtsaMatcherFound) {
           onLtsaMatcherFound(null)
@@ -265,36 +288,39 @@ export const SitesSelect = observer(function ({
       {/* Auto-matched Jurisdiction Display - Only in automatic mode */}
       {!manualMode && showJurisdiction && (
         <Flex bg="greys.grey03" px={6} py={2} gap={2} w="full" direction="column">
-          <FormLabel mb={0}>{t("permitProject.new.jurisdictionTitle")}</FormLabel>
-          <ChakraInput isDisabled value={jurisdiction?.qualifiedName || ""} />
+          <FormControl isInvalid={!!jurisdictionErrorMessage}>
+            <FormLabel mb={0}>{t("permitProject.new.jurisdictionTitle")}</FormLabel>
+            <ChakraInput isDisabled value={jurisdiction?.qualifiedName || ""} />
+            {jurisdictionErrorMessage && <FormErrorMessage>{jurisdictionErrorMessage}</FormErrorMessage>}
+          </FormControl>
         </Flex>
       )}
 
       {/* Manual Jurisdiction Selector - Only in manual mode */}
       {manualMode && showJurisdiction && (
         <Flex bg="greys.grey03" px={6} py={2} gap={4} w="full" direction="column">
-          <FormControl w="full" zIndex={1}>
+          <FormControl w="full" zIndex={1} isInvalid={!!jurisdictionErrorMessage}>
             <FormLabel>{t("permitProject.new.jurisdictionTitle")}</FormLabel>
             <InputGroup w="full">
-              <Controller
-                name={jurisdictionIdFieldName}
-                control={control}
-                render={({ field: { onChange, value } }) => {
-                  return (
-                    <JurisdictionSelect
-                      onChange={(selectValue) => {
-                        if (selectValue) addJurisdiction(selectValue)
-                        onChange(selectValue?.id)
-                      }}
-                      onFetch={() => setValue(jurisdictionIdFieldName, null)}
-                      selectedOption={value ? { label: getJurisdictionById(value)?.reverseQualifiedName, value } : null}
-                      menuPortalTarget={document.body}
-                      isDisabled={isDisabled}
-                    />
-                  )
+              <JurisdictionSelect
+                onChange={(selectValue) => {
+                  if (selectValue) addJurisdiction(selectValue)
+                  jurisdictionField.onChange(selectValue?.id)
                 }}
+                onFetch={() => setValue(jurisdictionIdFieldName, null, { shouldValidate: true })}
+                selectedOption={
+                  jurisdictionField.value
+                    ? {
+                        label: getJurisdictionById(jurisdictionField.value)?.reverseQualifiedName,
+                        value: jurisdictionField.value,
+                      }
+                    : null
+                }
+                menuPortalTarget={document.body}
+                isDisabled={isDisabled}
               />
             </InputGroup>
+            {jurisdictionErrorMessage && <FormErrorMessage>{jurisdictionErrorMessage}</FormErrorMessage>}
           </FormControl>
         </Flex>
       )}

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -318,6 +318,20 @@ class NotificationService
   end
 
   def self.publish_customization_update_event(customization)
+    throttle_key =
+      "customization_update_notification:" \
+        "#{customization.jurisdiction_id}:#{customization.template_version_id}"
+
+    throttle_acquired =
+      Rails.cache.write(
+        throttle_key,
+        true,
+        expires_in: 2.hours,
+        unless_exist: true
+      )
+
+    return unless throttle_acquired
+
     template_version = customization.template_version
     jurisdiction_id = customization.jurisdiction_id
     relevant_submitter_ids =

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -693,5 +693,42 @@ RSpec.describe NotificationService do
         expect(payload.keys).to contain_exactly(matching_submitter.id)
       end
     end
+
+    it "throttles repeated notifications for the same jurisdiction and template version" do
+      allow(NotificationPushJob).to receive(:perform_async)
+      allow(Rails.cache).to receive(:write).and_return(true, false)
+
+      requirement_template = create(:requirement_template)
+      template_version =
+        create(:template_version, requirement_template: requirement_template)
+      jurisdiction = create(:sub_district)
+      customization =
+        create(
+          :jurisdiction_template_version_customization,
+          jurisdiction: jurisdiction,
+          template_version: template_version
+        )
+      submitter = create(:user, :submitter)
+
+      create(
+        :permit_application,
+        submitter: submitter,
+        template_version: template_version,
+        jurisdiction: jurisdiction
+      )
+
+      2.times do
+        described_class.publish_customization_update_event(customization)
+      end
+
+      expect(Rails.cache).to have_received(:write).with(
+        "customization_update_notification:" \
+          "#{jurisdiction.id}:#{template_version.id}",
+        true,
+        expires_in: 2.hours,
+        unless_exist: true
+      ).twice
+      expect(NotificationPushJob).to have_received(:perform_async).once
+    end
   end
 end


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-4727-bug-in-app-notifications-bundle-repetitive-permit-update-notifications-for-r-ms` (merge-base range).

This PR fixes two validation/notification issues: repeated customization update notifications are throttled per jurisdiction/template version, and project creation now surfaces missing jurisdiction validation directly under the jurisdiction selector in the site select UI.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-4727](https://hous-bssb.atlassian.net/browse/HUB-4727) |
| 🗂️ Jira Story / Task | [HUB-4751](https://hous-bssb.atlassian.net/browse/HUB-4751) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Throttles repeated customization update notifications using `Rails.cache` for the same jurisdiction and template version.
- Adds spec coverage to confirm repeated customization update events enqueue only one notification job within the throttle window.
- Adds required jurisdiction validation support to `SitesSelect`, displaying the error under the jurisdiction field in both automatic and manual jurisdiction modes.
- Updates the new project screen to require a resolved jurisdiction before creating a project.

---

## 🧪 Steps to QA

1. Log in as a user who can create projects.
2. Navigate to `/projects/new`.
3. Leave the project name empty and click **Create project**.
4. Verify the project name field still shows its required validation message.
5. Leave the site/jurisdiction unresolved and click **Create project**.
6. Verify `Jurisdiction is required` appears under the jurisdiction selector/display within the site select.
7. Switch to manual jurisdiction selection and verify the same validation appears under the manual jurisdiction selector when no jurisdiction is selected.
8. Select a valid jurisdiction and verify the jurisdiction validation clears.
9. Add before/after screenshots for the validation UI if applicable.

**Expected Behaviour:**
Users see the missing jurisdiction validation message directly under the jurisdiction selector/display, matching the existing project name validation pattern.

**Before this change:**
Project creation could fail validation for a missing jurisdiction without showing the message under the jurisdiction selector.

**After this change:**
The missing jurisdiction error is visible where the user needs to take action.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [x] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4727]: https://hous-bssb.atlassian.net/browse/HUB-4727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HUB-4751]: https://hous-bssb.atlassian.net/browse/HUB-4751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ