### PR TITLE
Hub 5238 bug rm submitter project overview 500 on empty state for project meetings

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -33,6 +33,13 @@ class Api::ApplicationController < ActionController::API
     results.select { |result| policy(result).send("#{policy_action}?".to_sym) }
   end
 
+  # Searchkick only invokes scope_results when ES returns >= 1 hit, so policy_scope
+  # inside that lambda is skipped on empty results and verify_policy_scoped fails.
+  def ensure_searchkick_policy_scoped!(model_class, search)
+    policy_scope(model_class) if search.hits.empty?
+    search
+  end
+
   def skip_pundit?
     devise_controller?
   end

--- a/app/controllers/api/concerns/search/jurisdiction_permit_applications.rb
+++ b/app/controllers/api/concerns/search/jurisdiction_permit_applications.rb
@@ -35,9 +35,12 @@ module Api::Concerns::Search::JurisdictionPermitApplications
     search_conditions[:body_options] = body_opts if body_opts.present?
 
     @jurisdiction_permit_application_search =
-      PermitApplication.search(
-        jurisdiction_permit_application_query,
-        **search_conditions
+      ensure_searchkick_policy_scoped!(
+        PermitApplication,
+        PermitApplication.search(
+          jurisdiction_permit_application_query,
+          **search_conditions
+        )
       )
 
     unread_status_counts = jurisdiction_application_unread_status_counts

--- a/app/controllers/api/concerns/search/jurisdiction_project_meetings.rb
+++ b/app/controllers/api/concerns/search/jurisdiction_project_meetings.rb
@@ -24,9 +24,12 @@ module Api::Concerns::Search::JurisdictionProjectMeetings
     }
 
     @jurisdiction_project_meeting_search =
-      ProjectMeeting.search(
-        jurisdiction_project_meeting_query,
-        **search_conditions
+      ensure_searchkick_policy_scoped!(
+        ProjectMeeting,
+        ProjectMeeting.search(
+          jurisdiction_project_meeting_query,
+          **search_conditions
+        )
       )
 
     @jurisdiction_project_meetings =

--- a/app/controllers/api/concerns/search/overheating_codes.rb
+++ b/app/controllers/api/concerns/search/overheating_codes.rb
@@ -20,7 +20,10 @@ module Api::Concerns::Search::OverheatingCodes
       scope_results: ->(relation) { policy_scope(relation) }
     }
     @overheating_code_search =
-      OverheatingCode.search(overheating_code_query, **search_conditions)
+      ensure_searchkick_policy_scoped!(
+        OverheatingCode,
+        OverheatingCode.search(overheating_code_query, **search_conditions)
+      )
   end
 
   private

--- a/app/controllers/api/concerns/search/pre_checks.rb
+++ b/app/controllers/api/concerns/search/pre_checks.rb
@@ -19,7 +19,11 @@ module Api::Concerns::Search::PreChecks
         ),
       scope_results: ->(relation) { policy_scope(relation) }
     }
-    @pre_check_search = PreCheck.search(pre_check_query, **search_conditions)
+    @pre_check_search =
+      ensure_searchkick_policy_scoped!(
+        PreCheck,
+        PreCheck.search(pre_check_query, **search_conditions)
+      )
   end
 
   private

--- a/app/controllers/api/concerns/search/project_meetings.rb
+++ b/app/controllers/api/concerns/search/project_meetings.rb
@@ -30,7 +30,10 @@ module Api::Concerns::Search::ProjectMeetings
     }
 
     @project_meeting_search =
-      ProjectMeeting.search(project_meeting_query, **search_conditions)
+      ensure_searchkick_policy_scoped!(
+        ProjectMeeting,
+        ProjectMeeting.search(project_meeting_query, **search_conditions)
+      )
   end
 
   private

--- a/app/controllers/api/concerns/search/project_permit_applications.rb
+++ b/app/controllers/api/concerns/search/project_permit_applications.rb
@@ -32,7 +32,10 @@ module Api::Concerns::Search::ProjectPermitApplications
     }
 
     @permit_application_search =
-      PermitApplication.search(permit_application_query, **search_conditions)
+      ensure_searchkick_policy_scoped!(
+        PermitApplication,
+        PermitApplication.search(permit_application_query, **search_conditions)
+      )
   end
 
   private

--- a/app/controllers/api/concerns/search/requirement_blocks.rb
+++ b/app/controllers/api/concerns/search/requirement_blocks.rb
@@ -2,25 +2,29 @@ module Api::Concerns::Search::RequirementBlocks
   extend ActiveSupport::Concern
 
   def perform_search
+    search_conditions = {
+      order: order,
+      match: :word_start,
+      where: {
+        discarded: discarded
+      },
+      page: search_params[:page],
+      per_page:
+        (
+          if search_params[:page]
+            (search_params[:per_page] || Kaminari.config.default_per_page)
+          else
+            nil
+          end
+        ),
+      includes: %i[taggings requirements],
+      scope_results: ->(relation) { policy_scope(relation) }
+    }
+
     @search =
-      RequirementBlock.search(
-        query,
-        order: order,
-        match: :word_start,
-        where: {
-          discarded: discarded
-        },
-        page: search_params[:page],
-        per_page:
-          (
-            if search_params[:page]
-              (search_params[:per_page] || Kaminari.config.default_per_page)
-            else
-              nil
-            end
-          ),
-        includes: %i[taggings requirements],
-        scope_results: ->(relation) { policy_scope(relation) }
+      ensure_searchkick_policy_scoped!(
+        RequirementBlock,
+        RequirementBlock.search(query, **search_conditions)
       )
   end
 

--- a/app/frontend/entrypoints/application.tsx
+++ b/app/frontend/entrypoints/application.tsx
@@ -24,14 +24,6 @@ const renderApp = (rootStore) => {
     const { t } = useTranslation()
 
     React.useEffect(() => {
-      if (import.meta.env.VITE_QA_MODE === "true") {
-        console.log("VITE_QA_MODE is true")
-      } else {
-        console.log("VITE_QA_MODE is false")
-      }
-    }, [])
-
-    React.useEffect(() => {
       if (!import.meta.env.VITE_MATOMO_URL) {
         console.warn("VITE_MATOMO_URL is not set")
         return


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5238-bug-rm-submitter-project-overview-500-on-empty-state-for-project-meetings` (merge-base range).

Fixes a 500 error on empty Searchkick-backed API search results caused by Pundit's `verify_policy_scoped` after-action. Searchkick only invokes `scope_results` when Elasticsearch returns one or more hits, so empty result sets skipped the `policy_scope` call and Pundit incorrectly treated the request as unscoped.

This PR adds a shared helper to mark Searchkick searches as policy-scoped when results are empty, and applies it to API search concerns that rely on `scope_results`.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                   |
| -------------------- | ------------------------------------------------------ |
| 🗂️ Jira Story / Task | [HUB-5238](https://yourorg.atlassian.net/browse/HUB-5238) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                    |
| 📑 Design / Figma    | N/A                                                    |
| 📚 Documentation     | N/A                                                    |

---

## ✨ Features / Changes Introduced

- Added `ensure_searchkick_policy_scoped!` to handle empty Searchkick result sets that would otherwise skip `scope_results`.
- Fixed project meeting search so empty meeting results no longer raise `Pundit::PolicyScopingNotPerformedError`.
- Applied the same guard to other API Searchkick concerns using `scope_results` for consistent behavior.

***

## 🧪 Steps to QA

1. Sign in as a user who can access a permit project with project meetings enabled.
2. Navigate to a project meetings page where the search returns no meeting results.
3. Verify the page loads successfully and shows the empty state instead of a 500 error.
4. Navigate to a project meetings page where the search returns at least one meeting result.
5. Verify meeting results still load normally.
6. Optionally verify another Searchkick-backed empty search, such as pre-checks or overheating codes, still loads successfully.

**Expected Behaviour:**

Empty Searchkick-backed search results return a successful API response and render the appropriate empty state.

**Before this change:**

Empty project meeting search results could raise `Pundit::PolicyScopingNotPerformedError` because `policy_scope` was never called.

**After this change:**

Empty and non-empty Searchkick-backed searches both satisfy Pundit's policy scoping verification.

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [x] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5238]: https://hous-bssb.atlassian.net/browse/HUB-5238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ