### PR TITLE
HUB-5308 adjust menu button font size

### DIFF
--- a/app/frontend/components/shared/jurisdiction/manage-jurisdiction-menu.tsx
+++ b/app/frontend/components/shared/jurisdiction/manage-jurisdiction-menu.tsx
@@ -21,7 +21,7 @@ export const ManageJurisdictionMenu = observer(function ManageJurisdictionMenu<T
   return (
     <Can action="jurisdiction:manage" data={{ jurisdiction }}>
       <Menu>
-        <MenuButton as={Button} aria-label="manage" variant="link">
+        <MenuButton as={Button} aria-label="manage" variant="link" fontSize="sm">
           {t("ui.manage")}
         </MenuButton>
         <MenuList boxShadow="elevations.elevation04">


### PR DESCRIPTION
## 📋 Description

The Manage link in the jurisdictions table used the default link button font size, which made it look larger than surrounding table text. This PR sets `fontSize="sm"` on that menu button so it matches the rest of the row.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type                 | Link                                                        |
| -------------------- | ----------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5308](https://hous-bssb.atlassian.net/browse/HUB-5308) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                         |
| 📑 Design / Figma    | <!-- Paste link -->                                         |
| 📚 Documentation     | <!-- Paste link -->                                         |

---

## ✨ Features / Changes Introduced

> List the key changes, features, or fixes introduced in this PR.

- Set `fontSize="sm"` on the Manage jurisdiction menu button so its text size matches other cells in the jurisdictions table

---

## 🧪 Steps to QA

> Provide clear, reproducible steps for the reviewer/QA engineer to verify the changes.

1. Sign in as a user who can manage jurisdictions
2. Open the jurisdictions list/table
3. Find a row with a **Manage** action
4. Compare the **Manage** link text size to neighbouring cell text (jurisdiction name, etc.)

**Expected Behaviour:**

> Manage link text size matches the surrounding table text (small / `sm`).

**Before this change:**

> Manage link appeared larger than other text in the row.

**After this change:**

> Manage link uses `sm` font size and aligns visually with the rest of the table.
>
> Please add before/after screenshots if possible.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5308]: https://hous-bssb.atlassian.net/browse/HUB-5308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ