### PR TITLE
Hub 5237 bug white screen error when trying to view any application as rm or submitter in both dev tes

### DIFF
--- a/app/frontend/components/shared/chefs/custom-formio-components/components/BCAddress/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/BCAddress/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import AddressEditProvider from "./editForm/Address.edit.provider.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         label: "Provider",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.api.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.api.js
@@ -1,2 +1,4 @@
 import ComponentEditApi from "formiojs/components/_classes/component/editForm/Component.edit.api"
-export default [...ComponentEditApi]
+import { interopDefault } from "../../../../../../utils/interop-default"
+
+export default [...interopDefault(ComponentEditApi)]

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.conditional.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.conditional.js
@@ -1,2 +1,4 @@
 import ComponentEditConditional from "formiojs/components/_classes/component/editForm/Component.edit.conditional"
-export default [...ComponentEditConditional]
+import { interopDefault } from "../../../../../../utils/interop-default"
+
+export default [...interopDefault(ComponentEditConditional)]

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.data.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.data.js
@@ -1,3 +1,5 @@
 import ComponentEditData from "formiojs/components/_classes/component/editForm/Component.edit.data"
 import TextFieldEditData from "formiojs/components/textfield/editForm/TextField.edit.data"
-export default [...ComponentEditData, ...TextFieldEditData]
+import { interopDefault } from "../../../../../../utils/interop-default"
+
+export default [...interopDefault(ComponentEditData), ...interopDefault(TextFieldEditData)]

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.layout.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.layout.js
@@ -1,2 +1,4 @@
 import ComponentEditLayout from "formiojs/components/_classes/component/editForm/Component.edit.layout"
-export default [...ComponentEditLayout]
+import { interopDefault } from "../../../../../../utils/interop-default"
+
+export default [...interopDefault(ComponentEditLayout)]

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.logic.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.logic.js
@@ -1,2 +1,4 @@
 import ComponentEditLogic from "formiojs/components/_classes/component/editForm/Component.edit.logic"
-export default [...ComponentEditLogic]
+import { interopDefault } from "../../../../../../utils/interop-default"
+
+export default [...interopDefault(ComponentEditLogic)]

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.validation.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/Common/Advanced.edit.validation.js
@@ -1,6 +1,11 @@
 import ComponentEditValidation from "formiojs/components/_classes/component/editForm/Component.edit.validation"
 import TextFieldEditValidation from "formiojs/components/textfield/editForm/TextField.edit.validation"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import UseForCopy from "./UseForCopy.js"
+
+const componentEditValidationComponents = interopDefault(ComponentEditValidation)
+const textFieldEditValidationComponents = interopDefault(TextFieldEditValidation)
+
 const kickbox = {
   type: "panel",
   label: "Kickbox",
@@ -17,7 +22,7 @@ const kickbox = {
     },
   ],
 }
-export default [kickbox, UseForCopy, ...ComponentEditValidation, ...TextFieldEditValidation]
+export default [kickbox, UseForCopy, ...componentEditValidationComponents, ...textFieldEditValidationComponents]
 // const neededposition = [
 //   'validate.isUseForCopy',
 //   'validateOn',

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/OrgBook/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/OrgBook/Component.form.js
@@ -1,9 +1,10 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditData from "./editForm/Orgbook.edit.data.js"
 import EditDisplay from "./editForm/Orgbook.edit.display.js"
 import EditValidation from "./editForm/Orgbook.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "display",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleAddressAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleAddressAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/address/Address.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleBCAddress/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleBCAddress/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import AddressEditProvider from "./editForm/Address.edit.provider.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         label: "Provider",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleButtonAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleButtonAdvanced/Component.form.js
@@ -1,2 +1,3 @@
 import baseEditForm from "formiojs/components/button/Button.form"
-export default baseEditForm
+import { interopDefault } from "../../../../../../utils/interop-default"
+export default interopDefault(baseEditForm)

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleButtonReset/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleButtonReset/Component.form.js
@@ -1,9 +1,10 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleButtonSubmit/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleButtonSubmit/Component.form.js
@@ -1,9 +1,10 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCheckbox/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCheckbox/Component.form.js
@@ -1,10 +1,11 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "display",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCheckboxAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCheckboxAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/checkbox/Checkbox.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCheckboxAdvanced/editForm/Component.edit.validation.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCheckboxAdvanced/editForm/Component.edit.validation.js
@@ -1,6 +1,8 @@
 import validationComponents from "formiojs/components/checkbox/editForm/Checkbox.edit.validation"
+import { interopDefault } from "../../../../../../../utils/interop-default"
 import common from "../../Common/Advanced.edit.validation.js"
 import { reArrangeComponents } from "../../Common/function.js"
+
 const neededposition = [
   "validate.isUseForCopy",
   "validate.required",
@@ -10,5 +12,7 @@ const neededposition = [
   "json-validation-json",
   "errors",
 ]
-const newPosition = reArrangeComponents(neededposition, [...validationComponents, ...common])
+const validationComponentItems = interopDefault(validationComponents)
+
+const newPosition = reArrangeComponents(neededposition, [...validationComponentItems, ...common])
 export default newPosition

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCheckboxes/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCheckboxes/Component.form.js
@@ -1,11 +1,12 @@
 import radioEditForm from "formiojs/components/radio/Radio.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditData from "./editForm/Component.edit.data.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return radioEditForm(
+  return interopDefault(radioEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCheckboxes/editForm/Component.edit.data.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCheckboxes/editForm/Component.edit.data.js
@@ -1,5 +1,8 @@
 import BuilderUtils from "formiojs/utils/builder"
 import get from "lodash/get"
+import { interopDefault } from "../../../../../../../utils/interop-default"
+
+const builderUtils = interopDefault(BuilderUtils)
 
 export default [
   {
@@ -55,7 +58,7 @@ export default [
         template: "{{ item.label }}",
         data: {
           custom(context) {
-            return BuilderUtils.getAvailableShortcuts(
+            return builderUtils.getAvailableShortcuts(
               get(context, "instance.options.editForm", {}),
               get(context, "instance.options.editComponent", {})
             )

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleColumns2/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleColumns2/Component.form.js
@@ -1,9 +1,10 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "display",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleColumns3/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleColumns3/Component.form.js
@@ -1,9 +1,10 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleColumns4/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleColumns4/Component.form.js
@@ -1,9 +1,10 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleContent/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleContent/Component.form.js
@@ -1,8 +1,9 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 export default function (...extend) {
-  const editForm = baseEditForm(
+  const editForm = interopDefault(baseEditForm)(
     [
       {
         key: "display",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCurrencyAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleCurrencyAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/currency/Currency.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDateTime/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDateTime/Component.form.js
@@ -1,4 +1,5 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import SimpleValidation from "../Common/Simple.edit.validation.js"
@@ -7,7 +8,7 @@ import EditDate from "./editForm/Component.edit.date.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 import EditTime from "./editForm/Component.edit.time.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "display",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDateTimeAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDateTimeAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/datetime/DateTime.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDateTimeAdvanced/editForm/Component.edit.validation.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDateTimeAdvanced/editForm/Component.edit.validation.js
@@ -1,6 +1,8 @@
 import validationComponents from "formiojs/components/datetime/editForm/DateTime.edit.validation"
+import { interopDefault } from "../../../../../../../utils/interop-default"
 import common from "../../Common/Advanced.edit.validation.js"
 import { reArrangeComponents } from "../../Common/function.js"
+
 const neededposition = [
   "validate.isUseForCopy",
   "validateOn",
@@ -16,5 +18,7 @@ const neededposition = [
   "json-validation-json",
   "errors",
 ]
-const newPosition = reArrangeComponents(neededposition, [...validationComponents, ...common])
+const validationComponentItems = interopDefault(validationComponents)
+
+const newPosition = reArrangeComponents(neededposition, [...validationComponentItems, ...common])
 export default newPosition

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDay/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDay/Component.form.js
@@ -1,4 +1,5 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditData from "./editForm/Component.edit.data.js"
@@ -8,7 +9,7 @@ import EditMonth from "./editForm/Component.edit.month.js"
 import EditValidation from "./editForm/Component.edit.validation.js"
 import EditYear from "./editForm/Component.edit.year.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "display",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDayAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDayAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/day/Day.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDayAdvanced/editForm/Component.edit.validation.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleDayAdvanced/editForm/Component.edit.validation.js
@@ -1,6 +1,8 @@
 import validationComponents from "formiojs/components/day/editForm/Day.edit.validation"
+import { interopDefault } from "../../../../../../../utils/interop-default"
 import common from "../../Common/Advanced.edit.validation.js"
 import { reArrangeComponents } from "../../Common/function.js"
+
 const neededposition = [
   "validate.isUseForCopy",
   "validateOn",
@@ -16,5 +18,7 @@ const neededposition = [
   "json-validation-json",
   "errors",
 ]
-const newPosition = reArrangeComponents(neededposition, [...validationComponents, ...common])
+const validationComponentItems = interopDefault(validationComponents)
+
+const newPosition = reArrangeComponents(neededposition, [...validationComponentItems, ...common])
 export default newPosition

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleEmail/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleEmail/Component.form.js
@@ -1,11 +1,12 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import SimpleValidation from "../Common/Simple.edit.validation.js"
 import EditData from "./editForm/Component.edit.data.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleEmailAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleEmailAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/email/Email.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleFieldSet/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleFieldSet/Component.form.js
@@ -1,9 +1,10 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleFile/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleFile/Component.form.js
@@ -1,4 +1,5 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import SimpleValidation from "../Common/Simple.edit.validation.js"
@@ -6,7 +7,7 @@ import EditData from "./editForm/Component.edit.data.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 import EditFile from "./editForm/Component.edit.file.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "display",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleHeading/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleHeading/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "display",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleNumber/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleNumber/Component.form.js
@@ -1,11 +1,12 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditData from "./editForm/Component.edit.data.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleNumberAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleNumberAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/number/Number.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleNumberAdvanced/editForm/Component.edit.validation.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleNumberAdvanced/editForm/Component.edit.validation.js
@@ -1,6 +1,8 @@
 import NumberEditValidation from "formiojs/components/number/editForm/Number.edit.validation"
+import { interopDefault } from "../../../../../../../utils/interop-default"
 import common from "../../Common/Advanced.edit.validation.js"
 import { reArrangeComponents } from "../../Common/function.js"
+
 const neededposition = [
   "validate.isUseForCopy",
   "validateOn",
@@ -13,5 +15,7 @@ const neededposition = [
   "custom-validation-js",
   "json-validation-json",
 ]
-const newPosition = reArrangeComponents(neededposition, [...NumberEditValidation, ...common])
+const numberEditValidationComponents = interopDefault(NumberEditValidation)
+
+const newPosition = reArrangeComponents(neededposition, [...numberEditValidationComponents, ...common])
 export default newPosition

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimplePanel/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimplePanel/Component.form.js
@@ -1,9 +1,10 @@
 import nestedComponentForm from "formiojs/components/_classes/nested/NestedComponent.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return nestedComponentForm(
+  return interopDefault(nestedComponentForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleParagraph/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleParagraph/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "display",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimplePasswordAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimplePasswordAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/password/Password.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimplePhoneNumber/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimplePhoneNumber/Component.form.js
@@ -1,11 +1,12 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import SimpleValidation from "../Common/Simple.edit.validation.js"
 import EditData from "./editForm/Component.edit.data.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimplePhoneNumberAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimplePhoneNumberAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/phonenumber/PhoneNumber.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleRadioAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleRadioAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/radio/Radio.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleRadioAdvanced/editForm/Component.edit.validation.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleRadioAdvanced/editForm/Component.edit.validation.js
@@ -1,6 +1,8 @@
 import validationComponents from "formiojs/components/radio/editForm/Radio.edit.validation"
+import { interopDefault } from "../../../../../../../utils/interop-default"
 import common from "../../Common/Advanced.edit.validation.js"
 import { reArrangeComponents } from "../../Common/function.js"
+
 const neededposition = [
   "validate.isUseForCopy",
   "validate.required",
@@ -11,5 +13,7 @@ const neededposition = [
   "json-validation-json",
   "errors",
 ]
-const newPosition = reArrangeComponents(neededposition, [...validationComponents, ...common])
+const validationComponentItems = interopDefault(validationComponents)
+
+const newPosition = reArrangeComponents(neededposition, [...validationComponentItems, ...common])
 export default newPosition

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleRadios/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleRadios/Component.form.js
@@ -1,11 +1,12 @@
 import radioEditForm from "formiojs/components/radio/Radio.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditData from "./editForm/Component.edit.data.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return radioEditForm(
+  return interopDefault(radioEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleRadios/editForm/Component.edit.data.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleRadios/editForm/Component.edit.data.js
@@ -1,5 +1,8 @@
 import BuilderUtils from "formiojs/utils/builder"
 import get from "lodash/get"
+import { interopDefault } from "../../../../../../../utils/interop-default"
+
+const builderUtils = interopDefault(BuilderUtils)
 
 export default [
   {
@@ -55,7 +58,7 @@ export default [
         template: "{{ item.label }}",
         data: {
           custom(context) {
-            return BuilderUtils.getAvailableShortcuts(
+            return builderUtils.getAvailableShortcuts(
               get(context, "instance.options.editForm", {}),
               get(context, "instance.options.editComponent", {})
             )

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSelect/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSelect/Component.form.js
@@ -1,11 +1,12 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditData from "./editForm/Component.edit.data.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSelectAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSelectAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/select/Select.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSelectAdvanced/editForm/Component.edit.validation.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSelectAdvanced/editForm/Component.edit.validation.js
@@ -1,6 +1,8 @@
 import validationComponents from "formiojs/components/select/editForm/Select.edit.validation"
+import { interopDefault } from "../../../../../../../utils/interop-default"
 import common from "../../Common/Advanced.edit.validation.js"
 import { reArrangeComponents } from "../../Common/function.js"
+
 const neededposition = [
   "validate.isUseForCopy",
   "validateOn",
@@ -32,5 +34,7 @@ const componentSpecific = {
     },
   },
 }
-const newPosition = reArrangeComponents(neededposition, [componentSpecific, ...validationComponents, ...common])
+const validationComponentItems = interopDefault(validationComponents)
+
+const newPosition = reArrangeComponents(neededposition, [componentSpecific, ...validationComponentItems, ...common])
 export default newPosition

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSelectBoxesAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSelectBoxesAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/selectboxes/SelectBoxes.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSelectBoxesAdvanced/editForm/Component.edit.validation.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSelectBoxesAdvanced/editForm/Component.edit.validation.js
@@ -1,6 +1,8 @@
 import validationComponents from "formiojs/components/selectboxes/editForm/SelectBoxes.edit.validation"
+import { interopDefault } from "../../../../../../../utils/interop-default"
 import common from "../../Common/Advanced.edit.validation.js"
 import { reArrangeComponents } from "../../Common/function.js"
+
 const neededposition = [
   "validate.isUseForCopy",
   "validate.required",
@@ -34,5 +36,7 @@ const componentSpecific = {
     },
   },
 }
-const newPosition = reArrangeComponents(neededposition, [componentSpecific, ...validationComponents, ...common])
+const validationComponentItems = interopDefault(validationComponents)
+
+const newPosition = reArrangeComponents(neededposition, [componentSpecific, ...validationComponentItems, ...common])
 export default newPosition

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSignatureAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSignatureAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/signature/Signature.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSurveyAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleSurveyAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/survey/Survey.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTabs/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTabs/Component.form.js
@@ -1,9 +1,10 @@
 import nestedComponentForm from "formiojs/components/_classes/nested/NestedComponent.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return nestedComponentForm(
+  return interopDefault(nestedComponentForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTagsAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTagsAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/tags/Tags.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTextArea/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTextArea/Component.form.js
@@ -1,11 +1,12 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditData from "./editForm/Component.edit.data.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTextAreaAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTextAreaAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/textarea/TextArea.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTextField/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTextField/Component.form.js
@@ -1,11 +1,12 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import EditData from "./editForm/Component.edit.data.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTextFieldAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTextFieldAdvanced/Component.form.js
@@ -1,8 +1,9 @@
 import baseEditForm from "formiojs/components/textfield/TextField.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditDisplay from "./editForm/Component.edit.display.js"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "display",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTime/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTime/Component.form.js
@@ -1,11 +1,12 @@
 import baseEditForm from "formiojs/components/_classes/component/Component.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import SimpleApi from "../Common/Simple.edit.api.js"
 import SimpleConditional from "../Common/Simple.edit.conditional.js"
 import SimpleValidation from "../Common/Simple.edit.validation.js"
 import EditData from "./editForm/Component.edit.data.js"
 import EditDisplay from "./editForm/Component.edit.display.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       EditDisplay,
       {

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTimeAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleTimeAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/time/Time.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleUrlAdvanced/Component.form.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/components/SimpleUrlAdvanced/Component.form.js
@@ -1,7 +1,8 @@
 import baseEditForm from "formiojs/components/url/Url.form"
+import { interopDefault } from "../../../../../../utils/interop-default"
 import EditValidation from "./editForm/Component.edit.validation.js"
 export default function (...extend) {
-  return baseEditForm(
+  return interopDefault(baseEditForm)(
     [
       {
         key: "validation",

--- a/app/frontend/components/shared/chefs/custom-formio-components/overrides/editform/utils.js
+++ b/app/frontend/components/shared/chefs/custom-formio-components/overrides/editform/utils.js
@@ -1,5 +1,8 @@
 import EditFormUtils from "formiojs/components/_classes/component/editForm/utils"
-const originalLogicVariablesTable = EditFormUtils.logicVariablesTable
+import { interopDefault } from "../../../../../../utils/interop-default"
+
+const editFormUtils = interopDefault(EditFormUtils)
+const originalLogicVariablesTable = editFormUtils.logicVariablesTable
 // decorate this function to include global updates to evalContext.
 function logicVariablesTable(additional = "") {
   // Avoid this showing up twice in the table (don't see a currently supported better way to override this atm)
@@ -12,4 +15,4 @@ function logicVariablesTable(additional = "") {
     "<tr><th>user</th><td>The currently logged in user</td></tr>"
   return originalLogicVariablesTable(additional + customEval)
 }
-EditFormUtils.logicVariablesTable = logicVariablesTable
+editFormUtils.logicVariablesTable = logicVariablesTable

--- a/app/frontend/components/shared/chefs/index.tsx
+++ b/app/frontend/components/shared/chefs/index.tsx
@@ -10,8 +10,16 @@ import { FILE_UPLOAD_MAX_SIZE } from "./additional-formio/constant"
 
 const defaultLabelTemplate = Templates.current.label.form
 const defaultButtonsTemplate = Templates.current.button.form
+const chefsTemplateGlobal = globalThis as typeof globalThis & {
+  __housOriginalLabelTemplate?: typeof defaultLabelTemplate
+  __housOriginalButtonsTemplate?: typeof defaultButtonsTemplate
+}
+const originalLabelTemplate = chefsTemplateGlobal.__housOriginalLabelTemplate ?? defaultLabelTemplate
+const originalButtonsTemplate = chefsTemplateGlobal.__housOriginalButtonsTemplate ?? defaultButtonsTemplate
+chefsTemplateGlobal.__housOriginalLabelTemplate = originalLabelTemplate
+chefsTemplateGlobal.__housOriginalButtonsTemplate = originalButtonsTemplate
 
-//container - we can add for main headers like Contact Info
+//container - we can add for main headers like Contact Info.
 //panels - are for section blocks, to put things inside panels, we need to target the components section under the body
 
 Templates.current = {
@@ -30,7 +38,7 @@ Templates.current = {
         )
       }
 
-      template = template.concat(defaultButtonsTemplate(ctx))
+      template = template.concat(originalButtonsTemplate(ctx))
       return template
     },
   },
@@ -40,7 +48,8 @@ Templates.current = {
       if (ctx?.component?.instructions) {
         template = `<div class="form-group-instructions">${ctx.component.instructions}</div>`
       }
-      template = template.concat(defaultLabelTemplate(ctx))
+      const baseLabelTemplate = originalLabelTemplate(ctx)
+      template = template.concat(baseLabelTemplate)
       if (ctx?.component?.computedCompliance) {
         let result = ctx?.component?.computedComplianceResult
         let computedComplianceHtml = ""

--- a/app/frontend/components/shared/date-picker.tsx
+++ b/app/frontend/components/shared/date-picker.tsx
@@ -7,6 +7,7 @@ import ReactDatePicker, { ReactDatePickerProps } from "react-datepicker"
 import "react-datepicker/dist/react-datepicker.css"
 import { useTranslation } from "react-i18next"
 import { datefnsAppDateFormat } from "../../constants"
+import { interopDefault } from "../../utils/interop-default"
 
 type IDatePickerPropsBase = {
   containerProps?: Partial<BoxProps>
@@ -71,6 +72,7 @@ const CustomInput = forwardRef<
 
 export function DatePicker({ containerProps, ...datePickerProps }: IDatePickerProps) {
   const sxStyles = containerProps?.sx || {}
+  const ReactDatePickerComponent = interopDefault(ReactDatePicker)
   return (
     <Box
       w={"200px"}
@@ -102,7 +104,7 @@ export function DatePicker({ containerProps, ...datePickerProps }: IDatePickerPr
         ) as SystemStyleObject
       }
     >
-      <ReactDatePicker
+      <ReactDatePickerComponent
         customInput={<CustomInput />}
         dateFormat={datefnsAppDateFormat}
         popperPlacement={"bottom-start"}

--- a/app/frontend/utils/interop-default.ts
+++ b/app/frontend/utils/interop-default.ts
@@ -1,0 +1,16 @@
+/**
+ * Unwrap a CJS/ESM interop default export when Vite exposes the module as
+ * `{ default: T }` instead of `T` directly (common with legacy packages like formiojs).
+ */
+export function interopDefault<T>(moduleValue: T | { default: T }): T {
+  if (
+    moduleValue != null &&
+    typeof moduleValue === "object" &&
+    "default" in moduleValue &&
+    (moduleValue as { default?: unknown }).default !== undefined
+  ) {
+    return (moduleValue as { default: T }).default
+  }
+
+  return moduleValue as T
+}

--- a/app/frontend/utils/sanitize-tiptap-content.ts
+++ b/app/frontend/utils/sanitize-tiptap-content.ts
@@ -1,4 +1,7 @@
 import DOMPurify from "dompurify"
+import { interopDefault } from "./interop-default"
+
+const domPurify = interopDefault(DOMPurify)
 
 /**
  * Sanitizes HTML content from TipTap editor to prevent XSS attacks.
@@ -74,7 +77,7 @@ export function sanitizeTipTapHtml(htmlContent: string | null | undefined): stri
   }
 
   // Add hook for additional link validation
-  DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+  domPurify.addHook("afterSanitizeAttributes", (node) => {
     // Ensure links open in new tab with secure attributes
     if (node.tagName === "A") {
       const href = node.getAttribute("href")
@@ -94,10 +97,10 @@ export function sanitizeTipTapHtml(htmlContent: string | null | undefined): stri
     }
   })
 
-  const sanitized = DOMPurify.sanitize(htmlContent, config)
+  const sanitized = domPurify.sanitize(htmlContent, config)
 
   // Remove the hook after use to avoid accumulation
-  DOMPurify.removeHook("afterSanitizeAttributes")
+  domPurify.removeHook("afterSanitizeAttributes")
 
   return sanitized
 }
@@ -124,7 +127,7 @@ export function isTipTapContentEmpty(htmlContent: string | null | undefined): bo
   // Safely extract text content using DOMPurify to handle incomplete tags
   // This prevents XSS by ensuring all HTML (including incomplete tags like <script) is removed
   // Use DOMPurify with no allowed tags to strip all HTML and get plain text
-  const textOnly = DOMPurify.sanitize(htmlContent, { ALLOWED_TAGS: [] })
+  const textOnly = domPurify.sanitize(htmlContent, { ALLOWED_TAGS: [] })
   const textContent = textOnly.trim()
   return textContent.length === 0
 }


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HEAD` (merge-base range).

Fixes a white-screen crash when viewing permit applications that render CHEFS/Formio forms (reported for both review managers and submitters in dev/test).

### Root cause

Recent frontend toolchain updates on `develop` — notably the **Vite 8** upgrade and related bundling changes — altered how legacy **CommonJS** modules from `formiojs` are exposed under ESM. CHEFS code assumed default imports from deep `formiojs` paths (e.g. validation edit-form arrays) were directly iterable and spread them as arrays, e.g. `export default [...ComponentEditValidation, ...TextFieldEditValidation]`.

Under the new bundling, those imports often resolve to module namespace objects where the real export lives on `.default`. Spreading the namespace object throws `TypeError: default is not iterable` at runtime and crashes form rendering.

### Fix

Introduces a shared `interopDefault` utility and applies it across CHEFS/Formio import sites — validation/data/api/layout/logic/conditional edit forms, component edit forms, `BuilderUtils`/`EditFormUtils` usage, template re-registration in `chefs/index.tsx`, and `react-datepicker` in the shared date picker.

### Residual risk

This class of bug is not limited to permit-application viewing. Any screen that loads CHEFS/Formio modules — form builder tabs, advanced field configuration panels, date pickers, or future features importing legacy CJS packages — could hit the same failure mode if an import site was missed or a new one is added without `interopDefault`. Failures may surface only when a specific form component or edit tab is opened, not on initial page load.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5237](https://hous-bssb.atlassian.net/browse/HUB-5237) |
| 📄 Related PR(s) | <!-- Vite 8 / Node engine upgrade PRs if relevant --> |
| 📑 Design / Figma | N/A |
| 📚 Documentation | N/A |

---

## ✨ Features / Changes Introduced

- Add `interopDefault` utility (`app/frontend/utils/interop-default.ts`) to safely unwrap CJS/ESM default exports from legacy packages
- Apply `interopDefault` across CHEFS Formio edit-form imports (validation, data, api, layout, logic, conditional) and all component `Component.form.js` wrappers
- Apply `interopDefault` to `BuilderUtils`, `EditFormUtils`, and `react-datepicker` usage
- Preserve original Formio label/button templates on `globalThis` in `chefs/index.tsx` to avoid compounding template overrides on module re-evaluation

---

## 🧪 Steps to QA

1. Log in as a **review manager** or **submitter** in dev/test.
2. **View a permit application** that uses Formio/CHEFS forms (standard QA flow).
3. Confirm the page loads and the form renders — no white screen.
4. Open the browser console and confirm there is no `default is not iterable` error from `Advanced.edit.validation.js` or similar CHEFS files.
5. If possible, spot-check a form with varied field types (text, select, checkbox, date) and confirm they render and are interactive.

**Expected Behaviour:**
Permit application forms load and render normally; no console errors related to Formio import interop.

**Before this change:**
Viewing affected permit applications caused a white screen with `TypeError: default is not iterable` in the console.

**After this change:**
Forms render successfully.

---

## ♿ UI Accessibility Checklist

> No new UI introduced. Existing form and date-picker behaviour is restored.

- [ ] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [ ] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5237]: https://hous-bssb.atlassian.net/browse/HUB-5237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ