### PR TITLE
Hub 4210 super admin can create edit and publish release notes

### DIFF
--- a/app/models/release_note.rb
+++ b/app/models/release_note.rb
@@ -6,7 +6,7 @@ class ReleaseNote < ApplicationRecord
     /\A(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?\z/
   enum :status, { draft: 0, published: 1 }, default: :draft
 
-  searchkick searchable: %i[release_date status created_at]
+  searchkick
 
   url_validatable :release_notes_url
   validates :version,

--- a/db/migrate/20260622180223_reindex_release_notes.rb
+++ b/db/migrate/20260622180223_reindex_release_notes.rb
@@ -1,0 +1,5 @@
+class ReindexReleaseNotes < ActiveRecord::Migration[7.2]
+  def change
+    ReleaseNote.reindex
+  end
+end


### PR DESCRIPTION
## 📋 Description

Fixes Elasticsearch errors when listing release notes in deployed environments. Release notes search was failing with `Searchkick::MissingIndexError` on fresh environments (no index provisioned) and `Searchkick::InvalidQueryError` / fielddata errors on `status` when the index was auto-created by Elasticsearch with incorrect mappings.

This PR:
- Adds a migration to bootstrap the release notes Searchkick index on deploy (`ReleaseNote.reindex`)
- Removes the redundant `searchable` option from `ReleaseNote` — release notes search uses a wildcard query (`"*"`) and only filters/sorts on `release_date`, `status`, and `created_at`; those fields are not full-text searched

> **Note:** The release notes feature itself is already on `stable`. This PR only contains the Elasticsearch provisioning fix (2 commits).

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                              |
| -------------------- | ----------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-4210](https://hous-bssb.atlassian.net/browse/HUB-4210)       |
| 📄 Related PR(s)     | <!-- Original release notes feature PR if applicable -->          |
| 📑 Design / Figma    | <!-- Paste link -->                                               |
| 📚 Documentation     | <!-- Paste link -->                                               |

---

## ✨ Features / Changes Introduced

- Add `ReindexReleaseNotes` migration to create the Elasticsearch index with correct Searchkick mappings on deploy (works even with zero release notes)
- Simplify `ReleaseNote` Searchkick config from `searchkick searchable: %i[release_date status created_at]` to `searchkick`, since those fields are used for filtering/sorting only

---

## 🧪 Steps to QA

1. Deploy this branch to a test environment (or run `rails db:migrate` against an environment where release notes have not been indexed yet)
2. **Before any release notes exist:** navigate to the public Release Notes page (unauthenticated)
3. Verify the page loads successfully with an empty list (no 500 / missing index error)
4. Sign in as a super admin and create a draft release note, then publish it
5. Return to the Release Notes page as an unauthenticated user and verify only published notes appear
6. Sign in as a non–super-admin user and verify the same published-only filtering works
7. As a super admin, verify the full list (drafts + published) is visible without `published_only`
8. Test year filtering and sorting (e.g. by release date, status) on the release notes list

**Expected Behaviour:**

- Release notes list loads without Elasticsearch errors in all cases above
- Published-only filtering works for public and non-admin users
- Super admins see all notes; sorting and year filters behave correctly

**Before this change:**

- Fresh environments could error with `Searchkick::MissingIndexError` (no index)
- Environments where the index was auto-created on first document could error with fielddata/`status` mapping errors when filtering published notes

**After this change:**

- Migration provisions the index on deploy with correct mappings
- Public and filtered release note searches work from the first deploy

---

## ♿ UI Accessibility Checklist

> No UI changes in this PR.

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4210]: https://hous-bssb.atlassian.net/browse/HUB-4210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ