### PR TITLE
Bugfix/july 31 bugfixes

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -61,6 +61,10 @@ RUN_COMPLIANCE_ON_SAVE=false
 ENABLE_TEMPLATE_FORCE_PUBLISH="true"
 VITE_ENABLE_TEMPLATE_FORCE_PUBLISH="true"
 
+# Reactotron MST/API tracking (DEV only). Default on; set false if local tabs OOM.
+# Restart Vite after changing.
+#VITE_REACTOTRON=false
+
 # Sidekiq
 SIDEKIQ_DEV_REDIS_URL="redis://localhost:6379/0"
 ANYCABLE_DEV_REDIS_URL="redis://localhost:6379/1"

--- a/app/frontend/components/domains/permit-application/checklist-sidebar.tsx
+++ b/app/frontend/components/domains/permit-application/checklist-sidebar.tsx
@@ -10,7 +10,7 @@ interface IChecklistSideBarProps {
 }
 
 export const ChecklistSideBar = observer(({ permitApplication, completedBlocks }: IChecklistSideBarProps) => {
-  const { formJson, stepCode } = permitApplication
+  const { formJson } = permitApplication
   const { selectedTabIndex, setSelectedTabIndex, indexOfBlockId, getBlockClass } = permitApplication
 
   const navHeight = document.getElementById("mainNav")?.offsetHeight
@@ -51,15 +51,9 @@ export const ChecklistSideBar = observer(({ permitApplication, completedBlocks }
                       {section.title}
                     </Heading>
                     {section?.components?.map((block) => {
-                      // todo: some better way to signify something is a Step Code block
-                      const isStepCodeBlock = block.components.some((component) =>
-                        component.key.includes("|energy_step_code")
-                      )
-                      const usingStepCodeTool = !!stepCode
-                      const showCompleted =
-                        usingStepCodeTool && isStepCodeBlock
-                          ? permitApplication.isStepCodeComplete
-                          : completedBlocks[block.key] || false
+                      // Completion for Energy Step Code blocks is decided in getCompletedBlocksFromForm
+                      // (digital tool method → stage checklist; file method → Form.io visible fields).
+                      const showCompleted = completedBlocks[block.key] || false
                       return (
                         <Tab
                           key={block.key}

--- a/app/frontend/components/domains/permit-project/add-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-project/add-permit-application-screen.tsx
@@ -57,6 +57,7 @@ export const AddPermitApplicationToProjectScreen = observer(() => {
   )
   const shouldOfferProjectMeetingAfterAdd =
     selectedTemplatesRequireProjectMeeting &&
+    !currentPermitProject?.activeProjectMeeting &&
     siteConfigurationStore.projectMeetingsEnabled &&
     (currentPermitProject?.jurisdiction?.projectMeetingsEnabled ?? false)
 

--- a/app/frontend/components/domains/step-code/part-3/checklist/pdf-content/index.tsx
+++ b/app/frontend/components/domains/step-code/part-3/checklist/pdf-content/index.tsx
@@ -31,17 +31,21 @@ export const Part3PDFContent = function StepCodePart3ChecklistPDFContent({
   // Use views from MST model (hardened helpers)
   const isMixedUse = isMixedUseChecklist(checklist as any)
   const isBaseline = isBaselineChecklist(checklist as any)
-  stepCode.updatedAt = checklist.updatedAt
+  // PdfGenerationJob may omit stepCode; never mutate the prop (Part 9 builds locally too)
+  const stepCodeForPdf = {
+    ...(stepCode ?? {}),
+    updatedAt: checklist.updatedAt ?? stepCode?.updatedAt,
+  }
   return (
     <PDFDocument assetDirectoryPath={assetDirectoryPath}>
       <CoverPage
         permitApplication={permitApplication}
-        stepCode={stepCode}
+        stepCode={stepCodeForPdf}
         subTitle={t("stepCodeChecklist.pdf.forPart3")}
         assetDirectoryPath={assetDirectoryPath}
       />
       <Page size="LETTER" style={page}>
-        <ProjectInfo stepCode={stepCode} />
+        <ProjectInfo stepCode={stepCodeForPdf} />
         {/* Placeholder for Step Code Performance Summary */}
         <StepCodePerformanceSummary checklist={checklist} />
         {/* Placeholder for Mixed Use/Baseline Summary (conditional) */}

--- a/app/frontend/components/domains/step-code/part-9/form-section/index.tsx
+++ b/app/frontend/components/domains/step-code/part-9/form-section/index.tsx
@@ -321,6 +321,7 @@ const MissingReportSection = function MissingReportSection() {
 
 const ReviewSection = observer(function ReviewSection() {
   const { checklist } = usePart9StepCode()
+  const { pathname } = useLocation()
   const formMethods = useForm({ mode: "onChange" })
   const { handleSubmit, formState } = formMethods
 
@@ -331,6 +332,10 @@ const ReviewSection = observer(function ReviewSection() {
 
   if (!checklist) return <SharedSpinner />
   if (!checklist.selectedReport) return <MissingReportSection />
+  if (!checklist.canAccessReview) {
+    const target = checklist.currentNavLink?.location ?? "start"
+    return <Navigate to={pathname.replace(/\/review$/, `/${target}`)} replace />
+  }
 
   return (
     <FormProvider {...formMethods}>
@@ -370,6 +375,7 @@ const ReviewSection = observer(function ReviewSection() {
 
 const ReportSection = observer(function ReportSection() {
   const { currentStepCode, checklist } = usePart9StepCode()
+  const { pathname } = useLocation()
   const formMethods = useForm({ mode: "onChange" })
   const { handleSubmit, formState } = formMethods
   const [isRegenerating, setIsRegenerating] = useState(false)
@@ -391,6 +397,10 @@ const ReportSection = observer(function ReportSection() {
 
   if (!checklist) return <SharedSpinner />
   if (!checklist.selectedReport) return <MissingReportSection />
+  if (!checklist.canAccessReport) {
+    const target = checklist.currentNavLink?.location ?? "start"
+    return <Navigate to={pathname.replace(/\/report$/, `/${target}`)} replace />
+  }
 
   return (
     <FormProvider {...formMethods}>

--- a/app/frontend/components/domains/step-code/part-9/sidebar/index.tsx
+++ b/app/frontend/components/domains/step-code/part-9/sidebar/index.tsx
@@ -3,6 +3,7 @@ import { t } from "i18next"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { usePart9StepCode } from "../../../../../hooks/resources/use-part-9-step-code"
+import { TPart9NavLinkKey } from "../../../../../types/types"
 import { ProjectInfoSidebarLink } from "../../sidebar/project-info-sidebar-link"
 import { usePart9Navigation } from "../use-part-9-navigation"
 import { navSections, reportDependentSectionKeys } from "./nav-sections"
@@ -15,6 +16,13 @@ export const Sidebar = observer(function Part9StepCodeSidebar() {
   const { infoPagePath } = usePart9Navigation()
   const reportAvailable = Boolean(checklist?.selectedReport)
 
+  const isSectionDisabled = (key: TPart9NavLinkKey) => {
+    if (reportDependentSectionKeys.includes(key) && !reportAvailable) return true
+    if (key === "review" && !checklist?.canAccessReview) return true
+    if (key === "report" && !checklist?.canAccessReport) return true
+    return false
+  }
+
   return (
     <VStack w="full" align="stretch" pt={4}>
       <ProjectInfoSidebarLink to={infoPagePath} />
@@ -22,7 +30,7 @@ export const Sidebar = observer(function Part9StepCodeSidebar() {
         <React.Fragment key={section.key}>
           <SectionHeader title={t(`stepCode.part9.sidebar.${section.key}`)} />
           {section.navLinks.map((navLink) => {
-            const isDisabled = reportDependentSectionKeys.includes(navLink.key) && !reportAvailable
+            const isDisabled = isSectionDisabled(navLink.key)
 
             return (
               checklist?.isRelevant(navLink.key) && (
@@ -31,11 +39,7 @@ export const Sidebar = observer(function Part9StepCodeSidebar() {
                   {navLink.subLinks.map(
                     (subLink) =>
                       checklist.isRelevant(subLink.key) && (
-                        <SubLink
-                          key={subLink.key}
-                          subLink={subLink}
-                          isDisabled={reportDependentSectionKeys.includes(subLink.key) && !reportAvailable}
-                        />
+                        <SubLink key={subLink.key} subLink={subLink} isDisabled={isSectionDisabled(subLink.key)} />
                       )
                   )}
                 </React.Fragment>

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -12,7 +12,11 @@ import { IPermitApplication } from "../../../models/permit-application"
 import { EFileUploadAttachmentType, EFlashMessageStatus, EStepCodeType } from "../../../types/enums"
 import { IErrorsBoxData } from "../../../types/types"
 import { getCompletedBlocksFromForm, getRequirementByKey } from "../../../utils/formio-component-traversal"
-import { singleRequirementFormJson, singleRequirementSubmissionData } from "../../../utils/formio-helpers"
+import {
+  getEnergyStepCodeMethodFromData,
+  singleRequirementFormJson,
+  singleRequirementSubmissionData,
+} from "../../../utils/formio-helpers"
 import { downloadFileFromStorage } from "../../../utils/utility-functions"
 import { CompareRequirementsBox } from "../../domains/permit-application/compare-requirements-box"
 import { ErrorsBox } from "../../domains/permit-application/errors-box"
@@ -65,7 +69,10 @@ export const RequirementForm = observer(
       isViewingPastRequests,
       inboxEnabled,
       sandbox,
+      isStepCodeComplete,
     } = permitApplication
+
+    const stepCodeCompletionOptions = { isStepCodeComplete }
 
     const shouldShowDiff = permitApplication?.shouldShowApplicationDiff(isEditing)
     const userShouldSeeDiff = permitApplication?.currentUserShouldSeeApplicationDiff
@@ -134,6 +141,13 @@ export const RequirementForm = observer(
       setUnsavedSubmissionData(displayedSubmissionData)
       // We don't want to trigger a re-render if the permitApplication itself changes, only if the derived data changes
     }, [displayedSubmissionData])
+
+    // Recompute block completion when the digital Step Code checklist completion flips
+    useEffect(() => {
+      if (onCompletedBlocksChange && formRef.current) {
+        onCompletedBlocksChange(getCompletedBlocksFromForm(formRef.current, stepCodeCompletionOptions))
+      }
+    }, [isStepCodeComplete])
 
     useEffect(() => {
       // The box observers need to be re-registered whenever a panel is collapsed
@@ -308,6 +322,18 @@ export const RequirementForm = observer(
     }
 
     const onFormSubmit = async (submission: any) => {
+      // Form.io does not validate the digital Step Code tool (button container, input:false).
+      if (getEnergyStepCodeMethodFromData(submission?.data) === "tool" && !isStepCodeComplete) {
+        setHasErrors(true)
+        setErrorBoxData([
+          {
+            label: t("permitApplication.edit.stepCodeToolIncomplete"),
+            id: "energy-step-code-tool",
+            class: "",
+          },
+        ])
+        return
+      }
       setHasErrors(null)
       setImminentSubmission(submission)
       onOpen()
@@ -321,7 +347,7 @@ export const RequirementForm = observer(
 
     const onBlur = (containerComponent) => {
       if (onCompletedBlocksChange) {
-        onCompletedBlocksChange(getCompletedBlocksFromForm(containerComponent.root))
+        onCompletedBlocksChange(getCompletedBlocksFromForm(containerComponent.root, stepCodeCompletionOptions))
       }
     }
     const onScroll = (event) => {
@@ -339,9 +365,10 @@ export const RequirementForm = observer(
 
       const componentType = component.type
 
-      if (componentType === "selectboxes" || componentType === "simplefile") {
+      // radio: energy_step_code_method toggles tool vs file visibility / completion rules
+      if (componentType === "selectboxes" || componentType === "simplefile" || componentType === "radio") {
         if (onCompletedBlocksChange) {
-          onCompletedBlocksChange(getCompletedBlocksFromForm(root))
+          onCompletedBlocksChange(getCompletedBlocksFromForm(root, stepCodeCompletionOptions))
         }
         setErrorBoxData(mapErrorBoxData(root.errors))
 
@@ -361,7 +388,7 @@ export const RequirementForm = observer(
       updateCollaborationAssignmentNodes?.()
 
       if (onCompletedBlocksChange) {
-        onCompletedBlocksChange(getCompletedBlocksFromForm(formRef.current))
+        onCompletedBlocksChange(getCompletedBlocksFromForm(formRef.current, stepCodeCompletionOptions))
       }
     }
 

--- a/app/frontend/entrypoints/application.tsx
+++ b/app/frontend/entrypoints/application.tsx
@@ -7,7 +7,7 @@ import { Helmet } from "react-helmet"
 import { Navigation } from "../components/domains/navigation"
 import "../i18n/i18n"
 import { useLanguageChange } from "../i18n/use-language-change"
-import { setupReactotron } from "../setup/reactotron"
+import { isReactotronEnabled, setupReactotron } from "../setup/reactotron"
 import { Provider, setupRootStore } from "../setup/root"
 import { GlobalStyles } from "../styles"
 import { theme } from "../styles/theme"
@@ -63,13 +63,12 @@ const renderApp = (rootStore) => {
 
 document.addEventListener("DOMContentLoaded", () => {
   const rootStore = setupRootStore()
-  if (import.meta.env.PROD) {
+  if (import.meta.env.PROD || !isReactotronEnabled()) {
     renderApp(rootStore)
-  } else if (import.meta.env.DEV) {
+  } else {
     setupReactotron(rootStore.environment.api).then((reactotron) => {
       // @ts-expect-error: trackMstNode is not part of the official Reactotron type definitions
       reactotron.trackMstNode(rootStore)
-      // set reactotron into console
       window.console.tron = reactotron
       renderApp(rootStore)
     })

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -2077,6 +2077,8 @@ Thank you,
             fullAddress: "Full address",
             pidPin: "PID / PIN",
             clickToWriteNickname: "Click to write a custom name",
+            stepCodeToolIncomplete:
+              "Complete the digital Step Code tool for the selected Energy Step Code method before submitting",
           },
           show: {
             wasSubmitted: "Application was submitted on {{ date }} to {{ jurisdictionName }}",

--- a/app/frontend/models/part-9-step-code-checklist.ts
+++ b/app/frontend/models/part-9-step-code-checklist.ts
@@ -12,7 +12,7 @@ import {
   EStepCodeType,
 } from "../types/enums"
 import { IPart9NavLink, IPart9SectionCompletionStatus, TPart9NavLinkKey } from "../types/types"
-import { canMarkChecklistComplete } from "../utils/can-mark-checklist-complete"
+import { areRelevantSectionsCompleteExcept, canMarkChecklistComplete } from "../utils/can-mark-checklist-complete"
 import { renameKeys } from "../utils/utility-functions"
 import { markParentStepCodeReportsStale } from "./step-code-base"
 import { StepCodeBuildingCharacteristicsSummaryModel } from "./step-code-building-characteristic-summary"
@@ -154,6 +154,12 @@ export const Part9StepCodeChecklistModel = types.snapshotProcessor(
         return self.status == EStepCodeChecklistStatus.complete
       },
       get canMarkComplete() {
+        return canMarkChecklistComplete(self.sectionCompletionStatus)
+      },
+      get canAccessReview() {
+        return areRelevantSectionsCompleteExcept(self.sectionCompletionStatus, ["review", "report"])
+      },
+      get canAccessReport() {
         return canMarkChecklistComplete(self.sectionCompletionStatus)
       },
       get stepRequirementId() {

--- a/app/frontend/setup/reactotron.ts
+++ b/app/frontend/setup/reactotron.ts
@@ -6,27 +6,30 @@ declare global {
   }
 }
 
+/** Opt out locally with VITE_REACTOTRON=false in .env (restart Vite after changing). */
+export const isReactotronEnabled = () => import.meta.env.DEV && import.meta.env.VITE_REACTOTRON !== "false"
+
 export const setupReactotron = async (api) => {
-  if (import.meta.env.DEV) {
-    window.global = globalThis
-    const { default: reactotron } = await import("reactotron-react-js")
-    const { mst } = await import("reactotron-mst")
-    const { default: apisaucePlugin } = await import("reactotron-apisauce")
+  if (!isReactotronEnabled()) return
 
-    reactotron
-      .configure({ name: "HOUS-permit-portal" })
-      .use(apisaucePlugin())
-      .use(
-        mst({
-          filter: (x) =>
-            !x.name.endsWith("@APPLY_SNAPSHOT") &&
-            !x.name.startsWith("mergeUpdate") &&
-            !x.name.endsWith("__beforeMergeUpdate"),
-        })
-      )
-      .connect()
+  window.global = globalThis
+  const { default: reactotron } = await import("reactotron-react-js")
+  const { mst } = await import("reactotron-mst")
+  const { default: apisaucePlugin } = await import("reactotron-apisauce")
 
-    api.addMonitor(reactotron.apisauce)
-    return reactotron
-  }
+  reactotron
+    .configure({ name: "HOUS-permit-portal" })
+    .use(apisaucePlugin())
+    .use(
+      mst({
+        filter: (x) =>
+          !x.name.endsWith("@APPLY_SNAPSHOT") &&
+          !x.name.startsWith("mergeUpdate") &&
+          !x.name.endsWith("__beforeMergeUpdate"),
+      })
+    )
+    .connect()
+
+  api.addMonitor(reactotron.apisauce)
+  return reactotron
 }

--- a/app/frontend/utils/can-mark-checklist-complete.ts
+++ b/app/frontend/utils/can-mark-checklist-complete.ts
@@ -1,8 +1,16 @@
+/** True when every relevant section is complete, ignoring `excludedKeys`. */
+export function areRelevantSectionsCompleteExcept(
+  sectionCompletionStatus: Record<string, { complete?: boolean; relevant?: boolean }> | null | undefined,
+  excludedKeys: string[]
+): boolean {
+  return Object.entries(sectionCompletionStatus ?? {}).every(
+    ([key, section]) => excludedKeys.includes(key) || !section?.relevant || section?.complete
+  )
+}
+
 /** True when every relevant section except `report` is complete. */
 export function canMarkChecklistComplete(
   sectionCompletionStatus: Record<string, { complete?: boolean; relevant?: boolean }> | null | undefined
 ): boolean {
-  return Object.entries(sectionCompletionStatus ?? {}).every(
-    ([key, section]) => key === "report" || !section?.relevant || section?.complete
-  )
+  return areRelevantSectionsCompleteExcept(sectionCompletionStatus, ["report"])
 }

--- a/app/frontend/utils/formio-component-traversal.ts
+++ b/app/frontend/utils/formio-component-traversal.ts
@@ -10,7 +10,12 @@ import {
   ITemplateVersionDiff,
 } from "../types/types"
 import { formatFileSize, getFileExtension } from "./file-utils"
-import { isNonRequirementKey, isRequirementInputComponent } from "./formio-helpers"
+import {
+  ENERGY_STEP_CODE_METHOD_REQUIREMENT_CODE,
+  isNonRequirementKey,
+  isRequirementInputComponent,
+  keyHasRequirementCode,
+} from "./formio-helpers"
 import { escapeForSingleQuotedJsString } from "./utility-functions"
 
 const findComponentsByType = (components, type) => {
@@ -65,13 +70,31 @@ export const getNestedComponentsIncomplete = (components) => {
   return invalidComponents
 }
 
-export const getCompletedBlocksFromForm = (rootComponent) => {
+const findEnergyStepCodeMethodValue = (components): "tool" | "file" | null => {
+  for (const comp of components || []) {
+    const key = comp?.component?.key || comp?.key
+    if (keyHasRequirementCode(key, ENERGY_STEP_CODE_METHOD_REQUIREMENT_CODE)) {
+      const value = typeof comp?.getValue === "function" ? comp.getValue() : comp?.dataValue
+      if (value === "tool" || value === "file") return value
+    }
+    const nested = findEnergyStepCodeMethodValue(comp?.components)
+    if (nested) return nested
+  }
+  return null
+}
+
+export const getCompletedBlocksFromForm = (rootComponent, options?: { isStepCodeComplete?: boolean }) => {
   const blocksList = findPanelComponents(rootComponent.components)
   let completedBlocks = {}
   blocksList.forEach((panelComponent) => {
     const incompleteComponents = getNestedComponentsIncomplete(panelComponent.components)
 
-    const complete = incompleteComponents.length == 0 //if there are any components with errors OR required fields with no value
+    // Digital tool field is a button container (input:false) so Form.io never marks it incomplete.
+    // When method is "tool", section completion must follow the selected stage checklist instead.
+    const toolSelected = findEnergyStepCodeMethodValue(panelComponent.components) === "tool"
+    const toolIncomplete = toolSelected && options?.isStepCodeComplete === false
+
+    const complete = incompleteComponents.length == 0 && !toolIncomplete
 
     return (completedBlocks[panelComponent?.component?.key] = complete)
   })

--- a/app/frontend/utils/formio-helpers.ts
+++ b/app/frontend/utils/formio-helpers.ts
@@ -22,6 +22,33 @@ export const isNonRequirementKey = (key: string) => {
   return false
 }
 
+export const ENERGY_STEP_CODE_METHOD_REQUIREMENT_CODE = "energy_step_code_method"
+
+export const keyHasRequirementCode = (key: string | undefined | null, requirementCode: string) => {
+  if (!key) return false
+  return key === requirementCode || key.endsWith(`|${requirementCode}`) || key.includes(`|${requirementCode}|`)
+}
+
+/** Selected Energy Step Code method from form submission section data ("tool" | "file"). */
+export const getEnergyStepCodeMethodFromData = (
+  data: Record<string, any> | null | undefined
+): "tool" | "file" | null => {
+  if (!data) return null
+
+  for (const section of Object.values(data)) {
+    if (!section || typeof section !== "object") continue
+    for (const [key, value] of Object.entries(section)) {
+      if (
+        keyHasRequirementCode(key, ENERGY_STEP_CODE_METHOD_REQUIREMENT_CODE) &&
+        (value === "tool" || value === "file")
+      ) {
+        return value
+      }
+    }
+  }
+  return null
+}
+
 /** True for actual answered fields — not content, resource buttons, documents chrome, etc. */
 export const isRequirementInputComponent = (requirement: { key?: string; type?: string; input?: boolean }) => {
   if (isNonRequirementKey(requirement?.key)) return false

--- a/app/jobs/pdf_generation_job.rb
+++ b/app/jobs/pdf_generation_job.rb
@@ -54,6 +54,7 @@ class PdfGenerationJob
         should_checklist_pdf_be_generated =
           submission_version.missing_step_code_checklist_pdf?
 
+        step_code = permit_application.step_code
         pdf_json_data = {
           permitApplication:
             camelize_response(
@@ -68,6 +69,30 @@ class PdfGenerationJob
           checklist:
             submission_version.has_step_code_checklist? &&
               camelize_response(submission_version.step_code_checklist_json),
+          # Part 3 checklist PDF reads project fields from stepCode (Part 9 builds them from checklist)
+          stepCode:
+            (
+              if should_checklist_pdf_be_generated && step_code.present?
+                camelize_response(
+                  {
+                    id: step_code.id,
+                    type: step_code.class.name,
+                    full_address: step_code.full_address,
+                    reference_number: step_code.reference_number,
+                    title: step_code.title,
+                    phase: step_code.phase,
+                    current_stage: step_code.current_stage,
+                    permit_date: step_code.permit_date,
+                    pid: step_code.pid,
+                    jurisdiction_name:
+                      (
+                        step_code.respond_to?(:jurisdiction_name) &&
+                          step_code.jurisdiction_name
+                      )
+                  }.compact
+                )
+              end
+            ),
           meta: {
             generationPaths: {
               permitApplication:

--- a/app/models/concerns/permit_application_status.rb
+++ b/app/models/concerns/permit_application_status.rb
@@ -186,6 +186,9 @@ module PermitApplicationStatus
     def can_submit?
       return false unless inbox_enabled? || sandbox.present?
       return false if template_version_disabled_by_jurisdiction?
+      if using_digital_energy_step_code_tool? && !step_code_complete?
+        return false
+      end
 
       signed =
         submission_data.dig("data", "section-completion-key", "signed").present?
@@ -218,12 +221,15 @@ module PermitApplicationStatus
       update(signed_off_at: Time.current)
 
       checklist = step_code_checklist
+      # Only snapshot / generate digital checklist PDF when the selected method is the tool
+      snapshot_checklist =
+        checklist.present? && using_digital_energy_step_code_tool?
       submission_versions.create!(
         form_json: self.form_json,
         submission_data: self.submission_data,
         step_code_checklist_json:
           (
-            if checklist.present?
+            if snapshot_checklist
               step_code.checklist_blueprint.render_as_hash(
                 checklist,
                 view: :extended

--- a/app/models/permit_application.rb
+++ b/app/models/permit_application.rb
@@ -663,6 +663,31 @@ class PermitApplication < ApplicationRecord
       end
   end
 
+  # Value of the Energy Step Code method radio: "tool" | "file" | nil
+  def energy_step_code_method
+    data = submission_data&.dig("data") || {}
+    data.each_value do |section|
+      next unless section.is_a?(Hash)
+
+      section.each do |key, value|
+        unless key.to_s.end_with?(
+                 "|#{Requirement::ENERGY_STEP_CODE_SELECT_REQUIREMENT_CODE}"
+               ) ||
+                 key.to_s ==
+                   Requirement::ENERGY_STEP_CODE_SELECT_REQUIREMENT_CODE
+          next
+        end
+
+        return value if value == "tool" || value == "file"
+      end
+    end
+    nil
+  end
+
+  def using_digital_energy_step_code_tool?
+    energy_step_code_method == "tool"
+  end
+
   def self.stats_by_template_jurisdiction_and_status
     sv_min =
       SubmissionVersion.select(

--- a/app/services/qa/permit_application_autofill_service.rb
+++ b/app/services/qa/permit_application_autofill_service.rb
@@ -296,6 +296,15 @@ class Qa::PermitApplicationAutofillService
 
   def select_value(component)
     values = component.dig("data", "values") || component["values"] || []
+
+    # Autofill uploads files for every file field (including energy step code report).
+    # Prefer "file" method so section completion matches what we actually filled.
+    if component["key"].to_s.include?("energy_step_code_method")
+      file_option =
+        values.find { |value| value.is_a?(Hash) && value["value"] == "file" }
+      return file_option["value"] if file_option
+    end
+
     first_value = values.first
 
     return "qa" unless first_value.is_a?(Hash)

--- a/spec/jobs/pdf_generation_job_spec.rb
+++ b/spec/jobs/pdf_generation_job_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe PdfGenerationJob, type: :job do
     allow(PermitApplication).to receive(:find).with("pa1").and_return(
       permit_application
     )
+    allow(permit_application).to receive(:step_code).and_return(nil)
 
     submission_version =
       instance_double(
@@ -104,6 +105,7 @@ RSpec.describe PdfGenerationJob, type: :job do
     allow(PermitApplication).to receive(:find).with("pa1").and_return(
       permit_application
     )
+    allow(permit_application).to receive(:step_code).and_return(nil)
 
     submission_version =
       instance_double(

--- a/spec/models/permit_application_spec.rb
+++ b/spec/models/permit_application_spec.rb
@@ -183,14 +183,28 @@ RSpec.describe PermitApplication, type: :model do
     end
 
     describe "submission snapshot" do
-      it "snapshots the permit-pinned checklist" do
+      def submission_data_with_method(method)
+        {
+          "data" => {
+            "sectionabc" => {
+              "formSubmissionDataRSTsectionabc|RBxyz|energy_step_code_method" =>
+                method
+            }
+          }
+        }
+      end
+
+      it "snapshots the permit-pinned checklist when method is the digital tool" do
         permit_application = create(:permit_application)
         step_code =
           create(:part_3_step_code, permit_application: permit_application)
         pre_construction = step_code.pre_construction_checklist
         create(:part_3_checklist, step_code: step_code, stage: :as_built)
         step_code.update!(current_stage: "as_built")
-        permit_application.update!(step_code_stage: "pre_construction")
+        permit_application.update!(
+          step_code_stage: "pre_construction",
+          submission_data: submission_data_with_method("tool")
+        )
 
         allow(permit_application).to receive(
           :zip_and_upload_supporting_documents
@@ -206,6 +220,83 @@ RSpec.describe PermitApplication, type: :model do
           permit_application.submission_versions.last.step_code_checklist_json
         expect(snapshot["id"]).to eq(pre_construction.id)
         expect(snapshot["stage"]).to eq("pre_construction")
+      end
+
+      it "does not snapshot the checklist when method is file upload" do
+        permit_application = create(:permit_application)
+        create(:part_3_step_code, permit_application: permit_application)
+        permit_application.update!(
+          submission_data: submission_data_with_method("file")
+        )
+
+        allow(permit_application).to receive(
+          :zip_and_upload_supporting_documents
+        )
+        allow(permit_application).to receive(:send_submit_notifications)
+        allow(permit_application).to receive(:form_json).and_return(
+          { "components" => [] }
+        )
+
+        permit_application.send(:handle_submission)
+
+        expect(
+          permit_application.submission_versions.last.step_code_checklist_json
+        ).to be_blank
+      end
+    end
+
+    describe "#energy_step_code_method" do
+      it "reads tool or file from submission data" do
+        permit_application =
+          create(
+            :permit_application,
+            submission_data: {
+              "data" => {
+                "section1" => {
+                  "formSubmissionDataRSTsection1|RB1|energy_step_code_method" =>
+                    "tool"
+                }
+              }
+            }
+          )
+
+        expect(permit_application.energy_step_code_method).to eq("tool")
+        expect(permit_application.using_digital_energy_step_code_tool?).to be(
+          true
+        )
+      end
+    end
+
+    describe "#can_submit?" do
+      it "is false when digital tool method is selected but step code is incomplete" do
+        permit_application =
+          create(
+            :permit_application,
+            submission_data: {
+              "data" => {
+                "section-completion-key" => {
+                  "signed" => true
+                },
+                "section1" => {
+                  "formSubmissionDataRSTsection1|RB1|energy_step_code_method" =>
+                    "tool"
+                }
+              }
+            }
+          )
+        create(:part_3_step_code, permit_application: permit_application)
+        allow(permit_application).to receive(:inbox_enabled?).and_return(true)
+        allow(permit_application).to receive(
+          :template_version_disabled_by_jurisdiction?
+        ).and_return(false)
+        allow(permit_application).to receive(
+          :using_current_template_version
+        ).and_return(true)
+        allow(permit_application).to receive(:step_code_complete?).and_return(
+          false
+        )
+
+        expect(permit_application.can_submit?).to be(false)
       end
     end
   end

--- a/spec/services/qa/permit_application_autofill_service_spec.rb
+++ b/spec/services/qa/permit_application_autofill_service_spec.rb
@@ -71,4 +71,29 @@ RSpec.describe Qa::PermitApplicationAutofillService do
       ).to eq(1)
     end
   end
+
+  it "prefers file for energy_step_code_method since autofill uploads report files" do
+    service =
+      described_class.new(
+        permit_application: permit_application,
+        current_user: user
+      )
+
+    value =
+      service.send(
+        :select_value,
+        {
+          "key" => "section-a|RBblock|energy_step_code_method",
+          "values" => [
+            {
+              "label" => "Utilizing the digital Step Code tool",
+              "value" => "tool"
+            },
+            { "label" => "By file upload", "value" => "file" }
+          ]
+        }
+      )
+
+    expect(value).to eq("file")
+  end
 end


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...vibes/replace-pdf` (merge-base range).

Fixes Energy Step Code / Part 9 PDF and completion flows so digital-tool vs file-upload methods are treated correctly end to end: section completion and submit gating follow the selected method, checklist PDFs only snapshot when the digital tool is used, and Part 3 PDF generation receives the `stepCode` payload it needs. Also fixes Part 9 review/report deep-links hanging on a spinner, skips the project-meeting prompt when a meeting already exists, and adds a `VITE_REACTOTRON` opt-out for local OOM.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [x] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5346](https://hous-bssb.atlassian.net/browse/HUB-5346), [HUB-5330](https://hous-bssb.atlassian.net/browse/HUB-5330) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- **Energy Step Code method-aware completion:** When method is `tool`, block/sidebar completion follows digital checklist completion (Form.io no longer treats the tool button as a filled field). Submit is blocked client- and server-side until the tool is complete.
- **Submission snapshot / PDF:** Checklist JSON is snapshotted and checklist PDF generation only runs when method is the digital tool; `PdfGenerationJob` passes `stepCode` project fields for Part 3; Part 3 PDF content no longer mutates the `stepCode` prop when it is missing.
- **HUB-5346:** Part 9 Review/Report routes redirect (and sidebar disables) when the checklist is not ready, so direct navigation no longer spins forever on download/report.
- **HUB-5330:** After adding a permit, do not offer a project meeting request if the project already has an active meeting.
- **Dev chore:** `VITE_REACTOTRON=false` skips Reactotron setup (documented in `.env_example`).
- **QA autofill:** Prefers `file` for `energy_step_code_method` so autofill matches uploaded report files.
- Specs updated for method helpers, submit gating, snapshot behaviour, PDF job doubles, and autofill.

---

## 🧪 Steps to QA

1. Open a permit application with Energy Step Code (digital tool vs file upload options).
2. Select **digital tool**, leave the Step Code incomplete → confirm the Energy Step Code section stays incomplete in the sidebar and submit is blocked with a clear error.
3. Complete the digital Step Code tool → section marks complete and submit is allowed; after submit, confirm a checklist PDF is generated when expected.
4. Select **file upload**, upload the required report → section completes without needing the digital tool; after submit, confirm no digital checklist PDF/snapshot is required for that path.
5. Part 9: with an incomplete checklist, open `/review` or `/report` directly (or via URL) → should redirect to an accessible section instead of hanging on a spinner; sidebar Review/Report stay disabled until ready. With a complete checklist, report download works.
6. On a project that already has an active project meeting, add a permit that would normally prompt for a meeting → meeting prompt should not appear.
7. (Optional local) With `VITE_REACTOTRON=false`, confirm the app still boots in DEV without Reactotron.

**Expected Behaviour:**
> Tool vs file methods drive completion, submit, and PDF behaviour correctly; Part 9 deep-links never hang; meeting prompt is skipped when a meeting already exists.

**Before this change:**
> Tool method could look complete while the checklist was unfinished; file method could still snapshot/generate checklist PDFs; Part 3 PDF could miss project fields / mutate props; Part 9 report/review URLs spun; meeting prompt could fire with an existing meeting.

**After this change:**
> Completion and submit match the selected method; PDFs/snapshots align with tool vs file; Part 9 navigates safely; meeting prompt respects an existing active meeting.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5346]: https://hous-bssb.atlassian.net/browse/HUB-5346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ