### PR TITLE
HUB-5399 add endpoint and service for builder restore

### DIFF
--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -348,6 +348,22 @@ class Api::TemplateVersionsController < Api::ApplicationController
     end
   end
 
+  def restore_layout
+    authorize @template_version, :restore_layout?
+
+    begin
+      RequirementTemplateStructureRestoreService.new(@template_version).call!
+      render_requirement_template_success(
+        "requirement_template.restore_layout_success"
+      )
+    rescue RequirementTemplateStructureRestoreError => e
+      render_error "requirement_template.restore_layout_error",
+                   message_opts: {
+                     error_message: e.message
+                   }
+    end
+  end
+
   def share_draft
     authorize @template_version, :update?
 

--- a/app/errors/requirement_template_structure_restore_error.rb
+++ b/app/errors/requirement_template_structure_restore_error.rb
@@ -1,0 +1,2 @@
+class RequirementTemplateStructureRestoreError < StandardError
+end

--- a/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
@@ -11,6 +11,7 @@ import { useMst } from "../../../../setup/root"
 import { ErrorScreen } from "../../../shared/base/error-screen"
 import { LoadingScreen } from "../../../shared/base/loading-screen"
 import { FloatingHelpDrawer } from "../../../shared/floating-help-drawer"
+import { ConfirmationModal } from "../../../shared/modals/confirmation-modal"
 import { RouterLinkButton } from "../../../shared/navigation/router-link-button"
 import { BuilderBottomFloatingButtons } from "../builder-bottom-floating-buttons"
 import { PublishScheduleModal } from "../publish-schedule-modal"
@@ -35,6 +36,7 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
   } = useSectionHighlight({ sections: denormalizedTemplate?.requirementTemplateSections })
   const [isCollapsedAll, setIsCollapsedAll] = useState(false)
   const [isTogglingPubliclyPreviewable, setIsTogglingPubliclyPreviewable] = useState(false)
+  const [isRestoringLayout, setIsRestoringLayout] = useState(false)
   const navigate = useNavigate()
 
   const isSuperAdmin = !!userStore.currentUser?.isSuperAdmin
@@ -116,6 +118,19 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
     }
   }
 
+  const handleRestoreLayout = async () => {
+    if (!templateVersion || !requirementTemplateId) return
+    setIsRestoringLayout(true)
+    try {
+      const updated = await requirementTemplateStore.restoreLayout(templateVersion.id)
+      if (updated) {
+        navigate(`/requirement-templates/${requirementTemplateId}/edit`)
+      }
+    } finally {
+      setIsRestoringLayout(false)
+    }
+  }
+
   return (
     <Box as="main" id="view-template-version">
       <BuilderHeader
@@ -187,6 +202,21 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
                   translationNamespace="templateVersionPreview.schedulePublish"
                   triggerLabel={t("templateVersionPreview.schedulePublish.triggerButton")}
                   hideManageAccessButton
+                />
+              )}
+              {isSuperAdmin && requirementTemplateId && (
+                <ConfirmationModal
+                  promptHeader={t("templateVersionPreview.restoreLayout.confirmTitle")}
+                  promptMessage={
+                    <Text whiteSpace="pre-line">{t("templateVersionPreview.restoreLayout.confirmBody")}</Text>
+                  }
+                  confirmText={t("templateVersionPreview.restoreLayout.confirmButton")}
+                  onConfirm={handleRestoreLayout}
+                  renderTrigger={(onOpen) => (
+                    <Button variant="secondary" onClick={onOpen} isLoading={isRestoringLayout}>
+                      {t("templateVersionPreview.restoreLayout.triggerButton")}
+                    </Button>
+                  )}
                 />
               )}
               {isSuperAdmin && requirementTemplateId && (

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4768,6 +4768,13 @@ Thank you,
           editSourceBlock: "Edit source block",
           immutableVersionNotice:
             "This early access version is an immutable snapshot. To revise it, update the source template in the builder and create a new early access version. Existing preview links will continue to show this version.",
+          restoreLayout: {
+            triggerButton: "Restore layout to builder",
+            confirmTitle: "Restore layout from this version?",
+            confirmBody:
+              "This will replace the current builder layout (sections, block arrangement, and show/hide rules) with the layout from this version.\n\nIt does not rewind the wording or settings inside shared question blocks. If a block from this version is missing or archived in the library, the restore will fail.\n\nAny unsaved builder edits will be lost.",
+            confirmButton: "Restore layout",
+          },
           schedulePublish: {
             triggerButton: "Promote",
             scheduleModalTitle: "Promote early access version?",

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -950,6 +950,10 @@ export class Api {
     )
   }
 
+  async restoreTemplateLayout(templateVersionId: string) {
+    return this.client.post<ApiResponse<IRequirementTemplate>>(`/template_versions/${templateVersionId}/restore_layout`)
+  }
+
   async shareDraft(templateVersionId: string) {
     return this.client.post<ApiResponse<ITemplateVersion>>(`/template_versions/${templateVersionId}/share_draft`)
   }

--- a/app/frontend/stores/requirement-template-store.ts
+++ b/app/frontend/stores/requirement-template-store.ts
@@ -262,6 +262,19 @@ export const RequirementTemplateStoreModel = types
 
       return false
     }),
+
+    restoreLayout: flow(function* (templateVersionId: string) {
+      const response = yield* toGenerator(self.environment.api.restoreTemplateLayout(templateVersionId))
+
+      if (response.ok) {
+        const templateData = response.data.data
+        templateData.isFullyLoaded = true
+        self.mergeUpdate(templateData, "requirementTemplateMap")
+        return self.requirementTemplateMap.get(templateData.id) as IRequirementTemplate
+      }
+
+      return false
+    }),
   }))
 
 export interface IRequirementTemplateStoreModel extends Instance<typeof RequirementTemplateStoreModel> {}

--- a/app/policies/template_version_policy.rb
+++ b/app/policies/template_version_policy.rb
@@ -79,6 +79,11 @@ class TemplateVersionPolicy < ApplicationPolicy
     update?
   end
 
+  def restore_layout?
+    user&.super_admin? && record&.requirement_template.present? &&
+      !record.requirement_template.discarded?
+  end
+
   def force_publish_draft?
     promote_draft? && ENV["ENABLE_TEMPLATE_FORCE_PUBLISH"] == "true"
   end

--- a/app/services/requirement_template_structure_restore_service.rb
+++ b/app/services/requirement_template_structure_restore_service.rb
@@ -1,0 +1,128 @@
+# Rebuilds a RequirementTemplate's sections and TemplateSectionBlock join rows
+# from a TemplateVersion's denormalized_template_json snapshot.
+# Re-links existing RequirementBlocks by ID; does not mutate block content.
+class RequirementTemplateStructureRestoreService
+  def initialize(template_version)
+    @template_version = template_version
+    @requirement_template = template_version.requirement_template
+  end
+
+  def call!
+    if @requirement_template.blank? || @requirement_template.discarded?
+      raise RequirementTemplateStructureRestoreError,
+            I18n.t(
+              "services.requirement_template_structure_restore_service.template_unavailable"
+            )
+    end
+
+    snapshot = @template_version.denormalized_template_json
+    if snapshot.blank?
+      raise RequirementTemplateStructureRestoreError,
+            I18n.t(
+              "services.requirement_template_structure_restore_service.empty_snapshot"
+            )
+    end
+
+    section_payloads = extract_sections(snapshot)
+    block_refs = collect_block_refs(section_payloads)
+    validate_blocks!(block_refs)
+
+    ActiveRecord::Base.transaction do
+      @requirement_template.requirement_template_sections.destroy_all
+
+      section_payloads.each_with_index do |section_payload, section_index|
+        section =
+          @requirement_template.requirement_template_sections.create!(
+            name: dig_key(section_payload, "name"),
+            position: section_index
+          )
+
+        extract_template_section_blocks(
+          section_payload
+        ).each_with_index do |tsb_payload, block_index|
+          section.template_section_blocks.create!(
+            requirement_block_id: block_id_from(tsb_payload),
+            position: block_index,
+            conditional: dig_key(tsb_payload, "conditional")
+          )
+        end
+      end
+
+      @requirement_template.touch
+      @requirement_template.reload
+    end
+  end
+
+  private
+
+  def extract_sections(snapshot)
+    sections = dig_key(snapshot, "requirement_template_sections")
+    unless sections.is_a?(Array)
+      raise RequirementTemplateStructureRestoreError,
+            I18n.t(
+              "services.requirement_template_structure_restore_service.malformed_snapshot"
+            )
+    end
+    sections
+  end
+
+  def extract_template_section_blocks(section_payload)
+    blocks = dig_key(section_payload, "template_section_blocks")
+    blocks.is_a?(Array) ? blocks : []
+  end
+
+  def collect_block_refs(section_payloads)
+    refs = []
+    section_payloads.each do |section_payload|
+      extract_template_section_blocks(section_payload).each do |tsb_payload|
+        id = block_id_from(tsb_payload)
+        name =
+          dig_key(tsb_payload, "requirement_block")&.then do |b|
+            dig_key(b, "name") || dig_key(b, "display_name")
+          end
+        refs << { id: id, name: name }
+      end
+    end
+    refs
+  end
+
+  def block_id_from(tsb_payload)
+    dig_key(tsb_payload, "requirement_block_id") ||
+      dig_key(dig_key(tsb_payload, "requirement_block") || {}, "id")
+  end
+
+  def validate_blocks!(block_refs)
+    missing = []
+
+    block_refs.each do |ref|
+      id = ref[:id]
+      if id.blank?
+        missing << (ref[:name].presence || "(missing id)")
+        next
+      end
+
+      block = RequirementBlock.find_by(id: id)
+      if block.nil? || block.discarded?
+        label = ref[:name].presence || block&.name || id
+        missing << label
+      end
+    end
+
+    return if missing.empty?
+
+    raise RequirementTemplateStructureRestoreError,
+          I18n.t(
+            "services.requirement_template_structure_restore_service.missing_blocks",
+            blocks: missing.uniq.join(", ")
+          )
+  end
+
+  # Snapshot JSON may use snake_case (Blueprinter render_as_hash) or camelCase.
+  def dig_key(hash, snake_key)
+    return nil unless hash.is_a?(Hash)
+
+    key = snake_key.to_s
+    camel_key = key.camelize(:lower)
+    hash[key] || hash[key.to_sym] || hash[camel_key] || hash[camel_key.to_sym]
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -617,6 +617,12 @@ en:
       promote_draft_error:
         title: Error
         message: "%{error_message}"
+      restore_layout_success:
+        title: ""
+        message: "Template layout restored from this version"
+      restore_layout_error:
+        title: Error
+        message: "%{error_message}"
       no_draft_error:
         title: Error
         message: "No early access version exists for this template"
@@ -1148,6 +1154,11 @@ en:
       publish_before_schedule_date: "Version cannot be published before it's scheduled date"
       copy_customizations_error: "Old jurisdiction customizations could not be copied to new template version for jurisdiction_id:%{jurisdiction_id}"
       copy_customizations_log_error: "Error copying customizations to new template version: %{message}"
+    requirement_template_structure_restore_service:
+      template_unavailable: "Cannot restore layout because the template is missing or archived"
+      empty_snapshot: "This version has no layout snapshot to restore from"
+      malformed_snapshot: "This version's layout snapshot is invalid"
+      missing_blocks: "Cannot restore layout. These blocks are missing or archived in the library: %{blocks}"
   formio:
     requirement_template:
       completion_title: "Completion"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,7 @@ Rails.application.routes.draw do
       member do
         delete "discard_draft", to: "template_versions#discard_draft"
         post "promote_draft", to: "template_versions#promote_draft"
+        post "restore_layout", to: "template_versions#restore_layout"
         post "invite_draft_previewers",
              to: "template_versions#invite_draft_previewers"
         post "share_draft", to: "template_versions#share_draft"

--- a/spec/controllers/template_versions_controller_spec.rb
+++ b/spec/controllers/template_versions_controller_spec.rb
@@ -316,4 +316,79 @@ RSpec.describe Api::TemplateVersionsController,
       end
     end
   end
+
+  describe "POST #restore_layout" do
+    let!(:requirement_template) do
+      create(:full_requirement_template, sections_count: 1)
+    end
+    let!(:template_version) do
+      create(
+        :template_version,
+        requirement_template: requirement_template,
+        status: :published,
+        denormalized_template_json:
+          RequirementTemplateBlueprint.render_as_hash(
+            requirement_template,
+            view: :template_snapshot
+          )
+      )
+    end
+
+    context "as a super admin" do
+      let!(:super_admin) { create(:user, :super_admin) }
+
+      before { sign_in super_admin }
+
+      it "restores the template layout from the version snapshot" do
+        original_names =
+          requirement_template
+            .requirement_template_sections
+            .order(:position)
+            .pluck(:name)
+        requirement_template.requirement_template_sections.destroy_all
+        requirement_template.requirement_template_sections.create!(
+          name: "Changed",
+          position: 0
+        )
+
+        post :restore_layout, params: { id: template_version.id }
+
+        expect(response).to have_http_status(:success)
+        expect(
+          requirement_template
+            .reload
+            .requirement_template_sections
+            .order(:position)
+            .pluck(:name)
+        ).to eq(original_names)
+      end
+
+      it "returns an error when blocks are missing" do
+        snapshot = template_version.denormalized_template_json.deep_dup
+        snapshot["requirement_template_sections"].first[
+          "template_section_blocks"
+        ].first[
+          "requirement_block"
+        ][
+          "id"
+        ] = SecureRandom.uuid
+        template_version.update!(denormalized_template_json: snapshot)
+
+        post :restore_layout, params: { id: template_version.id }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(json_response.dig("meta", "message", "message")).to match(
+          /missing or archived/i
+        )
+      end
+    end
+
+    context "as a non-admin user" do
+      it "denies access" do
+        post :restore_layout, params: { id: template_version.id }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end

--- a/spec/policies/template_version_policy_spec.rb
+++ b/spec/policies/template_version_policy_spec.rb
@@ -139,6 +139,20 @@ RSpec.describe TemplateVersionPolicy, type: :policy do
       expect(draft_policy(admin, published_record).promote_draft?).to be false
     end
 
+    it "permits restore_layout for super admins on any version with a kept template" do
+      kept_template =
+        double("RequirementTemplate", discarded?: false, present?: true)
+      discarded_template =
+        double("RequirementTemplate", discarded?: true, present?: true)
+      version = double("TemplateVersion", requirement_template: kept_template)
+      discarded_version =
+        double("TemplateVersion", requirement_template: discarded_template)
+
+      expect(draft_policy(admin, version).restore_layout?).to be true
+      expect(draft_policy(non_admin, version).restore_layout?).to be false
+      expect(draft_policy(admin, discarded_version).restore_layout?).to be false
+    end
+
     it "permits force publishing draft versions only when enabled" do
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with(

--- a/spec/services/requirement_template_structure_restore_service_spec.rb
+++ b/spec/services/requirement_template_structure_restore_service_spec.rb
@@ -1,0 +1,176 @@
+require "rails_helper"
+
+RSpec.describe RequirementTemplateStructureRestoreService do
+  let!(:template) { create(:full_requirement_template, sections_count: 2) }
+  let!(:template_version) do
+    create(
+      :template_version,
+      requirement_template: template,
+      denormalized_template_json:
+        RequirementTemplateBlueprint.render_as_hash(
+          template,
+          view: :template_snapshot
+        ),
+      status: :published
+    )
+  end
+
+  describe "#call!" do
+    it "rebuilds sections, block order, and conditionals from the snapshot" do
+      first_tsb =
+        template
+          .requirement_template_sections
+          .order(:position)
+          .first
+          .template_section_blocks
+          .order(:position)
+          .first
+      conditional = {
+        "when_block_id" => first_tsb.requirement_block_id,
+        "when_requirement_code" => "energy_step_code",
+        "eq" => "yes",
+        "show" => true
+      }
+      first_tsb.update!(conditional: conditional)
+
+      # Snapshot after conditional is set
+      template_version.update!(
+        denormalized_template_json:
+          RequirementTemplateBlueprint.render_as_hash(
+            template.reload,
+            view: :template_snapshot
+          )
+      )
+
+      # Capture expected layout before destroy_all clears join rows
+      expected_names =
+        template.requirement_template_sections.order(:position).pluck(:name)
+      expected_block_ids_by_section =
+        template
+          .requirement_template_sections
+          .order(:position)
+          .map do |section|
+            section
+              .template_section_blocks
+              .order(:position)
+              .pluck(:requirement_block_id)
+          end
+      first_block_id = first_tsb.requirement_block_id
+
+      # Mutate live layout so restore has something to reverse
+      template.requirement_template_sections.destroy_all
+      leftover_section =
+        template.requirement_template_sections.create!(
+          name: "Leftover",
+          position: 0
+        )
+      leftover_section.template_section_blocks.create!(
+        requirement_block: create(:requirement_block),
+        position: 0
+      )
+
+      result = described_class.new(template_version.reload).call!
+
+      expect(result.id).to eq(template.id)
+      restored = result.requirement_template_sections.order(:position).to_a
+      expect(restored.map(&:name)).to eq(expected_names)
+
+      restored.each_with_index do |section, i|
+        expect(
+          section
+            .template_section_blocks
+            .order(:position)
+            .map(&:requirement_block_id)
+        ).to eq(expected_block_ids_by_section[i])
+      end
+
+      restored_first_tsb =
+        restored.first.template_section_blocks.find_by(
+          requirement_block_id: first_block_id
+        )
+      expect(restored_first_tsb.conditional).to eq(conditional)
+    end
+
+    it "aborts with no partial writes when a block is missing" do
+      snapshot = template_version.denormalized_template_json.deep_dup
+      missing_id = SecureRandom.uuid
+      snapshot["requirement_template_sections"].first[
+        "template_section_blocks"
+      ].first[
+        "requirement_block"
+      ][
+        "id"
+      ] = missing_id
+      template_version.update!(denormalized_template_json: snapshot)
+
+      section_ids_before =
+        template.requirement_template_sections.pluck(:id).sort
+
+      expect { described_class.new(template_version).call! }.to raise_error(
+        RequirementTemplateStructureRestoreError,
+        /missing or archived/
+      )
+
+      expect(
+        template.reload.requirement_template_sections.pluck(:id).sort
+      ).to eq(section_ids_before)
+    end
+
+    it "aborts when a referenced block is discarded" do
+      block =
+        template.requirement_template_sections.first.requirement_blocks.first
+      block.discard
+
+      expect { described_class.new(template_version).call! }.to raise_error(
+        RequirementTemplateStructureRestoreError,
+        /missing or archived/
+      )
+    end
+
+    it "raises when the snapshot is empty" do
+      template_version.update!(denormalized_template_json: {})
+
+      expect { described_class.new(template_version).call! }.to raise_error(
+        RequirementTemplateStructureRestoreError,
+        /no layout snapshot/
+      )
+    end
+
+    it "raises when the snapshot is malformed" do
+      template_version.update!(
+        denormalized_template_json: {
+          "requirement_template_sections" => "not-an-array"
+        }
+      )
+
+      expect { described_class.new(template_version).call! }.to raise_error(
+        RequirementTemplateStructureRestoreError,
+        /invalid/
+      )
+    end
+
+    it "raises when the parent template is discarded" do
+      template.discard
+
+      expect { described_class.new(template_version).call! }.to raise_error(
+        RequirementTemplateStructureRestoreError,
+        /missing or archived/
+      )
+    end
+
+    it "accepts camelCase snapshot keys" do
+      snake =
+        RequirementTemplateBlueprint.render_as_hash(
+          template,
+          view: :template_snapshot
+        )
+      camel = snake.deep_transform_keys { |k| k.to_s.camelize(:lower) }
+      template_version.update!(denormalized_template_json: camel)
+
+      template.requirement_template_sections.destroy_all
+
+      result = described_class.new(template_version).call!
+      expect(result.requirement_template_sections.count).to be > 0
+    end
+  end
+end


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...HUB-5399-bug-template-builder-is-empty-for-sitings-and-sheds-permit` (merge-base range).

Adds a super-admin action to restore a permit template’s **builder layout** (sections, block arrangement, and block show/hide rules) from a published, draft, scheduled, or deprecated `TemplateVersion` snapshot.

Motivation: when the live builder is empty or out of sync with a known-good version (e.g. sitings/sheds), admins can snap the template structure back from that version without rewriting shared question-block content. Restore re-links existing library blocks by ID; it aborts if any referenced block is missing or archived.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5399](https://hous-bssb.atlassian.net/browse/HUB-5399) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- `RequirementTemplateStructureRestoreService` rebuilds live sections / `TemplateSectionBlock` join rows from `denormalized_template_json`, preserving order and conditionals; does not mutate shared block field content
- `POST /api/template_versions/:id/restore_layout` (super admin only); fails clearly when blocks are missing/archived or the snapshot is empty/invalid
- Template version screen: “Restore layout to builder” with confirmation copy explaining limits; on success navigates to the builder
- Specs for service, policy, and controller

---

## 🧪 Steps to QA

1. Sign in as a **super admin**.
2. Open a permit template that has at least one published, draft, or deprecated version with a real layout snapshot.
3. In the **builder**, change the layout (reorder/remove sections or blocks) and save so it no longer matches that version.
4. Open that version’s template version screen.
5. Click **Restore layout to builder**, read the confirmation, and confirm.
6. Confirm you land in the builder and the sections/blocks/order match the version you restored from.
7. Confirm shared block question wording was **not** rolled back if those blocks were edited in the library after the version was created.
8. (Optional) Archive a block used by a version, attempt restore, and confirm it fails with a message listing the missing/archived block(s).
9. Sign in as a non–super-admin and confirm the restore control is not available / API is forbidden.

**Expected Behaviour:**
> Layout (sections, block placement, show/hide rules) matches the chosen version; block library content is unchanged; missing blocks block the restore entirely.

**Before this change:**
> No way to restore builder structure from a template version snapshot via the UI.

**After this change:**
> Super admins can restore layout from a version screen into the live builder, with an explicit confirmation of what does and does not restore.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5399]: https://hous-bssb.atlassian.net/browse/HUB-5399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ