### PR TITLE
fix draft permit app policy scoping with active meetings

### DIFF
--- a/app/blueprints/permit_project_blueprint.rb
+++ b/app/blueprints/permit_project_blueprint.rb
@@ -118,7 +118,7 @@ class PermitProjectBlueprint < Blueprinter::Base
     association :permit_applications,
                 blueprint: PermitApplicationBlueprint,
                 view: :jurisdiction_review_inbox do |permit_project, _options|
-      permit_project.permit_applications.kept.select(&:visible_to_reviewers?)
+      permit_project.permit_applications.kept.select(&:submitted_at_least_once?)
     end
     association :recent_permit_applications,
                 blueprint: PermitApplicationBlueprint,

--- a/app/controllers/api/concerns/search/jurisdiction_permit_applications.rb
+++ b/app/controllers/api/concerns/search/jurisdiction_permit_applications.rb
@@ -312,12 +312,23 @@ module Api::Concerns::Search::JurisdictionPermitApplications
     and_conditions << { jurisdiction_id: @jurisdiction.id }
     and_conditions << { discarded: jurisdiction_permit_application_discarded }
 
+    permit_project_id =
+      jurisdiction_permit_application_search_params[:permit_project_id]
+    # Project Permits tab may include new_draft when the project has an active
+    # meeting (matches PermitApplicationPolicy::Scope). Jurisdiction Applications
+    # list never does — drafts there ghost-page after scope_results.
+    active_meeting_request =
+      permit_project_id.present? &&
+        PermitProject.find_by(id: permit_project_id)&.has_active_project_meeting
+
     statuses = search_filters.delete(:status)
 
     if status_filter
       and_conditions << { status: status_filter }
     elsif statuses.present?
       and_conditions << { status: statuses }
+    elsif !active_meeting_request
+      and_conditions << { status: { not: "new_draft" } }
     end
 
     unless current_user.super_admin?
@@ -343,8 +354,6 @@ module Api::Concerns::Search::JurisdictionPermitApplications
       and_conditions << { review_collaborator_user_ids: assigned }
     end
 
-    permit_project_id =
-      jurisdiction_permit_application_search_params[:permit_project_id]
     if permit_project_id.present?
       and_conditions << { permit_project_id: permit_project_id }
     end

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/reviewer-workspace-sidebar.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/reviewer-workspace-sidebar.tsx
@@ -55,9 +55,15 @@ export const ReviewerWorkspaceSidebar = ({ tabsData, title, ...rest }: IReviewer
             px={4}
             py={0}
             fontWeight="normal"
+            color="text.primary"
+            _visited={{ color: "text.primary" }}
+            _active={{ color: "text.primary" }}
+            _hover={{ color: "text.primary", textDecoration: "none" }}
             _selected={{
               bg: "background.blueLight",
               fontWeight: "bold",
+              color: "text.primary",
+              _visited: { color: "text.primary" },
             }}
           >
             <Flex align="center" justify="space-between" w="full">

--- a/app/frontend/components/domains/permit-application/review-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/review-permit-application-screen.tsx
@@ -137,9 +137,16 @@ export const ReviewPermitApplicationScreen = observer(() => {
   // @ts-ignore
   const permitHeaderHeight = permitHeaderRef?.current?.offsetHeight ?? 0
 
-  if (currentPermitApplication.status === EPermitApplicationStatus.newDraft) return <NotFoundScreen />
+  // Meeting drafts are policy-visible for review staff; open them read-only so
+  // RMs can inspect form contents during an active project meeting.
+  const isMeetingDraft =
+    currentPermitApplication.status === EPermitApplicationStatus.newDraft &&
+    currentPermitApplication.hasActiveProjectMeeting
+  if (currentPermitApplication.status === EPermitApplicationStatus.newDraft && !isMeetingDraft) {
+    return <NotFoundScreen />
+  }
 
-  const isReadOnly = currentPermitApplication.isReviewReadOnly
+  const isReadOnly = currentPermitApplication.isReviewReadOnly || isMeetingDraft
   const canStartReview =
     currentPermitApplication.status === EPermitApplicationStatus.newlySubmitted ||
     currentPermitApplication.status === EPermitApplicationStatus.resubmitted

--- a/app/frontend/components/domains/permit-project/project-sidebar-tab-list.tsx
+++ b/app/frontend/components/domains/permit-project/project-sidebar-tab-list.tsx
@@ -44,11 +44,21 @@ export const ProjectSidebarTabList = ({ top = 0, tabsData, children, ...rest }: 
       {tabsData ? (
         <VStack align="stretch" spacing={1} w="full" pt={8}>
           {tabsData.map((tabData) => (
-            <Tab key={tabData.label} as={RouterLink} to={tabData.to} onClick={handleTabLinkClick} w="full">
+            <Tab
+              key={tabData.label}
+              as={RouterLink}
+              to={tabData.to}
+              onClick={handleTabLinkClick}
+              w="full"
+              color="text.primary"
+              _visited={{ color: "text.primary" }}
+              _active={{ color: "text.primary" }}
+              _hover={{ color: "text.primary", textDecoration: "none" }}
+            >
               <Flex align="center" justify="space-between" w="full" gap={3}>
                 <Flex align="center" minW={0} flex={1} gap={2}>
-                  <Icon as={tabData.icon} boxSize={5} flexShrink={0} />
-                  <Text as="span" fontSize="md" lineHeight={6} whiteSpace="nowrap">
+                  <Icon as={tabData.icon} boxSize={5} flexShrink={0} color="currentColor" />
+                  <Text as="span" fontSize="md" lineHeight={6} whiteSpace="nowrap" color="currentColor">
                     {tabData.label}
                   </Text>
                 </Flex>

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -479,7 +479,7 @@ export const RequirementForm = observer(
               status={EFlashMessageStatus.error}
             />
           )}
-          {permitApplication?.isSubmitted || readOnlyProp ? (
+          {permitApplication?.isSubmitted ? (
             <CustomMessageBox
               description={t("permitApplication.show.wasSubmitted", {
                 date: format(permitApplication.submittedAt, "MMM d, yyyy h:mm a"),
@@ -487,7 +487,7 @@ export const RequirementForm = observer(
               })}
               status={EFlashMessageStatus.info}
             />
-          ) : (
+          ) : !readOnlyProp ? (
             <CustomMessageBox
               title={
                 jurisdiction &&
@@ -521,7 +521,7 @@ export const RequirementForm = observer(
               }
               status={EFlashMessageStatus.info}
             />
-          )}
+          ) : null}
           <Box bg="greys.grey03" p={3} borderRadius="sm">
             <Text fontStyle="italic">
               {t("site.foippaWarning")}

--- a/app/frontend/styles/theme/components/tabs.ts
+++ b/app/frontend/styles/theme/components/tabs.ts
@@ -4,16 +4,31 @@ export const Tabs = {
       tab: {
         justifyContent: "flex-start",
         textDecoration: "none",
+        color: "text.primary",
+        // Tabs are RouterLinks for copy/open-in-new-tab. :visited ignores
+        // `inherit` in most browsers — use an explicit color.
+        _visited: {
+          color: "text.primary",
+        },
+        _active: {
+          color: "text.primary",
+        },
         _hover: {
           bg: "greys.grey02",
           textDecoration: "none",
+          color: "text.primary",
         },
         _selected: {
           fontWeight: "bold",
           bg: "background.blueLight",
+          color: "text.primary",
+          _visited: {
+            color: "text.primary",
+          },
           _hover: {
             bg: "hover.blue",
             textDecoration: "none",
+            color: "text.primary",
           },
         },
         _focus: {

--- a/app/models/concerns/permit_application_status.rb
+++ b/app/models/concerns/permit_application_status.rb
@@ -121,7 +121,7 @@ module PermitApplicationStatus
       self.class.submitted_statuses.include?(status)
     end
 
-    def visible_to_reviewers?
+    def submitted_at_least_once?
       submitted? || revisions_requested?
     end
 

--- a/app/models/permit_collaboration.rb
+++ b/app/models/permit_collaboration.rb
@@ -175,7 +175,7 @@ class PermitCollaboration < ApplicationRecord
         errors.add(:base, :must_be_draft_for_submission)
       end
     elsif review?
-      unless permit_application.visible_to_reviewers?
+      unless permit_application.submitted_at_least_once?
         errors.add(:base, :must_be_submitted_for_review)
       end
     end

--- a/app/models/permit_project.rb
+++ b/app/models/permit_project.rb
@@ -237,7 +237,7 @@ class PermitProject < ApplicationRecord
     permit_applications
       .kept
       .includes(:submitter, :template_version, requirement_template: :taggings)
-      .select(&:visible_to_reviewers?)
+      .select(&:submitted_at_least_once?)
       .sort_by(&:updated_at)
       .last(limit)
   end

--- a/app/policies/permit_application_policy.rb
+++ b/app/policies/permit_application_policy.rb
@@ -129,7 +129,7 @@ class PermitApplicationPolicy < ApplicationPolicy
           .jurisdictions
           .find_by(id: permit_collaboration.permit_application.jurisdiction_id)
           .present? &&
-        permit_collaboration.permit_application.visible_to_reviewers?
+        permit_collaboration.permit_application.submitted_at_least_once?
     else
       false
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -511,7 +511,7 @@ if north_van.present?
 
     idx = 0
     while inbox_test_project.reload.permit_applications.kept.count(
-            &:visible_to_reviewers?
+            &:submitted_at_least_once?
           ) < inbox_test_visible_app_target
       break if idx >= 100 # safety: avoid infinite loop if statuses fail to seed
 
@@ -530,7 +530,7 @@ if north_van.present?
       idx += 1
     end
 
-    puts "  ✓ #{inbox_test_project_title}: #{inbox_test_project.permit_applications.kept.count(&:visible_to_reviewers?)} reviewer-visible permit applications"
+    puts "  ✓ #{inbox_test_project_title}: #{inbox_test_project.permit_applications.kept.count(&:submitted_at_least_once?)} reviewer-visible permit applications"
   else
     puts "  (skipped Inbox test project: need submitter, reviewer, and published template versions)"
   end

--- a/spec/concerns/permit_application_search_spec.rb
+++ b/spec/concerns/permit_application_search_spec.rb
@@ -158,6 +158,26 @@ RSpec.describe Api::Concerns::Search::JurisdictionPermitApplications,
             revisions_requested_permit_applications
         )
       end
+
+      it "excludes new_draft from ES totals so pages are not policy-stripped" do
+        controller.perform_jurisdiction_permit_application_search
+        search =
+          controller.instance_variable_get(
+            :@jurisdiction_permit_application_search
+          )
+        meta =
+          controller.instance_variable_get(
+            :@jurisdiction_permit_application_meta
+          )
+
+        expect(search.results.map(&:status)).not_to include("new_draft")
+        expect(meta[:total_count]).to eq(
+          submitted_permit_applications.size +
+            resubmitted_permit_applications.size +
+            revisions_requested_permit_applications.size
+        )
+        expect(meta[:status_counts].values.sum).to eq(meta[:total_count])
+      end
     end
 
     context "when searching for the jurisdictions permit applications as a review manager" do
@@ -425,6 +445,21 @@ RSpec.describe Api::Concerns::Search::JurisdictionPermitApplications,
             ).results
 
           expect(results).to match_array(draft_permit_applications)
+        end
+      end
+
+      context "when the scoped permit project has no active meeting" do
+        let(:target_project) { draft_permit_applications.first.permit_project }
+
+        it "excludes draft applications for that permit project" do
+          controller.perform_jurisdiction_permit_application_search
+          results =
+            controller.instance_variable_get(
+              :@jurisdiction_permit_application_search
+            ).results
+
+          expect(results).to be_empty
+          expect(results).not_to include(*draft_permit_applications)
         end
       end
     end

--- a/spec/policies/permit_application_policy_spec.rb
+++ b/spec/policies/permit_application_policy_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe PermitApplicationPolicy do
               "PermitApplication",
               jurisdiction_id: jurisdiction.id,
               submitted?: true,
-              visible_to_reviewers?: true
+              submitted_at_least_once?: true
             )
         )
       expect(


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop` on `HUB-5315-bug-🔥-bug-bash-fix-submission-inbox-list-align-es-filters-with-policy-scope-empty-pages-drafts-address-sort` (staged/working-tree changes; no commits on the branch yet beyond `develop`).

Submission Inbox Applications list searched Elasticsearch with a broader filter than `PermitApplicationPolicy::Scope`, then dropped unauthorized rows via `scope_results` without fixing pagination. That produced sparse/empty pages, inflated totals, and “missing” apps under sorts (e.g. permit type / address) because many early hits were `new_draft`s policy stripped.

This PR aligns list-mode ES with review visibility: exclude `new_draft` by default, but allow drafts when the search is scoped to a project that has an **active meeting** (project Permits tab). Reviewers can open those meeting drafts read-only. Also renames `visible_to_reviewers?` → `submitted_at_least_once?` and fixes RouterLink sidebar tab `:visited` blue styling.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5315](https://hous-bssb.atlassian.net/browse/HUB-5315) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Jurisdiction Applications list ES `where` excludes `new_draft` so pagination/`total_count` match policy-visible apps (no ghost pages after `scope_results`)
- Project-scoped Permits search still includes `new_draft` when the project has an active meeting
- Review screen allows meeting drafts read-only; other drafts still Not Found
- Requirement form no longer formats `submittedAt` for read-only non-submitted apps (fixes white-screen crash)
- Rename `visible_to_reviewers?` → `submitted_at_least_once?` (call sites updated)
- Sidebar RouterLink tabs use explicit `text.primary` for `:visited` (no leftover blue “Activity” link colour)
- Specs: list totals exclude drafts; project with/without active meeting draft inclusion

---

## 🧪 Steps to QA

1. As Review Manager, open **Applications → List** for a jurisdiction with many drafts (e.g. North Vancouver).
2. Clear filters; sort by **Permit type** and by **Address**. Confirm each page is full (aside from the last page) and totals align with openable apps / status counts (not inflated by drafts).
3. Confirm `new_draft` rows do **not** appear on the jurisdiction Applications list.
4. Open a project with an **active meeting** → **Applications** tab. Confirm meeting drafts appear.
5. Open a meeting draft via `/permit-applications/:id`. Confirm the review form loads **read-only** (not Not Found / not white screen).
6. Click **Go to project**. Confirm sidebar tabs (Overview, Applications, Activity, etc.) stay normal text colour after visiting (no blue visited links).
7. Open a project **without** an active meeting → Applications tab. Confirm drafts are not listed.
8. Spot-check **Columns (kanban)** on Applications — still no draft column behaviour regression.

**Expected Behaviour:**
> List pages are stable; sorts only reorder; meeting drafts are project-scoped and openable read-only; sidebar tabs don’t look like visited hyperlinks.

**Before this change:**
> Sparse/empty list pages and wrong totals when drafts clustered early in ES results; meeting drafts 404’d on open; visited sidebar tabs turned blue.

**After this change:**
> ES filter matches inbox visibility; meeting drafts work on project Permits + read-only review; tab styling stays consistent.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [ ] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5315]: https://hous-bssb.atlassian.net/browse/HUB-5315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ