### PR TITLE
HUB-4531 enhace and bugfix block edit modal

### DIFF
--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -45,12 +45,12 @@ export const FieldsSetup = observer(function FieldsSetup({
   })
   const watchedRequirements = watch("requirementsAttributes")
 
-  const [requirementIdsToEdit, setRequirementIdsToEdit] = useState<Record<string, boolean>>({})
+  const [requirementIdToEdit, setRequirementIdToEdit] = useState<string | undefined>()
 
   const { isOpen: isInReorderMode, onToggle } = useDisclosure()
 
   const toggleRequirementToEdit = (requirementId: string) => {
-    setRequirementIdsToEdit((pastState) => ({ ...pastState, [requirementId]: !pastState[requirementId] }))
+    setRequirementIdToEdit((pastRequirementId) => (pastRequirementId === requirementId ? undefined : requirementId))
   }
 
   const { onUseRequirement, onRemoveRequirement, disabledRequirementTypeOptions } = useRequirementLogic({
@@ -63,7 +63,7 @@ export const FieldsSetup = observer(function FieldsSetup({
   const hasFields = fields.length > 0
 
   function isRequirementInEditMode(id: string) {
-    return !isInReorderMode && !!requirementIdsToEdit[id]
+    return !isInReorderMode && requirementIdToEdit === id
   }
 
   return (

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
@@ -194,65 +194,71 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
           formProps={formProps}
           confirmCloseTitle={t("requirementsLibrary.modals.unsavedChanges.title")}
           confirmCloseBody={t("requirementsLibrary.modals.unsavedChanges.body")}
-          confirmCloseButtonText={t("requirementsLibrary.modals.unsavedChanges.discard")}
+          confirmCloseButtonText={t("ui.confirm")}
         >
-          <ModalCloseButton fontSize={"11px"} />
-          {(requirementBlock as IRequirementBlock)?.isDiscarded && (
-            <Tag
-              borderRadius="sm"
-              border="1px solid"
-              borderColor={"semantic.error"}
-              backgroundColor={"semantic.errorLight"}
-              w={"fit-content"}
-              py={1}
-              px={2}
-              color={"semantic.error"}
-              ml={"2.75rem"}
-              mb={2}
-            >
-              <HStack>
-                <Archive />
-                <Text textTransform={"capitalize"} fontSize={"sm"}>
-                  {t("requirementsLibrary.modals.archived")}
+          {({ onClose: closeFormModal }) => (
+            <>
+              <ModalCloseButton fontSize={"11px"} />
+              {(requirementBlock as IRequirementBlock)?.isDiscarded && (
+                <Tag
+                  borderRadius="sm"
+                  border="1px solid"
+                  borderColor={"semantic.error"}
+                  backgroundColor={"semantic.errorLight"}
+                  w={"fit-content"}
+                  py={1}
+                  px={2}
+                  color={"semantic.error"}
+                  ml={"2.75rem"}
+                  mb={2}
+                >
+                  <HStack>
+                    <Archive />
+                    <Text textTransform={"capitalize"} fontSize={"sm"}>
+                      {t("requirementsLibrary.modals.archived")}
+                    </Text>
+                  </HStack>
+                </Tag>
+              )}
+              <ModalHeader display={"flex"} justifyContent={"space-between"} pt={4} px={"2.75rem"} pb={0}>
+                <Text as={"h2"} fontSize={"2xl"}>
+                  {t(`requirementsLibrary.modals.${requirementBlock ? "edit" : "create"}.title`)}
                 </Text>
-              </HStack>
-            </Tag>
-          )}
-          <ModalHeader display={"flex"} justifyContent={"space-between"} pt={4} px={"2.75rem"} pb={0}>
-            <Text as={"h2"} fontSize={"2xl"}>
-              {t(`requirementsLibrary.modals.${requirementBlock ? "edit" : "create"}.title`)}
-            </Text>
-            <HStack>
-              <Button
-                variant={"primary"}
-                isLoading={isSubmitting}
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handleSubmit(onSubmit)()
-                }}
-              >
-                {t("ui.onlySave")}
-              </Button>
-              <Button variant={"secondary"} onClick={onClose} isDisabled={isSubmitting}>
-                {t("ui.cancel")}
-              </Button>
-            </HStack>
-          </ModalHeader>
-          <ModalBody px={"2.75rem"}>
-            {showEditWarning && (
-              <CalloutBanner type={"warning"} title={t("requirementsLibrary.modals.templateEditWarning")} />
-            )}
-            <HStack spacing={9} w={"full"} h={"full"} alignItems={"flex-start"}>
-              <BlockSetup
-                requirementBlock={
-                  (requirementBlock as IRequirementBlock)?.restore ? (requirementBlock as IRequirementBlock) : undefined
-                }
-                withOptionsMenu={withOptionsMenu}
-              />
+                <HStack>
+                  <Button
+                    variant={"primary"}
+                    isLoading={isSubmitting}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      handleSubmit(onSubmit)()
+                    }}
+                  >
+                    {t("ui.onlySave")}
+                  </Button>
+                  <Button variant={"secondary"} onClick={closeFormModal} isDisabled={isSubmitting}>
+                    {t("ui.cancel")}
+                  </Button>
+                </HStack>
+              </ModalHeader>
+              <ModalBody px={"2.75rem"}>
+                {showEditWarning && (
+                  <CalloutBanner type={"warning"} title={t("requirementsLibrary.modals.templateEditWarning")} />
+                )}
+                <HStack spacing={9} w={"full"} h={"full"} alignItems={"flex-start"}>
+                  <BlockSetup
+                    requirementBlock={
+                      (requirementBlock as IRequirementBlock)?.restore
+                        ? (requirementBlock as IRequirementBlock)
+                        : undefined
+                    }
+                    withOptionsMenu={withOptionsMenu}
+                  />
 
-              <FieldsSetup requirementBlock={requirementBlock} isEditable={isEditable} />
-            </HStack>
-          </ModalBody>
+                  <FieldsSetup requirementBlock={requirementBlock} isEditable={isEditable} />
+                </HStack>
+              </ModalBody>
+            </>
+          )}
         </FormModal>
       )}
     </>

--- a/app/frontend/components/shared/editor/editor.tsx
+++ b/app/frontend/components/shared/editor/editor.tsx
@@ -112,7 +112,9 @@ export const Editor = observer(
     }, [debouncedHandleChange, htmlValue, editor])
 
     useEffect(() => {
-      return () => debouncedHandleChange.cancel()
+      return () => {
+        debouncedHandleChange.flush()
+      }
     }, [debouncedHandleChange])
 
     // Handle autoFocus

--- a/app/frontend/components/shared/form-modal.tsx
+++ b/app/frontend/components/shared/form-modal.tsx
@@ -9,7 +9,7 @@ interface IFormModalProps<T extends FieldValues> {
   isOpen: boolean
   onClose: () => void
   formProps: UseFormReturn<T>
-  children: React.ReactNode
+  children: React.ReactNode | ((props: { onClose: () => void }) => React.ReactNode)
   modalProps?: Omit<ModalProps, "isOpen" | "onClose" | "children">
   confirmCloseTitle?: string
   confirmCloseBody?: string
@@ -74,7 +74,7 @@ export const FormModal = observer(function FormModal<T extends FieldValues>({
             maxW={"full"}
             {...(modalProps?.size ? {} : { w: "min(1170px, 95%)", maxW: "full" })}
           >
-            {children}
+            {typeof children === "function" ? children({ onClose: handleClose }) : children}
           </ModalContent>
         </FormProvider>
       </Modal>
@@ -87,9 +87,7 @@ export const FormModal = observer(function FormModal<T extends FieldValues>({
         title={confirmCloseTitle || t("ui.confirmation.unsavedChangesTitle")}
         body={confirmCloseBody || t("ui.confirmation.unsavedChangesBody")}
         onConfirm={handleConfirmClose}
-        confirmButtonProps={{
-          children: confirmCloseButtonText || t("ui.confirmation.discardChanges"),
-        }}
+        triggerText={confirmCloseButtonText || t("ui.confirmation.discardChanges")}
       />
     </>
   )


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-4531-bug-admin-panel-permit-templates-catalog-edit-template-confirmation-dialog-required-to-prevent-lost-data` (merge-base range; no committed branch diff yet) plus current working-tree changes for the requirements modal/editor files.

This PR improves the requirements library edit modal so admins are less likely to lose in-progress changes or get stuck with confusing field-edit state. It also fixes a TipTap editor timing issue where quickly pressing `Done` could cancel a pending debounced rich-text update before the preview/form state received it.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                        |
| -------------------- | ----------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-4531](https://yourorg.atlassian.net/browse/HUB-4531)   |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                         |
| 📑 Design / Figma    | <!-- Paste link -->                                         |
| 📚 Documentation     | <!-- Paste link -->                                         |

---

## ✨ Features / Changes Introduced

- Requirement field editing in the edit requirement block modal is now single-selection: opening one field’s editor closes the previously edited field.
- Unsaved changes confirmation is now used consistently when closing the requirement block modal via overlay, close button, or cancel.
- The unsaved changes confirmation button label now matches the requested `Confirm` modal copy.
- Pending debounced TipTap editor changes are flushed on editor cleanup so quick `Done` interactions reliably update help text/instructions previews.

***

## 🧪 Steps to QA

1. Navigate to `/requirements-library?currentPage=1` as a user who can edit requirement blocks.
2. Open an existing requirement block.
3. Edit one requirement field, then edit another requirement field.
4. Verify only one requirement field is in edit mode at a time.
5. Change a field value, then try closing the modal using the overlay, close button, and cancel button.
6. Verify the unsaved changes confirmation appears, `Never mind` keeps the modal open, and `Confirm` discards changes and closes the modal.
7. Add or edit help text, immediately select `Done`, and verify the preview updates.
8. Add or edit instructions, immediately select `Done`, and verify the preview updates.
9. Add before/after screenshots for the modal close confirmation and field editing behavior.

**Expected Behaviour:**

Only one requirement field can be edited at once, unsaved edits are protected by a confirmation modal on close, and rich-text help/instruction changes appear reliably after selecting `Done`.

**Before this change:**

Multiple requirement fields could remain in edit mode at the same time. The modal cancel action could bypass the guarded close path. Quick rich-text edits could appear inconsistent because pending debounced editor updates were canceled during editor cleanup.

**After this change:**

Field edit mode is single-selection, all common close paths use the unsaved changes confirmation, and pending editor updates are flushed before cleanup so previews stay in sync.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [ ] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-4531]: https://hous-bssb.atlassian.net/browse/HUB-4531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ