### PR TITLE
HUB-4210 super admin can create edit and publish release notes fixes

### DIFF
--- a/app/controllers/api/concerns/search/release_notes.rb
+++ b/app/controllers/api/concerns/search/release_notes.rb
@@ -1,12 +1,6 @@
 module Api::Concerns::Search::ReleaseNotes
   extend ActiveSupport::Concern
 
-  SORTABLE_COLUMNS = {
-    "release_date" => :release_date,
-    "updated_at" => :updated_at,
-    "status" => :status
-  }.freeze
-
   def perform_release_note_search
     where_clause = release_note_where_clause
     order = release_note_order
@@ -45,8 +39,8 @@ module Api::Concerns::Search::ReleaseNotes
     year = release_note_search_params[:year].presence
     return filters unless year
 
-    start_date = Date.new(year.to_i, 1, 1)
-    end_date = Date.new(year.to_i, 12, 31)
+    start_date = Date.new(year.to_i, 1, 1).beginning_of_day
+    end_date = Date.new(year.to_i, 12, 31).end_of_day
     filters.merge(release_date: start_date..end_date)
   end
 
@@ -60,14 +54,28 @@ module Api::Concerns::Search::ReleaseNotes
   end
 
   def release_note_order
-    sort = release_note_search_params[:sort]
-    field = SORTABLE_COLUMNS[sort&.dig(:field).to_s]
-    direction = (sort&.dig(:direction).to_s.downcase == "asc" ? :asc : :desc)
-    # Use created_at to break ties when release_date (including time) is the same
-    if field
-      { field => direction, :created_at => direction }
+    if (sort = release_note_search_params[:sort])
+      {
+        sort[:field] => {
+          order: sort[:direction],
+          unmapped_type: "long"
+        },
+        :created_at => {
+          order: sort[:direction],
+          unmapped_type: "long"
+        }
+      }
     else
-      { release_date: :desc, created_at: :desc }
+      {
+        release_date: {
+          order: :desc,
+          unmapped_type: "long"
+        },
+        created_at: {
+          order: :desc,
+          unmapped_type: "long"
+        }
+      }
     end
   end
 

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -537,7 +537,7 @@ const AppRoutes = observer(() => {
       <Route path="/configuration-management/global-feature-access" element={<AdminGlobalFeatureAccessScreen />} />
       <Route path="/configuration-management/release-notes" element={<ReleaseNotesManagementScreen />} />
       <Route path="/configuration-management/release-notes/new" element={<ReleaseNoteFormScreen />} />
-      <Route path="/configuration-management/release-notes/:releaseNoteId/edit" element={<ReleaseNoteFormScreen />} />
+      <Route path="/configuration-management/release-notes/:releaseNoteId" element={<ReleaseNoteFormScreen />} />
       <Route
         path="/configuration-management/global-feature-access/submission-inbox"
         element={<AdminSubmissionInboxScreen />}

--- a/app/frontend/components/domains/super-admin/site-configuration-management/release-note-form-screen.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/release-note-form-screen.tsx
@@ -220,7 +220,7 @@ export const ReleaseNoteFormScreen = observer(function ReleaseNoteFormScreen() {
       const publishResult = await publishReleaseNote(createResult.data.id, data)
       if (!publishResult.ok) {
         console.error("Failed to publish release note after create:", publishResult.error)
-        navigate(`/configuration-management/release-notes/${createResult.data.id}/edit`, { replace: true })
+        navigate(`/configuration-management/release-notes/${createResult.data.id}`, { replace: true })
         return
       }
     } else {

--- a/app/frontend/components/domains/super-admin/site-configuration-management/release-notes-screen.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/release-notes-screen.tsx
@@ -85,7 +85,7 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
           <ReleaseNotesGridCell py={0} justifyContent="flex-end">
             <Button
               as={ReactRouterLink}
-              to={`/configuration-management/release-notes/${note.id}/edit`}
+              to={`/configuration-management/release-notes/${note.id}`}
               variant="secondary"
               size="sm"
               h="32px"

--- a/app/models/release_note.rb
+++ b/app/models/release_note.rb
@@ -21,6 +21,8 @@ class ReleaseNote < ApplicationRecord
 
   scope :published, -> { where(status: :published) }
 
+  after_commit :refresh_release_note_search_index, on: %i[create update]
+
   def search_data
     {
       id: id,
@@ -56,5 +58,9 @@ class ReleaseNote < ApplicationRecord
     return unless persisted? && status_was == "published" && version_changed?
 
     errors.add(:version, "cannot be changed once a release note is published")
+  end
+
+  def refresh_release_note_search_index
+    ReleaseNote.search_index.refresh
   end
 end

--- a/app/models/release_note.rb
+++ b/app/models/release_note.rb
@@ -6,7 +6,7 @@ class ReleaseNote < ApplicationRecord
     /\A(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?\z/
   enum :status, { draft: 0, published: 1 }, default: :draft
 
-  searchkick
+  searchkick searchable: %i[release_date status created_at]
 
   url_validatable :release_notes_url
   validates :version,

--- a/spec/factories/release_notes.rb
+++ b/spec/factories/release_notes.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :release_note do
-    version { Faker::App.semantic_version }
+    version { Faker::App.unique.semantic_version }
     release_date { Faker::Date.between(from: 1.year.ago, to: Time.current) }
     content { Faker::Lorem.paragraph }
     release_notes_url { Faker::Internet.url }

--- a/spec/requests/release_notes_spec.rb
+++ b/spec/requests/release_notes_spec.rb
@@ -287,6 +287,20 @@ RSpec.describe "ReleaseNotes", type: :request do
     end
   end
 
+  describe "#index with no release notes" do
+    before do
+      ReleaseNote.delete_all
+      ReleaseNote.reindex
+    end
+
+    it "returns an empty response" do
+      get release_notes_path
+
+      expect(response).to have_http_status(:success)
+      expect(subject).to eq([])
+    end
+  end
+
   describe "#show" do
     it "returns a release note" do
       setup


### PR DESCRIPTION
## 📋 Description

Follow-up fixes and polish for the super-admin release notes management flow. The main create/edit/publish feature already exists on `develop`; this PR addresses Searchkick edge cases, year-filter accuracy, admin routing, and list freshness after save.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                              |
| -------------------- | ----------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-4210](https://hous-bssb.atlassian.net/browse/HUB-4210)       |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                               |
| 📑 Design / Figma    | <!-- Paste link -->                                               |
| 📚 Documentation     | <!-- Paste link -->                                               |

---

## ✨ Features / Changes Introduced

- Fix release notes search returning 500 when the Elasticsearch index is empty by adding `unmapped_type` to sort clauses and aligning sort handling with other Searchkick concerns
- Fix year filtering excluding release notes on Dec 31 by using `beginning_of_day` / `end_of_day` for the `release_date` range
- Refresh the release notes Searchkick index after create/update so newly saved notes appear in the admin list immediately after redirect
- Simplify admin release note edit URLs from `/configuration-management/release-notes/:id/edit` to `/configuration-management/release-notes/:id`
- Use unique semantic versions in the release note factory to avoid flaky uniqueness failures in specs
- Add request spec coverage for empty release notes index responses

---

## 🧪 Steps to QA

1. Sign in as a super admin
2. Go to **Configuration Management → Release Notes**
3. With no release notes in the environment, verify the list loads successfully (no 500) and shows the empty state
4. Create a new release note and save as draft; verify you are redirected to the list and the new note appears without manually refreshing
5. Open an existing release note from the list; verify the URL is `/configuration-management/release-notes/:id` (no `/edit`)
6. Edit and publish a release note; verify the updated note appears in the list with the correct status
7. On the public `/release-notes` page, filter by a year that includes a note dated Dec 31; verify that note is included

**Expected Behaviour:**

- Admin release notes list/search works with zero records
- Saved release notes appear in the admin list immediately after redirect
- Year filtering includes notes across the full calendar year, including Dec 31
- Admin edit links use `/configuration-management/release-notes/:id`

**Before this change:**

- Empty Searchkick index could cause a 500 on list load
- Newly created notes could be missing from the admin list until Elasticsearch refreshed
- Year filter could exclude Dec 31 release notes due to timezone boundaries
- Admin edit URLs used a `/edit` suffix

**After this change:**

- Empty list loads successfully
- Saved notes appear in the list right away
- Year filtering is timezone-safe
- Admin edit URLs are simplified

---

## ♿ UI Accessibility Checklist

> Minor routing/link updates only; no new UI patterns introduced.

- [ ] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [ ] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4210]: https://hous-bssb.atlassian.net/browse/HUB-4210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ