### PR TITLE
pull and verify git lfs assets before image build

### DIFF
--- a/.github/actions/openshift-deploy/action.yml
+++ b/.github/actions/openshift-deploy/action.yml
@@ -58,6 +58,25 @@ runs:
         ref: ${{ inputs.branch }}
         lfs: true
 
+    - name: Hydrate and verify Git LFS assets
+      id: hydrate-lfs-assets
+      shell: bash
+      run: |
+        git lfs pull
+        ruby <<'RUBY'
+        pointer_header = "version https://git-lfs.github.com/spec/v1"
+        unhydrated_paths =
+          `git lfs ls-files --name-only`.lines.map(&:chomp).select do |path|
+            File.file?(path) &&
+              File.open(path, "rb") { |file| file.read(pointer_header.bytesize) } ==
+                pointer_header
+          end
+
+        if unhydrated_paths.any?
+          abort("Git LFS files were not hydrated:\n#{unhydrated_paths.join("\n")}")
+        end
+        RUBY
+
     - name: Update GITHUB_SHA with checked-out commit SHA
       id: capture-git-sha
       shell: bash


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5222-bug-overheating-codes-tool-pdf-generation-500-on-download-report` (merge-base range).

This PR fixes deployed environments shipping Git LFS pointer files instead of hydrated binary assets in the Docker image. The issue caused public PDF links to fail with “Failed to load PDF document” and caused overheating code PDF generation to 500 when HexaPDF attempted to parse an LFS pointer as a PDF.

The shared OpenShift deploy action now explicitly runs `git lfs pull` after checking out the deploy branch and fails before image build if any LFS-tracked file is still an unhydrated pointer.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [x] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                 |
| -------------------- | -------------------- |
| 🗂️ Jira Story / Task | HUB-5222             |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->  |
| 📑 Design / Figma    | N/A                  |
| 📚 Documentation     | N/A                  |

---

## ✨ Features / Changes Introduced

- Hydrates Git LFS assets explicitly in the shared OpenShift deploy action before building the Docker image.
- Adds a deployment guard that checks all Git LFS-tracked files for the LFS pointer header.
- Fails the deploy early if any LFS asset is not hydrated, preventing broken PDFs from being published into dev/test/prod images.

***

## 🧪 Steps to QA

1. Run a dev or test deployment for this branch from GitHub Actions.
2. Verify the `Hydrate and verify Git LFS assets` step completes before the Docker image build.
3. After deployment, open the Letter of Assurance page and click the PDF download links.
4. Verify the PDFs open successfully in a browser tab instead of showing “Failed to load PDF document”.
5. In the overheating code tool, click **Download Report** from the summary screen.
6. Verify the generated PDF downloads successfully and the backend does not return a 500.

**Expected Behaviour:**

Git LFS-backed assets are hydrated before the Docker image is built, public PDF links render correctly, and overheating code report generation succeeds.

**Before this change:**

Deployed images could contain 131-byte Git LFS pointer files instead of actual PDF binaries. Public PDF links failed to load, and backend PDF generation failed with `HexaPDF::MalformedPDFError`.

**After this change:**

Deployments fail early if any LFS asset remains a pointer, preventing broken PDF assets from reaching deployed environments.

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others