### PR TITLE
update project state manual transitions

### DIFF
--- a/app/models/concerns/permit_project_state.rb
+++ b/app/models/concerns/permit_project_state.rb
@@ -2,13 +2,13 @@ module PermitProjectState
   extend ActiveSupport::Concern
 
   MANUAL_TRANSITIONS = {
-    draft: [],
-    queued: %i[waiting in_progress closed],
+    draft: %i[],
+    queued: %i[waiting in_progress ready permit_issued active closed],
     waiting: %i[queued in_progress ready permit_issued active closed],
-    in_progress: %i[queued waiting ready permit_issued active closed],
-    ready: %i[permit_issued waiting closed],
-    permit_issued: %i[active waiting closed ready],
-    active: %i[complete waiting closed queued],
+    in_progress: %i[queued waiting ready closed],
+    ready: %i[in_progress permit_issued waiting closed],
+    permit_issued: %i[in_progress active waiting closed ready],
+    active: %i[complete waiting closed queued in_progress],
     complete: %i[active queued],
     closed: %i[queued]
   }.freeze

--- a/spec/models/concerns/permit_project_state_spec.rb
+++ b/spec/models/concerns/permit_project_state_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe PermitProjectState, type: :model do
       it "returns valid transitions for queued" do
         project.update_column(:state, PermitProject.states[:queued])
         expect(project.allowed_manual_transitions).to eq(
-          %i[waiting in_progress closed]
+          %i[waiting in_progress ready permit_issued active closed]
         )
       end
     end


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5142-story-submitter-sees-project-meeting-guidance-advisory-when-confirming-permit-submission-project-meeting-request-workflow` (merge-base range).

This PR adds project meeting requirement advisories to the permit submission flow. Jurisdictions can now mark specific digital permit applications as requiring a project meeting, and submitters see guidance during permit submission with a link to request a meeting or view an active meeting request.

Note: the analyzed range is large and includes broader project meeting workflow work already present on this branch.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                                 |
| -------------------- | -------------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5142](https://yourorg.atlassian.net/browse/HUB-5142)            |
| 📄 Related PR(s)     | <!-- Add related project meeting workflow PRs if needed -->          |
| 📑 Design / Figma    | <!-- Paste link -->                                                  |
| 📚 Documentation     | <!-- Paste link -->                                                  |

---

## ✨ Features / Changes Introduced

- Adds a jurisdiction-level digital permit setting to mark a permit application type as requiring a project meeting.
- Persists and serializes `requires_project_meeting` on jurisdiction template version customizations.
- Shows a project meeting advisory in the permit application submission confirmation modal when the selected permit type requires a meeting and project meetings are enabled.
- Links submitters to either request a new project meeting or view their active meeting request.
- Adds specs for serialization, persistence, and project meeting requirement behavior.

***

## 🧪 Steps to QA

1. Sign in as a review manager for a jurisdiction with project meetings enabled.
2. Go to the digital building permits area and open the settings for a permit application type.
3. Turn on **Require project meeting at submission** and confirm the setting saves successfully.
4. Sign in as a submitter and create or open a project with that permit application type.
5. Start the permit application submission flow.
6. Confirm the submission modal displays the project meeting advisory.
7. Select the advisory link and confirm it opens the project meeting request flow when there is no active meeting request.
8. If the project already has an active meeting request, confirm the advisory links to the active meeting request instead.
9. Turn project meetings off for the jurisdiction or site configuration and confirm the advisory is not shown.

**Expected Behaviour:**

Submitters are advised to request a project meeting before submitting permit applications that the jurisdiction has flagged as requiring one.

**Before this change:**

Submitters could submit these permit applications without contextual guidance that a project meeting may be required.

**After this change:**

Submitters see an advisory during submission, with a direct path to request or view the relevant project meeting.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5142]: https://hous-bssb.atlassian.net/browse/HUB-5142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ