### PR TITLE
convert shared question wording and redundant boolean

### DIFF
--- a/app/blueprints/requirement_blueprint.rb
+++ b/app/blueprints/requirement_blueprint.rb
@@ -30,30 +30,22 @@ class RequirementBlueprint < Blueprinter::Base
     requirement.effective_instructions
   end
 
-  field :uses_shared_question do |requirement|
-    requirement.requirement_question_id.present?
-  end
-
+  # Bank defaults / placement overrides — only when linked (FK present).
+  # Linked vs local is requirement_question_id; no separate "shared" flag.
   field :default_hint do |requirement|
-    if requirement.requirement_question.present?
-      requirement.requirement_question.hint
-    end
+    requirement.requirement_question&.hint
   end
 
   field :default_instructions do |requirement|
-    if requirement.requirement_question.present?
-      requirement.requirement_question.instructions
-    end
+    requirement.requirement_question&.instructions
   end
 
   field :hint_override do |requirement|
-    if requirement.requirement_question.present?
-      requirement.read_attribute(:hint)
-    end
+    requirement.read_attribute(:hint) if requirement.requirement_question
   end
 
   field :instructions_override do |requirement|
-    if requirement.requirement_question.present?
+    if requirement.requirement_question
       requirement.read_attribute(:instructions)
     end
   end

--- a/app/frontend/components/domains/requirements-library/add-questions-modal.tsx
+++ b/app/frontend/components/domains/requirements-library/add-questions-modal.tsx
@@ -60,10 +60,10 @@ export const AddQuestionsModal = observer(function AddQuestionsModal({
             leftIcon={<Plus size={12} />}
             variant={"primary"}
             onClick={onOpen}
-            aria-label={t("requirementsLibrary.sharedQuestions.addQuestion")}
+            aria-label={t("requirementsLibrary.bankQuestions.addQuestion")}
             {...defaultButtonProps}
           >
-            {t("requirementsLibrary.sharedQuestions.addQuestion")}
+            {t("requirementsLibrary.bankQuestions.addQuestion")}
           </Button>
         ))}
       <Drawer isOpen={isOpen} placement="left" onClose={onClose} finalFocusRef={btnRef}>
@@ -71,7 +71,7 @@ export const AddQuestionsModal = observer(function AddQuestionsModal({
         <DrawerContent maxW="min(1320px, 95vw)" display="flex" flexDir="column">
           <DrawerCloseButton fontSize={"xs"} color={"greys.white"} top={5} right={4} zIndex={1} />
           <DrawerHeader color={"greys.white"} backgroundColor={"theme.blueAlt"} p={6} pt={10} fontSize={"2xl"}>
-            {t("requirementsLibrary.sharedQuestions.addQuestionsTitle")}
+            {t("requirementsLibrary.bankQuestions.addQuestionsTitle")}
           </DrawerHeader>
 
           <DrawerBody p={6} display="flex" flexDir="column" minH={0} flex={1}>

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-helper-text.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-helper-text.tsx
@@ -11,15 +11,15 @@ export type TEditableHelperTextProps<TFieldValues extends FieldValues> = TEditab
 export function EditableHelperText<TFieldValues extends FieldValues>({
   controlProps,
   defaultValue,
-  usesSharedQuestion = false,
+  usesBankQuestion = false,
   isQuestionBankDefault = false,
 }: TEditableHelperTextProps<TFieldValues>) {
   const {
     field: { onChange, value },
   } = useController(controlProps)
   const { t } = useTranslation()
-  const isUsingSharedDefault = usesSharedQuestion && value == null
-  const htmlValue = (isUsingSharedDefault ? defaultValue : value) ?? ""
+  const isUsingBankDefault = usesBankQuestion && value == null
+  const htmlValue = (isUsingBankDefault ? defaultValue : value) ?? ""
 
   return (
     <Box>
@@ -33,10 +33,10 @@ export function EditableHelperText<TFieldValues extends FieldValues>({
           </Tooltip>
         </HStack>
       )}
-      {usesSharedQuestion && (
+      {usesBankQuestion && (
         <Text fontSize={"xs"} mb={1} color={"text.secondary"}>
           {t(
-            isUsingSharedDefault
+            isUsingBankDefault
               ? "requirementsLibrary.modals.usingSharedDefault"
               : "requirementsLibrary.modals.customizedForBlock"
           )}
@@ -51,7 +51,7 @@ export function EditableHelperText<TFieldValues extends FieldValues>({
         htmlValue={htmlValue}
         onChange={onChange}
         onRemove={
-          usesSharedQuestion && !isUsingSharedDefault
+          usesBankQuestion && !isUsingBankDefault
             ? (setEditMode) => {
                 onChange(null)
                 setEditMode(false)
@@ -64,7 +64,7 @@ export function EditableHelperText<TFieldValues extends FieldValues>({
             {t(
               isQuestionBankDefault
                 ? "questionBank.modals.addDefaultHelpText"
-                : usesSharedQuestion
+                : usesBankQuestion
                   ? "requirementsLibrary.modals.addCustomHelpText"
                   : "requirementsLibrary.modals.addHelpText"
             )}
@@ -73,7 +73,7 @@ export function EditableHelperText<TFieldValues extends FieldValues>({
         editText={t(
           isQuestionBankDefault
             ? "questionBank.modals.editDefaultHelpText"
-            : isUsingSharedDefault
+            : isUsingBankDefault
               ? "requirementsLibrary.modals.customizeHelpText"
               : "requirementsLibrary.modals.editHelpTextLabel"
         )}

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-instructions-text.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/editable-instructions-text.tsx
@@ -11,15 +11,15 @@ export type TEditableInstructionsTextProps<TFieldValues extends FieldValues> = T
 export function EditableInstructionsText<TFieldValues extends FieldValues>({
   controlProps,
   defaultValue,
-  usesSharedQuestion = false,
+  usesBankQuestion = false,
   isQuestionBankDefault = false,
 }: TEditableInstructionsTextProps<TFieldValues>) {
   const {
     field: { onChange, value },
   } = useController({ ...controlProps })
   const { t } = useTranslation()
-  const isUsingSharedDefault = usesSharedQuestion && value == null
-  const htmlValue = (isUsingSharedDefault ? defaultValue : value) ?? ""
+  const isUsingBankDefault = usesBankQuestion && value == null
+  const htmlValue = (isUsingBankDefault ? defaultValue : value) ?? ""
 
   return (
     <Box>
@@ -33,10 +33,10 @@ export function EditableInstructionsText<TFieldValues extends FieldValues>({
           </Tooltip>
         </HStack>
       )}
-      {usesSharedQuestion && (
+      {usesBankQuestion && (
         <Text fontSize={"xs"} mb={1} color={"text.secondary"}>
           {t(
-            isUsingSharedDefault
+            isUsingBankDefault
               ? "requirementsLibrary.modals.usingSharedDefault"
               : "requirementsLibrary.modals.customizedForBlock"
           )}
@@ -51,7 +51,7 @@ export function EditableInstructionsText<TFieldValues extends FieldValues>({
         htmlValue={htmlValue}
         onChange={onChange}
         onRemove={
-          usesSharedQuestion && !isUsingSharedDefault
+          usesBankQuestion && !isUsingBankDefault
             ? (setEditMode) => {
                 onChange(null)
                 setEditMode(false)
@@ -64,7 +64,7 @@ export function EditableInstructionsText<TFieldValues extends FieldValues>({
             {t(
               isQuestionBankDefault
                 ? "questionBank.modals.addDefaultInstructions"
-                : usesSharedQuestion
+                : usesBankQuestion
                   ? "requirementsLibrary.modals.addCustomInstructions"
                   : "requirementsLibrary.modals.addInstructions"
             )}
@@ -73,7 +73,7 @@ export function EditableInstructionsText<TFieldValues extends FieldValues>({
         editText={t(
           isQuestionBankDefault
             ? "questionBank.modals.editDefaultInstructions"
-            : isUsingSharedDefault
+            : isUsingBankDefault
               ? "requirementsLibrary.modals.customizeInstructions"
               : "requirementsLibrary.modals.editInstructionsLabel"
         )}

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/options-menu.tsx
@@ -22,9 +22,10 @@ import { DataValidationSetupModal } from "./data-validation-setup-modal"
 export interface IRequirementOptionsMenu {
   menuButtonProps?: Partial<ButtonProps>
   onRemove?: () => void
-  onDetachSharedQuestion?: () => void
-  onOpenSharedQuestion?: () => void
-  isSharedQuestion?: boolean
+  onDetachBankQuestion?: () => void
+  onOpenBankQuestion?: () => void
+  // Placement is linked to a bank question (requirementQuestionId set).
+  isBankLinked?: boolean
   emitOpenState?: (isOpen: boolean) => void
   index: number
   disabledOptions?: Array<"remove" | "conditional">
@@ -42,9 +43,9 @@ export const OptionsMenu = observer(function OptionsMenu({
   hidePlacementConfiguration = false,
   menuButtonProps,
   onRemove,
-  onDetachSharedQuestion,
-  onOpenSharedQuestion,
-  isSharedQuestion = false,
+  onDetachBankQuestion,
+  onOpenBankQuestion,
+  isBankLinked = false,
   emitOpenState,
   index,
   hasDataValidation = false,
@@ -111,19 +112,19 @@ export const OptionsMenu = observer(function OptionsMenu({
           </>
         )}
 
-        {isSharedQuestion && (
+        {isBankLinked && (
           <>
             <MenuDivider />
-            <MenuItem color={"text.primary"} onClick={onOpenSharedQuestion}>
+            <MenuItem color={"text.primary"} onClick={onOpenBankQuestion}>
               <HStack spacing={2} fontSize={"sm"}>
                 <BookOpen />
-                <Text as={"span"}>{t("requirementsLibrary.sharedQuestions.openInQuestionBank")}</Text>
+                <Text as={"span"}>{t("requirementsLibrary.bankQuestions.openInQuestionBank")}</Text>
               </HStack>
             </MenuItem>
-            <MenuItem color={"text.primary"} onClick={onDetachSharedQuestion}>
+            <MenuItem color={"text.primary"} onClick={onDetachBankQuestion}>
               <HStack spacing={2} fontSize={"sm"}>
                 <LinkBreak />
-                <Text as={"span"}>{t("requirementsLibrary.sharedQuestions.detach")}</Text>
+                <Text as={"span"}>{t("requirementsLibrary.bankQuestions.detach")}</Text>
               </HStack>
             </MenuItem>
           </>

--- a/app/frontend/components/domains/requirements-library/requirement-field-edit/types.ts
+++ b/app/frontend/components/domains/requirements-library/requirement-field-edit/types.ts
@@ -18,7 +18,8 @@ export type TIsMultipleFilesCheckboxProps<TFieldValues extends FieldValues> = IC
 
 export type TEditableRichTextProps<TFieldValues extends FieldValues> = IControlProps<TFieldValues> & {
   defaultValue?: string | null
-  usesSharedQuestion?: boolean
+  // Placement is linked to a bank question (derive from requirementQuestionId in callers).
+  usesBankQuestion?: boolean
   isQuestionBankDefault?: boolean
 }
 

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/field-controls-header.tsx
@@ -18,9 +18,9 @@ interface IProps {
   requirementType: ERequirementType
   requirementCode: string
   onRemove: IRequirementOptionsMenu["onRemove"]
-  onDetachSharedQuestion?: IRequirementOptionsMenu["onDetachSharedQuestion"]
-  onOpenSharedQuestion?: IRequirementOptionsMenu["onOpenSharedQuestion"]
-  isSharedQuestion?: boolean
+  onDetachBankQuestion?: IRequirementOptionsMenu["onDetachBankQuestion"]
+  onOpenBankQuestion?: IRequirementOptionsMenu["onOpenBankQuestion"]
+  isBankLinked?: boolean
   disabledMenuOptions?: IRequirementOptionsMenu["disabledOptions"]
   hideConditional?: boolean
   hidePlacementConfiguration?: boolean
@@ -43,9 +43,9 @@ export function FieldControlsHeader({
   computedCompliance,
   dataValidation,
   onRemove,
-  onDetachSharedQuestion,
-  onOpenSharedQuestion,
-  isSharedQuestion = false,
+  onDetachBankQuestion,
+  onOpenBankQuestion,
+  isBankLinked = false,
   index,
   requirementCode,
 }: IProps) {
@@ -61,7 +61,7 @@ export function FieldControlsHeader({
       {/* Keep stale configuration removable even when field removal and conditionals are protected. */}
       {isRequirementInEditMode &&
         !hidePlacementConfiguration &&
-        (isSharedQuestion ||
+        (isBankLinked ||
           !(
             disabledMenuOptions.includes("remove") &&
             disabledMenuOptions.includes("conditional") &&
@@ -73,9 +73,9 @@ export function FieldControlsHeader({
               size: "sm",
             }}
             onRemove={onRemove}
-            onDetachSharedQuestion={onDetachSharedQuestion}
-            onOpenSharedQuestion={onOpenSharedQuestion}
-            isSharedQuestion={isSharedQuestion}
+            onDetachBankQuestion={onDetachBankQuestion}
+            onOpenBankQuestion={onOpenBankQuestion}
+            isBankLinked={isBankLinked}
             disabledOptions={disabledMenuOptions}
             hideConditional={hideConditional}
             hidePlacementConfiguration={hidePlacementConfiguration}

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/fields-setup.tsx
@@ -67,7 +67,7 @@ export const FieldsSetup = observer(function FieldsSetup({
     setRequirementIdToEdit((pastRequirementId) => (pastRequirementId === requirementId ? undefined : requirementId))
   }
 
-  const { onUseRequirement, onUseSharedQuestion, onRemoveRequirement, disabledRequirementTypeOptions } =
+  const { onUseRequirement, onUseBankQuestion, onRemoveRequirement, disabledRequirementTypeOptions } =
     useRequirementLogic({
       append,
       remove,
@@ -80,7 +80,7 @@ export const FieldsSetup = observer(function FieldsSetup({
   const linkedQuestionIds = useMemo(
     () =>
       (watchedRequirements as IRequirementAttributes[] | undefined)
-        ?.filter((requirement) => requirement.usesSharedQuestion && requirement.requirementQuestionId)
+        ?.filter((requirement) => requirement.requirementQuestionId)
         .map((requirement) => requirement.requirementQuestionId as string) ?? [],
     [watchedRequirements]
   )
@@ -95,9 +95,9 @@ export const FieldsSetup = observer(function FieldsSetup({
         leftIcon={<Plus size={12} />}
         variant={"primary"}
         onClick={onOpenAddQuestions}
-        aria-label={t("requirementsLibrary.sharedQuestions.addQuestion")}
+        aria-label={t("requirementsLibrary.bankQuestions.addQuestion")}
       >
-        {t("requirementsLibrary.sharedQuestions.addQuestion")}
+        {t("requirementsLibrary.bankQuestions.addQuestion")}
       </Button>
       <FieldsSetupDrawer
         disabledRequirementTypeOptions={disabledRequirementTypeOptions}
@@ -106,10 +106,10 @@ export const FieldsSetup = observer(function FieldsSetup({
           <Button
             leftIcon={<Plus size={12} />}
             variant={"primary"}
-            aria-label={t("requirementsLibrary.sharedQuestions.addFormField")}
+            aria-label={t("requirementsLibrary.bankQuestions.addFormField")}
             {...props}
           >
-            {t("requirementsLibrary.sharedQuestions.addFormField")}
+            {t("requirementsLibrary.bankQuestions.addFormField")}
           </Button>
         )}
       />
@@ -232,7 +232,7 @@ export const FieldsSetup = observer(function FieldsSetup({
         isOpen={isAddQuestionsOpen}
         onOpen={onOpenAddQuestions}
         onClose={onCloseAddQuestions}
-        onUse={onUseSharedQuestion}
+        onUse={onUseBankQuestion}
         disabledQuestionIds={linkedQuestionIds}
       />
     </Box>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/requirement-field-row.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/requirement-field-row.tsx
@@ -99,11 +99,12 @@ export const RequirementFieldRow = ({
   const watchedRequirementCode = watch(`requirementsAttributes.${index}.requirementCode`)
   const watchedComputedCompliance = watch(`requirementsAttributes.${index}.inputOptions.computedCompliance`)
   const watchedDataValidation = watch(`requirementsAttributes.${index}.inputOptions.dataValidation`)
-  const usesSharedQuestion = watch(`requirementsAttributes.${index}.usesSharedQuestion`)
   const requirementQuestionId = watch(`requirementsAttributes.${index}.requirementQuestionId`)
+  // Linked vs local is just the FK — no separate "shared" flag on the form.
+  const usesBankQuestion = !!requirementQuestionId
   const defaultHint = watch(`requirementsAttributes.${index}.defaultHint`)
   const defaultInstructions = watch(`requirementsAttributes.${index}.defaultInstructions`)
-  const displayedHint = usesSharedQuestion && watchedHint == null ? defaultHint : watchedHint
+  const displayedHint = usesBankQuestion && watchedHint == null ? defaultHint : watchedHint
 
   const [questionViewer, setQuestionViewer] = useState<{ id: string; key: number } | null>(null)
   // Editable inputs use defaultValue / useFieldArray local state — remount after bank sync.
@@ -117,7 +118,8 @@ export const RequirementFieldRow = ({
     disabledMenuOptions.push("remove")
   }
 
-  const handleDetachSharedQuestion = () => {
+  const handleDetachBankQuestion = () => {
+    // Copy bank defaults onto the placement, then drop the FK (local-only field).
     if (watchedHint == null) {
       setValue(`requirementsAttributes.${index}.hint`, defaultHint ?? "")
     }
@@ -125,12 +127,11 @@ export const RequirementFieldRow = ({
       setValue(`requirementsAttributes.${index}.instructions`, defaultInstructions ?? "")
     }
     setValue(`requirementsAttributes.${index}.requirementQuestionId`, null)
-    setValue(`requirementsAttributes.${index}.usesSharedQuestion`, false)
     setValue(`requirementsAttributes.${index}.defaultHint`, null)
     setValue(`requirementsAttributes.${index}.defaultInstructions`, null)
   }
 
-  const handleOpenSharedQuestion = async () => {
+  const handleOpenBankQuestion = async () => {
     if (!requirementQuestionId) return
     const question = await requirementQuestionStore.fetchRequirementQuestion(requirementQuestionId)
     if (question) {
@@ -138,7 +139,7 @@ export const RequirementFieldRow = ({
     }
   }
 
-  const handleSharedQuestionSaved = (question: IRequirementQuestion) => {
+  const handleBankQuestionSaved = (question: IRequirementQuestion) => {
     const currentOptions = getValues(`requirementsAttributes.${index}.inputOptions`) ?? {}
     setValue(`requirementsAttributes.${index}.label`, question.label)
     setValue(`requirementsAttributes.${index}.inputType`, question.inputType)
@@ -180,9 +181,9 @@ export const RequirementFieldRow = ({
       pos={"relative"}
       bg={isEditing ? "greys.grey04" : "transparent"}
     >
-      {usesSharedQuestion && (
+      {usesBankQuestion && (
         <Tag size="sm" bg="semantic.infoLight" color="text.primary" mb={2}>
-          {t("requirementsLibrary.sharedQuestions.sharedQuestion")}
+          {t("requirementsLibrary.bankQuestions.bankLinked")}
         </Tag>
       )}
       <ErrorMessage
@@ -216,13 +217,13 @@ export const RequirementFieldRow = ({
             editableHelperTextProps={{
               controlProps: { control, name: `requirementsAttributes.${index}.hint` },
               defaultValue: defaultHint,
-              usesSharedQuestion,
+              usesBankQuestion,
               isQuestionBankDefault: hidePlacementConfiguration,
             }}
             editableInstructionsTextProps={{
               controlProps: { control, name: `requirementsAttributes.${index}.instructions` },
               defaultValue: defaultInstructions,
-              usesSharedQuestion,
+              usesBankQuestion,
               isQuestionBankDefault: hidePlacementConfiguration,
             }}
             isOptionalCheckboxProps={
@@ -300,7 +301,7 @@ export const RequirementFieldRow = ({
                 : undefined
             }
             requirementCode={watchedRequirementCode}
-            lockDefinition={!!usesSharedQuestion}
+            lockDefinition={usesBankQuestion}
           />
         </Box>
       )}
@@ -335,9 +336,9 @@ export const RequirementFieldRow = ({
         isRequirementInEditMode={isEditing}
         toggleRequirementToEdit={showEditControls ? toggleEdit : undefined}
         onRemove={onRemove}
-        onDetachSharedQuestion={handleDetachSharedQuestion}
-        onOpenSharedQuestion={handleOpenSharedQuestion}
-        isSharedQuestion={!!usesSharedQuestion}
+        onDetachBankQuestion={handleDetachBankQuestion}
+        onOpenBankQuestion={handleOpenBankQuestion}
+        isBankLinked={usesBankQuestion}
         elective={watchedElective}
         conditional={hideConditional ? undefined : (watchedConditional as IFormConditional)}
         computedCompliance={hidePlacementConfiguration ? undefined : watchedComputedCompliance}
@@ -354,7 +355,7 @@ export const RequirementFieldRow = ({
           requirementQuestion={viewingQuestion}
           autoOpen
           triggerButtonProps={{ display: "none" }}
-          onSaved={handleSharedQuestionSaved}
+          onSaved={handleBankQuestionSaved}
         />
       )}
     </Box>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/use-requirement-logic.ts
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/use-requirement-logic.ts
@@ -33,7 +33,7 @@ export const useRequirementLogic = ({
 }: UseRequirementLogicProps) => {
   const { t } = useTranslation()
 
-  const onUseSharedQuestion = (question: IRequirementQuestion) => {
+  const onUseBankQuestion = (question: IRequirementQuestion) => {
     const requirementCodeAlreadyUsed = watchedRequirements?.some(
       (requirement) => requirement.requirementCode === question.requirementCode
     )
@@ -41,7 +41,6 @@ export const useRequirementLogic = ({
     append({
       id: `dummy-${uuidv4()}`,
       requirementQuestionId: question.id,
-      usesSharedQuestion: true,
       defaultHint: question.hint ?? null,
       defaultInstructions: question.instructions ?? null,
       requirementCode: requirementCodeAlreadyUsed ? `dummy-${uuidv4()}` : question.requirementCode,
@@ -216,7 +215,7 @@ export const useRequirementLogic = ({
 
   return {
     onUseRequirement,
-    onUseSharedQuestion,
+    onUseBankQuestion,
     onRemoveRequirement,
     disabledRequirementTypeOptions,
   }

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -2263,11 +2263,11 @@ Thank you,
           hasAutomatedCompliance: "Has automated compliance",
           inputNotSupported: "Input type not yet supported",
           associationsInfo: "Sections, tags, etc...",
-          sharedQuestions: {
+          bankQuestions: {
             addQuestion: "Add question",
             addFormField: "Add form field",
             addQuestionsTitle: "Add one or more questions",
-            sharedQuestion: "Question Bank",
+            bankLinked: "Question Bank",
             openInQuestionBank: "Open in Question Bank",
             detach: "Detach and edit locally",
           },

--- a/app/frontend/models/requirement-block.ts
+++ b/app/frontend/models/requirement-block.ts
@@ -70,8 +70,9 @@ export const RequirementBlockModel = types
         const { inputOptions, conditional, ...baseAttributes } = requirement
         const formAttributes = {
           ...baseAttributes,
-          hint: requirement.usesSharedQuestion ? requirement.hintOverride : requirement.hint,
-          instructions: requirement.usesSharedQuestion ? requirement.instructionsOverride : requirement.instructions,
+          // Linked placements store overrides separately; local fields use hint/instructions directly.
+          hint: requirement.requirementQuestionId ? requirement.hintOverride : requirement.hint,
+          instructions: requirement.requirementQuestionId ? requirement.instructionsOverride : requirement.instructions,
         }
 
         if (!conditional) {

--- a/app/frontend/models/requirement.ts
+++ b/app/frontend/models/requirement.ts
@@ -8,7 +8,6 @@ export const RequirementModel = types
     label: types.string,
     requirementCode: types.string,
     requirementQuestionId: types.maybeNull(types.string),
-    usesSharedQuestion: types.optional(types.boolean, false),
     hint: types.maybeNull(types.string),
     instructions: types.maybeNull(types.string),
     defaultHint: types.maybeNull(types.string),

--- a/app/frontend/stores/requirement-block-store.ts
+++ b/app/frontend/stores/requirement-block-store.ts
@@ -195,9 +195,10 @@ export const RequirementBlockStoreModel = types
       const clonedParams: IRequirementBlockParams = {
         ...copyableRequirementsAttributes,
         requirementsAttributes: requirementBlock.requirements?.map((attr) => {
-          const { id, requirementQuestionId, usesSharedQuestion, ...rest } = attr
-          if (usesSharedQuestion && requirementQuestionId) {
-            return { ...rest, requirementQuestionId, usesSharedQuestion } as unknown as IRequirementAttributes
+          const { id, requirementQuestionId, ...rest } = attr
+          // Keep the bank link on copy; local (detached) fields omit the FK.
+          if (requirementQuestionId) {
+            return { ...rest, requirementQuestionId } as unknown as IRequirementAttributes
           }
           return rest as unknown as IRequirementAttributes
         }),

--- a/app/frontend/types/api-request.ts
+++ b/app/frontend/types/api-request.ts
@@ -47,7 +47,6 @@ export interface IRequirementAttributes {
   hint?: string | null
   instructions?: string | null
   requirementQuestionId?: string | null
-  usesSharedQuestion?: boolean
   defaultHint?: string | null
   defaultInstructions?: string | null
   required?: boolean

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -226,7 +226,7 @@ class Requirement < ApplicationRecord
   end
 
   def effective_hint
-    return read_attribute(:hint) unless requirement_question.present?
+    return read_attribute(:hint) unless requirement_question
 
     if read_attribute(:hint).nil?
       requirement_question.hint
@@ -236,7 +236,7 @@ class Requirement < ApplicationRecord
   end
 
   def effective_instructions
-    return read_attribute(:instructions) unless requirement_question.present?
+    return read_attribute(:instructions) unless requirement_question
 
     if read_attribute(:instructions).nil?
       requirement_question.instructions

--- a/spec/models/requirement_spec.rb
+++ b/spec/models/requirement_spec.rb
@@ -71,9 +71,9 @@ RSpec.describe Requirement, type: :model, search: true do
       payload =
         RequirementBlueprint.render_as_hash(requirement).deep_stringify_keys
 
+      expect(payload["requirement_question_id"]).to eq(bank_question.id)
       expect(
         payload.slice(
-          "uses_shared_question",
           "default_hint",
           "default_instructions",
           "hint_override",
@@ -81,13 +81,13 @@ RSpec.describe Requirement, type: :model, search: true do
         )
       ).to eq(
         {
-          "uses_shared_question" => true,
           "default_hint" => "<p>Shared help</p>",
           "default_instructions" => "<p>Shared instructions</p>",
           "hint_override" => nil,
           "instructions_override" => "<p>Block instructions</p>"
         }
       )
+      expect(payload).not_to have_key("uses_shared_question")
     end
 
     it "does not create a requirement question when the FK is nil" do
@@ -103,7 +103,9 @@ RSpec.describe Requirement, type: :model, search: true do
       expect(requirement.effective_hint).to eq("<p>Local help</p>")
       payload =
         RequirementBlueprint.render_as_hash(requirement).deep_stringify_keys
-      expect(payload["uses_shared_question"]).to eq(false)
+      expect(payload["requirement_question_id"]).to be_nil
+      expect(payload["default_hint"]).to be_nil
+      expect(payload).not_to have_key("uses_shared_question")
     end
   end
 


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff origin/HUB-5193-super-admin-can-identify-bank-linked-fields-and-add-block-only-fields-to-the-question-bank-from-the-requirement-block-editor-question-management...HEAD` (merge-base range).

Follow-up cleanup on HUB-5193 after review: the `shared` boolean on `RequirementQuestion` was already removed, but the API/FE still carried a redundant `uses_shared_question` / `usesSharedQuestion` flag and “shared question” naming that implied a second question type. Linked vs local is solely `requirement_question_id` (detach nulls the FK). This PR drops the boolean, derives bank-link state from the FK, renames FE identifiers/i18n to bank-link language, and simplifies the requirement blueprint with `&.` / truthy association checks.

**Stacked on:** `HUB-5193-super-admin-can-identify-bank-linked-fields-and-add-block-only-fields-to-the-question-bank-from-the-requirement-block-editor-question-management`.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5193](https://hous-bssb.atlassian.net/browse/HUB-5193) |
| 📄 Related PR(s) | <!-- HUB-5193 parent PR --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Remove `uses_shared_question` from `RequirementBlueprint` (was identical to `requirement_question_id.present?`)
- Serialize bank defaults/overrides with `requirement_question&.…` / truthy association checks
- Drop `usesSharedQuestion` from MST, form attrs, and API types; derive `usesBankQuestion` from `!!requirementQuestionId`
- Rename FE shared handlers/props (`isBankLinked`, `onDetachBankQuestion`, `onOpenBankQuestion`, `onUseBankQuestion`)
- i18n: `sharedQuestions` → `bankQuestions` (tag key `bankLinked`)
- Specs assert `requirement_question_id` + defaults and that `uses_shared_question` is absent

---

## 🧪 Steps to QA

1. Sign in as a **super admin**.
2. Open a **requirement block** that includes a question-bank-linked field (Question Bank tag).
3. Confirm help/instructions still show bank defaults when unset, and block-level overrides still work.
4. Use **Open in Question Bank** → modal opens for that question; save a label/default change and confirm the block field updates.
5. Use **Detach and edit locally** → tag disappears; field remains editable with copied text; saving the block keeps it local (no bank link).
6. **Add question** from the bank into a block → new field is tagged and linked; definition fields stay locked.
7. **Add form field** (

[HUB-5193]: https://hous-bssb.atlassian.net/browse/HUB-5193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ