### PR TITLE
merge overheating codes on user promote

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,10 @@ class User < ApplicationRecord
            foreign_key: "creator_id",
            inverse_of: :creator,
            dependent: :destroy
+  has_many :overheating_codes,
+           foreign_key: "creator_id",
+           inverse_of: :creator,
+           dependent: :destroy
 
   has_many :permit_projects,
            class_name: "PermitProject",

--- a/app/services/promote_user.rb
+++ b/app/services/promote_user.rb
@@ -36,11 +36,16 @@ class PromoteUser
     if existing_user.valid?
       ActiveRecord::Base.transaction do
         merge_collaborations
+        merge_overheating_codes
         invited_user.destroy!
         existing_user.jurisdiction_ids = jurisdiction_ids
         existing_user.save!
       end
     end
+  end
+
+  def merge_overheating_codes
+    invited_user.overheating_codes.update_all(creator_id: existing_user.id)
   end
 
   def merge_collaborations

--- a/spec/services/promote_user_spec.rb
+++ b/spec/services/promote_user_spec.rb
@@ -3,8 +3,17 @@ require "rails_helper"
 RSpec.describe PromoteUser do
   before { allow(ActiveRecord::Base).to receive(:transaction).and_yield }
 
+  def stub_overheating_codes(invited_user)
+    overheating_codes = double("OverheatingCodes")
+    allow(invited_user).to receive(:overheating_codes).and_return(
+      overheating_codes
+    )
+    allow(overheating_codes).to receive(:update_all)
+    overheating_codes
+  end
+
   it "merges invitation fields and jurisdictions and destroys invited user when valid" do
-    existing_user = instance_double("User", jurisdiction_ids: ["j1"])
+    existing_user = instance_double("User", jurisdiction_ids: ["j1"], id: "e1")
     invited_user =
       instance_double("User", jurisdiction_ids: ["j2"], submitter?: false)
 
@@ -19,6 +28,7 @@ RSpec.describe PromoteUser do
     allow(invited_user).to receive(:destroy!)
     allow(invited_user).to receive(:reload)
     allow(invited_user).to receive(:collaborations).and_return([])
+    stub_overheating_codes(invited_user)
 
     service =
       described_class.new(
@@ -62,7 +72,8 @@ RSpec.describe PromoteUser do
       instance_double(
         "User",
         jurisdiction_ids: [],
-        collaborations: existing_collabs
+        collaborations: existing_collabs,
+        id: "e1"
       )
     invited_user =
       instance_double(
@@ -80,6 +91,7 @@ RSpec.describe PromoteUser do
     allow(existing_user).to receive(:save!)
     allow(invited_user).to receive(:destroy!)
     allow(invited_user).to receive(:reload)
+    stub_overheating_codes(invited_user)
 
     invited_user_collab =
       instance_double(
@@ -103,5 +115,21 @@ RSpec.describe PromoteUser do
     expect(invited_user_collab).to have_received(:update).with(
       user: existing_user
     )
+  end
+
+  it "reassigns overheating codes from invited user before destroy" do
+    allow(ActiveRecord::Base).to receive(:transaction).and_call_original
+
+    existing_user = create(:user, :submitter)
+    invited_user = create(:user, :review_manager, confirmed: false)
+    overheating_code = create(:overheating_code, creator: invited_user)
+
+    described_class.new(
+      existing_user: existing_user,
+      invited_user: invited_user
+    ).call
+
+    expect(overheating_code.reload.creator_id).to eq(existing_user.id)
+    expect(User.exists?(invited_user.id)).to be false
   end
 end


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5279-story-accepting-a-jurisdiction-staff-invitation-via-keycloak-fails-with-a-500-when-the-invited-user-owns-any-overheating-codes-records` (merge-base range).

Two related fixes:

1. **Invite accept / promote user (HUB-5279):** Accepting a jurisdiction staff invitation via Keycloak could 500 when the invited user owned overheating codes. `PromoteUser` destroyed the invited user after merging collaborations but left `overheating_codes.creator_id` pointing at the deleted row. Codes are now reassigned to the surviving user before destroy, and `User` gains a proper `overheating_codes` association.

2. **Meeting UI when disabled (HUB-5280):** With project meetings turned off (site and/or jurisdiction), calendar indicators, the meeting-requests filter, and the active-meeting notice still showed. Those controls now respect the feature flags.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5279](https://hous-bssb.atlassian.net/browse/HUB-5279), [HUB-5280](https://hous-bssb.atlassian.net/browse/HUB-5280) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Reassign `overheating_codes` from invited → existing user in `PromoteUser` before destroy
- Add `User.has_many :overheating_codes` (`dependent: :destroy`)
- Spec for overheating-code reassignment on promote
- Hide `ActiveProjectMeetingIndicator` when site/jurisdiction meetings are off (kanban, inbox list, projects grid)
- Hide `ActiveProjectMeetingNotice` when meetings are off
- Hide `MeetingRequestsFilter` in submission inbox and projects grid when meetings are off

---

## 🧪 Steps to QA

### Invite accept / overheating codes
1. Use an account that has overheating code records and can receive a jurisdiction staff invite for the same identity/email
2. Accept the staff invitation via the Keycloak invite flow
3. Confirm login completes without a 500 and the user is staff for the jurisdiction
4. Confirm previously created overheating codes still exist under the promoted account

### Meeting UI when disabled
1. Turn off project meetings for the jurisdiction (or site-wide)
2. Open the submission inbox Projects → Columns view for a project that has an active meeting
3. Confirm kanban cards show **no** calendar icon, and the Meeting requests filter is absent
4. Open a project overview that would otherwise show an active meeting notice — confirm the notice is hidden
5. As a submitter, open All projects — confirm Meeting requests filter and calendar indicators are hidden when meetings are off
6. Turn meetings back on and confirm indicator, filter, and notice behave as before

**Expected Behaviour:**
Invite accept succeeds with overheating codes intact; meeting affordances only appear when the feature is enabled.

**Before this change:**
Invite accept could FK-error on `overheating_codes`; disabled meetings still showed calendar icons / filter / notice.

**After this change:**
Promote reassigns codes cleanly; meeting UI is gated on the feature flags.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

UI changes are hide/show only (no new interactive patterns). Checklist N/A beyond confirming hidden controls are fully removed from the DOM when disabled.

- [ ] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [ ] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5279]: https://hous-bssb.atlassian.net/browse/HUB-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ