### PR TITLE
HUB-5054 cad currency unit label is not located in close proximity to respective field

### DIFF
--- a/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-block-accordion.tsx
@@ -291,7 +291,7 @@ export const RequirementBlockAccordion = observer(function RequirementBlockAccor
                       position="relative"
                       pr="var(--app-permit-fieldset-right-white-space)"
                       sx={{
-                        "& input": {
+                        "& .chakra-input__group": {
                           maxW: "var(--app-permit-input-field-short)",
                         },
                       }}

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
@@ -141,9 +141,9 @@ const requirementsComponentMap = {
       <GenericFieldDisplay
         inputDisplay={
           <InputGroup>
-            {unit === "cad" && <InputLeftElement>$</InputLeftElement>}
+            {unit === ENumberUnit.cad && <InputLeftElement>$</InputLeftElement>}
             <Input bg={"white"} />
-            {unit !== "cad" && <InputRightElement>{unit === undefined ? "unit" : unit}</InputRightElement>}
+            {unit !== ENumberUnit.cad && <InputRightElement>{unit === undefined ? "unit" : unit}</InputRightElement>}
           </InputGroup>
         }
         {...genericieldDisplayProps}

--- a/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-display/index.tsx
@@ -141,8 +141,9 @@ const requirementsComponentMap = {
       <GenericFieldDisplay
         inputDisplay={
           <InputGroup>
-            <InputRightElement mr={2}>{unit === undefined ? "unit" : unit}</InputRightElement>
+            {unit === "cad" && <InputLeftElement>$</InputLeftElement>}
             <Input bg={"white"} />
+            {unit !== "cad" && <InputRightElement>{unit === undefined ? "unit" : unit}</InputRightElement>}
           </InputGroup>
         }
         {...genericieldDisplayProps}


### PR DESCRIPTION
## 📋 Description

CAD currency fields in the requirements library displayed the unit label (`cad`) in a right-side adornment that sat far from the input. The max-width constraint was applied only to the `<input>` element, not the full Chakra `InputGroup`, so the currency label was visually detached from the field.

This PR fixes the layout by constraining the entire input group width and rendering CAD fields with a `$` prefix on the left (matching standard currency input patterns) instead of a `cad` suffix on the right.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5054](https://yourorg.atlassian.net/browse/HUB-5054) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                        |
| 📑 Design / Figma    | <!-- Paste link -->                                        |
| 📚 Documentation     | <!-- Paste link -->                                        |

---

## ✨ Features / Changes Introduced

- Apply `maxW` to `.chakra-input__group` (not just `input`) in `requirement-block-accordion.tsx` so unit adornments stay within the short input field width
- For number fields with `cad` unit, show `$` in `InputLeftElement` instead of `cad` in `InputRightElement`
- Other number units (mm, sqft, etc.) continue to display as a right-side unit label

---

## 🧪 Steps to QA

1. Open a permit application or requirement template preview that includes a **number** field with the **CAD** unit
2. Confirm the `$` symbol appears immediately to the left of the input, within the same compact field width as other short inputs
3. Open a requirement block that includes number fields with other units (e.g. mm, sqft, m)
4. Confirm those units still appear on the right side of the input, adjacent to the field
5. Check the layout in the requirement block accordion (template preview and live permit form views)

[HUB-5054]: https://hous-bssb.atlassian.net/browse/HUB-5054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ