### PR TITLE
add project meetings ics attachments to invite emails

### DIFF
--- a/app/frontend/components/domains/jurisdictions/submission-inbox/reviewer-meeting-detail-content.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/reviewer-meeting-detail-content.tsx
@@ -4,7 +4,6 @@ import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { useNavigate } from "react-router-dom"
 import { datefnsTableDateTimeFormat } from "../../../../constants"
 import { usePermitProject } from "../../../../hooks/resources/use-permit-project"
 import { useProjectMeeting } from "../../../../hooks/resources/use-project-meeting"
@@ -14,6 +13,7 @@ import { EFlashMessageStatus, EProjectMeetingStatus } from "../../../../types/en
 import { ErrorScreen } from "../../../shared/base/error-screen"
 import { LoadingScreen } from "../../../shared/base/loading-screen"
 import { ConfirmationModal } from "../../../shared/confirmation-modal"
+import { RouterLinkButton } from "../../../shared/navigation/router-link-button"
 import { ProjectMeetingStatusTag } from "../../../shared/project-meetings/project-meeting-status-tag"
 import { ReviewerScheduledMeetingBanner } from "../../project-meeting/detail/banners/reviewer-scheduled-meeting-banner"
 import { ScheduleMeetingBanner } from "../../project-meeting/detail/banners/schedule-meeting-banner"
@@ -31,7 +31,6 @@ interface ReviewerMeetingDetailContentProps {
 export const ReviewerMeetingDetailContent = observer(
   ({ jurisdictionId, permitProject }: ReviewerMeetingDetailContentProps) => {
     const { t } = useTranslation()
-    const navigate = useNavigate()
     const { currentProjectMeeting, error: projectMeetingError, isLoading } = useProjectMeeting()
     const { currentPermitProject, error: permitProjectError } = usePermitProject(
       permitProject?.id ?? currentProjectMeeting?.permitProjectId
@@ -106,9 +105,15 @@ export const ReviewerMeetingDetailContent = observer(
 
     return (
       <Box as="section">
-        <Button leftIcon={<CaretLeft size={20} />} variant="link" mb={6} px={0} onClick={() => navigate(-1)}>
+        <RouterLinkButton
+          to={`/jurisdictions/${jurisdictionId}/meetings`}
+          leftIcon={<CaretLeft size={20} />}
+          variant="link"
+          mb={6}
+          px={0}
+        >
           {t("ui.back")}
-        </Button>
+        </RouterLinkButton>
 
         <HStack justify="space-between" align="flex-start" mb={8}>
           <Box>

--- a/app/mailers/permit_hub_mailer.rb
+++ b/app/mailers/permit_hub_mailer.rb
@@ -301,6 +301,10 @@ class PermitHubMailer < ApplicationMailer
 
   def notify_project_meeting_scheduled(project_meeting)
     set_project_meeting_scheduled_variables(project_meeting)
+    attach_project_meeting_calendar(
+      project_meeting,
+      hub_meeting_url: @project_meeting_url
+    )
     @contact_first_name =
       contact_first_name(project_meeting.contact_name, @user)
 
@@ -315,6 +319,10 @@ class PermitHubMailer < ApplicationMailer
     recipient_email
   )
     set_project_meeting_scheduled_variables(project_meeting)
+    attach_project_meeting_calendar(
+      project_meeting,
+      hub_meeting_url: @reviewer_project_meeting_url
+    )
 
     send_mail(
       email: recipient_email,
@@ -327,6 +335,10 @@ class PermitHubMailer < ApplicationMailer
 
   def notify_project_meeting_rescheduled(project_meeting)
     set_project_meeting_scheduled_variables(project_meeting)
+    attach_project_meeting_calendar(
+      project_meeting,
+      hub_meeting_url: @project_meeting_url
+    )
     @contact_first_name =
       contact_first_name(project_meeting.contact_name, @user)
 
@@ -341,6 +353,10 @@ class PermitHubMailer < ApplicationMailer
     recipient_email
   )
     set_project_meeting_scheduled_variables(project_meeting)
+    attach_project_meeting_calendar(
+      project_meeting,
+      hub_meeting_url: @reviewer_project_meeting_url
+    )
 
     send_mail(
       email: recipient_email,
@@ -588,6 +604,20 @@ class PermitHubMailer < ApplicationMailer
     else
       project_meeting.contact_method.to_s.humanize
     end
+  end
+
+  def attach_project_meeting_calendar(project_meeting, hub_meeting_url:)
+    return if project_meeting.confirmed_date.blank?
+
+    generator =
+      ProjectMeetingIcsGenerator.new(
+        project_meeting,
+        hub_meeting_url: hub_meeting_url
+      )
+    attachments[generator.filename] = {
+      mime_type: "text/calendar; method=PUBLISH; charset=UTF-8",
+      content: generator.generate
+    }
   end
 
   # Helper method to attach a file from a FileUploadAttachment subclass instance

--- a/app/services/project_meeting_ics_generator.rb
+++ b/app/services/project_meeting_ics_generator.rb
@@ -1,0 +1,130 @@
+# ponytail: default 1-hour duration; add duration field if meetings vary
+class ProjectMeetingIcsGenerator
+  DEFAULT_DURATION = 1.hour
+  TIME_ZONE = "America/Vancouver"
+  PRODID = "-//Building Permit Hub//Project Meeting//EN"
+
+  def initialize(project_meeting, hub_meeting_url:)
+    @project_meeting = project_meeting
+    @hub_meeting_url = hub_meeting_url
+  end
+
+  def filename
+    number =
+      @project_meeting.permit_project&.number.to_s.gsub(/[^a-zA-Z0-9_-]/, "-")
+    label = number.presence || @project_meeting.id
+    "project-meeting-#{label}.ics"
+  end
+
+  def generate
+    [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:#{PRODID}",
+      "CALSCALE:GREGORIAN",
+      "METHOD:PUBLISH",
+      event_block,
+      "END:VCALENDAR"
+    ].join("\r\n")
+  end
+
+  private
+
+  attr_reader :project_meeting, :hub_meeting_url
+
+  def event_block
+    start_at = project_meeting.confirmed_date.in_time_zone(TIME_ZONE)
+    end_at = start_at + DEFAULT_DURATION
+
+    lines = [
+      "BEGIN:VEVENT",
+      "UID:#{uid}",
+      "DTSTAMP:#{utc_timestamp(Time.current)}",
+      "DTSTART;TZID=#{TIME_ZONE}:#{local_timestamp(start_at)}",
+      "DTEND;TZID=#{TIME_ZONE}:#{local_timestamp(end_at)}",
+      "SUMMARY:#{escape(summary)}",
+      "DESCRIPTION:#{escape(description)}",
+      "SEQUENCE:#{project_meeting.updated_at.to_i}",
+      "STATUS:CONFIRMED"
+    ]
+    lines << "LOCATION:#{escape(location)}" if location.present?
+    if project_meeting.meeting_url.present?
+      lines << "URL:#{escape(project_meeting.meeting_url)}"
+    end
+    lines.concat(["END:VEVENT"])
+    lines.join("\r\n")
+  end
+
+  def uid
+    host =
+      Addressable::URI.parse(FrontendUrlHelper.root_url).host ||
+        "buildingpermithub.gov.bc.ca"
+    "project-meeting-#{project_meeting.id}@#{host}"
+  end
+
+  def summary
+    number = project_meeting.permit_project&.number
+    "Project meeting#{number.present? ? " (#{number})" : ""}"
+  end
+
+  def description
+    permit_project = project_meeting.permit_project
+    parts = []
+    if permit_project&.title.present?
+      parts << "Project: #{permit_project.title}"
+    end
+    if permit_project&.number.present?
+      parts << "Project number: #{permit_project.number}"
+    end
+    parts << "Contact method: #{contact_method_label}"
+    if project_meeting.meeting_url.present?
+      parts << "Meeting link: #{project_meeting.meeting_url}"
+    end
+    if hub_meeting_url.present?
+      parts << "View in Building Permit Hub: #{hub_meeting_url}"
+    end
+    parts.join("\\n")
+  end
+
+  def location
+    case project_meeting.contact_method
+    when "videoconference"
+      project_meeting.meeting_url.presence || "Videoconference"
+    when "in_person"
+      project_meeting.permit_project&.full_address
+    when "phone"
+      project_meeting.contact_phone_number.presence || "Phone call"
+    end
+  end
+
+  def contact_method_label
+    case project_meeting.contact_method
+    when "phone"
+      "Phone"
+    when "in_person"
+      "In-person meeting"
+    when "videoconference"
+      "Videoconference"
+    else
+      project_meeting.contact_method.to_s.humanize
+    end
+  end
+
+  def escape(value)
+    value
+      .to_s
+      .gsub("\\", "\\\\")
+      .gsub(";", "\\;")
+      .gsub(",", "\\,")
+      .gsub("\n", "\\n")
+      .gsub("\r", "")
+  end
+
+  def utc_timestamp(time)
+    time.utc.strftime("%Y%m%dT%H%M%SZ")
+  end
+
+  def local_timestamp(time)
+    time.strftime("%Y%m%dT%H%M%S")
+  end
+end

--- a/app/views/permit_hub_mailer/notify_project_meeting_rescheduled.html.erb
+++ b/app/views/permit_hub_mailer/notify_project_meeting_rescheduled.html.erb
@@ -14,6 +14,10 @@
           </p>
 
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 12px;">
+            A calendar invite is attached to this email.
+          </p>
+
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 12px;">
             <strong>Project:</strong><br>
             <%= @permit_project.title %>
           </p>

--- a/app/views/permit_hub_mailer/notify_project_meeting_rescheduled_to_jurisdiction.html.erb
+++ b/app/views/permit_hub_mailer/notify_project_meeting_rescheduled_to_jurisdiction.html.erb
@@ -14,6 +14,10 @@
           </p>
 
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 12px;">
+            A calendar invite is attached to this email.
+          </p>
+
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 12px;">
             <strong>Project address:</strong><br>
             <%= @permit_project.full_address %>
           </p>

--- a/app/views/permit_hub_mailer/notify_project_meeting_scheduled.html.erb
+++ b/app/views/permit_hub_mailer/notify_project_meeting_scheduled.html.erb
@@ -14,6 +14,10 @@
           </p>
 
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 12px;">
+            A calendar invite is attached to this email.
+          </p>
+
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 12px;">
             <strong>Project:</strong><br>
             <%= @permit_project.title %>
           </p>

--- a/app/views/permit_hub_mailer/notify_project_meeting_scheduled_to_jurisdiction.html.erb
+++ b/app/views/permit_hub_mailer/notify_project_meeting_scheduled_to_jurisdiction.html.erb
@@ -14,6 +14,10 @@
           </p>
 
           <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 12px;">
+            A calendar invite is attached to this email.
+          </p>
+
+          <p style="font-family: 'Open Sans', sans-serif; font-size: 16px; line-height: 26px; font-weight: normal; margin: 0; margin-bottom: 12px;">
             <strong>Project address:</strong><br>
             <%= @permit_project.full_address %>
           </p>

--- a/spec/mailers/permit_hub_mailer_spec.rb
+++ b/spec/mailers/permit_hub_mailer_spec.rb
@@ -418,11 +418,21 @@ RSpec.describe PermitHubMailer, type: :mailer do
         contact_method: "videoconference",
         confirmed_date: Time.zone.parse("2026-01-20 09:30"),
         meeting_url: "https://example.com/meeting",
-        permit_project: permit_project
+        permit_project: permit_project,
+        updated_at: Time.zone.parse("2026-01-20 08:00")
       )
+    attachments_hash = {}
+    allow(mailer).to receive(:attachments).and_return(attachments_hash)
 
     mailer.notify_project_meeting_scheduled(project_meeting)
 
+    expect(attachments_hash.keys.first).to end_with(".ics")
+    expect(attachments_hash.values.first[:mime_type]).to include(
+      "text/calendar"
+    )
+    expect(attachments_hash.values.first[:content]).to include(
+      "BEGIN:VCALENDAR"
+    )
     expect(mailer).to have_received(:send_mail).with(
       email: "jane@example.com",
       template_key: "notify_project_meeting_scheduled"
@@ -436,6 +446,7 @@ RSpec.describe PermitHubMailer, type: :mailer do
       instance_double(
         "PermitProject",
         id: "project-id",
+        title: nil,
         number: "P-123",
         full_address: "1127 Winnipeg St",
         jurisdiction: jurisdiction
@@ -451,7 +462,8 @@ RSpec.describe PermitHubMailer, type: :mailer do
         contact_method: "phone",
         confirmed_date: Time.zone.parse("2026-01-20 09:30"),
         meeting_url: nil,
-        permit_project: permit_project
+        permit_project: permit_project,
+        updated_at: Time.zone.parse("2026-01-20 08:00")
       )
 
     mailer.notify_project_meeting_scheduled_to_jurisdiction(
@@ -494,7 +506,8 @@ RSpec.describe PermitHubMailer, type: :mailer do
         contact_method: "videoconference",
         confirmed_date: Time.zone.parse("2026-01-20 09:30"),
         meeting_url: "https://example.com/meeting",
-        permit_project: permit_project
+        permit_project: permit_project,
+        updated_at: Time.zone.parse("2026-01-20 08:00")
       )
 
     mailer.notify_project_meeting_rescheduled(project_meeting)
@@ -512,6 +525,7 @@ RSpec.describe PermitHubMailer, type: :mailer do
       instance_double(
         "PermitProject",
         id: "project-id",
+        title: nil,
         number: "P-123",
         full_address: "1127 Winnipeg St",
         jurisdiction: jurisdiction
@@ -527,7 +541,8 @@ RSpec.describe PermitHubMailer, type: :mailer do
         contact_method: "phone",
         confirmed_date: Time.zone.parse("2026-01-20 09:30"),
         meeting_url: nil,
-        permit_project: permit_project
+        permit_project: permit_project,
+        updated_at: Time.zone.parse("2026-01-20 08:00")
       )
 
     mailer.notify_project_meeting_rescheduled_to_jurisdiction(

--- a/spec/services/project_meeting_ics_generator_spec.rb
+++ b/spec/services/project_meeting_ics_generator_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe ProjectMeetingIcsGenerator do
+  subject(:generator) do
+    described_class.new(
+      project_meeting,
+      hub_meeting_url: "http://example.test/projects/1/meetings/2"
+    )
+  end
+
+  let(:project_meeting) do
+    create(
+      :project_meeting,
+      :scheduled,
+      contact_method: :videoconference,
+      confirmed_date: Time.zone.parse("2026-01-20 09:30"),
+      meeting_url: "https://example.com/meeting"
+    )
+  end
+
+  before do
+    allow(FrontendUrlHelper).to receive(:root_url).and_return(
+      "http://example.test/"
+    )
+  end
+
+  describe "#filename" do
+    it "uses the project number in the filename" do
+      expect(generator.filename).to eq(
+        "project-meeting-#{project_meeting.permit_project.number}.ics"
+      )
+    end
+  end
+
+  describe "#generate" do
+    let(:ics) { generator.generate }
+
+    it "returns a valid iCalendar document" do
+      expect(ics).to include("BEGIN:VCALENDAR")
+      expect(ics).to include("BEGIN:VEVENT")
+      expect(ics).to include("END:VEVENT")
+      expect(ics).to include("END:VCALENDAR")
+    end
+
+    it "includes the meeting time in Vancouver time" do
+      expect(ics).to include("DTSTART;TZID=America/Vancouver:20260120T093000")
+      expect(ics).to include("DTEND;TZID=America/Vancouver:20260120T103000")
+    end
+
+    it "uses a stable UID for the meeting" do
+      expect(ics).to include(
+        "UID:project-meeting-#{project_meeting.id}@example.test"
+      )
+    end
+
+    it "includes the videoconference link as the location" do
+      expect(ics).to include("LOCATION:https://example.com/meeting")
+    end
+
+    it "includes the hub meeting URL in the description" do
+      expect(ics).to include(
+        "View in Building Permit Hub: http://example.test/projects/1/meetings/2"
+      )
+    end
+  end
+end


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...HUB-5240-story-add-ability-to-add-meeting-to-calendar` (merge-base range).

Project meeting scheduled and rescheduled emails now include a `.ics` calendar attachment so submitters and jurisdiction reviewers can add the meeting to their calendar in one click. A new `ProjectMeetingIcsGenerator` builds the invite with meeting time (America/Vancouver), location/contact method, meeting link, and a link back to the meeting in the Hub.

Email templates for all four scheduled/rescheduled notifications note that a calendar invite is attached.

Also fixes the reviewer meeting detail **Back** button to navigate to the jurisdiction meetings list (`/jurisdictions/:slug/meetings`) instead of browser history (`navigate(-1)`), so users always return to the meetings inbox even when arriving from a deep link.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5240](https://hous-bssb.atlassian.net/browse/HUB-5240) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Add `ProjectMeetingIcsGenerator` to produce iCalendar (`.ics`) files for confirmed project meetings
- Attach calendar invites to submitter and jurisdiction emails for scheduled and rescheduled meetings via `PermitHubMailer#attach_project_meeting_calendar`
- Update four meeting notification email templates to mention the attached calendar invite
- Fix reviewer meeting detail back navigation to go to `/jurisdictions/:slug/meetings` instead of browser back
- Add `ProjectMeetingIcsGenerator` specs and extend `PermitHubMailer` specs for ICS attachment behaviour

---

## 🧪 Steps to QA

### Calendar invite emails

1. Log in as a jurisdiction reviewer and schedule a project meeting (or reschedule an existing one) with a confirmed date/time.
2. Check the submitter notification email (and jurisdiction notification email if applicable).
3. Confirm the email body includes “A calendar invite is attached to this email.”
4. Open the `.ics` attachment and add it to a calendar app (Google Calendar, Outlook, Apple Calendar).
5. Verify the event shows the correct date/time, project number in the title, location/link based on contact method (videoconference URL, in-person address, or phone), and a “View in Building Permit Hub” link in the description.
6. Reschedule the meeting and confirm the updated email includes a new `.ics` with the new time.

### Reviewer meeting detail back button

1. Log in as a jurisdiction reviewer and go to **Meetings** for a jurisdiction (e.g. `/jurisdictions/corporation-of-the-city-of-north-vancouver/meetings`).
2. Open a meeting detail page from the list.
3. Click **Back**.
4. Confirm you land on the jurisdiction meetings list, not a previous unrelated page (e.g. kanban or submission inbox).

**Expected Behaviour:**
- Scheduled/rescheduled emails include a valid `.ics` attachment recipients can import into their calendar.
- Reviewer meeting detail **Back** always returns to the jurisdiction meetings list.

**Before this change:**
- Meeting emails had no calendar attachment; users had to manually create calendar events.
- **Back** on the reviewer meeting detail page used browser history, which could send users to an unexpected prior page.

**After this change:**
- Meeting emails include an importable calendar invite with meeting details and a Hub link.
- **Back** consistently navigates to the jurisdiction meetings inbox.

---

## ♿ UI Accessibility Checklist

> Minor navigation change only (back button switched from `onClick` history navigation to a `RouterLinkButton`).

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5240]: https://hous-bssb.atlassian.net/browse/HUB-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ