### PR TITLE
Hub 4748 admin banner notifications create alternate banner warning when keycloak b ce id login service unavailable

### DIFF
--- a/app/controllers/api/omniauth_callbacks_controller.rb
+++ b/app/controllers/api/omniauth_callbacks_controller.rb
@@ -1,6 +1,11 @@
 class Api::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include BaseControllerMethods
 
+  SERVICE_UNAVAILABLE_FAILURE_TYPES = %w[
+    service_unavailable
+    temporarily_unavailable
+  ].freeze
+
   def keycloak
     origin_query =
       Rack::Utils.parse_nested_query(URI(request.env["omniauth.origin"]).query)
@@ -24,7 +29,7 @@ class Api::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       ).call
     @user = result.user
 
-    if @user&.valid? && @user&.persisted?
+    if @user&.valid? && @user.persisted?
       sign_in(resource_name, @user, store: false)
       request.reset_csrf_token # explicitly reset the CSRF token here for CSRF Fixation protection (we are not using Devise's config.clean_up_csrf_token_on_authentication because it is causing issues)
       redirect_to root_path
@@ -42,6 +47,21 @@ class Api::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def failure
-    redirect_to login_path(frontend_flash_message("omniauth.failure", "error"))
+    redirect_to login_path(
+                  frontend_flash_message(omniauth_failure_message_key, "error")
+                )
+  end
+
+  private
+
+  def omniauth_failure_message_key
+    puts "request.get_header('omniauth.error.type'): #{request.get_header("omniauth.error.type")}"
+    if SERVICE_UNAVAILABLE_FAILURE_TYPES.include?(
+         request.get_header("omniauth.error.type").to_s
+       )
+      "omniauth.service_unavailable"
+    else
+      "omniauth.failure"
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -256,6 +256,9 @@ en:
       failure:
         title: Login failed
         message: Please try again or contact your adminstrator for support
+      service_unavailable:
+        title: Login service unavailable
+        message: The BCeID login service may be unavailable. Please contact BCeID 77000 Service Desk staff for support.
       bceid_failure_with_message:
         title: BCeID login failed
         message: "%{error_message}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,7 +258,7 @@ en:
         message: Please try again or contact your adminstrator for support
       service_unavailable:
         title: Login service unavailable
-        message: The BCeID login service may be unavailable. Please contact BCeID 77000 Service Desk staff for support.
+        message: The login service may be unavailable. Please contact BCeID or BC Services Card for support.
       bceid_failure_with_message:
         title: BCeID login failed
         message: "%{error_message}"


### PR DESCRIPTION
## 📋 Description

When Keycloak or the upstream BCeID / BC Services Card login service is unavailable, OmniAuth failures previously showed the generic "Login failed" flash message. This PR detects service-unavailability error types from OmniAuth and redirects to the login page with a more specific banner explaining that the login service may be down and where to get support.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                                 |
| -------------------- | -------------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-4748](https://hous-bssb.atlassian.net/browse/HUB-4748)          |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                                  |
| 📑 Design / Figma    | <!-- Paste link -->                                                  |
| 📚 Documentation     | <!-- Paste link -->                                                  |

---

## ✨ Features / Changes Introduced

- Added `SERVICE_UNAVAILABLE_FAILURE_TYPES` (`service_unavailable`, `temporarily_unavailable`) to classify OmniAuth failures caused by upstream login service outages
- Updated `Api::OmniauthCallbacksController#failure` to select the flash message key based on `omniauth.error.type`
- Added `omniauth.service_unavailable` translation with title "Login service unavailable" and copy directing users to contact BCeID or BC Services Card for support
- Minor cleanup: use `@user.persisted?` instead of `@user&.persisted?` after the validity check in the Keycloak callback

---

## 🧪 Steps to QA

1. Open the login page while logged out
2. Trigger an OmniAuth failure with a service-unavailable error type (e.g. simulate Keycloak/BCeID being unreachable, or hit `/api/auth/failure` with `omniauth.error.type` set to `service_unavailable` or `temporarily_unavailable`)
3. Confirm you are redirected back to the login page with an error flash banner
4. Verify the banner title is **"Login service unavailable"** and the message reads: _"The login service may be unavailable. Please contact BCeID or BC Services Card for support."_
5. Trigger a generic OmniAuth failure (any other `omniauth.error.type`) and confirm the existing **"Login failed"** message still appears

**Expected Behaviour:**

- Service-unavailable login failures show the new, more helpful banner on the login screen
- All other login failures continue to show the generic failure message

**Before this change:**

- All OmniAuth failures showed the generic "Login failed" flash, even when the upstream identity provider was unavailable

**After this change:**

- Service-unavailable failures show a distinct banner with guidance to contact BCeID or BC Services Card

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

_Note: This PR only changes flash message copy rendered in the existing toast component; no new UI elements were added._

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-4748]: https://hous-bssb.atlassian.net/browse/HUB-4748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ