### PR TITLE
tighten up question views and ui refresh

### DIFF
--- a/app/blueprints/requirement_question_blueprint.rb
+++ b/app/blueprints/requirement_question_blueprint.rb
@@ -43,47 +43,75 @@ class RequirementQuestionBlueprint < Blueprinter::Base
     requirement_question.computed_compliance?
   end
 
+  # List/search: block names only. Nesting templates here made every index row
+  # pull the full blast radius (slow + fat JSON the table never reads).
   view :extended do
     field :requirement_blocks do |requirement_question|
-      blocks =
+      RequirementQuestionBlueprint.serialize_usage_blocks(
+        requirement_question,
+        include_templates: false
+      )
+    end
+  end
+
+  # Show/modal: blocks + the permit templates that use them.
+  view :with_usage do
+    field :requirement_blocks do |requirement_question|
+      RequirementQuestionBlueprint.serialize_usage_blocks(
+        requirement_question,
+        include_templates: true
+      )
+    end
+  end
+
+  def self.serialize_usage_blocks(requirement_question, include_templates:)
+    blocks =
+      if include_templates
+        # Fresh query so we can eager-load the template tree in one go.
         requirement_question
           .requirement_blocks
           .kept
           .distinct
           .includes(
-            requirement_template_sections: {
-              requirement_template: %i[
-                template_category
-                published_template_version
-              ]
-            }
+            requirement_templates: %i[
+              template_category
+              published_template_version
+            ]
           )
-          .sort_by { |block| block.name.to_s.downcase }
+          .to_a
+      elsif requirement_question.association(:requirement_blocks).loaded?
+        # Searchkick already includes requirement_blocks — don't re-query.
+        requirement_question.requirement_blocks.select(&:kept?).uniq(&:id)
+      else
+        requirement_question.requirement_blocks.kept.distinct.to_a
+      end
 
-      blocks.map do |block|
+    blocks
+      .sort_by { |block| block.name.to_s.downcase }
+      .map do |block|
+        payload = { id: block.id, name: block.name }
+        next payload unless include_templates
+
+        # Through-assoc includes discarded templates; drop them here (usually few).
         templates =
           block
-            .requirement_template_sections
-            .filter_map(&:requirement_template)
+            .requirement_templates
             .select(&:kept?)
             .uniq(&:id)
             .sort_by { |rt| rt.nickname.to_s.downcase }
 
-        {
-          id: block.id,
-          name: block.name,
+        payload.merge(
           requirement_templates:
             templates.map do |rt|
               {
                 id: rt.id,
                 nickname: rt.nickname,
                 template_category_label: rt.template_category&.label,
-                # Template-level: has a live published version (not a snapshot check).
+                # Live published version on the template (not a historical snapshot).
                 published: rt.published_template_version.present?
               }
             end
-        }
+        )
       end
-    end
   end
 end

--- a/app/controllers/api/concerns/search/requirement_questions.rb
+++ b/app/controllers/api/concerns/search/requirement_questions.rb
@@ -17,16 +17,8 @@ module Api::Concerns::Search::RequirementQuestions
             nil
           end
         ),
-      includes: [
-        :taggings,
-        {
-          requirement_blocks: {
-            requirement_template_sections: {
-              requirement_template: :template_category
-            }
-          }
-        }
-      ],
+      # Index only needs block id/name (:extended). Templates load on show (:with_usage).
+      includes: %i[taggings requirement_blocks],
       scope_results: ->(relation) { policy_scope(relation) }
     }
 

--- a/app/controllers/api/requirement_questions_controller.rb
+++ b/app/controllers/api/requirement_questions_controller.rb
@@ -15,6 +15,7 @@ class Api::RequirementQuestionsController < Api::ApplicationController
                      meta: page_meta(@search),
                      blueprint: RequirementQuestionBlueprint,
                      blueprint_opts: {
+                       # Block names only — nested templates are show/modal (:with_usage).
                        view: :extended
                      }
                    }
@@ -28,7 +29,8 @@ class Api::RequirementQuestionsController < Api::ApplicationController
                    {
                      blueprint: RequirementQuestionBlueprint,
                      blueprint_opts: {
-                       view: :extended
+                       # Modal "where used" panel needs nested templates.
+                       view: :with_usage
                      }
                    }
   end
@@ -44,7 +46,7 @@ class Api::RequirementQuestionsController < Api::ApplicationController
                      {
                        blueprint: RequirementQuestionBlueprint,
                        blueprint_opts: {
-                         view: :extended
+                         view: :with_usage
                        }
                      }
     else
@@ -64,7 +66,7 @@ class Api::RequirementQuestionsController < Api::ApplicationController
                      {
                        blueprint: RequirementQuestionBlueprint,
                        blueprint_opts: {
-                         view: :extended
+                         view: :with_usage
                        }
                      }
     else
@@ -85,7 +87,7 @@ class Api::RequirementQuestionsController < Api::ApplicationController
                      {
                        blueprint: RequirementQuestionBlueprint,
                        blueprint_opts: {
-                         view: :extended
+                         view: :with_usage
                        }
                      }
     else
@@ -106,7 +108,7 @@ class Api::RequirementQuestionsController < Api::ApplicationController
                      {
                        blueprint: RequirementQuestionBlueprint,
                        blueprint_opts: {
-                         view: :extended
+                         view: :with_usage
                        }
                      }
     else

--- a/app/frontend/components/domains/question-bank/question-bank-modal/index.tsx
+++ b/app/frontend/components/domains/question-bank/question-bank-modal/index.tsx
@@ -99,6 +99,8 @@ export const QuestionBankModal = observer(function QuestionBankModal({
   const handleOpen = () => {
     reset(getDefaultValues())
     onOpen()
+    // Index only has block names; show loads the template tree for the usage panel.
+    requirementQuestion?.refresh()
   }
 
   useEffect(() => {
@@ -112,20 +114,6 @@ export const QuestionBankModal = observer(function QuestionBankModal({
       handleOpen()
     }
   }, [autoOpen])
-
-  // When the user edits a block/template in another tab, refresh usage on return.
-  useEffect(() => {
-    if (!isOpen || !requirementQuestion) return
-
-    const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        requirementQuestion.refresh()
-      }
-    }
-
-    document.addEventListener("visibilitychange", onVisibilityChange)
-    return () => document.removeEventListener("visibilitychange", onVisibilityChange)
-  }, [isOpen, requirementQuestion])
 
   const onSubmit = async (data: IRequirementQuestionForm) => {
     const field = data.requirementsAttributes[0]

--- a/app/frontend/components/domains/question-bank/question-bank-modal/question-usage-section.tsx
+++ b/app/frontend/components/domains/question-bank/question-bank-modal/question-usage-section.tsx
@@ -31,6 +31,7 @@ const expandableBlockIds = (blocks: TQuestionUsageBlock[]) =>
   new Set(blocks.filter((block) => (block.requirementTemplates ?? []).length > 0).map((block) => block.id))
 
 interface IQuestionUsageSectionProps {
+  // From MST: names arrive with the list; nested templates arrive after modal refresh (show).
   linkedBlocks: TQuestionUsageBlock[]
 }
 

--- a/app/frontend/models/requirement-question.ts
+++ b/app/frontend/models/requirement-question.ts
@@ -14,7 +14,8 @@ export type TQuestionUsageTemplate = {
 export type TQuestionUsageBlock = {
   id: string
   name: string
-  requirementTemplates: TQuestionUsageTemplate[]
+  // Present on show (:with_usage); list/search omits this to keep the index light.
+  requirementTemplates?: TQuestionUsageTemplate[]
 }
 
 export const RequirementQuestionModel = types
@@ -52,7 +53,8 @@ export const RequirementQuestionModel = types
       }
       return response.ok
     }),
-    // Refetch server state (usage, labels, etc.) without touching the open form.
+    // Show endpoint (:with_usage) — pulls nested templates. RHF form state is separate,
+    // so this only refreshes MST fields the usage panel / banners read.
     refresh: flow(function* () {
       const response = yield* toGenerator(self.environment.api.fetchRequirementQuestion(self.id))
       if (response.ok) {

--- a/app/models/requirement_block.rb
+++ b/app/models/requirement_block.rb
@@ -21,6 +21,7 @@ class RequirementBlock < ApplicationRecord
 
   has_many :template_section_blocks, dependent: :destroy
   has_many :requirement_template_sections, through: :template_section_blocks
+  # Used by question-bank "where used" (block → templates that include it).
   has_many :requirement_templates, through: :requirement_template_sections
 
   accepts_nested_attributes_for :requirements, allow_destroy: true

--- a/spec/blueprints/requirement_question_blueprint_spec.rb
+++ b/spec/blueprints/requirement_question_blueprint_spec.rb
@@ -3,65 +3,88 @@
 require "rails_helper"
 
 RSpec.describe RequirementQuestionBlueprint do
+  def build_usage_graph
+    question = create(:requirement_question)
+    category = create(:template_category, label: "Residential")
+    used_block = create(:requirement_block, name: "Agent authorization")
+    unused_block = create(:requirement_block, name: "Orphan block")
+    discarded_block = create(:requirement_block, name: "Archived block")
+    discarded_block.discard
+
+    create(
+      :requirement,
+      requirement_question: question,
+      requirement_block: used_block
+    )
+    create(
+      :requirement,
+      requirement_question: question,
+      requirement_block: unused_block
+    )
+    create(
+      :requirement,
+      requirement_question: question,
+      requirement_block: discarded_block
+    )
+
+    kept_template =
+      create(
+        :requirement_template,
+        nickname: "Residential - Part 9 - New Build",
+        template_category: category
+      )
+    discarded_template =
+      create(:requirement_template, nickname: "Retired template")
+    discarded_template.discard
+
+    section =
+      create(:requirement_template_section, requirement_template: kept_template)
+    create(
+      :template_section_block,
+      requirement_template_section: section,
+      requirement_block: used_block
+    )
+
+    discarded_section =
+      create(
+        :requirement_template_section,
+        requirement_template: discarded_template
+      )
+    create(
+      :template_section_block,
+      requirement_template_section: discarded_section,
+      requirement_block: used_block
+    )
+
+    { question: question, used_block: used_block, kept_template: kept_template }
+  end
+
   describe "extended view requirement_blocks" do
-    it "nests kept permit templates under each linked requirement block" do
-      question = create(:requirement_question)
-      category = create(:template_category, label: "Residential")
-      used_block = create(:requirement_block, name: "Agent authorization")
-      unused_block = create(:requirement_block, name: "Orphan block")
-      discarded_block = create(:requirement_block, name: "Archived block")
-      discarded_block.discard
-
-      create(
-        :requirement,
-        requirement_question: question,
-        requirement_block: used_block
-      )
-      create(
-        :requirement,
-        requirement_question: question,
-        requirement_block: unused_block
-      )
-      create(
-        :requirement,
-        requirement_question: question,
-        requirement_block: discarded_block
-      )
-
-      kept_template =
-        create(
-          :requirement_template,
-          nickname: "Residential - Part 9 - New Build",
-          template_category: category
-        )
-      discarded_template =
-        create(:requirement_template, nickname: "Retired template")
-      discarded_template.discard
-
-      section =
-        create(
-          :requirement_template_section,
-          requirement_template: kept_template
-        )
-      create(
-        :template_section_block,
-        requirement_template_section: section,
-        requirement_block: used_block
-      )
-
-      discarded_section =
-        create(
-          :requirement_template_section,
-          requirement_template: discarded_template
-        )
-      create(
-        :template_section_block,
-        requirement_template_section: discarded_section,
-        requirement_block: used_block
-      )
+    it "returns kept blocks without nesting templates (keeps the index light)" do
+      question = build_usage_graph[:question]
 
       payload =
         described_class.render_as_hash(question, view: :extended)[
+          :requirement_blocks
+        ]
+
+      expect(payload.map { |block| block[:name] }).to eq(
+        ["Agent authorization", "Orphan block"]
+      )
+      payload.each do |block|
+        expect(block).not_to have_key(:requirement_templates)
+      end
+    end
+  end
+
+  describe "with_usage view requirement_blocks" do
+    it "nests kept permit templates under each linked requirement block" do
+      graph = build_usage_graph
+      question = graph[:question]
+      kept_template = graph[:kept_template]
+
+      payload =
+        described_class.render_as_hash(question, view: :with_usage)[
           :requirement_blocks
         ]
 
@@ -86,7 +109,7 @@ RSpec.describe RequirementQuestionBlueprint do
         status: :published
       )
       published_payload =
-        described_class.render_as_hash(question, view: :extended)[
+        described_class.render_as_hash(question, view: :with_usage)[
           :requirement_blocks
         ]
       published_agent =


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff origin/HUB-5193-super-admin-can-identify-bank-linked-fields-and-add-block-only-fields-to-the-question-bank-from-the-requirement-block-editor-question-management...origin/HUB-5143-super-admin-can-view-where-a-question-is-used-requirement-blocks-and-permit-templates-question-management` (merge-base range).

Super admins editing a question bank item could see linked requirement blocks, but not the permit templates those blocks sit in — so the blast radius of a shared question was incomplete. This PR adds a “Where this question is used” panel that nests kept blocks under their kept templates (with published status), opens linked blocks/templates in new tabs, and includes related copy/UX polish in the question bank and requirements library editors.

**Stacked on:** `HUB-5193` (question-bank / bank-linked field work).

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5143](https://hous-bssb.atlassian.net/browse/HUB-5143) |
| 📄 Related PR(s) | <!-- HUB-5193 PR --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Extended requirement-question payload nests kept requirement blocks → kept permit templates (nickname, category, published flag)
- New **Where this question is used** accordion in the question bank modal (full hierarchy / compact views, block & template counts)
- Block and template links open in a new tab; requirement library supports `?openRequirementBlockId=` deep-link auto-open
- Published template status tag when a live published version exists
- Help/instructions editors: shared/bank defaults show in the field (skip empty “Add…” CTA); TipTap empty state no longer clears shared defaults incorrectly
- Copy/UX polish: modal padding, picker horizontal scroll for wide fields, FormModal confirm trigger cleanup, i18n updates
- Specs for blueprint nesting + `requirement_block` → `requirement_templates` association

---

## 🧪 Steps to QA

1. Sign in as a **super admin**.
2. Open **Question Bank** and edit a question that is used in at least one requirement block (ideally a block that appears on a published permit template and one that does not).
3. In the modal, expand **Where this question is used**.
4. Verify the summary counts (blocks · templates), hierarchy vs compact toggle, and that templates list under the correct blocks.
5. Confirm discarded/archived blocks and templates do **not** appear; orphan blocks (no templates) show the empty-templates message.
6. Click a requirement block link → new tab opens Requirements Library with that block modal open.
7. Click a permit template link → new tab opens that template’s edit screen; published templates show the Published tag.
8. Edit a question with no linked blocks → empty state and “Add to requirement block” link behave as expected.
9. Spot-check bank default / shared help text & instructions: defaults appear in the field without an extra “Add…” CTA; clearing a local override can return to the shared default.
10. In the question picker (from a requirement block), confirm wide fields can scroll horizontally without breaking the row layout.

**Expected Behaviour:**
> Super admins can see the full blast radius of a bank question (blocks + templates), navigate to those records in new tabs, and still edit the question without the usage panel getting in the way.

**Before this change:**
> Question modal listed linked requirement blocks only (or opened them in-place); templates using those blocks were not visible.

**After this change:**
> Usage panel shows blocks nested with their permit templates, published status, and external links into the library/template editors.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [x] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5143]: https://hous-bssb.atlassian.net/browse/HUB-5143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ