### PR TITLE
Hub 4834 new submitters my profile page notification email address save without clicking save changes

### DIFF
--- a/app/frontend/components/domains/users/profile-screen.tsx
+++ b/app/frontend/components/domains/users/profile-screen.tsx
@@ -235,7 +235,7 @@ export const ProfileScreen = observer(({}: IProfileScreenProps) => {
                 {t("user.receiveNotifications")}
               </Heading>
               {currentUser.isUnconfirmed && !currentUser.confirmationSentAt ? (
-                <EmailFormControl fieldName="email" label={t("user.notificationsEmail")} showIcon required />
+                <ConfirmationEmailField label={t("user.notificationsEmail")} isSubmitting={isSubmitting} />
               ) : (
                 <>
                   {currentUser.unconfirmedEmail ? (
@@ -324,7 +324,7 @@ export const ProfileScreen = observer(({}: IProfileScreenProps) => {
                   {isEditingEmail ? (
                     <>
                       <Divider my={4} />
-                      <EmailFormControl showIcon label={t("user.newEmail")} fieldName="email" required />
+                      <ConfirmationEmailField label={t("user.newEmail")} isSubmitting={isSubmitting} />
                     </>
                   ) : (
                     <Button
@@ -415,6 +415,24 @@ function Section({ children }) {
   return (
     <Flex as="section" direction="column" gap={4} w="full" p={6} borderWidth={1} borderColor="border.light">
       {children}
+    </Flex>
+  )
+}
+
+interface IConfirmationEmailFieldProps {
+  label: string
+  isSubmitting: boolean
+}
+
+const ConfirmationEmailField: React.FC<IConfirmationEmailFieldProps> = ({ label, isSubmitting }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Flex direction="column" gap={4} align="flex-start">
+      <EmailFormControl fieldName="email" label={label} showIcon required />
+      <Button variant="secondary" type="submit" isLoading={isSubmitting} loadingText={t("ui.loading")}>
+        {t("user.sendConfirmationEmail")}
+      </Button>
     </Flex>
   )
 }

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4536,6 +4536,7 @@ Thank you,
             "Action required: please click the link in the verification email that was sent to you. You will continue to receive emails at <strong>{{email}}</strong> until your new email is confirmed. <br/><br/>(Didn't receive it? <1>Resend email</1>)",
           confirmationRequired:
             "Action required: please click the link in the verification email that was sent to you. <br/><br/>(Didn't receive it? <1>Resend email</1>)",
+          sendConfirmationEmail: "Send confirmation email",
           receiveNotifications: "Receive notifications",
           notificationsEmail: "Notification email address",
           firstName: "First name",


### PR DESCRIPTION
## 📋 Description

New submitters on the My Profile page must set a notification email address and trigger a confirmation email before they can receive notifications. Previously, the only way to submit that email was the page-level **Save** button at the bottom of the form — easy to miss when the email input sits higher on the page in the notifications section.

This PR adds a dedicated **Send confirmation email** button directly below the notification email input in both flows where the user is entering or changing an email:
1. **New unconfirmed submitters** who have not yet received a confirmation email
2. **Existing users** who click **Change email** and enter a new address

The new button submits the same profile form (including the email field) so users no longer need to scroll down and click **Save** to send the confirmation email.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                                 |
| -------------------- | -------------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-4834](https://hous-bssb.atlassian.net/browse/HUB-4834)         |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                                  |
| 📑 Design / Figma    | <!-- Paste link -->                                                  |
| 📚 Documentation     | <!-- Paste link -->                                                  |

---

## ✨ Features / Changes Introduced

- Added a `ConfirmationEmailField` component that wraps the email input with a **Send confirmation email** submit button
- Used `ConfirmationEmailField` for new unconfirmed submitters setting their initial notification email
- Used `ConfirmationEmailField` when an existing user is editing their email address
- Added `user.sendConfirmationEmail` i18n string ("Send confirmation email")

---

## 🧪 Steps to QA

### New unconfirmed submitter — initial notification email

1. Log in as a **new submitter** who has not yet confirmed their notification email (unconfirmed, no confirmation email sent)
2. Navigate to **My Profile**
3. In the **Receive notifications** section, enter a notification email address
4. Verify a **Send confirmation email** button appears directly below the email input
5. Click **Send confirmation email**
6. Verify the confirmation email is sent and the UI reflects the pending confirmation state (without needing to scroll to the bottom **Save** button)

### Existing user — change email

1. Log in as a user with a **verified** notification email
2. Navigate to **My Profile**
3. In the **Receive notifications** section, click **Change email**
4. Enter a new email address
5. Verify a **Send confirmation email** button appears below the new email input
6. Click **Send confirmation email**
7. Verify the confirmation email is sent for the new address and the pending/unverified state is shown

### Regression — page-level Save still works

1. On the profile page, change other fields (e.g. first name, notification preferences)
2. Click the page-level **Save** button at the bottom
3. Verify profile updates still save correctly

**Expected Behaviour:**

- Users can send a confirmation email from a button adjacent to the email input
- The button shows a loading state while submitting
- The page-level **Save** button continues to work for other profile changes

**Before this change:**

- Users had to scroll to the bottom of the profile form and click **Save** to submit their notification email — no localized action near the email field

**After this change:**

- A **Send confirmation email** button sits directly below the email input in both the new-submitter and change-email flows

> Please add before/after screenshots of the notification email section for reviewers.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4834]: https://hous-bssb.atlassian.net/browse/HUB-4834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ