### PR TITLE
HUB-5348 hide assignment modal from submitter when submitted

### DIFF
--- a/app/frontend/components/domains/permit-application/collaborator-management/collaborator-assignment-modal.tsx
+++ b/app/frontend/components/domains/permit-application/collaborator-management/collaborator-assignment-modal.tsx
@@ -40,6 +40,9 @@ export const CollaboratorAssignmentModal = observer(function AssignmentModal({
   const contentRef = React.useRef<HTMLDivElement>(null)
 
   const canManage = permitApplication.canUserManageCollaborators(currentUser, collaborationType)
+  // Submission block assignment is draft-only (mirrors StatusSelect / create_permit_collaboration?).
+  // Review-side rules are intentionally unchanged.
+  const showAssignTrigger = collaborationType !== ECollaborationType.submission || permitApplication.isDraft
 
   const changeScreen = (screen: EAssignmentModalScreen) => {
     // review does have the ability to invite new collaborators. They should already be present for a jurisdiction
@@ -95,6 +98,8 @@ export const CollaboratorAssignmentModal = observer(function AssignmentModal({
 
   const onInviteCollaborator = (user: { email: string; firstName: string; lastName: string }) =>
     permitApplication.inviteNewCollaborator(ECollaboratorType.assignee, user, requirementBlockId)
+
+  if (!showAssignTrigger) return null
 
   return (
     <>


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5348-bug-bug-bash-hide-assign-on-non-draft-permit-applications` (merge-base range).

On non-draft permit applications, requirement-block **Assign** stayed clickable for submission collaboration even though assignment is draft-only (backend `create_permit_collaboration?` already requires `draft?`). The Assign trigger in `CollaboratorAssignmentModal` is now hidden when collaboration type is submission and the application is not draft (`new_draft` / `revisions_requested`). Review-side Assign is unchanged.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5348](https://hous-bssb.atlassian.net/browse/HUB-5348) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

> List the key changes, features, or fixes introduced in this PR.

- Hide requirement-block **Assign** for submission collaboration when the permit application is not draft
- Leave review collaboration Assign behavior unchanged
- Keep existing assignee avatars visible (rendered separately from the Assign trigger)

---

## 🧪 Steps to QA

> Provide clear, reproducible steps for the reviewer/QA engineer to verify the changes.

1. As a submitter, open a **non-draft** application on `/permit-applications/:id/edit` (e.g. newly submitted, approved).
2. Expand a requirement block and confirm **Assign (n)** is not shown; STATUS remains draft-gated as before.
3. As a submitter, open a **draft** application (`new_draft` or `revisions_requested`) on `/permit-applications/:id/edit`.
4. Expand a requirement block and confirm **Assign** still opens and assignment works.
5. As review staff, open a submitted application on `/permit-applications/:id` and confirm review-side **Assign** still appears and works.

**Expected Behaviour:**
> Submission Assign only on draft applications; review Assign unchanged; avatars can still show when present.

**Before this change:**
> Assign stayed clickable on submitted/approved applications in the edit/fillable form.

**After this change:**
> Assign is hidden for submission collabs outside draft; draft + revisions_requested still work.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5348]: https://hous-bssb.atlassian.net/browse/HUB-5348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ