### PR TITLE
HUB-5254 redirect template version base route to template catalogue

### DIFF
--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -558,6 +558,7 @@ const AppRoutes = observer(() => {
       <Route path="/requirement-templates" element={<RequirementTemplatesScreen />} />
       <Route path="/requirement-templates/new" element={<NewRequirementTemplateScreen />} />
       <Route path="/requirement-templates/:requirementTemplateId/edit" element={<EditRequirementTemplateScreen />} />
+      <Route path="/template-versions" element={<RedirectScreen path="/requirement-templates" />} />
       <Route path="/template-versions/:templateVersionId" element={<TemplateVersionScreen />} />
       <Route path="/configuration-management" element={<SiteConfigurationManagementScreen />} />
       <Route path="/configuration-management/sitewide-message" element={<SitewideMessageScreen />} />


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5254-bug-admin-panel-permit-templates-catalog-edit-template-view-published-scheduled-or-ea-template-template-versions-breadcrumb-error` (merge-base range).

The template version detail screen breadcrumb links to `/template-versions`, but no route existed for that base path—only `/template-versions/:templateVersionId`. Clicking the first breadcrumb from a published, scheduled, or early-access template version view therefore hit an unrouted URL and broke navigation.

This PR adds a redirect from `/template-versions` to `/requirement-templates` (the permit templates catalogue), so the breadcrumb resolves correctly.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5254](https://yourorg.atlassian.net/browse/HUB-5254) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                        |
| 📑 Design / Figma    | <!-- Paste link -->                                        |
| 📚 Documentation     | <!-- Paste link -->                                        |

---

## ✨ Features / Changes Introduced

- Added a super-admin route for `/template-versions` that redirects to `/requirement-templates`
- Fixes breadcrumb navigation from the template version detail screen back to the templates catalogue

---

## 🧪 Steps to QA

1. Log in as a super admin
2. Go to **Permit templates** (`/requirement-templates`)
3. Open a template and view a **published**, **scheduled**, or **early access** template version (`/template-versions/:id`)
4. Click the first breadcrumb (**Template versions** / catalogue label)

**Expected Behaviour:**

- You are taken to the permit templates catalogue (`/requirement-templates`) without an error or blank screen

**Before this change:**

- Clicking the breadcrumb navigated to `/template-versions`, which had no matching route and caused a navigation/breadcrumb error

**After this change:**

- `/template-versions` redirects to `/requirement-templates`, and the breadcrumb works as expected

---

## ♿ UI Accessibility Checklist

> No meaningful UI changes in this PR — routing fix only.

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5254]: https://hous-bssb.atlassian.net/browse/HUB-5254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ