### PR TITLE
Hub 5400 bug energy step code p 9 tool report generation failing

### DIFF
--- a/app/frontend/components/domains/step-code/part-9/checklist/building-characteristics-summary/dynamic-characteristics-grid/ventilation.tsx
+++ b/app/frontend/components/domains/step-code/part-9/checklist/building-characteristics-summary/dynamic-characteristics-grid/ventilation.tsx
@@ -1,7 +1,7 @@
 import { t } from "i18next"
 import React from "react"
 import { useFieldArray, useFormContext } from "react-hook-form"
-import { NumberFormControl, TextFormControl } from "../../../../../../shared/form/input-form-control"
+import { NumberFormControl } from "../../../../../../shared/form/input-form-control"
 import { GridColumnHeader } from "../../shared/grid/column-header"
 import { GridData } from "../../shared/grid/data"
 import { DetailsInput } from "../details-input"
@@ -46,7 +46,7 @@ export const Ventilation = function BuildingCharacteristicsSummaryVentilation() 
               />
             </GridData>
             <GridData borderRightWidth={1} borderTopWidth={borderTopWidth}>
-              <TextFormControl
+              <NumberFormControl
                 fieldName={`${fieldArrayName}.${index}.litersPerSec`}
                 hint={index == fields.length - 1 && t(`${i18nPrefix}.litersPerSec`)}
               />

--- a/app/frontend/components/domains/step-code/part-9/form-section/index.tsx
+++ b/app/frontend/components/domains/step-code/part-9/form-section/index.tsx
@@ -212,7 +212,7 @@ const ChecklistRouteSection = observer(function ChecklistRouteSection({
   requiresReport,
   children,
 }: IChecklistRouteSectionProps) {
-  const { currentStepCode, checklist } = usePart9StepCode()
+  const { checklist } = usePart9StepCode()
   const formMethods = useForm({ mode: "onChange" })
   const { handleSubmit, reset, formState } = formMethods
 

--- a/app/frontend/components/shared/form/input-form-control.tsx
+++ b/app/frontend/components/shared/form/input-form-control.tsx
@@ -64,8 +64,12 @@ export const TextFormControl = (props: IInputFormControlProps) => {
       ...inputProps,
     },
     validate: {
-      satisfiesLength: (str) =>
-        (!props.required && !str) || (str?.length >= 1 && str?.length <= effectiveMax) || t("ui.invalidInput"),
+      // Values may arrive as numbers (e.g. H2K-populated building characteristics).
+      satisfiesLength: (value) => {
+        if (!props.required && (value === null || value === undefined || value === "")) return true
+        const str = String(value)
+        return (str.length >= 1 && str.length <= effectiveMax) || t("ui.invalidInput")
+      },
       ...validate,
     },
   }
@@ -115,9 +119,10 @@ export const UrlFormControl = (props: IInputFormControlProps) => {
 }
 
 export const NumberFormControl = (props: IInputFormControlProps) => {
+  // step "any" accepts H2K-sourced values with >2 decimal places (e.g. 34.9241 L/s).
   return (
     <InputFormControl
-      {...(R.mergeDeepRight({ inputProps: { type: "number", step: 0.01 } }, props) as IInputFormControlProps)}
+      {...(R.mergeDeepRight({ inputProps: { type: "number", step: "any" } }, props) as IInputFormControlProps)}
     />
   )
 }

--- a/app/frontend/hooks/resources/use-part-9-step-code.ts
+++ b/app/frontend/hooks/resources/use-part-9-step-code.ts
@@ -47,10 +47,12 @@ export const usePart9StepCode = () => {
   const currentStepCode = stepCodeStore.currentStepCode as IPart9StepCode
 
   useEffect(() => {
-    if (currentStepCode && Object.values(EStepCodeChecklistStage).includes(stage as EStepCodeChecklistStage)) {
-      currentStepCode.setCurrentStage(stage as EStepCodeChecklistStage)
-    }
-  }, [currentStepCode, stage])
+    if (!currentStepCode) return
+    if (!Object.values(EStepCodeChecklistStage).includes(stage as EStepCodeChecklistStage)) return
+    // Re-apply when a StepCode merge resets currentStage away from the route stage.
+    if (currentStepCode.currentStage === stage) return
+    currentStepCode.setCurrentStage(stage as EStepCodeChecklistStage)
+  }, [currentStepCode, stage, currentStepCode?.currentStage])
 
   const checklist = currentStepCode?.currentChecklist
 

--- a/app/frontend/hooks/resources/use-permit-application.ts
+++ b/app/frontend/hooks/resources/use-permit-application.ts
@@ -1,12 +1,11 @@
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { useLocation, useParams } from "react-router-dom"
+import { useParams } from "react-router-dom"
 import { useMst } from "../../setup/root"
 import { isUUID } from "../../utils/utility-functions"
 
 export const usePermitApplication = ({ review }: { review?: boolean } = {}) => {
   const { permitApplicationId } = useParams()
-  const { pathname } = useLocation()
   const { permitApplicationStore, sandboxStore } = useMst()
   const { currentSandbox } = sandboxStore
 
@@ -35,7 +34,9 @@ export const usePermitApplication = ({ review }: { review?: boolean } = {}) => {
         setError(new Error(t("errors.fetchPermitApplication")))
       }
     })()
-  }, [pathname, currentSandbox?.id])
+    // Refetch only when the permit application identity or sandbox changes — not on every
+    // nested route segment (e.g. part-9 section navigation), which would wipe loaded Step Code checklists.
+  }, [permitApplicationId, currentSandbox?.id, review])
 
   return { currentPermitApplication, error }
 }

--- a/app/frontend/models/part-9-step-code.ts
+++ b/app/frontend/models/part-9-step-code.ts
@@ -90,10 +90,13 @@ export const Part9StepCodeModel = types.snapshotProcessor(
     preProcessor(snapshot: any) {
       const processed = { ...snapshot }
       if (Array.isArray(processed.checklists)) {
-        const map = processed.checklists.reduce((acc: Record<string, any>, checklist: any) => {
-          if (checklist && checklist.id) acc[checklist.id] = checklist
-          return acc
-        }, {})
+        // Deep-merge each checklist so PA/list payloads (summary fields only) do not
+        // wipe extended client state (complianceReports, dataEntries, isLoaded).
+        const map: Record<string, any> = { ...(processed.checklistsMap || {}) }
+        processed.checklists.forEach((checklist: any) => {
+          if (!checklist?.id) return
+          map[checklist.id] = { ...(map[checklist.id] || {}), ...checklist }
+        })
         processed.checklistsMap = map
         delete processed.checklists
       } else if (processed.checklistsMap == null) {

--- a/app/models/part_9_step_code.rb
+++ b/app/models/part_9_step_code.rb
@@ -169,39 +169,38 @@ class Part9StepCode < StepCode
     summary =
       checklist.building_characteristics_summary ||
         checklist.create_building_characteristics_summary
-    update_attrs =
-      merge_building_characteristics_summary_attrs(summary, generated_attrs)
-    summary.update!(update_attrs) if update_attrs.present?
+    # Re-import replaces H2K-mapped fields so a new file overwrites prior values
+    # (including manual edits on those fields). other_lines are not H2K-mapped and
+    # are left alone.
+    summary.update!(
+      replace_building_characteristics_summary_attrs(generated_attrs)
+    )
   end
 
-  def merge_building_characteristics_summary_attrs(summary, generated_attrs)
+  def replace_building_characteristics_summary_attrs(generated_attrs)
     BUILDING_CHARACTERISTICS_LINE_KEYS
-      .each_with_object({}) do |key, attrs|
-        generated_lines = generated_attrs[key]
-        next if generated_lines.blank?
-
-        attrs[key] = merge_characteristic_lines(
-          summary.public_send(key),
-          generated_lines
-        )
+      .index_with do |key|
+        characteristic_array(generated_attrs[key]).reject do |line|
+          blank_characteristic_line?(line)
+        end
       end
       .tap do |attrs|
-        attrs[:windows_glazed_doors] = merge_windows_glazed_doors(
-          summary.windows_glazed_doors,
-          generated_attrs[:windows_glazed_doors]
-        )
-        attrs[:airtightness] = merge_characteristic_hash(
-          summary.airtightness,
+        windows = generated_attrs[:windows_glazed_doors]
+        attrs[:windows_glazed_doors] = if windows.present?
+          characteristic_hash(windows)
+        else
+          { lines: [] }
+        end
+        attrs[:airtightness] = characteristic_hash(
           generated_attrs[:airtightness]
         )
-        attrs[:fossil_fuels] = merge_characteristic_hash(
-          summary.fossil_fuels,
+        attrs[:fossil_fuels] = characteristic_hash(
           generated_attrs[:fossil_fuels]
         )
-        attrs.compact!
       end
   end
 
+  # Still used to combine mappings from multiple H2K data entries before replace.
   def merge_building_characteristics_attrs(existing_attrs, new_attrs)
     merged_attrs = existing_attrs.deep_dup
     BUILDING_CHARACTERISTICS_LINE_KEYS.each do |key|
@@ -259,15 +258,6 @@ class Part9StepCode < StepCode
           generated_attrs["performance_type"],
       lines: lines
     }.compact
-  end
-
-  def merge_characteristic_hash(existing, generated)
-    return if generated.blank?
-
-    existing_attrs = characteristic_hash(existing)
-    return generated if existing_attrs.blank?
-
-    existing_attrs
   end
 
   def characteristic_array(value)

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -33,7 +33,13 @@ if SHRINE_USE_S3
     region: ENV["BCGOV_OBJECT_STORAGE_REGION"] || "no-region-needed", # We are using Object Storage which does not require this, put in a dummy variable.  For dev testing will need a region.
     access_key_id: ENV["BCGOV_OBJECT_STORAGE_ACCESS_KEY_ID"],
     secret_access_key: ENV["BCGOV_OBJECT_STORAGE_SECRET_ACCESS_KEY"],
-    force_path_style: true
+    force_path_style: true,
+    # aws-sdk-s3 >= 1.178 defaults to flexible checksums that BCGOV Object Storage
+    # rejects ("x-amz-sdk-checksum-algorithm specified, but no corresponding
+    # x-amz-checksum-* are found"). Only send checksums when the API requires them.
+    # https://github.com/aws/aws-sdk-ruby/discussions/3165
+    request_checksum_calculation: "when_required",
+    response_checksum_validation: "when_required"
   }
   Shrine.storages = {
     cache:

--- a/spec/models/part_9_step_code_spec.rb
+++ b/spec/models/part_9_step_code_spec.rb
@@ -106,17 +106,28 @@ RSpec.describe Part9StepCode, type: :model do
       expect(summary.fossil_fuels.presence).to eq("yes")
     end
 
-    it "does not duplicate generated rows or overwrite non-empty manual fields on re-import" do
+    it "overwrites H2K-mapped fields on re-import without duplicating rows" do
       step_code.process_current_h2k_files(checklist)
       summary = checklist.reload.building_characteristics_summary
       roof_count = summary.roof_ceilings_lines.count
-      summary.update!(airtightness: { details: "Manual air barrier" })
+      summary.update!(
+        airtightness: {
+          details: "Manual air barrier"
+        },
+        ventilation_lines: [
+          { details: "Stale HRV", percent_eff: 50, liters_per_sec: 10 }
+        ]
+      )
 
       step_code.process_current_h2k_files(checklist)
 
       summary.reload
       expect(summary.roof_ceilings_lines.count).to eq(roof_count)
-      expect(summary.airtightness.details).to eq("Manual air barrier")
+      expect(summary.airtightness.details).not_to eq("Manual air barrier")
+      expect(summary.ventilation_lines.map(&:details)).not_to include(
+        "Stale HRV"
+      )
+      expect(summary.ventilation_lines.map(&:details)).to include("HRV - VanEE")
     end
   end
 


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff origin/develop...HUB-5400-bug-energy-step-code-p-9-tool-report-generation-failing` (merge-base range). Local `develop` was already at `HEAD`, so `origin/develop` was used as the PR base.

Fixes several Part 9 Step Code pain points around staged checklists and H2K-driven building characteristics.

**Checklist progress regression:** Saving and continuing between as-built sections briefly showed correct completion, then the UI snapped back to the pre-construction checklist (including “upload H2K”). Root cause: `usePermitApplication` refetched the permit application on every pathname change; the PA payload’s summary checklists replaced loaded checklist state and reset `currentStage` to `pre_construction`.

**H2K decimal validation:** Values like `34.9241` L/s from HOT2000 were flagged “Invalid input” because ventilation L/s used `TextFormControl` (length check fails on numbers) and `NumberFormControl` used `step: 0.01`.

**H2K re-upload:** Re-processing an H2K file merged into existing building characteristics and preferred prior/manual values. Re-import now replaces H2K-mapped fields from the new file(s).

Also includes a Shrine/S3 checksum header fix for BCGov Object Storage compatibility.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5400](https://hous-bssb.atlassian.net/browse/HUB-5400) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Stop permit-application refetch on every nested route change; refetch only when `permitApplicationId`, sandbox, or `review` changes
- Deep-merge Part 9 checklists on Step Code snapshot merge so summary PA payloads don’t wipe `complianceReports` / `isLoaded`
- Re-sync `currentStage` from the route when a merge drifts it away from the URL stage
- Accept H2K-precision decimals: `NumberFormControl` uses `step: "any"`; text length validation coerces non-strings; ventilation L/s uses `NumberFormControl`
- On H2K re-import, replace H2K-mapped building characteristics instead of merging/preserving old values (`other_lines` unchanged)
- Spec updated for overwrite-on-reimport behaviour
- Shrine S3 client: only send/validate checksums when required (BCGov Object Storage)

---

## 🧪 Steps to QA

1. Open a permit application with both **pre-construction** (in progress) and **as-built** Part 9 checklists; ensure as-built has an H2K file and completed early sections.
2. On as-built, go to a mid-flow compliance section (e.g. Completed by / Energy performance) and click **Save and continue**.
3. Confirm sidebar completion stays on the as-built checklist (no flash of “upload H2K” / pre-construction progress) and the next section loads normally. Repeat for 1–2 more sections.
4. Hard-refresh mid-flow and confirm stage/section still look correct.
5. On Building characteristics, confirm H2K-populated values with >2 decimals (e.g. ventilation L/s `34.9241`) are accepted — no “Invalid input”.
6. Edit a building-characteristics field, re-upload a different H2K on the import step, save, return to Building characteristics — confirm H2K-mapped fields reflect the new file (old/manual values on those fields overwritten; any `other` lines still present).
7. Smoke: upload a supporting document / H2K file and confirm uploads succeed against BCGov storage if that env is in use.

**Expected Behaviour:**
> As-built section navigation keeps the correct checklist and reports; H2K decimals validate; re-upload refreshes building characteristics from the new file.

**Before this change:**
> Save and continue briefly marked sections complete, then regresssed to pre-construction / locked-until-H2K until refresh. High-precision H2K numbers failed validation. Re-upload left prior building-characteristics values in place.

**After this change:**
> Progress and stage stay stable across section saves; H2K decimals work; re-upload overwrites H2K-mapped characteristics.

---

## ♿ UI Accessibility Checklist

> No intentional a11y surface changes (form control types/validation and fetch behaviour only). Spot-check that invalid number states still expose error text to assistive tech if you retest building characteristics.

- [ ] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [ ] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5400]: https://hous-bssb.atlassian.net/browse/HUB-5400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ