### PR TITLE
HUB-4782 update not found copy

### DIFF
--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -3957,7 +3957,7 @@ Thank you,
             foundTitle: "Digital seal found",
             notFoundTitle: "Digital seal not found",
             noSignaturesFound:
-              "We could not find a digital seal (signature) from an AIBC or EGBC member. You can use this document to submit a permit application through Building Permit Hub. Documents without digital seals may be reviewed manually, which could take longer.",
+              "We could not find a digital seal from an AIBC or EGBC member on this document. You can still use this document in a permit application. The local building authority may need to review it manually, which could take longer than reviewing documents with valid digital seals.",
             systemFailureTitle: "We could not check the digital seal",
             systemFailureMessage:
               "Try uploading the document again. You can still submit permit applications with this document. If you keep seeing this message, contact the team at <1>{{email}}</1>",


### PR DESCRIPTION
## 📋 Description

Updates the copy shown when digital seal validation does not find an AIBC or EGBC seal on an uploaded document. The previous message was technically accurate but felt alarming and vague about what the submitter could do next.

The new copy clarifies that:
- no digital seal was found on **this document**
- the document can **still be used** in a permit application
- the **local building authority** may need to review it manually
- manual review may take longer than documents with valid digital seals

This string is used in the permit application form’s digital seal compliance warning (draft/edit flow) and in the standalone Check Digital Seals tool.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-4782](https://yourorg.atlassian.net/browse/HUB-4782) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                        |
| 📑 Design / Figma    | <!-- Paste link -->                                        |
| 📚 Documentation     | <!-- Paste link -->                                        |

---

## ✨ Features / Changes Introduced

- Updated `projectReadinessTools.digitalSealValidator.noSignaturesFound` copy in `app/frontend/i18n/i18n.ts`
- Removed redundant “(signature)” wording
- Reframed the message to be clearer and less alarming for submitters editing draft permit applications

---

## 🧪 Steps to QA

1. Log in as a submitter and open a **draft permit application** that includes a file upload field with digital seal validation (e.g. architectural drawing).
2. Upload a document **without** a valid AIBC/EGBC digital seal.
3. Confirm the compliance warning appears after validation runs.
4. Verify the warning shows the updated copy:

   > We could not find a digital seal from an AIBC or EGBC member on this document. You can still use this document in a permit application. The local building authority may need to review it manually, which could take longer than reviewing documents with valid digital seals.

5. Optionally, go to **Project Readiness Tools → Check digital seals**, upload the same document, and confirm the same message appears in the “not found” result state.

**Expected Behaviour:**

- Submitters see clearer, more reassuring guidance when no digital seal is found
- The message still communicates that manual review may be required and may take longer

**Before this change:**

> We could not find a digital seal (signature) from an AIBC or EGBC member. You can use this document to submit a permit application through Building Permit Hub. Documents without digital seals may be reviewed manually, which could take longer.

**After this change:**

> We could not find a digital seal from an AIBC or EGBC member on this document. You can still use this document in a permit application. The local building authority may need to review it manually, which could take longer than reviewing documents with valid digital seals.

_Add before/after screenshots of the warning in the draft permit application form._

---

## ♿ UI Accessibility Checklist

> Copy-only change; no structural UI or interaction changes.

- N/A — no UI structure, markup, or accessibility behaviour changed in this PR

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant _(copy-only; no tests required)_
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4782]: https://hous-bssb.atlassian.net/browse/HUB-4782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ