### PR TITLE
update content disposition calls and fix zipfile generation

### DIFF
--- a/app/frontend/components/domains/permit-application/submission-download-modal.tsx
+++ b/app/frontend/components/domains/permit-application/submission-download-modal.tsx
@@ -19,7 +19,7 @@ import {
 import { Download, FileArrowDown, FileZip, Gear } from "@phosphor-icons/react"
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
-import React, { useEffect } from "react"
+import React, { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { datefnsAppDateFormat } from "../../../constants"
 import { IPermitApplication } from "../../../models/permit-application"
@@ -44,6 +44,13 @@ export const SubmissionDownloadModal = observer(
     const applicationJsonName = `permit-application-${permitApplication.id}.json`
 
     const { isOpen, onOpen, onClose } = useDisclosure()
+    const zipGenerationTriggeredRef = useRef(false)
+
+    useEffect(() => {
+      if (!isOpen) {
+        zipGenerationTriggeredRef.current = false
+      }
+    }, [isOpen])
 
     useEffect(() => {
       if (!isOpen) return
@@ -59,16 +66,26 @@ export const SubmissionDownloadModal = observer(
     }, [checklist?.isLoaded])
 
     useEffect(() => {
-      if (!permitApplication?.isFullyLoaded) {
+      if (!permitApplication?.isFullyLoaded || !isOpen) {
         return
       }
 
-      if (!permitApplication.isSubmitted || !permitApplication.missingPdfs.length) {
+      const needsZipGeneration = permitApplication.isSubmitted && !zipfileUrl && !zipGenerationTriggeredRef.current
+
+      if (!needsZipGeneration) {
         return
       }
 
+      zipGenerationTriggeredRef.current = true
       permitApplication.generateMissingPdfs()
-    }, [permitApplication?.isFullyLoaded, permitApplication?.missingPdfs, checklist?.isLoaded])
+    }, [
+      permitApplication?.isFullyLoaded,
+      permitApplication?.isSubmitted,
+      permitApplication?.missingPdfs,
+      checklist?.isLoaded,
+      isOpen,
+      zipfileUrl,
+    ])
 
     return (
       <>
@@ -89,7 +106,7 @@ export const SubmissionDownloadModal = observer(
               <>
                 <ModalHeader>
                   <VStack w="full" align="start">
-                    <Heading as="h1" fontSize="2xl" textTransform={"capitalize"}>
+                    <Heading as="h1" fontSize="2xl">
                       {t("permitApplication.show.downloadHeading")}
                       <br />
                       <Text as="span" fontSize="lg" color="text.secondary">
@@ -198,7 +215,7 @@ const FileDownloadLink = function ApplicationFileDownloadLink({ url, name, size,
   )
 }
 
-function MissingPdf({ pdfKey }: { pdfKey: "permit_application_pdf" }) {
+function MissingPdf({ pdfKey }: { pdfKey: string }) {
   const { t } = useTranslation()
 
   const getMissingPdfLabel = () => {

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -889,11 +889,6 @@ export const PermitApplicationModel = types.snapshotProcessor(
       resetCompareAfter: () => {
         self.showingCompareAfter = false
       },
-
-      generateMissingPdfs: flow(function* () {
-        const response = yield self.environment.api.generatePermitApplicationMissingPdfs(self.id)
-        return response.ok
-      }),
     }))
     .actions((self) => ({
       handleSocketSupportingDocsUpdate: (data: IPermitApplicationSupportingDocumentsUpdate) => {

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -388,6 +388,7 @@ export interface IDownloadableFile {
   fileUrl: string
   fileName: string
   fileSize: number
+  createdAt: Date
 }
 
 export interface IEULA {

--- a/app/models/concerns/form_supporting_documents.rb
+++ b/app/models/concerns/form_supporting_documents.rb
@@ -149,7 +149,7 @@ module FormSupportingDocuments
       public: false,
       expires_in: 3600,
       response_content_disposition:
-        "attachment; filename=\"#{zipfile.original_filename}\""
+        ContentDisposition.attachment(zipfile.original_filename)
     )
   end
 

--- a/app/models/file_upload_attachment.rb
+++ b/app/models/file_upload_attachment.rb
@@ -93,10 +93,7 @@ class FileUploadAttachment < ApplicationRecord
     disposition: "attachment",
     filename: download_filename
   )
-    ActionDispatch::Http::ContentDisposition.format(
-      disposition: disposition,
-      filename: filename.presence || "download"
-    )
+    ContentDisposition.public_send(disposition, filename.presence || "download")
   end
 
   prepend FilenamePreservingFileUrl

--- a/app/models/part_9_step_code/data_entry.rb
+++ b/app/models/part_9_step_code/data_entry.rb
@@ -27,7 +27,7 @@ class Part9StepCode::DataEntry < ApplicationRecord
       public: false,
       expires_in: 3600,
       response_content_disposition:
-        "attachment; filename=\"#{h2k_file.original_filename}\""
+        ContentDisposition.attachment(h2k_file.original_filename)
     )
   end
 end

--- a/app/models/supporting_document.rb
+++ b/app/models/supporting_document.rb
@@ -148,7 +148,7 @@ class SupportingDocument < FileUploadAttachment
 
     file.url(
       response_content_disposition:
-        "#{disposition}; filename=\"#{standardized_filename}\"",
+        ContentDisposition.public_send(disposition, standardized_filename),
       **options
     )
   end

--- a/app/services/wrappers/archistar.rb
+++ b/app/services/wrappers/archistar.rb
@@ -55,10 +55,7 @@ class Wrappers::Archistar < Wrappers::Base
           else
             doc.file.url(
               response_content_disposition:
-                ActionDispatch::Http::ContentDisposition.format(
-                  disposition: "attachment",
-                  filename: doc.file.original_filename
-                )
+                ContentDisposition.attachment(doc.file.original_filename)
             )
           end
         ),


### PR DESCRIPTION
## 📋 Description

Fixes the "Download all attached files as ZIP" button staying disabled on the permit application download modal for reviewers.

**Root cause:** `ZipfileJob` was failing in Sidekiq when building presigned download URLs. `FileUploadAttachment#file_content_disposition` used `ActionDispatch::Http::ContentDisposition`, which is not available in the Sidekiq job process. That prevented the supporting-documents zip from being created and broadcast over websockets.

**Secondary issue:** The download modal only triggered `generateMissingPdfs` when `missingPdfs` was non-empty. If the zip simply did not exist (or had been cleared) but PDFs were already present, no regeneration was requested and the ZIP button remained disabled until a full page refresh.

This PR standardizes `Content-Disposition` header generation via the `content_disposition` gem (already used by Shrine) and broadens the modal trigger to enqueue zip generation whenever a submitted application has no `zipfileUrl`.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5239](https://yourorg.atlassian.net/browse/HUB-5239) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                        |
| 📑 Design / Figma    | <!-- Paste link -->                                        |
| 📚 Documentation     | <!-- Paste link -->                                        |

---

## ✨ Features / Changes Introduced

- Replace `ActionDispatch::Http::ContentDisposition` with `ContentDisposition` across file URL builders (`FileUploadAttachment`, `SupportingDocument`, `FormSupportingDocuments`, `Part9StepCode::DataEntry`, `Archistar` wrapper) so Sidekiq jobs can generate presigned URLs reliably
- Trigger zip/PDF generation from the download modal whenever `zipfileUrl` is missing (not only when `missingPdfs` is non-empty), with a ref guard to avoid duplicate enqueue calls while the modal is open
- Remove duplicate `generateMissingPdfs` MST action definition from `permit-application.ts`
- Add `createdAt` to `IDownloadableFile` to match supporting document blueprint output
- Minor modal cleanup: remove unnecessary heading capitalization transform; widen `MissingPdf` key type to `string`

---

## 🧪 Steps to QA

1. Ensure Sidekiq and AnyCable are running locally (production-like async path).
2. Open a submitted permit application as a reviewer.
3. Open the **Download Application** modal.
4. If a zip already exists, clear it (or use an application without one) and reopen the modal.
5. Confirm the ZIP button is initially disabled while generation is in progress.
6. Wait for `ZipfileJob` to complete and the `update_supporting_documents` websocket update to arrive.
7. Confirm the **Download all attached files as ZIP** button becomes enabled without refreshing the page.
8. Click the ZIP button and confirm the download succeeds.
9. Repeat as a submitter on the edit screen to confirm individual file downloads still work.

**Expected Behaviour:**

- Sidekiq completes `ZipfileJob` without `uninitialized constant ActionDispatch::Http::ContentDisposition` errors.
- The download modal enqueues zip generation when needed and enables the ZIP button after the websocket update.
- Individual supporting document download links continue to work.

**Before this change:**

- ZIP download button could remain disabled even though individual files were listed.
- Sidekiq could error during zip creation due to missing `ContentDisposition` constant.

**After this change:**

- Zip generation completes in Sidekiq and the modal updates via websocket.
- ZIP download becomes available without requiring a manual page refresh.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5239]: https://hous-bssb.atlassian.net/browse/HUB-5239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ