### PR TITLE
Bugfix/july 15 fixes

### DIFF
--- a/app/frontend/components/domains/project-meeting/project-meeting-screen/sections/authorization-documents-section.tsx
+++ b/app/frontend/components/domains/project-meeting/project-meeting-screen/sections/authorization-documents-section.tsx
@@ -18,7 +18,6 @@ import {
 } from "../../../../../types/enums"
 import { FileDownloadButton } from "../../../../shared/base/file-download-button"
 import { useProjectMeetingNavigation } from "../../use-project-meeting-navigation"
-import { ACCEPTED_DOCUMENT_TYPES } from "../shared/constants"
 import { activeDocumentsForType, documentsForType } from "../shared/document-utils"
 import { DocumentsTable } from "../shared/documents-table"
 import { FormActions } from "../shared/form-actions"
@@ -83,7 +82,6 @@ export const AuthorizationDocumentsSection = observer(({ meeting }: Authorizatio
     onUploadSuccess: handleUploadSuccess(EMeetingRequestDocumentType.authorization),
     maxNumberOfFiles: 10,
     autoProceed: true,
-    allowedFileTypes: ACCEPTED_DOCUMENT_TYPES,
   })
 
   const handleRemoveFile = (documentId: string) => {
@@ -163,11 +161,7 @@ export const AuthorizationDocumentsSection = observer(({ meeting }: Authorizatio
           onRemoveFile={handleRemoveFile}
           onUndoRemoveFile={handleUndoRemoveFile}
         />
-        <UppyDashboardField
-          uppy={authorizationUppy}
-          acceptedFormatsLabel={t("projectMeeting.sections.documents.acceptedFormats")}
-          mb={2}
-        />
+        <UppyDashboardField uppy={authorizationUppy} mb={2} />
         <FormErrorMessage>{documentError}</FormErrorMessage>
       </FormControl>
       <FormActions

--- a/app/frontend/components/domains/project-meeting/project-meeting-screen/sections/contact-details-section.tsx
+++ b/app/frontend/components/domains/project-meeting/project-meeting-screen/sections/contact-details-section.tsx
@@ -7,6 +7,7 @@ import { useParams } from "react-router-dom"
 import { IProjectMeeting } from "../../../../../models/project-meeting"
 import { useMst } from "../../../../../setup/root"
 import { EFlashMessageStatus } from "../../../../../types/enums"
+import { isValidPhoneNumber } from "../../../../../utils/utility-functions"
 import { useProjectMeetingNavigation } from "../../use-project-meeting-navigation"
 import { FormActions } from "../shared/form-actions"
 import { SectionHeading } from "../shared/section-heading"
@@ -60,9 +61,14 @@ export const ContactDetailsSection = observer(({ meeting }: ContactDetailsSectio
           />
           <FormErrorMessage>{errors.contactEmail?.message as string}</FormErrorMessage>
         </FormControl>
-        <FormControl>
+        <FormControl isInvalid={!!errors.contactPhoneNumber}>
           <FormLabel>{t("projectMeeting.contactPhoneNumber")}</FormLabel>
-          <Input {...register("contactPhoneNumber")} />
+          <Input
+            {...register("contactPhoneNumber", {
+              validate: (str) => !str || isValidPhoneNumber(str) || t("ui.invalidPhone"),
+            })}
+          />
+          <FormErrorMessage>{errors.contactPhoneNumber?.message as string}</FormErrorMessage>
         </FormControl>
       </VStack>
       <FormActions isSubmitting={formState.isSubmitting} />

--- a/app/frontend/components/domains/project-meeting/project-meeting-screen/sections/documents-section.tsx
+++ b/app/frontend/components/domains/project-meeting/project-meeting-screen/sections/documents-section.tsx
@@ -10,7 +10,6 @@ import { IProjectMeeting } from "../../../../../models/project-meeting"
 import { useMst } from "../../../../../setup/root"
 import { EFlashMessageStatus, EMeetingRequestDocumentType } from "../../../../../types/enums"
 import { useProjectMeetingNavigation } from "../../use-project-meeting-navigation"
-import { ACCEPTED_DOCUMENT_TYPES } from "../shared/constants"
 import { documentsForType } from "../shared/document-utils"
 import { DocumentsTable } from "../shared/documents-table"
 import { FormActions } from "../shared/form-actions"
@@ -65,7 +64,6 @@ export const DocumentsSection = observer(({ meeting }: DocumentsSectionProps) =>
     onUploadSuccess: handleUploadSuccess,
     maxNumberOfFiles: 10,
     autoProceed: true,
-    allowedFileTypes: ACCEPTED_DOCUMENT_TYPES,
   })
 
   const handleRemoveFile = (documentId: string) => {
@@ -110,10 +108,7 @@ export const DocumentsSection = observer(({ meeting }: DocumentsSectionProps) =>
         onRemoveFile={handleRemoveFile}
         onUndoRemoveFile={handleUndoRemoveFile}
       />
-      <UppyDashboardField
-        uppy={supportingDocumentsUppy}
-        acceptedFormatsLabel={t("projectMeeting.sections.documents.acceptedFormats")}
-      />
+      <UppyDashboardField uppy={supportingDocumentsUppy} />
       <FormActions
         isSubmitting={formState.isSubmitting}
         isDisabled={isUploading}

--- a/app/frontend/components/domains/project-meeting/project-meeting-screen/shared/constants.ts
+++ b/app/frontend/components/domains/project-meeting/project-meeting-screen/shared/constants.ts
@@ -1,1 +1,0 @@
-export const ACCEPTED_DOCUMENT_TYPES = ["application/pdf", ".pdf", ".jpg", ".jpeg", ".png", ".doc", ".docx"]

--- a/app/frontend/components/domains/project-meeting/project-meeting-screen/shared/uppy-dashboard-field.tsx
+++ b/app/frontend/components/domains/project-meeting/project-meeting-screen/shared/uppy-dashboard-field.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from "@chakra-ui/react"
+import { Box } from "@chakra-ui/react"
 import { Uppy } from "@uppy/core"
 import "@uppy/core/dist/style.min.css"
 import Dashboard from "@uppy/react/lib/Dashboard.js"
@@ -14,19 +14,11 @@ const uppyDashboardSx = {
 
 interface UppyDashboardFieldProps {
   uppy: Uppy
-  acceptedFormatsLabel?: string
   mb?: number
 }
 
-export const UppyDashboardField = ({ uppy, acceptedFormatsLabel, mb = 6 }: UppyDashboardFieldProps) => (
-  <>
-    <Box position="relative" w="100%" mb={2} sx={uppyDashboardSx}>
-      <Dashboard uppy={uppy} width="100%" height={220} proudlyDisplayPoweredByUppy={false} />
-    </Box>
-    {acceptedFormatsLabel && (
-      <Text fontSize="sm" color="text.secondary" mt={2} mb={mb}>
-        {acceptedFormatsLabel}
-      </Text>
-    )}
-  </>
+export const UppyDashboardField = ({ uppy, mb = 6 }: UppyDashboardFieldProps) => (
+  <Box position="relative" w="100%" mb={mb} sx={uppyDashboardSx}>
+    <Dashboard uppy={uppy} width="100%" height={220} proudlyDisplayPoweredByUppy={false} />
+  </Box>
 )

--- a/app/frontend/components/shared/chefs/index.tsx
+++ b/app/frontend/components/shared/chefs/index.tsx
@@ -57,14 +57,18 @@ Templates.current = {
 
         if (result) {
           if (ctx?.component?.computedCompliance?.module == "DigitalSealValidator") {
-            // For multi-file uploads, show validation for each file
-            const currentFileMessages = result.filter((fileMessage) =>
-              ctx.value?.find((v) => {
-                const idSegments = fileMessage.id.split("/")
-                const fileMessageId = idSegments[idSegments.length - 1]
-                return fileMessageId == v.id
-              })
-            )
+            // For multi-file uploads, show validation for each file.
+            // Normalize ids: compliance messages use full shrine paths, form values often use basename only.
+            const fileIdTail = (id) => (typeof id === "string" ? id.split("/").pop() : id)
+            const currentFiles = Array.isArray(ctx.value) ? ctx.value : []
+            // During websocket triggerRedraw, ctx.value can briefly be empty while result is already set —
+            // fall back to the compliance result (already scoped to active docs server-side).
+            const currentFileMessages =
+              currentFiles.length === 0
+                ? result
+                : result.filter((fileMessage) =>
+                    currentFiles.find((v) => fileIdTail(fileMessage.id) == fileIdTail(v.id))
+                  )
 
             if (currentFileMessages.length > 0) {
               showWarning = currentFileMessages.some((fileMessage) => fileMessage.error)

--- a/app/frontend/components/shared/form/input-form-control.tsx
+++ b/app/frontend/components/shared/form/input-form-control.tsx
@@ -45,8 +45,12 @@ interface ISelectFormControlProps extends IInputFormControlProps<Partial<SelectP
 }
 
 const isValidUrl = (url: string) => {
-  const regex = /^(https?:\/\/)?([a-z0-9-]+\.)+[a-z]{2,}(\/[\w./%-]*)?\/?$/i
-  return regex.test(url)
+  try {
+    const parsed = new URL(/^https?:\/\//i.test(url) ? url : `https://${url}`)
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
 }
 
 export const TextFormControl = (props: IInputFormControlProps) => {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -371,6 +371,7 @@ const options = {
           invalidInput: "Invalid input",
           invalidUrl: "Invalid url",
           invalidEmail: "Invalid email",
+          invalidPhone: "Enter a valid phone number",
           selectPlaceholder: "Select",
           selectApplicable: "Select applicable:",
           clickHere: "Click here",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1581,7 +1581,7 @@ Thank you,
               "{{jurisdictionName}} has not yet added any local resources. Contact your local government for additional guidance.",
           },
           rollupStatusDescription: {
-            empty: "No permits yet",
+            empty: "No applications yet",
             inProgress: "{{remaining}} of {{total}} permit(s) remaining",
             submitted: "{{count}} permit(s) waiting for response",
             waitingOnYou: "{{count}} permit(s) returned for revision",
@@ -1883,7 +1883,7 @@ Thank you,
         },
         permitApplication: {
           goToApplication: "Go to permit application",
-          noneFound: "No permits yet",
+          noneFound: "No applications yet",
           noneFoundExplanation:
             "Missing permits? You might have used a login option different from the one you used to create the permits. Log out and try logging back in with the BCeID or BC Services Card Account you used to create them.",
           submissionBlockModal: {

--- a/app/frontend/utils/utility-functions.ts
+++ b/app/frontend/utils/utility-functions.ts
@@ -275,6 +275,13 @@ export function telHref(phone: string): string {
   return digits ? `tel:${digits}` : `tel:${phone}`
 }
 
+/** Optional field: blank is valid; otherwise 7–15 digits (E.164). */
+export function isValidPhoneNumber(value?: string | null): boolean {
+  if (!value?.trim()) return true
+  const digits = value.replace(/\D/g, "")
+  return digits.length >= 7 && digits.length <= 15
+}
+
 export function mailtoHref(email: string): string {
   return `mailto:${email.trim()}`
 }

--- a/app/jobs/automated_compliance/autopopulate_job.rb
+++ b/app/jobs/automated_compliance/autopopulate_job.rb
@@ -8,7 +8,15 @@ class AutomatedCompliance::AutopopulateJob
     unfilled = permit_application.automated_compliance_unique_unfilled_modules
 
     if unfilled.length > 0
-      unfilled.each { |cm_name| match(cm_name, permit_application) }
+      unfilled.each do |cm_name|
+        begin
+          match(cm_name, permit_application)
+        rescue StandardError => e
+          Rails.logger.error(
+            "Autopopulate module #{cm_name} failed for permit_application #{permit_application_id}: #{e.class} #{e.message}"
+          )
+        end
+      end
       # In the future start a sidekiq batch to kick these things off
 
       # set front end form updates, force these to get picked up for processing

--- a/app/models/project_meeting.rb
+++ b/app/models/project_meeting.rb
@@ -167,6 +167,11 @@ class ProjectMeeting < ApplicationRecord
       errors.add(:request_property_information, :blank)
     end
 
+    # Requester-edit wizard saves relationship first, then collects auth docs.
+    if persisted? && !draft? && will_save_change_to_requester_relationship?
+      return
+    end
+
     if authorization_required? &&
          active_meeting_request_documents.none?(&:document_type_authorization?)
       errors.add(:meeting_request_documents, :authorization_required)

--- a/app/services/wrappers/ltsa_parcel_map_bc.rb
+++ b/app/services/wrappers/ltsa_parcel_map_bc.rb
@@ -54,7 +54,8 @@ class Wrappers::LtsaParcelMapBc < Wrappers::Base
     response = get("#{HISTORIC_SERVICE}/query", query_params, true)
 
     # Assume if there is a parcel description match not to use LTSA geometry matching
-    if response.success? && JSON.parse(response.body).dig("features").length > 0
+    # features can be missing/null on success (e.g. empty ArcGIS payload)
+    if response.success? && JSON.parse(response.body).dig("features")&.any?
       return parse_attributes_from_response(response)
     end
 

--- a/spec/models/project_meeting_spec.rb
+++ b/spec/models/project_meeting_spec.rb
@@ -72,6 +72,34 @@ RSpec.describe ProjectMeeting, type: :model do
       expect(meeting).to be_valid
     end
 
+    it "allows changing requester relationship on a submitted meeting before auth docs are uploaded" do
+      meeting =
+        create(
+          :project_meeting,
+          :open,
+          requester_relationship: :owner_or_landholder
+        )
+
+      meeting.requester_relationship = :other
+
+      expect(meeting).to be_valid
+    end
+
+    it "still requires authorization documents after relationship is changed to non-owner" do
+      meeting =
+        create(
+          :project_meeting,
+          :open,
+          requester_relationship: :owner_or_landholder
+        )
+      meeting.update!(requester_relationship: :other)
+
+      meeting.contact_name = "Still Missing Auth Docs"
+
+      expect(meeting).not_to be_valid
+      expect(meeting.errors[:meeting_request_documents]).to be_present
+    end
+
     it "does not require property information when jurisdiction has requests disabled" do
       meeting =
         build(:project_meeting, :open, request_property_information: nil)

--- a/spec/requests/api/project_meetings_spec.rb
+++ b/spec/requests/api/project_meetings_spec.rb
@@ -509,6 +509,28 @@ RSpec.describe "Api::ProjectMeetings", type: :request do
       )
     end
 
+    it "allows changing relationship to non-owner on an open meeting without auth docs yet" do
+      meeting =
+        create(
+          :project_meeting,
+          :open,
+          permit_project: permit_project,
+          requester_relationship: :owner_or_landholder
+        )
+
+      patch "/api/permit_projects/#{permit_project.id}/meetings/#{meeting.id}",
+            params: {
+              project_meeting: {
+                requester_relationship: "other"
+              }
+            },
+            headers: headers,
+            as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response.dig("data", "requester_relationship")).to eq("other")
+    end
+
     it "forbids updating a completed meeting" do
       meeting =
         create(:project_meeting, :completed, permit_project: permit_project)

--- a/spec/services/wrappers/ltsa_parcel_map_bc_spec.rb
+++ b/spec/services/wrappers/ltsa_parcel_map_bc_spec.rb
@@ -25,6 +25,32 @@ RSpec.describe Wrappers::LtsaParcelMapBc, type: :service do
     end
   end
 
+  describe "#historic_site_by_pid" do
+    it "falls through when success response has no features key" do
+      empty_response =
+        instance_double(
+          Faraday::Response,
+          success?: true,
+          body: { error: "layer not found" }.to_json
+        )
+      geometry_response =
+        instance_double(
+          Faraday::Response,
+          success?: true,
+          body: { features: [] }.to_json
+        )
+
+      allow(wrapper).to receive(:get).and_return(
+        empty_response,
+        geometry_response
+      )
+
+      expect { wrapper.historic_site_by_pid(pid: "031562868") }.to raise_error(
+        Errors::GeometryError
+      )
+    end
+  end
+
   describe "#get_feature_attributes_by_pid_or_pin" do
     it "raises when both pid and pin are blank" do
       expect {


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...bugfix/july-15-fixes` (merge-base range).

Bundle of July 15 bug fixes across project meetings, phone inputs, document uploads, and automated compliance.

The main meeting bug: editing requester relationship on an already-submitted meeting returned 422 because submission validation required authorization documents before the wizard’s next step could collect them. Relationship updates on submitted meetings now skip that check so the flow can continue to authorization documents; later updates still enforce auth docs when needed.

Also includes shared phone-field validation, Uppy accepted-types cleanup for meeting uploads, safer historic-site / autopopulate compliance handling, and related climate-zone copy updates in i18n.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5128](https://hous-bssb.atlassian.net/browse/HUB-5128), [HUB-5276](https://hous-bssb.atlassian.net/browse/HUB-5276) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Allow changing requester relationship on a submitted project meeting without requiring authorization documents in the same request (wizard can proceed to auth-docs step); still require auth docs on subsequent non-relationship updates
- Specs covering relationship change on open meetings and continued auth-doc enforcement afterward
- Reuse shared `PhoneFormControl` / `isValidPhoneNumber` for project meeting contact details and profile phone fields
- Drop frontend-hardcoded accepted document types for meeting uploads; lean on Uppy/backend rules and remove unused constants/labels
- Guard LTSA historic-site parsing when a successful response has no `features` array; isolate autopopulate module failures so one bad module does not abort the job
- Climate zone configuration copy updates in i18n (location/HDD wording)

---

## 🧪 Steps to QA

1. Open an **active submitted** project meeting as the project owner and choose **Edit requester information**.
2. Change relationship from owner to a non-owner option (e.g. Other) and continue.
3. Confirm save succeeds and you land on **Authorization documents**; upload a doc and continue through contact details back to the meeting detail.
4. On meeting contact details (and user profile), enter invalid then valid phone numbers and confirm validation behaviour.
5. On meeting document upload steps, confirm uploads still work and accepted-format messaging still makes sense.
6. If possible, exercise a permit application that uses historic-site / automated compliance autopopulate and confirm the form still loads when one module fails or historic-site returns an empty payload.

**Expected Behaviour:**
> Requester relationship can be updated on submitted meetings; non-owner path routes to authorization documents. Phone and upload flows remain usable. Compliance/historic-site edge cases no longer hard-crash the flow.

**Before this change:**
> Changing requester relationship on a submitted meeting returned 422 (“Project meeting request could not be updated”) when switching to a non-owner without auth docs yet.

**After this change:**
> Relationship saves, user continues to authorization documents, then contact details.

This PR also fixes URL validation behaviour

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5128]: https://hous-bssb.atlassian.net/browse/HUB-5128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ