### PR TITLE
HUB-5211 add validation to prevent removing the last contact for a feature

### DIFF
--- a/app/controllers/api/jurisdictions_controller.rb
+++ b/app/controllers/api/jurisdictions_controller.rb
@@ -58,22 +58,34 @@ class Api::JurisdictionsController < Api::ApplicationController
         end
       end
     end
-    if @jurisdiction.update(permitted_params)
-      render_success @jurisdiction,
-                     "jurisdiction.update_success",
-                     {
-                       blueprint: JurisdictionBlueprint,
-                       blueprint_opts: {
-                         view: :base,
-                         current_user: current_user
+    begin
+      if @jurisdiction.update(permitted_params)
+        render_success @jurisdiction,
+                       "jurisdiction.update_success",
+                       {
+                         blueprint: JurisdictionBlueprint,
+                         blueprint_opts: {
+                           view: :base,
+                           current_user: current_user
+                         }
                        }
+      else
+        render_error "jurisdiction.update_error",
+                     message_opts: {
+                       error_message:
+                         @jurisdiction.errors.full_messages.join(", ")
                      }
-    else
-      render_error "jurisdiction.update_error",
-                   message_opts: {
-                     error_message:
-                       @jurisdiction.errors.full_messages.join(", ")
-                   }
+      end
+    rescue ActiveRecord::RecordNotDestroyed => e
+      record = e.respond_to?(:record) ? e.record : nil
+      error_message =
+        record&.errors&.full_messages&.to_sentence.presence || e.message
+
+      render_error(
+        "jurisdiction.update_error",
+        { message_opts: { error_message: error_message } },
+        e
+      )
     end
   end
 

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/feature-access-screen/project-meetings.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/feature-access-screen/project-meetings.tsx
@@ -88,17 +88,17 @@ export const ProjectMeetingsJurisdictionFeatureAccessScreen = observer(() => {
             </Link>
           </Flex>
 
+          <SubmissionContactForm
+            jurisdiction={currentJurisdiction}
+            heading={recipientHeading(t(`${i18nPrefix}.projectMeetings`))}
+            contactClass={ESubmissionContactClass.meeting}
+            emailLabel={t(`${i18nPrefix}.projectMeetingsEmailLabel`)}
+            addEmailLabel={t(`${i18nPrefix}.projectMeetingsAddEmail`)}
+            confirmationRequiredLabel={t(`${i18nPrefix}.projectMeetingsConfirmationRequired`)}
+          />
+
           {projectMeetingsEnabled && (
             <>
-              <SubmissionContactForm
-                jurisdiction={currentJurisdiction}
-                heading={recipientHeading(t(`${i18nPrefix}.projectMeetings`))}
-                contactClass={ESubmissionContactClass.meeting}
-                emailLabel={t(`${i18nPrefix}.projectMeetingsEmailLabel`)}
-                addEmailLabel={t(`${i18nPrefix}.projectMeetingsAddEmail`)}
-                confirmationRequiredLabel={t(`${i18nPrefix}.projectMeetingsConfirmationRequired`)}
-              />
-
               <Flex align="center" w="100%" justify="space-between" gap={6}>
                 <Flex align="flex-start" direction="column">
                   <Heading as="h2" fontSize="lg" fontWeight="bold" m={0} mb={2}>
@@ -115,16 +115,14 @@ export const ProjectMeetingsJurisdictionFeatureAccessScreen = observer(() => {
                 />
               </Flex>
 
-              {propertyInformationRequestsEnabled && (
-                <SubmissionContactForm
-                  jurisdiction={currentJurisdiction}
-                  heading={recipientHeading(t(`${i18nPrefix}.propertyInformation`))}
-                  contactClass={ESubmissionContactClass.propertyInformation}
-                  emailLabel={t(`${i18nPrefix}.propertyInformationEmailLabel`)}
-                  addEmailLabel={t(`${i18nPrefix}.propertyInformationAddEmail`)}
-                  confirmationRequiredLabel={t(`${i18nPrefix}.propertyInformationConfirmationRequired`)}
-                />
-              )}
+              <SubmissionContactForm
+                jurisdiction={currentJurisdiction}
+                heading={recipientHeading(t(`${i18nPrefix}.propertyInformation`))}
+                contactClass={ESubmissionContactClass.propertyInformation}
+                emailLabel={t(`${i18nPrefix}.propertyInformationEmailLabel`)}
+                addEmailLabel={t(`${i18nPrefix}.propertyInformationAddEmail`)}
+                confirmationRequiredLabel={t(`${i18nPrefix}.propertyInformationConfirmationRequired`)}
+              />
             </>
           )}
         </Flex>

--- a/app/frontend/components/shared/form/email-list-editable-block.tsx
+++ b/app/frontend/components/shared/form/email-list-editable-block.tsx
@@ -1,4 +1,4 @@
-import { Alert, Box, Button, FormControl, HStack, Input, VStack } from "@chakra-ui/react"
+import { Alert, Badge, Box, Button, FormControl, HStack, Input, VStack } from "@chakra-ui/react"
 import { Pencil, Plus, Warning } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
@@ -83,10 +83,17 @@ export const EmailListEditableBlock = observer(function EmailListEditableBlock({
 
   const onRemove = (index: number, item?: IEmailListItem) => {
     if (item && update && buildDestroyedItem) {
-      update(index, buildDestroyedItem(item))
+      const destroyedItem = buildDestroyedItem(item)
+      update(index, destroyedItem)
     } else {
       remove(index)
     }
+  }
+
+  const onRestore = (index: number, item?: IEmailListItem) => {
+    if (!item || !update) return
+
+    update(index, item)
   }
 
   useEffect(() => {
@@ -112,23 +119,46 @@ export const EmailListEditableBlock = observer(function EmailListEditableBlock({
         {fields.map((f, index) => {
           const trueIndex = getIndex(f)
           const itemId = getValues(`${fieldArrayName}.${trueIndex}.id`)
+          const isMarkedForDestruction = Boolean(getValues(`${fieldArrayName}.${trueIndex}._destroy`))
           const item = itemId && getItem ? getItem(itemId) : undefined
           return (
             <React.Fragment key={f.id || generateUUID()}>
               <Input type="hidden" name={`${fieldArrayName}.${trueIndex}.id`} value={itemId || ""} />
-              <HStack flex={1} w="full">
+              <HStack
+                flex={1}
+                w="full"
+                opacity={isMarkedForDestruction ? 0.65 : 1}
+                bg={isMarkedForDestruction ? "semantic.errorLight" : undefined}
+                borderColor={isMarkedForDestruction ? "semantic.error" : undefined}
+                borderWidth={isMarkedForDestruction ? 1 : 0}
+                borderRadius="md"
+                p={isMarkedForDestruction ? 2 : 0}
+              >
                 <EmailFormControl
                   pos="relative"
                   label={emailLabel}
                   fieldName={`${fieldArrayName}.${trueIndex}.email`}
-                  inputProps={{ isDisabled: !isEditing }}
+                  inputProps={{
+                    isDisabled: !isEditing || isMarkedForDestruction,
+                    textDecoration: isMarkedForDestruction ? "line-through" : undefined,
+                  }}
                   required={isEditing}
-                  validate={isEditing}
+                  validate={isEditing && !isMarkedForDestruction}
                   handleRemove={() => onRemove(trueIndex, item)}
-                  isRemovable={isEditing}
+                  isRemovable={isEditing && !isMarkedForDestruction}
                   hideLabel={index !== 0}
                   showIcon
                 />
+                {isEditing && isMarkedForDestruction && (
+                  <HStack alignSelf="end" mb={1.5} spacing={2}>
+                    <Badge colorScheme="red" variant="subtle">
+                      {t("ui.markedForRemoval")}
+                    </Badge>
+                    <Button size="xs" variant="secondary" onClick={() => onRestore(trueIndex, item)}>
+                      {t("ui.undo")}
+                    </Button>
+                  </HStack>
+                )}
                 {!isEditing && showConfirmationWarning && item && !item.confirmedAt && confirmationRequiredLabel && (
                   <Alert
                     status="warning"

--- a/app/models/application_submission_contact.rb
+++ b/app/models/application_submission_contact.rb
@@ -13,6 +13,10 @@ class ApplicationSubmissionContact < SubmissionContact
     "your Building Permit Hub Submission inbox"
   end
 
+  def feature_enabled_attribute
+    :inbox_enabled?
+  end
+
   private
 
   def only_one_default_per_jurisdiction

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -107,6 +107,8 @@ class Jurisdiction < ApplicationRecord
             allow_blank: true
   validates :office_telephone, phone: true, allow_blank: true
   validate :inbox_enabled_requires_inbox_setup
+  validate :project_meetings_enabled_requires_setup
+  validate :property_information_requests_enabled_requires_setup
   validate :no_duplicate_part3_occupancy_pathways
 
   # Validation to ensure at least one sandbox exists
@@ -536,6 +538,34 @@ class Jurisdiction < ApplicationRecord
         )
       )
     end
+  end
+
+  def project_meetings_enabled_requires_setup
+    return if new_record?
+    return unless project_meetings_enabled
+    return unless will_save_change_to_project_meetings_enabled?
+    return if confirmed_project_meeting_contacts.exists?
+
+    errors.add(
+      :project_meetings_enabled,
+      I18n.t(
+        "activerecord.errors.models.jurisdiction.enabled_project_meetings_requires_setup"
+      )
+    )
+  end
+
+  def property_information_requests_enabled_requires_setup
+    return if new_record?
+    return unless property_information_requests_enabled
+    return unless will_save_change_to_property_information_requests_enabled?
+    return if confirmed_property_information_contacts.exists?
+
+    errors.add(
+      :property_information_requests_enabled,
+      I18n.t(
+        "activerecord.errors.models.jurisdiction.enabled_property_information_requests_requires_setup"
+      )
+    )
   end
 
   def no_duplicate_part3_occupancy_pathways

--- a/app/models/meeting_submission_contact.rb
+++ b/app/models/meeting_submission_contact.rb
@@ -10,4 +10,8 @@ class MeetingSubmissionContact < SubmissionContact
   def confirmation_configured_feature
     "project meeting notifications"
   end
+
+  def feature_enabled_attribute
+    :project_meetings_enabled?
+  end
 end

--- a/app/models/property_information_submission_contact.rb
+++ b/app/models/property_information_submission_contact.rb
@@ -10,4 +10,8 @@ class PropertyInformationSubmissionContact < SubmissionContact
   def confirmation_configured_feature
     "property information request notifications"
   end
+
+  def feature_enabled_attribute
+    :property_information_requests_enabled?
+  end
 end

--- a/app/models/submission_contact.rb
+++ b/app/models/submission_contact.rb
@@ -1,6 +1,8 @@
 class SubmissionContact < ApplicationRecord
   belongs_to :jurisdiction
 
+  before_destroy :ensure_enabled_feature_remains_configured
+
   validates :email,
             presence: true,
             uniqueness: {
@@ -40,5 +42,41 @@ class SubmissionContact < ApplicationRecord
   def confirmation_configured_feature
     raise NotImplementedError,
           "#{self.class} must implement #confirmation_configured_feature"
+  end
+
+  def feature_enabled_attribute
+    raise NotImplementedError,
+          "#{self.class} must implement #feature_enabled_attribute"
+  end
+
+  private
+
+  def ensure_enabled_feature_remains_configured
+    return if destroyed_by_association.present?
+    return unless confirmed?
+    return unless associated_feature_enabled?
+    return if another_confirmed_contact_exists?
+
+    errors.add(
+      :base,
+      I18n.t(
+        "activerecord.errors.models.submission_contact.last_confirmed_contact",
+        feature: confirmation_heading.downcase
+      )
+    )
+    throw(:abort)
+  end
+
+  def associated_feature_enabled?
+    jurisdiction&.public_send(feature_enabled_attribute)
+  end
+
+  def another_confirmed_contact_exists?
+    self
+      .class
+      .confirmed
+      .where(jurisdiction_id: jurisdiction_id)
+      .where.not(id: id)
+      .exists?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,8 @@ en:
         jurisdiction:
           no_sandboxes: "Jurisdiction must have at least one sandbox."
           enabled_inbox_requires_setup: "can only be toggled on once all emails are set up."
+          enabled_project_meetings_requires_setup: "can only be toggled on once at least one project meeting contact is confirmed."
+          enabled_property_information_requests_requires_setup: "can only be toggled on once at least one property information contact is confirmed."
         submission_contact:
           last_confirmed_contact: "cannot be deleted while %{feature} is enabled. Turn the setting off before deleting the last confirmed contact."
         part3_occupancy_required_step:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,8 @@ en:
         jurisdiction:
           no_sandboxes: "Jurisdiction must have at least one sandbox."
           enabled_inbox_requires_setup: "can only be toggled on once all emails are set up."
+        submission_contact:
+          last_confirmed_contact: "cannot be deleted while %{feature} is enabled. Turn the setting off before deleting the last confirmed contact."
         part3_occupancy_required_step:
           duplicate_pathway: "A pathway with identical energy step and zero carbon step already exists for this occupancy."
         jurisdiction_template_version_customizations:

--- a/spec/controllers/jurisdictions_controller_spec.rb
+++ b/spec/controllers/jurisdictions_controller_spec.rb
@@ -215,6 +215,7 @@ RSpec.describe Api::JurisdictionsController, type: :controller do
   describe "PATCH #update project meetings flag" do
     it "allows jurisdiction managers" do
       manager = create(:user, :review_manager, jurisdiction: jurisdiction)
+      create(:meeting_submission_contact, jurisdiction: jurisdiction)
       sign_in manager
 
       patch :update,
@@ -232,6 +233,10 @@ RSpec.describe Api::JurisdictionsController, type: :controller do
 
     it "updates property information request access" do
       manager = create(:user, :review_manager, jurisdiction: jurisdiction)
+      create(
+        :property_information_submission_contact,
+        jurisdiction: jurisdiction
+      )
       sign_in manager
 
       patch :update,
@@ -255,6 +260,7 @@ RSpec.describe Api::JurisdictionsController, type: :controller do
     it "allows technical support members" do
       tech = create(:user, role: :technical_support)
       create(:jurisdiction_membership, user: tech, jurisdiction: jurisdiction)
+      create(:meeting_submission_contact, jurisdiction: jurisdiction)
       sign_in tech
 
       patch :update,

--- a/spec/factories/sub_districts.rb
+++ b/spec/factories/sub_districts.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :sub_district do
+  factory :sub_district, aliases: [:jurisdiction] do
     sequence(:name) { |n| "#{Faker::Address.city} #{n}" }
     type { "SubDistrict" }
     locality_type { "city" }

--- a/spec/models/jurisdiction_spec.rb
+++ b/spec/models/jurisdiction_spec.rb
@@ -220,15 +220,62 @@ RSpec.describe Jurisdiction, type: :model do
       end
     end
 
+    describe "feature setup requirements" do
+      let(:jurisdiction) { create(:sub_district) }
+
+      it "requires a confirmed project meeting contact before enabling project meetings" do
+        jurisdiction.project_meetings_enabled = true
+
+        expect(jurisdiction).not_to be_valid
+        expect(jurisdiction.errors[:project_meetings_enabled]).to include(
+          I18n.t(
+            "activerecord.errors.models.jurisdiction.enabled_project_meetings_requires_setup"
+          )
+        )
+      end
+
+      it "allows project meetings to be enabled with a confirmed project meeting contact" do
+        create(:meeting_submission_contact, jurisdiction: jurisdiction)
+
+        jurisdiction.project_meetings_enabled = true
+
+        expect(jurisdiction).to be_valid
+      end
+
+      it "requires a confirmed property information contact before enabling property information requests" do
+        jurisdiction.property_information_requests_enabled = true
+
+        expect(jurisdiction).not_to be_valid
+        expect(
+          jurisdiction.errors[:property_information_requests_enabled]
+        ).to include(
+          I18n.t(
+            "activerecord.errors.models.jurisdiction.enabled_property_information_requests_requires_setup"
+          )
+        )
+      end
+
+      it "allows property information requests to be enabled with a confirmed property information contact" do
+        create(
+          :property_information_submission_contact,
+          jurisdiction: jurisdiction
+        )
+
+        jurisdiction.property_information_requests_enabled = true
+
+        expect(jurisdiction).to be_valid
+      end
+    end
+
     describe "submission contact deletion" do
       let(:jurisdiction) { create(:sub_district) }
 
       it "prevents deleting the last confirmed contact through nested attributes when its feature is enabled" do
-        jurisdiction.update!(project_meetings_enabled: true)
         contact =
           create(:meeting_submission_contact, jurisdiction: jurisdiction)
+        jurisdiction.update!(project_meetings_enabled: true)
 
-        expect(
+        expect {
           jurisdiction.update(
             submission_contacts_attributes: [
               {
@@ -238,7 +285,7 @@ RSpec.describe Jurisdiction, type: :model do
               }
             ]
           )
-        ).to be(false)
+        }.to raise_error(ActiveRecord::RecordNotDestroyed)
 
         expect(MeetingSubmissionContact.exists?(contact.id)).to be(true)
       end

--- a/spec/models/jurisdiction_spec.rb
+++ b/spec/models/jurisdiction_spec.rb
@@ -219,6 +219,30 @@ RSpec.describe Jurisdiction, type: :model do
         )
       end
     end
+
+    describe "submission contact deletion" do
+      let(:jurisdiction) { create(:sub_district) }
+
+      it "prevents deleting the last confirmed contact through nested attributes when its feature is enabled" do
+        jurisdiction.update!(project_meetings_enabled: true)
+        contact =
+          create(:meeting_submission_contact, jurisdiction: jurisdiction)
+
+        expect(
+          jurisdiction.update(
+            submission_contacts_attributes: [
+              {
+                id: contact.id,
+                type: "MeetingSubmissionContact",
+                _destroy: true
+              }
+            ]
+          )
+        ).to be(false)
+
+        expect(MeetingSubmissionContact.exists?(contact.id)).to be(true)
+      end
+    end
   end
 
   describe "#should_index?" do

--- a/spec/models/project_meeting_spec.rb
+++ b/spec/models/project_meeting_spec.rb
@@ -162,13 +162,13 @@ RSpec.describe ProjectMeeting, type: :model do
 
     it "enqueues property information notifications when enabled and requested" do
       meeting = create(:project_meeting, request_property_information: true)
-      meeting.permit_project.jurisdiction.update!(
-        property_information_requests_enabled: true
-      )
       create(
         :property_information_submission_contact,
         jurisdiction: meeting.permit_project.jurisdiction,
         email: "property-info@example.com"
+      )
+      meeting.permit_project.jurisdiction.update!(
+        property_information_requests_enabled: true
       )
 
       expect { meeting.submit_request! }.to have_enqueued_mail(
@@ -179,13 +179,13 @@ RSpec.describe ProjectMeeting, type: :model do
 
     it "does not enqueue property information notifications when not requested" do
       meeting = create(:project_meeting, request_property_information: false)
-      meeting.permit_project.jurisdiction.update!(
-        property_information_requests_enabled: true
-      )
       create(
         :property_information_submission_contact,
         jurisdiction: meeting.permit_project.jurisdiction,
         email: "property-info@example.com"
+      )
+      meeting.permit_project.jurisdiction.update!(
+        property_information_requests_enabled: true
       )
 
       expect { meeting.submit_request! }.not_to have_enqueued_mail(

--- a/spec/models/submission_contact_spec.rb
+++ b/spec/models/submission_contact_spec.rb
@@ -89,5 +89,96 @@ RSpec.describe SubmissionContact, type: :model do
         )
       }.to have_enqueued_mail(PermitHubMailer, :submission_contact_confirm)
     end
+
+    it "prevents deleting the last confirmed application submission contact while inbox is enabled" do
+      jurisdiction = create(:sub_district)
+      contact = jurisdiction.application_submission_contacts.first
+
+      expect { contact.destroy! }.to raise_error(
+        ActiveRecord::RecordNotDestroyed
+      )
+      expect(contact.errors[:base]).to include(
+        I18n.t(
+          "activerecord.errors.models.submission_contact.last_confirmed_contact",
+          feature: "submission inbox"
+        )
+      )
+      expect(ApplicationSubmissionContact.exists?(contact.id)).to be(true)
+    end
+
+    it "prevents deleting the last confirmed project meeting contact while project meetings are enabled" do
+      jurisdiction = create(:sub_district, project_meetings_enabled: true)
+      contact = create(:meeting_submission_contact, jurisdiction: jurisdiction)
+
+      expect { contact.destroy! }.to raise_error(
+        ActiveRecord::RecordNotDestroyed
+      )
+      expect(contact.errors[:base]).to include(
+        I18n.t(
+          "activerecord.errors.models.submission_contact.last_confirmed_contact",
+          feature: "project meetings"
+        )
+      )
+      expect(MeetingSubmissionContact.exists?(contact.id)).to be(true)
+    end
+
+    it "prevents deleting the last confirmed property information contact while property information requests are enabled" do
+      jurisdiction =
+        create(
+          :sub_district,
+          project_meetings_enabled: true,
+          property_information_requests_enabled: true
+        )
+      contact =
+        create(
+          :property_information_submission_contact,
+          jurisdiction: jurisdiction
+        )
+
+      expect { contact.destroy! }.to raise_error(
+        ActiveRecord::RecordNotDestroyed
+      )
+      expect(contact.errors[:base]).to include(
+        I18n.t(
+          "activerecord.errors.models.submission_contact.last_confirmed_contact",
+          feature: "property information requests"
+        )
+      )
+      expect(PropertyInformationSubmissionContact.exists?(contact.id)).to be(
+        true
+      )
+    end
+
+    it "allows deleting an application submission contact when another confirmed contact remains" do
+      jurisdiction = create(:sub_district)
+      contact = jurisdiction.application_submission_contacts.first
+      create(:application_submission_contact, jurisdiction: jurisdiction)
+
+      expect { contact.destroy! }.to change(
+        ApplicationSubmissionContact,
+        :count
+      ).by(-1)
+    end
+
+    it "allows deleting the last confirmed application submission contact when inbox is disabled" do
+      jurisdiction = create(:sub_district)
+      contact = jurisdiction.application_submission_contacts.first
+      jurisdiction.update!(inbox_enabled: false)
+
+      expect { contact.destroy! }.to change(
+        ApplicationSubmissionContact,
+        :count
+      ).by(-1)
+    end
+
+    it "allows deleting the last confirmed project meeting contact when project meetings are disabled" do
+      jurisdiction = create(:sub_district, project_meetings_enabled: false)
+      contact = create(:meeting_submission_contact, jurisdiction: jurisdiction)
+
+      expect { contact.destroy! }.to change(
+        MeetingSubmissionContact,
+        :count
+      ).by(-1)
+    end
   end
 end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -787,12 +787,12 @@ RSpec.describe NotificationService do
     it "sends only to confirmed property information recipient emails when enabled and requested" do
       meeting = create(:project_meeting, request_property_information: true)
       jurisdiction = meeting.permit_project.jurisdiction
-      jurisdiction.update!(property_information_requests_enabled: true)
       create(
         :property_information_submission_contact,
         jurisdiction: jurisdiction,
         email: "property-info@example.com"
       )
+      jurisdiction.update!(property_information_requests_enabled: true)
 
       expect {
         described_class.publish_property_information_request_received_event(
@@ -825,12 +825,12 @@ RSpec.describe NotificationService do
     it "does not send when the submitter did not request property information" do
       meeting = create(:project_meeting, request_property_information: false)
       jurisdiction = meeting.permit_project.jurisdiction
-      jurisdiction.update!(property_information_requests_enabled: true)
       create(
         :property_information_submission_contact,
         jurisdiction: jurisdiction,
         email: "property-info@example.com"
       )
+      jurisdiction.update!(property_information_requests_enabled: true)
 
       expect {
         described_class.publish_property_information_request_received_event(
@@ -844,8 +844,9 @@ RSpec.describe NotificationService do
 
     it "does not send when no recipients are configured" do
       meeting = create(:project_meeting, request_property_information: true)
-      meeting.permit_project.jurisdiction.update!(
-        property_information_requests_enabled: true
+      meeting.permit_project.jurisdiction.update_column(
+        :property_information_requests_enabled,
+        true
       )
 
       expect {


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-4972-story-reviewer-can-view-full-project-meeting-request-details-and-attachments-project-meeting-request-workflow` (merge-base range).

This PR adds the project meeting request workflow, with reviewer-facing support for viewing full project meeting request details, related project/property/requester information, uploaded attachments, authorization documents, and meeting status context. It also introduces the supporting backend models, APIs, policies, notifications, inbox/search surfaces, configuration settings, and test coverage needed for jurisdictions and reviewers to manage project meeting requests end to end.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | HUB-4972                                                   |
| 📄 Related PR(s)     | Related workflow tickets in range: HUB-4968, HUB-4970, HUB-5138, HUB-5140 |
| 📑 Design / Figma    | <!-- Paste link -->                                        |
| 📚 Documentation     | <!-- Paste link -->                                        |

---

## ✨ Features / Changes Introduced

- Adds project meeting request backend support, including `ProjectMeeting`, meeting request documents, status handling, policies, routes, blueprints, and search APIs.
- Adds reviewer workspace and inbox UI for project meetings, including filters, unread indicators, status tags, tables, detail panels, and project meeting tabs.
- Adds reviewer project meeting detail screens with request details, requester information, project/property information, meeting notes, documents, authorization documents, and status banners.
- Adds submitter-facing project meeting request creation/review/sent screens and project-level meeting request navigation.
- Adds project meeting notification emails for submitted and scheduled meeting flows, including jurisdiction-recipient notifications.
- Adds jurisdiction and global configuration surfaces for project meeting access, property information request access, and related submission contact setup.
- Extends submission contact handling to support application, project meeting, and property information contact types.
- Adds request specs, model specs, policy specs, mailer specs, service specs, factories, and support helpers for the new workflow.

---

## 🧪 Steps to QA

1. As an admin/review manager, enable project meetings for a jurisdiction from configuration management.
2. Configure project meeting notification recipients and confirm the relevant contact email flow behaves as expected.
3. As a submitter, open a permit project and start a project meeting request.
4. Complete the request form, including requester/contact details, project/property information, discussion details, and uploaded attachments.
5. Submit the request and verify the sent/confirmation state is shown.
6. As a reviewer/review manager, navigate to the submission/project meeting inbox.
7. Verify the project meeting request appears with the correct status, unread state, filters, and project context.
8. Open the project meeting request detail view and verify all request sections and attachments are visible.
9. Verify authorization documents and request documents can be viewed from the detail screen.
10. Schedule or update the meeting status where applicable and verify the correct banners/status indicators and notification emails are shown.

**Expected Behaviour:**

Reviewers can find project meeting requests from the inbox or project context, open the full detail view, review all submitted request information and attachments, and see the current status and relevant meeting notes/actions.

**Before this change:**

Project meeting requests did not have a complete reviewer workflow for viewing full request details and attachments from the project meeting request workflow.

**After this change:**

Project meeting requests are represented across the backend, inbox/search, project tabs, notification flows, and reviewer detail UI, allowing reviewers to inspect and act on submitted request details and attachments.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [x] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others