### PR TITLE
HUB-4973 add project meeting audits

### DIFF
--- a/app/models/concerns/activity_feed_preloader.rb
+++ b/app/models/concerns/activity_feed_preloader.rb
@@ -7,6 +7,7 @@ module ActivityFeedPreloader
       preload_permit_block_statuses(audits)
       preload_permit_project_collaborations(audits)
       preload_submission_versions(audits)
+      preload_project_meetings(audits)
     end
 
     private
@@ -40,6 +41,22 @@ module ActivityFeedPreloader
         records: records,
         associations: {
           collaborator: :user,
+          permit_project: :jurisdiction
+        }
+      ).call
+    end
+
+    def preload_project_meetings(audits)
+      records =
+        audits
+          .select { |a| a.auditable_type == "ProjectMeeting" }
+          .map(&:auditable)
+          .compact
+      return if records.empty?
+
+      ActiveRecord::Associations::Preloader.new(
+        records: records,
+        associations: {
           permit_project: :jurisdiction
         }
       ).call

--- a/app/models/project_meeting.rb
+++ b/app/models/project_meeting.rb
@@ -9,6 +9,18 @@ class ProjectMeeting < ApplicationRecord
                meeting_notes
                status
              ]
+  audited on: %i[update],
+          only: %i[
+            status
+            submitted_at
+            confirmed_date
+            scheduled_at
+            completed_at
+            closed_at
+            contact_method
+            meeting_url
+          ],
+          associated_with: :permit_project
 
   include ProjectMeetingStatus
 

--- a/app/presenters/project_audit_formatters/project_meeting_formatter.rb
+++ b/app/presenters/project_audit_formatters/project_meeting_formatter.rb
@@ -1,0 +1,55 @@
+module ProjectAuditFormatters
+  class ProjectMeetingFormatter < BaseFormatter
+    def description
+      case audit.action
+      when "update"
+        format_update_message
+      else
+        I18n.t("project_audit.fallback.generic_change", user: user_display)
+      end
+    end
+
+    private
+
+    def format_update_message
+      if changes.key?("status")
+        format_status_change
+      elsif schedule_details_changed?
+        "#{user_display} rescheduled the project meeting"
+      else
+        "#{user_display} updated the project meeting"
+      end
+    end
+
+    def format_status_change
+      case new_status_from_changes
+      when "open"
+        "#{user_display} submitted a project meeting request"
+      when "scheduled"
+        "#{user_display} scheduled the project meeting"
+      when "completed"
+        "#{user_display} completed the project meeting"
+      when "closed"
+        "#{user_display} cancelled the project meeting"
+      else
+        "#{user_display} changed the project meeting status"
+      end
+    end
+
+    def new_status_from_changes
+      status_value = Array.wrap(changes["status"]).last
+      return nil if status_value.nil?
+
+      if status_value.is_a?(Integer) || status_value.to_s.match?(/\A\d+\z/)
+        return ProjectMeeting.statuses.key(status_value.to_i)
+      end
+
+      status_value.to_s
+    end
+
+    def schedule_details_changed?
+      changes.key?("confirmed_date") || changes.key?("contact_method") ||
+        changes.key?("meeting_url")
+    end
+  end
+end

--- a/app/presenters/project_audit_presenter.rb
+++ b/app/presenters/project_audit_presenter.rb
@@ -7,7 +7,8 @@ class ProjectAuditPresenter
     "PermitBlockStatus" => ProjectAuditFormatters::PermitBlockStatusFormatter,
     "PermitProjectCollaboration" =>
       ProjectAuditFormatters::PermitProjectCollaborationFormatter,
-    "SubmissionVersion" => ProjectAuditFormatters::SubmissionVersionFormatter
+    "SubmissionVersion" => ProjectAuditFormatters::SubmissionVersionFormatter,
+    "ProjectMeeting" => ProjectAuditFormatters::ProjectMeetingFormatter
   }.freeze
 
   attr_reader :audit, :viewer

--- a/spec/models/concerns/audit_role_filter_spec.rb
+++ b/spec/models/concerns/audit_role_filter_spec.rb
@@ -25,6 +25,21 @@ RSpec.describe AuditRoleFilter do
     ApplicationAudit.visible_to_role(base_scope, user)
   end
 
+  def stub_project_meeting_notifications
+    allow(NotificationService).to receive(
+      :publish_project_meeting_submitted_event
+    )
+    allow(NotificationService).to receive(
+      :publish_project_meeting_request_received_event
+    )
+    allow(NotificationService).to receive(
+      :publish_property_information_request_received_event
+    )
+    allow(NotificationService).to receive(
+      :publish_project_meeting_scheduled_event
+    )
+  end
+
   describe ".visible_to_role for submitters" do
     it "excludes project state and read/unread changes" do
       Audited.audit_class.as_user(reviewer) { project.begin_progress! }
@@ -127,6 +142,36 @@ RSpec.describe AuditRoleFilter do
       expect(read_audit).to be_present
       expect(visible_audits_for(owner)).not_to include(read_audit)
     end
+
+    it "includes project meeting activity" do
+      stub_project_meeting_notifications
+      meeting =
+        create(
+          :project_meeting,
+          :open,
+          permit_project: project,
+          requested_by: owner
+        )
+
+      Audited
+        .audit_class
+        .as_user(reviewer) do
+          meeting.assign_attributes(
+            contact_method: :phone,
+            confirmed_date: 1.week.from_now
+          )
+          meeting.schedule!
+        end
+
+      schedule_audit =
+        ApplicationAudit
+          .where(auditable_type: "ProjectMeeting", auditable_id: meeting.id)
+          .where("audited_changes ? 'status'")
+          .last
+
+      expect(schedule_audit).to be_present
+      expect(visible_audits_for(owner)).to include(schedule_audit)
+    end
   end
 
   describe "excluding_redundant_viewed_at_audits" do
@@ -186,6 +231,23 @@ RSpec.describe AuditRoleFilter do
           .last
 
       expect(visible_audits_for(reviewer)).to include(state_audit)
+    end
+
+    it "includes project meeting activity" do
+      stub_project_meeting_notifications
+      meeting =
+        create(:project_meeting, permit_project: project, requested_by: owner)
+
+      Audited.audit_class.as_user(owner) { meeting.submit_request! }
+
+      submit_audit =
+        ApplicationAudit
+          .where(auditable_type: "ProjectMeeting", auditable_id: meeting.id)
+          .where("audited_changes ? 'status'")
+          .last
+
+      expect(submit_audit).to be_present
+      expect(visible_audits_for(reviewer)).to include(submit_audit)
     end
   end
 end

--- a/spec/models/project_activity_auditing_spec.rb
+++ b/spec/models/project_activity_auditing_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Project activity auditing", type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:jurisdiction) { create(:sub_district) }
   let(:reviewer) { create(:user, :review_manager, jurisdiction: jurisdiction) }
   let(:owner) { create(:user, :submitter) }
@@ -36,6 +38,28 @@ RSpec.describe "Project activity auditing", type: :model do
       )
       .where("audited_changes ? 'viewed_at'")
       .order(:created_at)
+  end
+
+  def project_meeting_audits
+    project_audits.where(auditable_type: "ProjectMeeting").order(
+      :created_at,
+      :id
+    )
+  end
+
+  def stub_project_meeting_notifications
+    allow(NotificationService).to receive(
+      :publish_project_meeting_submitted_event
+    )
+    allow(NotificationService).to receive(
+      :publish_project_meeting_request_received_event
+    )
+    allow(NotificationService).to receive(
+      :publish_property_information_request_received_event
+    )
+    allow(NotificationService).to receive(
+      :publish_project_meeting_scheduled_event
+    )
   end
 
   it "records project state changes" do
@@ -122,6 +146,99 @@ RSpec.describe "Project activity auditing", type: :model do
     Audited.audit_class.as_user(reviewer) { project.update_viewed_at }
 
     expect(permit_project_viewed_at_update_audits.count).to eq(read_count)
+  end
+
+  context "with a project meeting" do
+    let!(:project_meeting) do
+      create(:project_meeting, permit_project: project, requested_by: owner)
+    end
+
+    before { stub_project_meeting_notifications }
+
+    it "records lifecycle and scheduling actions in order" do
+      start_time = Time.zone.local(2026, 1, 1, 9, 0, 0)
+
+      travel_to(start_time) do
+        Audited.audit_class.as_user(owner) { project_meeting.submit_request! }
+      end
+
+      project_meeting.reload
+      travel_to(start_time + 10.minutes) do
+        Audited
+          .audit_class
+          .as_user(reviewer) do
+            project_meeting.assign_attributes(
+              contact_method: :phone,
+              confirmed_date: 1.week.from_now
+            )
+            project_meeting.schedule!
+          end
+      end
+
+      project_meeting.reload
+      travel_to(start_time + 20.minutes) do
+        Audited
+          .audit_class
+          .as_user(reviewer) do
+            project_meeting.update!(confirmed_date: 2.weeks.from_now)
+          end
+      end
+
+      project_meeting.reload
+      travel_to(start_time + 30.minutes) do
+        Audited.audit_class.as_user(reviewer) { project_meeting.complete! }
+      end
+
+      audits = project_meeting_audits.to_a
+
+      expect(audits.map(&:associated_type)).to all(eq("PermitProject"))
+      expect(audits.map(&:associated_id)).to all(eq(project.id))
+      expect(audits.map(&:user)).to eq([owner, reviewer, reviewer, reviewer])
+      expect(audits.map(&:created_at)).to eq(
+        [
+          start_time,
+          start_time + 10.minutes,
+          start_time + 20.minutes,
+          start_time + 30.minutes
+        ]
+      )
+      expect(audits.map(&:audited_changes)).to match(
+        [
+          a_hash_including("status", "submitted_at"),
+          a_hash_including("status", "scheduled_at", "confirmed_date"),
+          a_hash_including("confirmed_date"),
+          a_hash_including("status", "completed_at")
+        ]
+      )
+    end
+
+    it "records cancelled meeting requests" do
+      Audited.audit_class.as_user(owner) { project_meeting.submit_request! }
+
+      project_meeting.reload
+      Audited.audit_class.as_user(owner) { project_meeting.close! }
+
+      close_audit =
+        project_meeting_audits.where("audited_changes ? 'closed_at'").last
+
+      expect(close_audit).to be_present
+      expect(close_audit.audited_changes["status"]).to eq(
+        [ProjectMeeting.statuses["open"], ProjectMeeting.statuses["closed"]]
+      )
+    end
+
+    it "does not record draft edits or read/unread changes" do
+      audit_count = project_meeting_audits.count
+
+      Audited
+        .audit_class
+        .as_user(owner) do
+          project_meeting.update!(meeting_notes: "Updated draft notes")
+          project_meeting.update_viewed_at
+        end
+
+      expect(project_meeting_audits.count).to eq(audit_count)
+    end
   end
 
   context "with a submitted permit application" do

--- a/spec/models/project_meeting_spec.rb
+++ b/spec/models/project_meeting_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe ProjectMeeting, type: :model do
           project_description: nil,
           request_property_information: nil
         )
+      meeting.permit_project.jurisdiction.update!(
+        property_information_requests_enabled: true
+      )
 
       expect(meeting).not_to be_valid
       expect(meeting.errors[:requester_relationship]).to be_present

--- a/spec/presenters/project_audit_formatters/project_meeting_formatter_spec.rb
+++ b/spec/presenters/project_audit_formatters/project_meeting_formatter_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe ProjectAuditFormatters::ProjectMeetingFormatter do
+  let(:user) { instance_double(User, name: "Alice", blank?: false) }
+  let(:viewer) { nil }
+  let(:auditable) { instance_double(ProjectMeeting, jurisdiction: nil) }
+
+  subject(:formatter) { described_class.new(audit, viewer) }
+
+  describe "#description" do
+    {
+      "open" => "Alice submitted a project meeting request",
+      "scheduled" => "Alice scheduled the project meeting",
+      "completed" => "Alice completed the project meeting",
+      "closed" => "Alice cancelled the project meeting"
+    }.each do |status, message|
+      context "when status changes to #{status}" do
+        let(:audit) do
+          build_audit_double(
+            user: user,
+            auditable: auditable,
+            auditable_type: "ProjectMeeting",
+            action: "update",
+            audited_changes: {
+              "status" => [ProjectMeeting.statuses["draft"], status]
+            }
+          )
+        end
+
+        it "returns the lifecycle message" do
+          expect(formatter.description).to eq(message)
+        end
+      end
+    end
+
+    context "when schedule details change without a status change" do
+      let(:audit) do
+        build_audit_double(
+          user: user,
+          auditable: auditable,
+          auditable_type: "ProjectMeeting",
+          action: "update",
+          audited_changes: {
+            "confirmed_date" => [1.week.from_now, 2.weeks.from_now]
+          }
+        )
+      end
+
+      it "returns the reschedule message" do
+        expect(formatter.description).to eq(
+          "Alice rescheduled the project meeting"
+        )
+      end
+    end
+
+    context "when a submitter views a staff user's meeting action" do
+      let(:jurisdiction) do
+        instance_double(
+          Jurisdiction,
+          qualified_name: "City Hall",
+          id: 1,
+          present?: true
+        )
+      end
+      let(:staff_user) do
+        instance_double(
+          User,
+          name: "Staff Person",
+          blank?: false,
+          jurisdiction_staff?: true
+        )
+      end
+      let(:submitter_viewer) do
+        instance_double(User, submitter?: true, present?: true)
+      end
+      let(:auditable) do
+        instance_double(ProjectMeeting, jurisdiction: jurisdiction)
+      end
+      let(:viewer) { submitter_viewer }
+      let(:audit) do
+        build_audit_double(
+          user: staff_user,
+          auditable: auditable,
+          auditable_type: "ProjectMeeting",
+          action: "update",
+          audited_changes: {
+            "status" => [
+              ProjectMeeting.statuses["open"],
+              ProjectMeeting.statuses["scheduled"]
+            ]
+          }
+        )
+      end
+
+      before do
+        allow(staff_user).to receive(:member_of?).with(
+          jurisdiction.id
+        ).and_return(true)
+      end
+
+      it "masks the staff name with the jurisdiction name" do
+        expect(formatter.description).to eq(
+          "City Hall scheduled the project meeting"
+        )
+      end
+    end
+  end
+end

--- a/spec/presenters/project_audit_presenter_spec.rb
+++ b/spec/presenters/project_audit_presenter_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe ProjectAuditPresenter do
       "PermitBlockStatus" => ProjectAuditFormatters::PermitBlockStatusFormatter,
       "PermitProjectCollaboration" =>
         ProjectAuditFormatters::PermitProjectCollaborationFormatter,
-      "SubmissionVersion" => ProjectAuditFormatters::SubmissionVersionFormatter
+      "SubmissionVersion" => ProjectAuditFormatters::SubmissionVersionFormatter,
+      "ProjectMeeting" => ProjectAuditFormatters::ProjectMeetingFormatter
     }.each do |type, formatter_class|
       context "when auditable_type is #{type}" do
         let(:auditable_type) { type }

--- a/spec/requests/api/project_audits_spec.rb
+++ b/spec/requests/api/project_audits_spec.rb
@@ -9,11 +9,27 @@ RSpec.describe "Api::ProjectAudits (project activities)", type: :request do
   let(:owner) { create(:user, :submitter) }
   let(:other_user) { create(:user, :submitter) }
   let(:jurisdiction) { create(:sub_district) }
+  let(:reviewer) { create(:user, :review_manager, jurisdiction: jurisdiction) }
   let!(:permit_project) do
     create(:permit_project, owner: owner, jurisdiction: jurisdiction)
   end
 
   before { sign_in owner }
+
+  def stub_project_meeting_notifications
+    allow(NotificationService).to receive(
+      :publish_project_meeting_submitted_event
+    )
+    allow(NotificationService).to receive(
+      :publish_project_meeting_request_received_event
+    )
+    allow(NotificationService).to receive(
+      :publish_property_information_request_received_event
+    )
+    allow(NotificationService).to receive(
+      :publish_project_meeting_scheduled_event
+    )
+  end
 
   describe "POST /api/permit_projects/:id/activities" do
     it "returns success for project owner" do
@@ -217,6 +233,68 @@ RSpec.describe "Api::ProjectAudits (project activities)", type: :request do
         expect(response).to have_http_status(:ok)
         ids = json_response["data"].map { |row| row["id"] }
         expect(ids).to include(audit.id)
+      end
+    end
+
+    context "with project meeting activity" do
+      before { stub_project_meeting_notifications }
+
+      it "returns staff meeting activity to the project owner" do
+        meeting =
+          create(
+            :project_meeting,
+            :open,
+            permit_project: permit_project,
+            requested_by: owner
+          )
+
+        Audited
+          .audit_class
+          .as_user(reviewer) do
+            meeting.assign_attributes(
+              contact_method: :phone,
+              confirmed_date: 1.week.from_now
+            )
+            meeting.schedule!
+          end
+
+        post "/api/permit_projects/#{permit_project.id}/activities",
+             params: {
+             },
+             headers: headers,
+             as: :json
+
+        expect(response).to have_http_status(:ok)
+        descriptions = json_response["data"].map { |row| row["description"] }
+        expect(descriptions).to include(
+          "#{jurisdiction.qualified_name} scheduled the project meeting"
+        )
+        expect(descriptions).not_to include(
+          "#{reviewer.name} scheduled the project meeting"
+        )
+      end
+
+      it "returns submitter meeting activity to review staff" do
+        meeting =
+          create(
+            :project_meeting,
+            permit_project: permit_project,
+            requested_by: owner
+          )
+        Audited.audit_class.as_user(owner) { meeting.submit_request! }
+
+        sign_in reviewer
+        post "/api/permit_projects/#{permit_project.id}/activities",
+             params: {
+             },
+             headers: headers,
+             as: :json
+
+        expect(response).to have_http_status(:ok)
+        descriptions = json_response["data"].map { |row| row["description"] }
+        expect(descriptions).to include(
+          "#{owner.name} submitted a project meeting request"
+        )
       end
     end
 


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff e8d1fb4ba...HUB-4973-story-reviewer-can-add-submitter-visible-notes-and-manage-meeting-request-status-project-meeting-request-workflow` (merge-base range after HUB-4972 / PR #1725).

This PR completes the reviewer side of the project meeting request workflow: review staff can manage meeting request status (schedule, reschedule, complete, close), add rich-text notes that are visible to submitters, and submitters can view those notes from meeting and project detail screens. It also tightens active-meeting rules and exposes draft permit applications to reviewers when a project has an open or scheduled meeting.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-4973](https://hous-bssb.atlassian.net/browse/HUB-4973) |
| 📄 Related PR(s) | #1725 (HUB-4972), #1723 (HUB-4971), #1732 (HUB-4967), #1712 (HUB-4970), #1704 (HUB-4968) |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- **Meeting notes (submitter-visible):** New `Note` model and API for project meetings; reviewers can add rich-text notes on open, scheduled, completed, and closed requests; notes are visible to project owners on meeting detail and aggregated on a new project **Notes** tab.
- **Notes export:** CSV download for individual meeting notes and all project meeting notes.
- **Status management:** Reviewers can schedule open requests, reschedule scheduled requests (with email notifications to submitter and jurisdiction contacts), mark meetings complete, and close/cancel requests via `transition_status` and dedicated `reschedule` endpoint.
- **Schedule UI:** `ScheduleMeetingBanner` supports schedule and reschedule modes; unified `ProjectMeetingStatusBanner` replaces fragmented submitter status banners.
- **Active meeting rules:** `ACTIVE_STATUSES` updated to `open` + `scheduled`; only one active meeting per project; draft submit blocked when another request is active; active-meeting indicators in project inbox/workspace views.
- **Reviewer access to draft permits:** `PermitApplicationPolicy` allows review staff to see `new_draft` applications when the parent project has an active meeting (show + search scope).
- **Policy scope fix:** Active project meeting ID selection respects `policy_scope(ProjectMeeting)` so visibility is authorization-aware.
- **Reviewer workspace:** Meeting detail refactor with notes section, status actions, and inbox Notes tab; project-level notes list in submission inbox project detail.
- **Supporting changes:** `NotePolicy`, `NoteStore`, submission contact validations, property-information step skipped when feature disabled, and comprehensive request/policy/model specs.

---

## 🧪 Steps to QA

> Prerequisites: project meetings enabled globally and for the test jurisdiction; prior meeting workflow stories merged (submitter can create/submit requests; reviewer can triage and view details).

### Reviewer — add notes and manage status

1. Log in as **review staff** for a jurisdiction with an **open** project meeting request.
2. Open the meeting from the **Meetings** workspace or a project's **Meetings** tab in the submission inbox.
3. Confirm the **notes visibility** banner explains notes are visible to the submitter.
4. Add a rich-text note and confirm it appears in the notes list with author and timestamp.
5. Use **Schedule meeting** to set contact method, date/time, and URL (for videoconference); confirm status moves to **Scheduled** and scheduled details display.
6. Use **Reschedule** to change date/time; confirm the meeting updates and reschedule emails are sent (check mail preview/logs if available).
7. Mark the meeting **Complete**, then verify status and that notes can still be viewed.
8. On another open/scheduled request, use **Close/Cancel** and confirm status updates.

### Submitter — view notes

1. Log in as the **project owner** (submitter) for the project from the steps above.
2. Open **Projects → [project] → Meetings** and open the scheduled/completed meeting.
3. Confirm reviewer notes are visible on the meeting detail screen (read-only).
4. Open the project **Notes** tab and confirm meeting notes are listed with links back to the meeting.
5. Download notes CSV from the meeting detail and project Notes tab; confirm exported content matches the UI.

### Active meeting and draft permit visibility

1. With an **open** or **scheduled** meeting on a project that also has a **new draft** permit application, log in as review staff.
2. Confirm the draft application is visible in the submission inbox / project detail (it should not be hidden solely because it is still draft).
3. As submitter, attempt to start a second meeting while one is active; confirm the UI blocks submission and the draft banner explains why.

### Regression

1. Confirm reviewers still cannot edit submitter-owned draft meeting requests.
2. Confirm meeting request documents remain downloadable for reviewers on submitted meetings.
3. Verify active-meeting indicators appear on project rows/cards in inbox views when expected.

**Expected Behaviour:**
- Reviewers can progress meeting requests through the lifecycle and leave submitter-visible notes at each stage.
- Submitters see those notes on meeting and project screens but cannot add reviewer notes.
- Only one open/scheduled meeting per project; reviewers gain context on draft permits tied to active meeting projects.

**Before this change:**
- Reviewers could view meeting details but could not add notes, reschedule, or drive status transitions from the UI.
- Submitters had no consolidated place to read reviewer meeting notes.
- Draft permits on meeting-active projects were hidden from reviewers.

**After this change:**
- Full reviewer note + status workflow is available end-to-end, with submitter read access and CSV export.

---

## ♿ UI Accessibility Checklist

- [ ] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [ ] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4973]: https://hous-bssb.atlassian.net/browse/HUB-4973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ