### PR TITLE
July 13 fixes

### DIFF
--- a/app/blueprints/user_blueprint.rb
+++ b/app/blueprints/user_blueprint.rb
@@ -71,6 +71,10 @@ class UserBlueprint < Blueprinter::Base
 
     association :jurisdictions, blueprint: JurisdictionBlueprint, view: :minimal
 
+    field :invitation_promotes_existing_submitter do |user, _options|
+      user.invitation_promotes_existing_submitter?
+    end
+
     field :invited_by_email do |user, _options|
       user.invited_by&.email
     end

--- a/app/frontend/components/domains/overheating-code/form-section/introduction.tsx
+++ b/app/frontend/components/domains/overheating-code/form-section/introduction.tsx
@@ -45,6 +45,15 @@ export const Introduction = observer(function Introduction() {
     <Box>
       <CustomMessageBox
         status={EFlashMessageStatus.info}
+        description={t(
+          "overheatingCode.sections.introduction.attribution",
+          "This form was originally created by the HVAC Designers of Canada and the Thermal Environmental Comfort Association (TECA), and has been digitized with their permission."
+        )}
+        mb={6}
+      />
+
+      <CustomMessageBox
+        status={EFlashMessageStatus.info}
         title={t(
           "overheatingCode.sections.introduction.standardTitle",
           "B.C. Single Zone Cooling Capacity — BCBC 9.33.3.1.; 9.33.5.1."

--- a/app/frontend/components/domains/users/accept-invitation-screen.tsx
+++ b/app/frontend/components/domains/users/accept-invitation-screen.tsx
@@ -47,9 +47,29 @@ const Content = observer(function Content({ invitedUser }: Readonly<IProps>) {
   const { sessionStore } = useMst()
   const { loggedIn } = sessionStore
 
-  const { invitedByEmail, invitedToJurisdiction, isSuperAdmin, email, role, jurisdiction } = invitedUser
+  const {
+    invitedByEmail,
+    invitedToJurisdiction,
+    isSuperAdmin,
+    email,
+    role,
+    jurisdiction,
+    invitationPromotesExistingSubmitter,
+  } = invitedUser
   const defaultedJurisdiction = invitedToJurisdiction ?? jurisdiction
   const showLoggedInStaffInviteWarning = loggedIn && !isSuperAdmin && role !== EUserRoles.submitter
+  const inviteWarningKey = (() => {
+    if (showLoggedInStaffInviteWarning && invitationPromotesExistingSubmitter) {
+      return "user.loggedInSubmitterStaffInviteWarning"
+    }
+    if (showLoggedInStaffInviteWarning) {
+      return "user.loggedInStaffInviteWarning"
+    }
+    if (invitationPromotesExistingSubmitter) {
+      return "user.submitterPromotionProjectAccessWarning"
+    }
+    return null
+  })()
 
   return (
     <CenterContainer>
@@ -91,16 +111,15 @@ const Content = observer(function Content({ invitedUser }: Readonly<IProps>) {
 
         <Divider my={4} />
 
+        {inviteWarningKey && (
+          <Alert status="warning" borderRadius="md" alignItems="flex-start">
+            <AlertIcon mt={1} />
+            <Text fontSize="sm">{t(inviteWarningKey)}</Text>
+          </Alert>
+        )}
+
         {loggedIn ? (
-          <>
-            {showLoggedInStaffInviteWarning && (
-              <Alert status="warning" borderRadius="md" alignItems="flex-start">
-                <AlertIcon mt={1} />
-                <Text fontSize="sm">{t("user.loggedInStaffInviteWarning")}</Text>
-              </Alert>
-            )}
-            <AcceptInviteForm />
-          </>
+          <AcceptInviteForm />
         ) : (
           <>
             <Heading as="h3" textAlign="center">

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4678,6 +4678,10 @@ Thank you,
           acceptInstructions: "Enter your login and other user info below to finalize your account creation.",
           loggedInStaffInviteWarning:
             "You are already signed in. Accepting this staff invitation will attach it to your currently signed-in account. If you need to use a different BCeID account, sign out first or open this invitation in a private/incognito window.",
+          submitterPromotionProjectAccessWarning:
+            "If you accept this invitation while signed in as a submitter, your account will become jurisdiction staff and you will lose access to any permit projects you currently own.",
+          loggedInSubmitterStaffInviteWarning:
+            "You are already signed in. Accepting this staff invitation will attach it to your current account and make it jurisdiction staff — you will lose access to any permit projects you currently own as a submitter. If you need to use a different BCeID account, sign out first or open this invitation in a private/incognito window.",
           rolesAndPermissions: "User roles & permissions",
           inviteInstructions:
             "Enter the email addresses of whom you wish to invite below.  For details about permissions for each role, please see",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -782,6 +782,8 @@ const options = {
           },
           sections: {
             introduction: {
+              attribution:
+                "This form was originally created by the HVAC Designers of Canada and the Thermal Environmental Comfort Association (TECA), and has been digitized with their permission.",
               standardTitle: "B.C. Single Zone Cooling Capacity — BCBC 9.33.3.1.; 9.33.5.1.",
               formVersion: "B.C. SZCG Form Set Ver 1.0",
               title: "Overheating Code Check",

--- a/app/frontend/models/user.ts
+++ b/app/frontend/models/user.ts
@@ -42,6 +42,7 @@ export const UserModel = types
     department: types.maybeNull(types.string),
     preference: types.frozen<IPreference>(),
     invitedToJurisdiction: types.maybeNull(types.frozen<IJurisdiction>()),
+    invitationPromotesExistingSubmitter: types.optional(types.boolean, false),
     licenseAgreements: types.maybeNull(types.frozen<ILicenseAgreement[]>()),
   })
   .extend(withRootStore())

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -226,6 +226,19 @@ class User < ApplicationRecord
     review_staff? || technical_support?
   end
 
+  # Inviting a submitter's email creates a staff user alongside them; accepting
+  # promotes the submitter via PromoteUser.
+  def invitation_promotes_existing_submitter?
+    return false unless jurisdiction_staff?
+
+    User
+      .kept
+      .submitter
+      .where("LOWER(email) = ?", email.to_s.strip.downcase)
+      .where.not(id: id)
+      .exists?
+  end
+
   def role_name
     role.gsub("_", " ")
   end

--- a/app/services/overheating_code_pdf_service.rb
+++ b/app/services/overheating_code_pdf_service.rb
@@ -7,6 +7,9 @@ class OverheatingCodePdfService
       .join("lib", "assets", "pdf_templates", "BC-SZCG-FormSetFill-Ver1.0a.pdf")
       .freeze
 
+  ATTRIBUTION =
+    "This form was originally created by the HVAC Designers of Canada and the Thermal Environmental Comfort Association (TECA), and has been digitized with their permission.".freeze
+
   KW_TO_BTUH = 3412.142
 
   FIELD_MAP = {
@@ -84,6 +87,8 @@ class OverheatingCodePdfService
     form.create_appearances(force: true)
     form.flatten
 
+    stamp_attribution!(doc)
+
     io = StringIO.new
     doc.write(io)
     io.string
@@ -95,6 +100,31 @@ class OverheatingCodePdfService
   end
 
   private
+
+  def stamp_attribution!(doc)
+    page = doc.pages[0]
+    canvas = page.canvas(type: :overlay)
+    box = page.box
+    margin_x = 20
+    strip_height = 22
+
+    canvas.fill_color(0.95, 0.95, 0.95)
+    canvas.rectangle(0, 0, box.width, strip_height).fill
+
+    fragment =
+      HexaPDF::Layout::TextFragment.create(
+        ATTRIBUTION,
+        font: doc.fonts.add("Helvetica"),
+        font_size: 7
+      )
+    result =
+      HexaPDF::Layout::TextLayouter.new.fit(
+        [fragment],
+        box.width - (margin_x * 2),
+        strip_height - 4
+      )
+    result.draw(canvas, margin_x, strip_height - 6)
+  end
 
   def resolve_value(source)
     case source

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -13,9 +13,7 @@
             <% newest_membership = @resource.jurisdiction_memberships.order(created_at: :desc).first %>
             for <strong><%= newest_membership.jurisdiction.name %></strong><% end %>.</p>
 
-          <%# Inviting a submitter's email creates a staff user alongside them; accepting promotes the submitter. %>
-          <% if @resource.jurisdiction_staff? &&
-               User.kept.submitter.where("LOWER(email) = ?", @resource.email.to_s.strip.downcase).where.not(id: @resource.id).exists? %>
+          <% if @resource.invitation_promotes_existing_submitter? %>
             <p><strong>Important:</strong> If you accept this invitation while signed in as a submitter, your account will become jurisdiction staff and you will lose access to any permit projects you currently own.</p>
           <% end %>
 

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -16,8 +16,7 @@
           <%# Inviting a submitter's email creates a staff user alongside them; accepting promotes the submitter. %>
           <% if @resource.jurisdiction_staff? &&
                User.kept.submitter.where("LOWER(email) = ?", @resource.email.to_s.strip.downcase).where.not(id: @resource.id).exists? %>
-            <p><strong>Important:</strong> If you are currently logged in as a submitter, accepting this invitation will change your account to jurisdiction staff.
-              You will lose access to any existing permit projects you currently own as a submitter.</p>
+            <p><strong>Important:</strong> If you accept this invitation while signed in as a submitter, your account will become jurisdiction staff and you will lose access to any permit projects you currently own.</p>
           <% end %>
 
           <% expires_at = @resource.invitation_created_at + User.invite_for %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -13,6 +13,13 @@
             <% newest_membership = @resource.jurisdiction_memberships.order(created_at: :desc).first %>
             for <strong><%= newest_membership.jurisdiction.name %></strong><% end %>.</p>
 
+          <%# Inviting a submitter's email creates a staff user alongside them; accepting promotes the submitter. %>
+          <% if @resource.jurisdiction_staff? &&
+               User.kept.submitter.where("LOWER(email) = ?", @resource.email.to_s.strip.downcase).where.not(id: @resource.id).exists? %>
+            <p><strong>Important:</strong> If you are currently logged in as a submitter, accepting this invitation will change your account to jurisdiction staff.
+              You will lose access to any existing permit projects you currently own as a submitter.</p>
+          <% end %>
+
           <% expires_at = @resource.invitation_created_at + User.invite_for %>
           <p>This invitation is valid for <%= distance_of_time_in_words(User.invite_for) %> and will expire on
             <strong><%= l(expires_at, format: :long) %></strong>.</p>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -68,4 +68,21 @@ RSpec.describe User, type: :model do
       expect(inviter.invitable_roles).to match_array([])
     end
   end
+
+  describe "#invitation_promotes_existing_submitter?" do
+    it "is true when inviting jurisdiction staff and a kept submitter shares the email" do
+      create(:user, :submitter, email: "shared@example.com")
+      invited =
+        create(:user, :reviewer, email: "shared@example.com", confirmed: false)
+
+      expect(invited.invitation_promotes_existing_submitter?).to be(true)
+    end
+
+    it "is false when no existing submitter shares the email" do
+      invited =
+        create(:user, :reviewer, email: "solo@example.com", confirmed: false)
+
+      expect(invited.invitation_promotes_existing_submitter?).to be(false)
+    end
+  end
 end

--- a/spec/requests/api/invitations_spec.rb
+++ b/spec/requests/api/invitations_spec.rb
@@ -83,6 +83,32 @@ RSpec.describe "Api::Invitations", type: :request do
 
       expect(response).to have_http_status(:ok)
       expect(json_response.dig("data", "id")).to eq(invited_user.id)
+      expect(
+        json_response.dig("data", "invitation_promotes_existing_submitter")
+      ).to eq(false)
+    end
+
+    it "flags when accepting would promote an existing submitter" do
+      email = "promote-me@example.com"
+      create(:user, :submitter, email: email)
+      # Same as Jurisdiction::UserInviter: create a second staff user alongside
+      # the submitter. User.invite! alone would find the existing submitter.
+      invited_user =
+        create(
+          :user,
+          :reviewer,
+          email: email,
+          confirmed: false,
+          jurisdiction: jurisdiction
+        )
+      invited_user.invite!(inviter)
+
+      get "/api/invitations/#{invited_user.raw_invitation_token}"
+
+      expect(response).to have_http_status(:ok)
+      expect(
+        json_response.dig("data", "invitation_promotes_existing_submitter")
+      ).to eq(true)
     end
 
     it "returns not found for an invalid token" do

--- a/spec/services/overheating_code_pdf_service_spec.rb
+++ b/spec/services/overheating_code_pdf_service_spec.rb
@@ -60,6 +60,16 @@ RSpec.describe OverheatingCodePdfService do
       expect(pdf_data).to include("John Q. Engineer")
       expect(pdf_data).to include("john@example.com")
     end
+
+    it "includes HVAC Designers of Canada and TECA attribution" do
+      pdf_data = service.generate
+      contents =
+        HexaPDF::Document.new(io: StringIO.new(pdf_data)).pages[0].contents.to_s
+
+      expect(contents).to include("HVAC Designers of Canada")
+      expect(contents).to include("TECA")
+      expect(contents).to include("digitized with their permission")
+    end
   end
 
   describe "#filename" do


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...july-13-fixes` (merge-base range).

Adds a clear warning when a staff invitation would promote an existing submitter (accepting converts the account to jurisdiction staff and removes access to permit projects they own), and restores required HVAC Designers of Canada / TECA attribution on the Overheating Code Check form and exported PDF.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-4863](https://hous-bssb.atlassian.net/browse/HUB-4863), [HUB-5259](https://hous-bssb.atlassian.net/browse/HUB-5259) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- **HUB-4863:** Detect when a staff invite shares an email with an existing submitter (`invitation_promotes_existing_submitter?`), expose it on the invitation API, and show a warning in the invite email and on the accept-invitation screen (including a combined message when already signed in).
- **HUB-5259:** Show HVAC Designers of Canada / TECA attribution on the Overheating Code Check introduction section and stamp the same attribution onto page 1 of the generated PDF.
- Specs covering the promotion flag (model + invitations API) and PDF attribution text.

---

## 🧪 Steps to QA

1. **Submitter promotion warning (invite email + accept screen)**
   - As jurisdiction staff, invite an email that already belongs to a submitter account to a staff role.
   - Open the invitation email and confirm the “Important” warning about losing access to owned permit projects.
   - Open the invite link while **signed out** and confirm the submitter-promotion warning on the accept screen.
   - Open the invite link while **signed in as that submitter** and confirm the combined logged-in + promotion warning.
   - Invite a staff email with **no** existing submitter and confirm neither the email nor accept screen shows the promotion warning (logged-in staff warning may still appear if already signed in as non-super-admin staff).

2. **Overheating Code attribution**
   - Open an Overheating Code Check application and go to the Introduction section.
   - Confirm the info message attributing the form to HVAC Designers of Canada and TECA.
   - Export / download the PDF and confirm the attribution appears on the first page (bottom strip).

**Expected Behaviour:**
> Users who would be promoted from submitter to staff are warned before accepting; the Overheating Code form and PDF credit HVAC Designers of Canada and TECA.

**Before this change:**
> No promotion warning on invite email/accept screen; form/PDF lacked required attribution.

**After this change:**
> Promotion risk is called out in email and UI; attribution is visible in the form intro and stamped on the PDF. Please attach before/after screenshots for the accept-invite warning and Overheating Code intro/PDF.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-4863]: https://hous-bssb.atlassian.net/browse/HUB-4863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HUB-5259]: https://hous-bssb.atlassian.net/browse/HUB-5259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ