### PR TITLE
Bugfix/july 29 fixes

### DIFF
--- a/app/frontend/components/domains/permit-application/review-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/review-permit-application-screen.tsx
@@ -146,7 +146,16 @@ export const ReviewPermitApplicationScreen = observer(() => {
     return <NotFoundScreen />
   }
 
-  const isReadOnly = currentPermitApplication.isReviewReadOnly || isMeetingDraft
+  // Form fields: locked except while actively in_review (combineChangeMarkers disables
+  // inputs then; revision buttons still need FormIO not globally readOnly).
+  // Once revisions are requested, keep FormIO readOnly until revisionMode — then drop it
+  // so revision buttons are clickable; fields stay locked via combineChangeMarkers.
+  const isReadOnly =
+    currentPermitApplication.isReviewReadOnly ||
+    isMeetingDraft ||
+    (currentPermitApplication.isRevisionsRequested && !revisionMode)
+  // Revision sidebar / "request revisions" chrome — available during and after review.
+  const canManageRevisions = currentPermitApplication.isInReview || currentPermitApplication.isRevisionsRequested
   const canStartReview =
     currentPermitApplication.status === EPermitApplicationStatus.newlySubmitted ||
     currentPermitApplication.status === EPermitApplicationStatus.resubmitted
@@ -248,7 +257,7 @@ export const ReviewPermitApplicationScreen = observer(() => {
             )}
           </Flex>
         </Flex>
-        {!isReadOnly && revisionMode && (
+        {canManageRevisions && revisionMode && (
           <Flex
             position="sticky"
             zIndex={11}
@@ -284,7 +293,7 @@ export const ReviewPermitApplicationScreen = observer(() => {
         )}
       </Flex>
       <Box id="sidebar-and-form-container" sx={{ "&:after": { content: `""`, display: "block", clear: "both" } }}>
-        {!isReadOnly && revisionMode && !hideRevisionList ? (
+        {canManageRevisions && revisionMode && !hideRevisionList ? (
           <RevisionSideBar
             permitApplication={currentPermitApplication}
             onCancel={() => setRevisionMode(false)}
@@ -312,18 +321,16 @@ export const ReviewPermitApplicationScreen = observer(() => {
                   />
                 )
 
-                if (isReadOnly) {
+                if (canManageRevisions) {
                   return (
                     <HStack spacing={6}>
-                      {canStartReview && (
-                        <Button
-                          variant="callout"
-                          leftIcon={<Swap />}
-                          onClick={handleStartReview}
-                          isLoading={isStartingReview}
-                          loadingText={t("permitApplication.show.startingReview")}
-                        >
-                          {t("permitApplication.show.readyForReview")}
+                      {!revisionMode && (
+                        <Button variant="callout" leftIcon={<NotePencil />} onClick={() => setRevisionMode(true)}>
+                          {currentPermitApplication.isRevisionsRequested
+                            ? t("permitApplication.show.viewRevisionRequests")
+                            : t("permitApplication.show.requestRevisions")}{" "}
+                          {currentPermitApplication?.latestRevisionRequests?.length > 0 &&
+                            `(${currentPermitApplication.latestRevisionRequests.length})`}
                         </Button>
                       )}
                       {collaboratorsButton}
@@ -333,13 +340,15 @@ export const ReviewPermitApplicationScreen = observer(() => {
 
                 return (
                   <HStack spacing={6}>
-                    {!revisionMode && (
-                      <Button variant="callout" leftIcon={<NotePencil />} onClick={() => setRevisionMode(true)}>
-                        {currentPermitApplication.isRevisionsRequested
-                          ? t("permitApplication.show.viewRevisionRequests")
-                          : t("permitApplication.show.requestRevisions")}{" "}
-                        {currentPermitApplication?.latestRevisionRequests?.length > 0 &&
-                          `(${currentPermitApplication.latestRevisionRequests.length})`}
+                    {canStartReview && (
+                      <Button
+                        variant="callout"
+                        leftIcon={<Swap />}
+                        onClick={handleStartReview}
+                        isLoading={isStartingReview}
+                        loadingText={t("permitApplication.show.startingReview")}
+                      >
+                        {t("permitApplication.show.readyForReview")}
                       </Button>
                     )}
                     {collaboratorsButton}

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -1033,7 +1033,7 @@
       padding-right: 4px;
       padding-top: 4px;
       padding-bottom: 4px;
-      transform: translateY(-50%);
+      transform: translateY(20%);
       font-size: 14px;
       width: "fit-content";
       white-space: nowrap;

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -400,6 +400,10 @@ export const RequirementForm = observer(
       }
     }
     const showVersionDiffContactWarning = shouldShowDiff && !userShouldSeeDiff
+    const previousSubmissionRequirement =
+      isPreviousSubmissionOpen && previousSubmissionKey && pastVersion?.formJson
+        ? getRequirementByKey(pastVersion.formJson, previousSubmissionKey)
+        : null
     return (
       <>
         <Flex
@@ -576,14 +580,12 @@ export const RequirementForm = observer(
           onSelect={handleSelectExistingStepCode}
         />
 
-        {isPreviousSubmissionOpen && (
+        {previousSubmissionRequirement && (
           <PreviousSubmissionModal
             isOpen={isPreviousSubmissionOpen}
             onOpen={onPreviousSubmissionOpen}
             onClose={onPreviousSubmissionClose}
-            requirementJson={singleRequirementFormJson(
-              getRequirementByKey(pastVersion.formJson, previousSubmissionKey)
-            )}
+            requirementJson={singleRequirementFormJson(previousSubmissionRequirement)}
             submissionData={singleRequirementSubmissionData(pastVersion.submissionData, previousSubmissionKey)}
           />
         )}

--- a/app/frontend/components/shared/revisions/revision-modal.tsx
+++ b/app/frontend/components/shared/revisions/revision-modal.tsx
@@ -161,7 +161,7 @@ export const RevisionModal: React.FC<IRevisionModalProps> = ({
                 onChange={(e) => setComment(e.target.value)}
                 placeholder={t("permitApplication.show.revision.comment")}
                 maxLength={350}
-                isDisabled={disableInput}
+                isDisabled={disableInput || isRevisionsRequested}
                 sx={{
                   _disabled: {
                     color: "text.primary",
@@ -169,7 +169,9 @@ export const RevisionModal: React.FC<IRevisionModalProps> = ({
                   },
                 }}
               />
-              {!disableInput && <FormHelperText>{t("permitApplication.show.revision.maxCharacters")}</FormHelperText>}
+              {!disableInput && !isRevisionsRequested && (
+                <FormHelperText>{t("permitApplication.show.revision.maxCharacters")}</FormHelperText>
+              )}
             </FormControl>
 
             <Divider />

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -281,15 +281,20 @@ export const PermitApplicationModel = types.snapshotProcessor(
             self.latestSubmissionVersion.submissionData
           )
         }
-        const changedMarkedFormJson = combineChangeMarkers(
-          diffColoredFormJson,
-          self.isSubmitted || self.isViewingPastRequests,
-          changedKeys
-        )
-        const revisionModeFormJson =
-          self.revisionMode || self.isRevisionsRequested
-            ? combineRevisionButtons(changedMarkedFormJson, self.isSubmitted, revisionRequestsToUse)
-            : changedMarkedFormJson // Use changedMarkedFormJson if not in revision mode
+        // Review staff on revisions_requested: lock fields the same way in_review does via
+        // isSubmitted. Submitters must still edit on the edit screen.
+        const disableRequirementFields =
+          self.isSubmitted ||
+          self.isViewingPastRequests ||
+          (self.isRevisionsRequested && !!self.rootStore.userStore.currentUser?.isReviewStaff)
+        const changedMarkedFormJson = combineChangeMarkers(diffColoredFormJson, disableRequirementFields, changedKeys)
+        // Review staff: buttons only after "View revision requests" (revisionMode).
+        // Submitters: always show while revisions are outstanding (sidebar is always open).
+        const showRevisionButtons =
+          self.revisionMode || (self.isRevisionsRequested && !self.rootStore.userStore.currentUser?.isReviewStaff)
+        const revisionModeFormJson = showRevisionButtons
+          ? combineRevisionButtons(changedMarkedFormJson, self.isSubmitted, revisionRequestsToUse)
+          : changedMarkedFormJson
 
         return revisionModeFormJson
       },

--- a/app/frontend/utils/formio-component-traversal.ts
+++ b/app/frontend/utils/formio-component-traversal.ts
@@ -10,7 +10,7 @@ import {
   ITemplateVersionDiff,
 } from "../types/types"
 import { formatFileSize, getFileExtension } from "./file-utils"
-import { isNonRequirementKey } from "./formio-helpers"
+import { isNonRequirementKey, isRequirementInputComponent } from "./formio-helpers"
 import { escapeForSingleQuotedJsString } from "./utility-functions"
 
 const findComponentsByType = (components, type) => {
@@ -362,10 +362,12 @@ export const combineChangeMarkers = (formJson: IFormJson, isInReview: boolean, c
       for (let i = 0; i < block.components.length; i++) {
         const requirement = block.components[i]
         requirement.disabled ||= isInReview
-        if (section.id === COMPLETTION_SECTION_ID || !changedKeys.includes(requirement.key)) continue
+        if (section.id === COMPLETTION_SECTION_ID) continue
+        if (!isRequirementInputComponent(requirement)) continue
+        if (!changedKeys.includes(requirement.key)) continue
 
         const changeMarker = convertToChangeMarker(requirement)
-        // Insert the revision button before the current requirement
+        // Insert the change marker before the current requirement
         block.components.splice(i, 0, changeMarker)
         // Move the index to the next requirement to skip the newly added marker
         i++

--- a/app/frontend/utils/formio-helpers.ts
+++ b/app/frontend/utils/formio-helpers.ts
@@ -14,9 +14,20 @@ export const singleRequirementFormJson = (requirementJson: IFormIORequirement): 
 }
 
 export const isNonRequirementKey = (key: string) => {
+  if (!key) return true
   const nonRequirementSuffixes = ["revision-button", "change-marker"]
+  if (nonRequirementSuffixes.some((suf) => key.endsWith(suf))) return true
+  // Injected jurisdiction resources (link/document buttons + labels)
+  if (key.includes("-resource-")) return true
+  return false
+}
 
-  return nonRequirementSuffixes.some((suf) => key.endsWith(suf))
+/** True for actual answered fields — not content, resource buttons, documents chrome, etc. */
+export const isRequirementInputComponent = (requirement: { key?: string; type?: string; input?: boolean }) => {
+  if (isNonRequirementKey(requirement?.key)) return false
+  if (!requirement?.input) return false
+  if (requirement.type === "button" || requirement.type === "content") return false
+  return true
 }
 
 export const singleRequirementSubmissionData = (submissionData: any, requirementKey: string) => {

--- a/app/services/template_versioning_service.rb
+++ b/app/services/template_versioning_service.rb
@@ -389,8 +389,9 @@ class TemplateVersioningService
 
   def self.produce_diff_hash(before_version, template_version)
     before_version ||= template_version.previous_version
+    return { added: [], changed: [], removed: [] } if before_version.blank?
 
-    before_json = before_version&.requirement_blocks_json
+    before_json = before_version.requirement_blocks_json
     after_json = template_version.requirement_blocks_json
 
     before_requirements =


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...bugfix/july-29-fixes` (merge-base range).

Fixes review-manager revision UX after revision requests are sent ([HUB-5427](https://hous-bssb.atlassian.net/browse/HUB-5427)).

When status flipped to `revisions_requested`, `isSubmitted` became false, so FormIO fields unlocked for review staff and revision chrome was tangled with form read-only. This PR separates **form field locking** from **revision tooling**, keeps fields locked for review staff after requests are sent, only injects revision buttons after “View revision requests”, and tightens related polish (read-only revision comment, answer-changed markers only on real inputs, safer previous-submission modal).

Also includes a small nil guard in template version comparison (not covered in QA below).

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5427](https://hous-bssb.atlassian.net/browse/HUB-5427) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Lock requirement form fields for review staff when status is `revisions_requested` (without blocking “View revision requests”)
- Show revision request buttons on the form only after entering revision mode (not on initial revisit)
- Keep revision comment read-only once revisions have already been sent
- Only attach “Answer changed” markers to real input requirements (not resources / content / buttons)
- Guard previous-submission modal so a missing requirement key does not white-screen
- Nudge “Answer changed” tag vertical alignment

---

## 🧪 Steps to QA

> Browser-based only. Log in as a **review manager**.

### A. Form stays locked after sending revision requests
1. Open a permit application that is `in_review` (or start review on a newly submitted one).
2. Click **Request revisions**, add at least one revision request, and send/finalize it.
3. Re-open the same application (now `revisions_requested`).

**Expected:** Form fields are not editable. You still see **View revision requests**.

**Before:** Fields became editable right after revision requests were created/revisited.

### B. Revision buttons only in revision mode
1. On that `revisions_requested` application, confirm no yellow revision pencil buttons appear on fields initially.
2. Click **View revision requests**.
3. Confirm revision buttons appear only on fields that already have requests, and clicking one opens the revision modal.

**Expected:** Modal is read-only (reason + comment disabled; Use/Delete disabled). Cancel/close still works.

### C. Answer changed markers
1. Open a resubmitted application where answers changed vs the previous submission (review view).
2. Confirm “Answer changed” tags appear on changed **requirement inputs** only — not on resource links/documents.
3. Click an “Answer changed” tag on a real field and confirm the previous-submission modal opens without a white screen.
4. Confirm tags sit roughly aligned with the field (not floating too high).

### D. Submitter still editable (regression)
1. As the submitter, open an application with `revisions_requested`.
2. Confirm the form is still editable and revision context is still available.

**Expected Behaviour:** Review staff can view/manage revision requests without editing application answers; submitters can still revise.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5427]: https://hous-bssb.atlassian.net/browse/HUB-5427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HUB-5427]: https://hous-bssb.atlassian.net/browse/HUB-5427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ