### PR TITLE
Add featre flag for overheating tools

### DIFF
--- a/app/blueprints/site_configuration_blueprint.rb
+++ b/app/blueprints/site_configuration_blueprint.rb
@@ -5,6 +5,7 @@ class SiteConfigurationBlueprint < Blueprinter::Base
          :allow_designated_reviewer,
          :code_compliance_enabled,
          :qa_tools_enabled,
+         :overheating_tool_enabled,
          :archistar_enabled_for_all_jurisdictions
 
   field :help_link_items do |site_configuration, _options|

--- a/app/controllers/api/overheating_codes_controller.rb
+++ b/app/controllers/api/overheating_codes_controller.rb
@@ -6,6 +6,7 @@ class Api::OverheatingCodesController < Api::ApplicationController
   skip_after_action :verify_policy_scoped, only: %i[index]
 
   def index
+    authorize OverheatingCode
     perform_overheating_code_search
     render_success @overheating_code_search.results,
                    nil,

--- a/app/controllers/api/site_configuration_controller.rb
+++ b/app/controllers/api/site_configuration_controller.rb
@@ -94,6 +94,7 @@ class Api::SiteConfigurationController < Api::ApplicationController
       :allow_designated_reviewer,
       :code_compliance_enabled,
       :qa_tools_enabled,
+      :overheating_tool_enabled,
       :archistar_enabled_for_all_jurisdictions,
       help_link_items: [
         get_started_link_item: %i[href title description show],

--- a/app/frontend/components/domains/navigation/index.tsx
+++ b/app/frontend/components/domains/navigation/index.tsx
@@ -321,6 +321,11 @@ const PreCheckViewer = lazy(() =>
 const OverheatingCodeForm = lazy(() =>
   import("../overheating-code").then((module) => ({ default: module.OverheatingCodeForm }))
 )
+const OverheatingCodeUnavailableScreen = lazy(() =>
+  import("../overheating-code/unavailable-screen").then((module) => ({
+    default: module.OverheatingCodeUnavailableScreen,
+  }))
+)
 
 const StepCodeChecklistPDFViewer = lazy(() =>
   import("../step-code/checklist/pdf-content/viewer").then((module) => ({
@@ -408,6 +413,12 @@ const TemplateCategoriesScreen = lazy(() =>
   }))
 )
 
+const OverheatingToolFeatureAccessScreen = lazy(() =>
+  import("../super-admin/site-configuration-management/overheating-tool-feature-access").then((module) => ({
+    default: module.OverheatingToolFeatureAccessScreen,
+  }))
+)
+
 const ReportingScreen = lazy(() =>
   import("../super-admin/reporting/reporting-screen").then((module) => ({ default: module.ReportingScreen }))
 )
@@ -483,7 +494,7 @@ const AppRoutes = observer(() => {
 
   const navigate = useNavigate()
   const { t } = useTranslation()
-  const { allowDesignatedReviewer } = siteConfigurationStore
+  const { allowDesignatedReviewer, overheatingToolEnabled } = siteConfigurationStore
   if (currentUser === undefined) {
     console.log("AppRoutes: currentUser is undefined, rendering LoadingScreen.")
     return <LoadingScreen />
@@ -549,6 +560,10 @@ const AppRoutes = observer(() => {
       <Route
         path="/configuration-management/global-feature-access/code-compliance"
         element={<CodeComplianceSetupScreen />}
+      />
+      <Route
+        path="/configuration-management/global-feature-access/overheating-tool"
+        element={<OverheatingToolFeatureAccessScreen />}
       />
       {qaModeEnabled && (
         <Route
@@ -759,11 +774,17 @@ const AppRoutes = observer(() => {
             <Route path="/pre-checks/:preCheckId/edit/" element={<PreCheckForm />} />
             <Route path="/pre-checks/:preCheckId/edit/:section" element={<PreCheckForm />} />
             <Route path="/pre-checks/:preCheckId/viewer" element={<PreCheckViewer />} />
-            <Route path="/overheating-codes" element={<ProjectDashboardScreen />} />
-            <Route path="/overheating-codes/new" element={<OverheatingCodeForm />} />
-            <Route path="/overheating-codes/new/:section" element={<OverheatingCodeForm />} />
-            <Route path="/overheating-codes/:overheatingCodeId/edit/" element={<OverheatingCodeForm />} />
-            <Route path="/overheating-codes/:overheatingCodeId/edit/:section" element={<OverheatingCodeForm />} />
+            {overheatingToolEnabled ? (
+              <>
+                <Route path="/overheating-codes" element={<ProjectDashboardScreen />} />
+                <Route path="/overheating-codes/new" element={<OverheatingCodeForm />} />
+                <Route path="/overheating-codes/new/:section" element={<OverheatingCodeForm />} />
+                <Route path="/overheating-codes/:overheatingCodeId/edit/" element={<OverheatingCodeForm />} />
+                <Route path="/overheating-codes/:overheatingCodeId/edit/:section" element={<OverheatingCodeForm />} />
+              </>
+            ) : (
+              <Route path="/overheating-codes/*" element={<OverheatingCodeUnavailableScreen />} />
+            )}
             <Route path="/documents" element={<ProjectDashboardScreen />} />
             {/* Already handled above with path-based tabs */}
             <Route path="/projects" element={<ProjectDashboardScreen />} />

--- a/app/frontend/components/domains/navigation/nav-bar.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar.tsx
@@ -149,6 +149,7 @@ function shouldHideSubNavbarForPath(path: string): boolean {
 export const NavBar = observer(function NavBar() {
   const { t } = useTranslation()
   const location = useLocation()
+  const { siteConfigurationStore } = useMst()
   const path = location.pathname
 
   if (isPreCheckPath(path)) {
@@ -172,7 +173,7 @@ export const NavBar = observer(function NavBar() {
     }
   }
 
-  if (isOverheatingCodeSubPath(path)) {
+  if (siteConfigurationStore.overheatingToolEnabled && isOverheatingCodeSubPath(path)) {
     return <OverheatingCodeNavBar />
   }
 

--- a/app/frontend/components/domains/overheating-code/unavailable-screen.tsx
+++ b/app/frontend/components/domains/overheating-code/unavailable-screen.tsx
@@ -1,0 +1,23 @@
+import { Box, Container, Heading, Text, VStack } from "@chakra-ui/react"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { RouterLinkButton } from "../../shared/navigation/router-link-button"
+
+export const OverheatingCodeUnavailableScreen = () => {
+  const { t } = useTranslation()
+
+  return (
+    <Container maxW="container.md" py={16}>
+      <VStack align="flex-start" spacing={6}>
+        <Box>
+          <Heading as="h1">{t("overheatingCode.unavailable.title")}</Heading>
+          <Text mt={4}>{t("overheatingCode.unavailable.description")}</Text>
+          <Text mt={4}>{t("overheatingCode.unavailable.savedWork")}</Text>
+        </Box>
+        <RouterLinkButton to="/project-readiness-tools" variant="primary">
+          {t("overheatingCode.unavailable.returnToTools")}
+        </RouterLinkButton>
+      </VStack>
+    </Container>
+  )
+}

--- a/app/frontend/components/domains/permit-project/index.tsx
+++ b/app/frontend/components/domains/permit-project/index.tsx
@@ -17,7 +17,7 @@ interface IProjectDashboardScreenProps {}
 
 export const ProjectDashboardScreen = observer(({}: IProjectDashboardScreenProps) => {
   const { t } = useTranslation()
-  const { preCheckStore, userStore, sandboxStore } = useMst()
+  const { preCheckStore, userStore, sandboxStore, siteConfigurationStore } = useMst()
   const { currentUser } = userStore
   const { isSandboxActive } = sandboxStore
   const location = useLocation()
@@ -34,12 +34,16 @@ export const ProjectDashboardScreen = observer(({}: IProjectDashboardScreenProps
       tabIndex: 2,
       badgeCount: preCheckStore.unviewedCount,
     },
-    {
-      label: t("overheatingCode.index.title", "Overheating"),
-      icon: Thermometer,
-      to: "overheating-codes",
-      tabIndex: 3,
-    },
+    ...(siteConfigurationStore.overheatingToolEnabled
+      ? [
+          {
+            label: t("overheatingCode.index.title", "Overheating"),
+            icon: Thermometer,
+            to: "overheating-codes",
+            tabIndex: 3,
+          },
+        ]
+      : []),
     // Disabled: Documents tab
     // { label: t("document.index.title", "Documents"), icon: File, to: "documents", tabIndex: 4 },
   ]
@@ -78,7 +82,9 @@ export const ProjectDashboardScreen = observer(({}: IProjectDashboardScreenProps
           <TabPanel p={0}>{isPending ? <LoadingScreen /> : <ProjectTabPanelContent />}</TabPanel>
           <TabPanel p={0}>{isPending ? <LoadingScreen /> : <StepCodeTabPanelContent />}</TabPanel>
           <TabPanel p={0}>{isPending ? <LoadingScreen /> : <PreCheckTabPanelContent />}</TabPanel>
-          <TabPanel p={0}>{isPending ? <LoadingScreen /> : <OverheatingCodeTabPanelContent />}</TabPanel>
+          {siteConfigurationStore.overheatingToolEnabled && (
+            <TabPanel p={0}>{isPending ? <LoadingScreen /> : <OverheatingCodeTabPanelContent />}</TabPanel>
+          )}
           {/* <TabPanel p={0}>{isPending ? <LoadingScreen /> : <ComingSoonPlaceholder />}</TabPanel> */}
         </TabPanels>
       </Tabs>

--- a/app/frontend/components/domains/project-readiness-tools/index.tsx
+++ b/app/frontend/components/domains/project-readiness-tools/index.tsx
@@ -9,6 +9,7 @@ export const ProjectReadinessToolsIndexScreen = () => {
   const { t } = useTranslation()
   const { siteConfigurationStore } = useMst()
   const codeComplianceEnabled = siteConfigurationStore.codeComplianceEnabled
+  const overheatingToolEnabled = siteConfigurationStore.overheatingToolEnabled
 
   const projectReadinessPageItems = [
     {
@@ -53,11 +54,15 @@ export const ProjectReadinessToolsIndexScreen = () => {
           description: t("projectReadinessTools.createLoaDescription"),
           href: "/project-readiness-tools/create-your-letters-of-assurance",
         },
-        {
-          linkText: t("projectReadinessTools.overheatingCodesLink"),
-          description: t("projectReadinessTools.overheatingCodesDescription"),
-          href: "/overheating-codes",
-        },
+        ...(overheatingToolEnabled
+          ? [
+              {
+                linkText: t("projectReadinessTools.overheatingCodesLink"),
+                description: t("projectReadinessTools.overheatingCodesDescription"),
+                href: "/overheating-codes",
+              },
+            ]
+          : []),
       ],
     },
   ]

--- a/app/frontend/components/domains/super-admin/site-configuration-management/global-feature-access.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/global-feature-access.tsx
@@ -26,6 +26,11 @@ export const AdminGlobalFeatureAccessScreen = observer(() => {
       enabled: siteConfigurationStore?.codeComplianceEnabled,
       route: "code-compliance",
     },
+    {
+      label: t(`${i18nPrefix}.overheatingTool`),
+      enabled: siteConfigurationStore?.overheatingToolEnabled,
+      route: "overheating-tool",
+    },
     ...(qaModeEnabled
       ? [
           {

--- a/app/frontend/components/domains/super-admin/site-configuration-management/overheating-tool-feature-access.tsx
+++ b/app/frontend/components/domains/super-admin/site-configuration-management/overheating-tool-feature-access.tsx
@@ -1,0 +1,62 @@
+import { Box, Container, Divider, Flex, Heading, HStack, Text, VStack } from "@chakra-ui/react"
+import { CaretLeft } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { useMst } from "../../../../setup/root"
+import { SharedSpinner } from "../../../shared/base/shared-spinner"
+import { SwitchButton } from "../../../shared/buttons/switch-button"
+import { RouterLinkButton } from "../../../shared/navigation/router-link-button"
+
+export const OverheatingToolFeatureAccessScreen = observer(() => {
+  const i18nPrefix = "siteConfiguration.globalFeatureAccess"
+  const { t } = useTranslation()
+  const { siteConfigurationStore } = useMst()
+  const { updateSiteConfiguration, configurationLoaded } = siteConfigurationStore
+
+  const updateOverheatingToolEnabled = async (checked: boolean) => {
+    await updateSiteConfiguration({ overheatingToolEnabled: checked })
+  }
+
+  if (!configurationLoaded) return <SharedSpinner />
+
+  return (
+    <Container maxW="container.lg" p={8} as={"main"}>
+      <VStack alignItems={"flex-start"} spacing={5} w={"full"} h={"full"}>
+        <Flex justifyContent={"space-between"} w={"full"} alignItems={"flex-end"}>
+          <Box>
+            <RouterLinkButton
+              variant={"link"}
+              to={`/configuration-management/global-feature-access/`}
+              leftIcon={<CaretLeft size={20} />}
+              style={{ textDecoration: "none" }}
+            >
+              {t("ui.back")}
+            </RouterLinkButton>
+            <Heading as="h1" marginTop={"15px"}>
+              {t(`${i18nPrefix}.overheatingTool`)}
+            </Heading>
+            <Text color="text.secondary" my={6}>
+              {t(`${i18nPrefix}.overheatingToolDescription`)}
+            </Text>
+          </Box>
+        </Flex>
+      </VStack>
+      <Flex justifyContent={"space-between"} w={"full"} alignItems={"flex-end"}>
+        <VStack justifyContent={"space-between"} w={"full"} alignItems={"flex-end"}>
+          <Flex direction="row" justify="space-between" w="100%">
+            <Text style={{ fontWeight: "bold" }}>{t(`${i18nPrefix}.overheatingTool`)}</Text>
+            <HStack spacing={5} align="center">
+              <SwitchButton
+                isChecked={siteConfigurationStore.overheatingToolEnabled || false}
+                onChange={(e) => updateOverheatingToolEnabled(e.target.checked)}
+                size={"lg"}
+              />
+            </HStack>
+          </Flex>
+          <Divider />
+        </VStack>
+      </Flex>
+    </Container>
+  )
+})

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -743,6 +743,14 @@ const options = {
             intro:
               "Your overheating code check results are stored here. Use this service to verify compliance with overheating requirements before submitting a permit application.",
           },
+          unavailable: {
+            title: "Overheating Code Check is temporarily unavailable",
+            description:
+              "This tool is currently unavailable while we update and validate it with our partner organizations.",
+            savedWork:
+              "If you started or saved an overheating code check before, your work is still saved and will be available when access is restored.",
+            returnToTools: "Return to Project Readiness Tools",
+          },
           columns: {
             issued_to: "Issued To",
             project_number: "Project #",
@@ -3780,6 +3788,9 @@ Thank you,
               submissionInbox: "Submissions",
               submissionInboxDescription:
                 "Enable review managers to accept and process permit applications. If you turn off this feature, submitters can't submit applications, and review managers won't receive new applications.",
+              overheatingTool: "Overheating tool",
+              overheatingToolDescription:
+                "Enable the Overheating Code Check tool for logged-in users. If turned off, users cannot access existing checks or start new ones.",
               toggleOn: "On",
               toggleOff: "Off",
               acceptPermitApplications: "Accept permit applications",
@@ -4648,6 +4659,9 @@ Thank you,
               jurisdictionsCount_other: "{{count}} jurisdictions enabled",
               searchJurisdictions: "Search and select jurisdictions...",
             },
+            overheatingTool: "Overheating tool",
+            overheatingToolDescription:
+              "Enable the Overheating Code Check tool for logged-in users. If turned off, users cannot access existing checks or start new ones.",
             qaTools: "QA tools",
             qaToolsDescription:
               "Enable QA tools for users who can access test helpers. This setting only applies when QA mode is enabled for the environment.",
@@ -5158,6 +5172,8 @@ Thank you,
             preview: "Preview",
             videos: "Videos",
             helpVideos: "Videos",
+            qaTools: "QA tools",
+            overheatingTool: "Overheating tool",
             templateCategories: "Permit categories",
           },
         },

--- a/app/frontend/stores/site-configuration-store.ts
+++ b/app/frontend/stores/site-configuration-store.ts
@@ -17,6 +17,7 @@ export const SiteConfigurationStoreModel = types.snapshotProcessor(
       allowDesignatedReviewer: types.maybeNull(types.boolean),
       codeComplianceEnabled: types.maybeNull(types.boolean),
       qaToolsEnabled: types.maybeNull(types.boolean),
+      overheatingToolEnabled: types.maybeNull(types.boolean),
       archistarEnabledForAllJurisdictions: types.maybeNull(types.boolean),
       sitewideMessage: types.maybeNull(types.string),
       helpLinkItems: types.frozen<IHelpLinkItems>(),

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -132,6 +132,7 @@ export interface ISiteConfigurationUpdateParams {
   allowDesignatedReviewer?: boolean | null
   codeComplianceEnabled?: boolean | null
   qaToolsEnabled?: boolean | null
+  overheatingToolEnabled?: boolean | null
   archistarEnabledForAllJurisdictions?: boolean | null
   sitewideMessage?: string | null
   helpLinkItems?: IHelpLinkItems

--- a/app/models/site_configuration.rb
+++ b/app/models/site_configuration.rb
@@ -40,6 +40,10 @@ class SiteConfiguration < ApplicationRecord
     instance.qa_tools_enabled
   end
 
+  def self.overheating_tool_enabled?
+    instance.overheating_tool_enabled
+  end
+
   def self.archistar_enabled_for_jurisdiction?(jurisdiction)
     return false unless instance.code_compliance_enabled # Global switch
     return true if instance.archistar_enabled_for_all_jurisdictions # Override

--- a/app/policies/overheating_code_policy.rb
+++ b/app/policies/overheating_code_policy.rb
@@ -1,14 +1,14 @@
 class OverheatingCodePolicy < ApplicationPolicy
   def index?
-    user.present?
+    overheating_tool_enabled? && user.present?
   end
 
   def show?
-    record.creator_id == user.id
+    overheating_tool_enabled? && record.creator_id == user.id
   end
 
   def create?
-    user.present?
+    overheating_tool_enabled? && user.present?
   end
 
   def update?
@@ -23,8 +23,16 @@ class OverheatingCodePolicy < ApplicationPolicy
     show?
   end
 
+  private
+
+  def overheating_tool_enabled?
+    SiteConfiguration.overheating_tool_enabled?
+  end
+
   class Scope < Scope
     def resolve
+      return scope.none unless SiteConfiguration.overheating_tool_enabled?
+
       scope.where(creator_id: user.id)
     end
   end

--- a/db/migrate/20251008184807_add_customizations_count_to_template_versions.rb
+++ b/db/migrate/20251008184807_add_customizations_count_to_template_versions.rb
@@ -6,6 +6,8 @@ class AddCustomizationsCountToTemplateVersions < ActiveRecord::Migration[7.2]
                default: 0,
                null: false
 
+    return unless column_exists?(:template_versions, :change_significance)
+
     # Reset column information so ActiveRecord knows about the new column
     TemplateVersion.reset_column_information
 

--- a/db/migrate/20260707200600_add_overheating_tool_enabled_to_site_configurations.rb
+++ b/db/migrate/20260707200600_add_overheating_tool_enabled_to_site_configurations.rb
@@ -1,0 +1,19 @@
+class AddOverheatingToolEnabledToSiteConfigurations < ActiveRecord::Migration[
+  7.1
+]
+  def up
+    unless column_exists?(:site_configurations, :overheating_tool_enabled)
+      add_column :site_configurations,
+                 :overheating_tool_enabled,
+                 :boolean,
+                 default: false,
+                 null: false
+    end
+  end
+
+  def down
+    if column_exists?(:site_configurations, :overheating_tool_enabled)
+      remove_column :site_configurations, :overheating_tool_enabled
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_02_180000) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_07_200600) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -98,9 +98,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_02_180000) do
     t.uuid "contactable_id"
     t.string "contact_type"
     t.index ["contactable_type", "contactable_id"], name: "index_contacts_on_contactable"
-  end
-
-  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
   end
 
   create_table "design_documents", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -907,6 +904,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_02_180000) do
     t.boolean "code_compliance_enabled", default: false, null: false
     t.boolean "archistar_enabled_for_all_jurisdictions", default: false, null: false
     t.boolean "qa_tools_enabled", default: false, null: false
+    t.boolean "overheating_tool_enabled", default: false, null: false
   end
 
   create_table "step_code_building_characteristics_summaries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/controllers/api/overheating_codes_controller_spec.rb
+++ b/spec/controllers/api/overheating_codes_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Api::OverheatingCodesController,
   before do
     sign_in user
     request.headers["ACCEPT"] = "application/json"
+    SiteConfiguration.instance.update!(overheating_tool_enabled: true)
   end
 
   describe "POST #index" do
@@ -37,6 +38,14 @@ RSpec.describe Api::OverheatingCodesController,
 
       expect(response).to have_http_status(:success)
       expect(json_response["data"]).to be_empty
+    end
+
+    it "returns forbidden when the overheating tool is disabled" do
+      SiteConfiguration.instance.update!(overheating_tool_enabled: false)
+
+      post :index, params: {}, format: :json
+
+      expect(response).to have_http_status(:forbidden)
     end
   end
 
@@ -95,6 +104,16 @@ RSpec.describe Api::OverheatingCodesController,
            as: :json
 
       expect(json_response["data"]["creator"]["id"]).to eq(user.id)
+    end
+
+    it "returns forbidden when the overheating tool is disabled" do
+      SiteConfiguration.instance.update!(overheating_tool_enabled: false)
+
+      expect do
+        post :create, params: { overheating_code: {} }, as: :json
+      end.not_to change(OverheatingCode, :count)
+
+      expect(response).to have_http_status(:forbidden)
     end
   end
 

--- a/spec/controllers/site_configuration_controller_spec.rb
+++ b/spec/controllers/site_configuration_controller_spec.rb
@@ -25,13 +25,15 @@ RSpec.describe Api::SiteConfigurationController, type: :controller do
           params: {
             site_configuration: {
               display_sitewide_message: true,
-              sitewide_message: "Maintenance window"
+              sitewide_message: "Maintenance window",
+              overheating_tool_enabled: true
             }
           },
           format: :json
 
       expect(response).to have_http_status(:ok)
       expect(SiteConfiguration.instance.display_sitewide_message).to eq(true)
+      expect(SiteConfiguration.instance.overheating_tool_enabled).to eq(true)
     end
   end
 

--- a/spec/models/site_configuration_spec.rb
+++ b/spec/models/site_configuration_spec.rb
@@ -26,6 +26,16 @@ RSpec.describe SiteConfiguration, type: :model do
     end
   end
 
+  describe ".overheating_tool_enabled?" do
+    before { SiteConfiguration.delete_all }
+
+    it "returns the global overheating tool flag" do
+      described_class.create!(overheating_tool_enabled: true)
+
+      expect(described_class.overheating_tool_enabled?).to eq(true)
+    end
+  end
+
   describe "singleton enforcement" do
     it "prevents creating a second record" do
       SiteConfiguration.create!

--- a/spec/policies/overheating_code_policy_spec.rb
+++ b/spec/policies/overheating_code_policy_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe OverheatingCodePolicy do
   let(:creator_context) { UserContext.new(creator, nil) }
   let(:other_user_context) { UserContext.new(other_user, nil) }
 
+  before { SiteConfiguration.instance.update!(overheating_tool_enabled: true) }
+
   permissions :show? do
     it "allows the creator" do
       expect(policy).to permit(creator_context, overheating_code)
@@ -64,6 +66,25 @@ RSpec.describe OverheatingCodePolicy do
     end
   end
 
+  describe "when the overheating tool is disabled" do
+    before do
+      SiteConfiguration.instance.update!(overheating_tool_enabled: false)
+    end
+
+    it "denies all actions" do
+      policy_instance = described_class.new(creator_context, overheating_code)
+
+      expect(policy_instance.index?).to be(false)
+      expect(policy_instance.show?).to be(false)
+      expect(policy_instance.update?).to be(false)
+      expect(policy_instance.destroy?).to be(false)
+      expect(policy_instance.restore?).to be(false)
+      expect(
+        described_class.new(creator_context, build(:overheating_code)).create?
+      ).to be(false)
+    end
+  end
+
   describe OverheatingCodePolicy::Scope do
     it "returns only overheating codes created by the user" do
       mine = create(:overheating_code, creator: creator)
@@ -72,6 +93,15 @@ RSpec.describe OverheatingCodePolicy do
       scope = described_class.new(creator_context, OverheatingCode.all).resolve
 
       expect(scope).to contain_exactly(mine)
+    end
+
+    it "returns no records when the overheating tool is disabled" do
+      SiteConfiguration.instance.update!(overheating_tool_enabled: false)
+      create(:overheating_code, creator: creator)
+
+      scope = described_class.new(creator_context, OverheatingCode.all).resolve
+
+      expect(scope).to be_empty
     end
   end
 end


### PR DESCRIPTION
## 📋 Description

HOTFIX TO STABLE

**Analyzed:** `git diff develop...HUB-5258-story-make-single-zone-cooling-tool-unavailable-until-its-reframed-and-validated` (merge-base range).

The Single Zone Cooling / Overheating Code Check tool was made live before it was ready for external scrutiny. This PR gates user access behind a global site configuration flag so the tool can be turned off in production while internal teams continue reframing and QA work.

When disabled, the tool is removed from user-facing navigation, direct/bookmarked links show a friendly unavailable message (including reassurance that saved work is preserved), and backend API access is blocked via policy. Super admins can re-enable the tool from Global Feature Access when it is ready to go live again.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                                 |
| -------------------- | -------------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5258](https://yourorg.atlassian.net/browse/HUB-5258)            |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                                  |
| 📑 Design / Figma    | <!-- Paste link -->                                                  |
| 📚 Documentation     | <!-- Paste link -->                                                  |

---

## ✨ Features / Changes Introduced

- Added `overheating_tool_enabled` site configuration flag (defaults to `false`) with migration and API/frontend wiring
- Added super admin toggle under **Configuration Management → Global feature access → Overheating tool**
- Hid the Overheating tab from the project dashboard when the flag is off
- Hid the Overheating link from **Project Readiness Tools** when the flag is off
- Added a dedicated unavailable screen for `/overheating-codes/*` when disabled, with messaging that saved/in-progress work is preserved
- Gated overheating-specific navbar so bookmarked edit links do not show the old tool header while disabled
- Gated `OverheatingCodePolicy` and API controller authorization so all overheating code endpoints return forbidden when disabled
- Added policy, controller, and model specs for the disabled-state behaviour
- Minor switch-button icon alignment fix in the feature access toggle

---

## 🧪 Steps to QA

### With the flag OFF (default after migration)

1. Log in as a **submitter** and open **Project Readiness Tools**
2. Confirm the **Verify compliance with BC overheating requirements** link is not shown
3. Open **My Projects** and confirm the **Overheating** sidebar tab is not shown
4. Navigate directly to `/overheating-codes`
5. Confirm a friendly unavailable message is shown (not a 404 or raw error), including text that saved work is preserved
6. Navigate directly to a previously bookmarked edit URL, e.g. `/overheating-codes/<id>/edit/introduction`
7. Confirm the same unavailable message is shown and the overheating-specific navbar is not displayed

### With the flag ON (super admin)

1. Log in as a **super admin**
2. Go to **Configuration Management → Global feature access → Overheating tool**
3. Turn the toggle **on**
4. As a submitter, confirm the Overheating link reappears on **Project Readiness Tools**
5. Confirm the **Overheating** tab reappears on the project dashboard
6. Open `/overheating-codes` and confirm the tool loads normally
7. Confirm you can start or resume an overheating code check

### API / saved data

1. With the flag **off**, attempt to access an existing overheating code via the UI or API
2. Confirm access is blocked (forbidden) rather than returning editable data
3. Turn the flag **back on** and confirm previously saved checks are still available

**Expected Behaviour:**

- No user role can discover or use the overheating tool while the flag is off
- Direct links show a clear unavailable message instead of a broken page
- Saved calculations remain in the database and become accessible again when the flag is turned on
- Super admins can toggle access on/off without code changes

**Before this change:**

- The overheating tool was visible in Project Readiness Tools and project navigation
- Direct links loaded the tool regardless of readiness state

**After this change:**

- The tool is hidden and blocked by default; only super admins can re-enable it globally

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [ ] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5258]: https://hous-bssb.atlassian.net/browse/HUB-5258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ