### PR TITLE
HUB-5210 add project specific meeting review screen

### DIFF
--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-meetings-tab.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-meetings-tab.tsx
@@ -1,22 +1,60 @@
-import { Box, Flex, Heading, HStack, Text } from "@chakra-ui/react"
+import { Box, Flex, Heading, HStack } from "@chakra-ui/react"
 import { CalendarBlank } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
 import React from "react"
 import { useTranslation } from "react-i18next"
+import { useMatch, useParams } from "react-router-dom"
+import { useSearch } from "../../../../../hooks/use-search"
+import { IPermitProject } from "../../../../../models/permit-project"
+import { IProjectMeeting } from "../../../../../models/project-meeting"
+import { useMst } from "../../../../../setup/root"
+import { ProjectMeetingInboxTable } from "../project-meeting-inbox-table"
+import { ReviewerMeetingDetailContent } from "../reviewer-meeting-detail-content"
 
-export const InboxMeetingsTab = () => {
+interface IProps {
+  permitProject: IPermitProject
+}
+
+export const InboxMeetingsTab = observer(({ permitProject }: IProps) => {
   const { t } = useTranslation()
+  const { jurisdictionId } = useParams<{ jurisdictionId: string }>()
+  const projectMeetingDetailMatch = useMatch(
+    "/jurisdictions/:jurisdictionId/submission-inbox/projects/:permitProjectId/meetings/:meetingId"
+  )
+  const { projectMeetingStore } = useMst()
+
+  useSearch(projectMeetingStore, projectMeetingDetailMatch ? [null] : [permitProject.id, "reviewer-project-meetings"])
+
+  if (projectMeetingDetailMatch?.params.meetingId && jurisdictionId) {
+    return (
+      <Flex direction="column" flex={1} minW={0} h="full" overflow="auto" bg="greys.white" p={10}>
+        <Box w="full" maxW="container.lg">
+          <ReviewerMeetingDetailContent jurisdictionId={jurisdictionId} />
+        </Box>
+      </Flex>
+    )
+  }
+
+  const getRowPath = (projectMeeting: IProjectMeeting) =>
+    `/jurisdictions/${jurisdictionId}/submission-inbox/projects/${permitProject.id}/meetings/${projectMeeting.id}`
 
   return (
-    <Flex direction="column" flex={1} bg="greys.white" p={10}>
-      <Box as="section">
+    <Flex direction="column" flex={1} minW={0} h="full" overflow="hidden" bg="greys.white" p={10}>
+      <Box as="section" flex={1} minH={0} display="flex" flexDirection="column">
         <HStack align="center" spacing={4} mb={6}>
           <CalendarBlank size={32} />
           <Heading as="h2" size="lg" mb={0}>
             {t("submissionInbox.projectDetail.meetings")}
           </Heading>
         </HStack>
-        <Text color="text.secondary">{t("submissionInbox.comingSoon")}</Text>
+        <ProjectMeetingInboxTable
+          searchStore={projectMeetingStore}
+          projectMeetings={projectMeetingStore.tableProjectMeetings}
+          getSortColumnHeader={projectMeetingStore.getProjectMeetingSortColumnHeader}
+          getRowPath={getRowPath}
+          noResultsDescription={t("permitProject.meetings.empty")}
+        />
       </Box>
     </Flex>
   )
-}
+})

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-project-detail-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-project-detail-screen.tsx
@@ -1,14 +1,16 @@
 import { Container, Flex, Heading, IconButton, TabPanel, TabPanels, Tabs, Text } from "@chakra-ui/react"
-import { CaretLeft, ClipboardText, SquaresFour, TrendUp } from "@phosphor-icons/react"
+import { CalendarBlank, CaretLeft, ClipboardText, SquaresFour, TrendUp } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
-import React, { useEffect, useTransition } from "react"
+import React, { useEffect, useMemo, useTransition } from "react"
 import { useTranslation } from "react-i18next"
 import { Link as RouterLink, useLocation, useNavigate, useParams } from "react-router-dom"
 import { usePermitProject } from "../../../../../hooks/resources/use-permit-project"
+import { useMst } from "../../../../../setup/root"
 import { ErrorScreen } from "../../../../shared/base/error-screen"
 import { LoadingScreen } from "../../../../shared/base/loading-screen"
 import { ActivityTabPanelContent } from "../../../permit-project/activity-tab-panel-content"
 import { ITabItem, ProjectSidebarTabList } from "../../../permit-project/project-sidebar-tab-list"
+import { InboxMeetingsTab } from "./inbox-meetings-tab"
 import { InboxOverviewTab } from "./inbox-overview-tab"
 import { InboxPermitsTab } from "./inbox-permits-tab"
 
@@ -18,28 +20,47 @@ export const InboxProjectDetailScreen = observer(() => {
   const location = useLocation()
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const { siteConfigurationStore } = useMst()
+  const projectMeetingsEnabled = Boolean(
+    siteConfigurationStore.projectMeetingsEnabled && currentPermitProject?.jurisdiction?.projectMeetingsEnabled
+  )
 
-  const TABS_DATA: ITabItem[] = [
-    { label: t("submissionInbox.projectDetail.overview"), icon: SquaresFour, to: "overview", tabIndex: 0 },
-    {
-      label: t("submissionInbox.projectDetail.permits"),
-      icon: ClipboardText,
-      to: "permits",
-      tabIndex: 1,
-    },
-    {
-      label: t("submissionInbox.projectDetail.activity"),
-      icon: TrendUp,
-      to: "activity",
-      tabIndex: 2,
-    },
-  ]
+  const TABS_DATA: ITabItem[] = useMemo(
+    () => [
+      { label: t("submissionInbox.projectDetail.overview"), icon: SquaresFour, to: "overview", tabIndex: 0 },
+      {
+        label: t("submissionInbox.projectDetail.permits"),
+        icon: ClipboardText,
+        to: "permits",
+        tabIndex: 1,
+      },
+      {
+        label: t("submissionInbox.projectDetail.activity"),
+        icon: TrendUp,
+        to: "activity",
+        tabIndex: 2,
+      },
+      ...(projectMeetingsEnabled
+        ? [
+            {
+              label: t("submissionInbox.projectDetail.meetings"),
+              icon: CalendarBlank,
+              to: "meetings",
+              tabIndex: 3,
+            },
+          ]
+        : []),
+    ],
+    [projectMeetingsEnabled, t]
+  )
 
   useEffect(() => {
+    if (!currentPermitProject) return
+
     if (!TABS_DATA.some((tab) => location.pathname.includes(tab.to))) {
       navigate("overview", { replace: true })
     }
-  }, [location.pathname, navigate])
+  }, [TABS_DATA, currentPermitProject, location.pathname, navigate])
 
   useEffect(() => {
     if (currentPermitProject) {
@@ -107,6 +128,11 @@ export const InboxProjectDetailScreen = observer(() => {
           <TabPanel flex={1} minH={0} minW={0} display="flex" flexDirection="column" overflow="hidden">
             {isPending ? <LoadingScreen /> : <ActivityTabPanelContent permitProject={currentPermitProject} fromInbox />}
           </TabPanel>
+          {projectMeetingsEnabled && (
+            <TabPanel flex={1} minH={0} minW={0} display="flex" flexDirection="column" overflow="hidden">
+              {isPending ? <LoadingScreen /> : <InboxMeetingsTab permitProject={currentPermitProject} />}
+            </TabPanel>
+          )}
         </TabPanels>
       </Tabs>
     </Flex>

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-meeting-inbox-table.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-meeting-inbox-table.tsx
@@ -6,8 +6,8 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 import { Link, useParams } from "react-router-dom"
 import { datefnsTableDateFormat, datefnsTableDateTimeFormat } from "../../../../constants"
+import { ISearch } from "../../../../lib/create-search-model"
 import { IProjectMeeting } from "../../../../models/project-meeting"
-import { IProjectMeetingInboxStore } from "../../../../stores/project-meeting-inbox-store"
 import { EFlashMessageStatus, EProjectMeetingSortFields } from "../../../../types/enums"
 import { ISort } from "../../../../types/types"
 import { CustomMessageBox } from "../../../shared/base/custom-message-box"
@@ -22,8 +22,11 @@ import { ProjectMeetingStatusTag } from "../../../shared/project-meetings/projec
 import { SortIcon } from "../../../shared/sort-icon"
 
 interface IProps {
-  searchStore: IProjectMeetingInboxStore
+  searchStore: ISearch
   projectMeetings: IProjectMeeting[]
+  getSortColumnHeader?: (field: EProjectMeetingSortFields) => string
+  getRowPath?: (projectMeeting: IProjectMeeting) => string
+  noResultsDescription?: React.ReactNode
 }
 
 const SORT_FIELDS = [
@@ -38,12 +41,14 @@ const SORT_FIELDS = [
 export const ProjectMeetingInboxTable = observer(function ProjectMeetingInboxTable({
   searchStore,
   projectMeetings,
+  getSortColumnHeader,
+  getRowPath,
+  noResultsDescription,
 }: IProps) {
   const { t } = useTranslation()
   const {
     toggleSort,
     sort,
-    getSortColumnHeader,
     currentPage,
     totalPages,
     totalCount,
@@ -54,6 +59,12 @@ export const ProjectMeetingInboxTable = observer(function ProjectMeetingInboxTab
   } = searchStore
 
   const listShowsNoResults = !isSearching && totalCount !== null && totalCount === 0
+  const { resetFilters } = searchStore as ISearch & { resetFilters?: () => void }
+  const storeGetSortColumnHeader = (
+    searchStore as { getSortColumnHeader?: (field: EProjectMeetingSortFields) => string }
+  ).getSortColumnHeader
+  const sortColumnHeader = (field: EProjectMeetingSortFields) =>
+    getSortColumnHeader?.(field) ?? storeGetSortColumnHeader?.(field) ?? field
 
   const renderListBody = () => {
     if (isSearching) {
@@ -72,12 +83,16 @@ export const ProjectMeetingInboxTable = observer(function ProjectMeetingInboxTab
             status={EFlashMessageStatus.info}
             title={t("submissionInbox.noMatchingMeetingsTitle")}
             description={
-              <Text>
-                {t("submissionInbox.noMatchingMeetingsDescription")}{" "}
-                <ChakraLink as="button" onClick={() => searchStore.resetFilters()} textDecoration="underline">
-                  {t("submissionInbox.clearAllFilters")}
-                </ChakraLink>
-              </Text>
+              resetFilters ? (
+                <Text>
+                  {t("submissionInbox.noMatchingMeetingsDescription")}{" "}
+                  <ChakraLink as="button" onClick={() => resetFilters()} textDecoration="underline">
+                    {t("submissionInbox.clearAllFilters")}
+                  </ChakraLink>
+                </Text>
+              ) : (
+                (noResultsDescription ?? t("submissionInbox.noMatchingMeetingsDescription"))
+              )
             }
           />
         </Flex>
@@ -85,7 +100,7 @@ export const ProjectMeetingInboxTable = observer(function ProjectMeetingInboxTab
     }
 
     return projectMeetings.map((projectMeeting) => (
-      <ProjectMeetingInboxRow key={projectMeeting.id} projectMeeting={projectMeeting} />
+      <ProjectMeetingInboxRow key={projectMeeting.id} projectMeeting={projectMeeting} getRowPath={getRowPath} />
     ))
   }
 
@@ -122,7 +137,7 @@ export const ProjectMeetingInboxTable = observer(function ProjectMeetingInboxTab
                 <SortableHeader
                   key={field}
                   field={field}
-                  label={getSortColumnHeader(field)}
+                  label={sortColumnHeader(field)}
                   sort={sort as ISort<EProjectMeetingSortFields>}
                   onToggleSort={toggleSort}
                 />
@@ -199,15 +214,18 @@ const formatDateTime = (date?: Date | null) => (date ? format(date, datefnsTable
 
 const ProjectMeetingInboxRow = observer(function ProjectMeetingInboxRow({
   projectMeeting,
+  getRowPath,
 }: {
   projectMeeting: IProjectMeeting
+  getRowPath?: (projectMeeting: IProjectMeeting) => string
 }) {
   const { jurisdictionId } = useParams()
+  const rowPath = getRowPath?.(projectMeeting) ?? `/jurisdictions/${jurisdictionId}/meetings/${projectMeeting.id}`
 
   return (
     <Box
       as={Link}
-      to={`/jurisdictions/${jurisdictionId}/meetings/${projectMeeting.id}`}
+      to={rowPath}
       className="project-meeting-inbox-grid-row"
       role="row"
       display="contents"

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/reviewer-meeting-detail-content.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/reviewer-meeting-detail-content.tsx
@@ -4,6 +4,7 @@ import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { useNavigate } from "react-router-dom"
 import { datefnsTableDateTimeFormat } from "../../../../constants"
 import { useProjectMeeting } from "../../../../hooks/resources/use-project-meeting"
 import { useMst } from "../../../../setup/root"
@@ -11,7 +12,6 @@ import { EFlashMessageStatus, EProjectMeetingStatus } from "../../../../types/en
 import { ErrorScreen } from "../../../shared/base/error-screen"
 import { LoadingScreen } from "../../../shared/base/loading-screen"
 import { ConfirmationModal } from "../../../shared/confirmation-modal"
-import { RouterLinkButton } from "../../../shared/navigation/router-link-button"
 import { ProjectMeetingStatusTag } from "../../../shared/project-meetings/project-meeting-status-tag"
 import { ReviewerScheduledMeetingBanner } from "../../project-meeting/detail/banners/reviewer-scheduled-meeting-banner"
 import { ScheduleMeetingBanner } from "../../project-meeting/detail/banners/schedule-meeting-banner"
@@ -33,6 +33,7 @@ const showScheduledBanner = (status: EProjectMeetingStatus, hasScheduledDetails:
 
 export const ReviewerMeetingDetailContent = observer(({ jurisdictionId }: ReviewerMeetingDetailContentProps) => {
   const { t } = useTranslation()
+  const navigate = useNavigate()
   const { currentProjectMeeting, error, isLoading } = useProjectMeeting()
   const { projectMeetingStore, uiStore, userStore } = useMst()
   const { currentUser } = userStore
@@ -76,15 +77,9 @@ export const ReviewerMeetingDetailContent = observer(({ jurisdictionId }: Review
 
   return (
     <Box as="section">
-      <RouterLinkButton
-        to={`/jurisdictions/${jurisdictionId}/meetings`}
-        leftIcon={<CaretLeft size={20} />}
-        variant="link"
-        mb={6}
-        px={0}
-      >
+      <Button leftIcon={<CaretLeft size={20} />} variant="link" mb={6} px={0} onClick={() => navigate(-1)}>
         {t("projectMeeting.detail.reviewer.backToMeetings")}
-      </RouterLinkButton>
+      </Button>
 
       <HStack justify="space-between" align="flex-start" mb={8}>
         <Box>

--- a/app/frontend/hooks/resources/use-project-meeting.ts
+++ b/app/frontend/hooks/resources/use-project-meeting.ts
@@ -10,10 +10,14 @@ export const useProjectMeeting = () => {
   }>()
   const projectMeetingDetailMatch = useMatch("/projects/:permitProjectId/meetings/:projectMeetingId")
   const reviewerMeetingDetailMatch = useMatch("/jurisdictions/:jurisdictionId/meetings/:meetingId")
+  const reviewerProjectMeetingDetailMatch = useMatch(
+    "/jurisdictions/:jurisdictionId/submission-inbox/projects/:permitProjectId/meetings/:meetingId"
+  )
   const projectMeetingId =
     projectMeetingIdParam ||
     projectMeetingDetailMatch?.params.projectMeetingId ||
-    reviewerMeetingDetailMatch?.params.meetingId
+    reviewerMeetingDetailMatch?.params.meetingId ||
+    reviewerProjectMeetingDetailMatch?.params.meetingId
   const { projectMeetingStore } = useMst()
   const { currentProjectMeeting, fetchProjectMeeting } = projectMeetingStore
   const [isLoading, setIsLoading] = useState(true)

--- a/spec/factories/sub_districts.rb
+++ b/spec/factories/sub_districts.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :sub_district do
+  factory :sub_district, aliases: [:jurisdiction] do
     sequence(:name) { |n| "#{Faker::Address.city} #{n}" }
     type { "SubDistrict" }
     locality_type { "city" }

--- a/spec/requests/api/project_meetings_spec.rb
+++ b/spec/requests/api/project_meetings_spec.rb
@@ -119,12 +119,20 @@ RSpec.describe "Api::ProjectMeetings", type: :request do
     let!(:meeting) do
       create(
         :project_meeting,
-        :open,
+        :scheduled,
         permit_project: permit_project,
         project_description: "Need zoning guidance."
       )
     end
     let!(:other_meeting) { create(:project_meeting, :completed) }
+    let!(:draft_meeting) do
+      create(
+        :project_meeting,
+        permit_project: permit_project,
+        project_description: "Draft meeting request.",
+        meeting_notes: "Initial draft notes."
+      )
+    end
 
     before { ProjectMeeting.reindex }
 
@@ -145,6 +153,45 @@ RSpec.describe "Api::ProjectMeetings", type: :request do
 
     it "does not return meetings to unrelated users" do
       sign_in other_user
+
+      post "/api/permit_projects/#{permit_project.id}/meetings/search",
+           params: {
+             query: "*",
+             page: 1,
+             per_page: 10
+           },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response["data"]).to be_empty
+    end
+
+    it "returns project-scoped submitted meeting requests for jurisdiction review staff" do
+      reviewer = create(:user, :reviewer, jurisdiction: jurisdiction)
+      sign_in reviewer
+
+      post "/api/permit_projects/#{permit_project.id}/meetings/search",
+           params: {
+             query: "*",
+             page: 1,
+             per_page: 10
+           },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response["data"].pluck("id")).to eq([meeting.id])
+      expect(json_response["data"].pluck("id")).not_to include(
+        draft_meeting.id,
+        other_meeting.id
+      )
+    end
+
+    it "does not return project meetings to review staff outside the jurisdiction" do
+      other_jurisdiction = create(:sub_district, project_meetings_enabled: true)
+      reviewer = create(:user, :reviewer, jurisdiction: other_jurisdiction)
+      sign_in reviewer
 
       post "/api/permit_projects/#{permit_project.id}/meetings/search",
            params: {


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-4972-story-reviewer-can-view-full-project-meeting-request-details-and-attachments-project-meeting-request-workflow` (merge-base range).

**Stack note:** This branch appears stacked on `HUB-4971-story-reviewer-can-triage-project-meeting-requests-in-meetings-workspace-project-meeting-request-workflow`; the branch-specific review scope is the three commits above that branch.

This PR adds the reviewer-facing project meeting request detail experience. Review staff can open a submitted project meeting request from the meetings workspace or project meetings tab and view the full request details, project context, requester information, attachments, and meeting notes in a dedicated detail view.

It also adds the supporting scheduling flow details, notification plumbing, and property information contact configuration needed for the project meeting request workflow.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                         |
| -------------------- | ---------------------------- |
| 🗂️ Jira Story / Task | HUB-4972                     |
| 🗂️ Related Task      | HUB-5140                     |
| 🗂️ Related Task      | HUB-5138                     |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->          |
| 📑 Design / Figma    | <!-- Paste link -->          |
| 📚 Documentation     | <!-- Paste link -->          |

---

## ✨ Features / Changes Introduced

- Adds a reviewer project meeting detail view with project information, requester information, request details, uploaded documents, and meeting notes.
- Allows reviewers to open project meeting requests from reviewer meeting inbox/workspace flows and project meeting tabs.
- Marks project meeting requests as viewed when review staff open the detail view.
- Adds reviewer scheduling and cancellation UI states, including scheduled-meeting and closed-request banners.
- Extends project meeting API loading so a reviewer can fetch a meeting request directly by ID through policy scope.
- Adds scheduled-meeting notification emails for submitters and jurisdiction contacts.
- Adds property information submission contacts and related jurisdiction configuration support.
- Adds/updates specs for project meeting status transitions, policies, API behavior, notifications, mailers, and jurisdiction/contact behavior.

***

## 🧪 Steps to QA

1. As a submitter, create and submit a project meeting request for a project, including request details and at least one attachment.
2. As review staff for the project jurisdiction, open the jurisdiction submission inbox and go to the meetings workspace.
3. Open the submitted project meeting request.
4. Verify the detail page shows the project information, requester information, request details, attachments, and meeting notes.
5. Verify the request is marked as viewed after opening it.
6. Schedule the meeting from the reviewer detail page with a contact method and confirmed date.
7. Verify the scheduled banner appears with the meeting details for review staff and the submitter.
8. Verify cancellation is available where expected and closed requests show the closed-state messaging.

**Expected Behaviour:**

Review staff can view the full project meeting request details and attachments from the meetings workflow, manage scheduling details, and see status-specific guidance without needing to navigate through submitter-only project pages.

**Before this change:**

Review staff could triage project meeting requests in the meetings workspace, but did not have the complete reviewer detail experience for viewing request contents and attachments.

**After this change:**

Review staff can open a meeting request and review the full request package, including project details, requester details, submitted documents, scheduling state, and meeting notes.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [x] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others