### PR TITLE
Hub 5202 submitter edit draft permit application digital seal validation make warning more user friendly in permit application

### DIFF
--- a/app/controllers/api/digital_seal_validator_controller.rb
+++ b/app/controllers/api/digital_seal_validator_controller.rb
@@ -1,9 +1,4 @@
 class Api::DigitalSealValidatorController < Api::ApplicationController
-  APPROVED_DIGITAL_SEAL_ORGANIZATION_PATTERNS = [
-    /\bAIBC\b|Architectural Institute of British Columbia/i,
-    /\bEGBC\b|Engineers and Geoscientists(?:\s+of)?\s+British Columbia/i
-  ].freeze
-
   def create
     authorize :digital_seal_validator, :create?
     file = digital_seal_validator_params[:file]
@@ -19,7 +14,7 @@ class Api::DigitalSealValidatorController < Api::ApplicationController
         file.content_type
       )
 
-    approved_signatures = approved_digital_seal_signatures(response.signatures)
+    approved_signatures = DigitalSealSignatureFilter.call(response.signatures)
     render json: {
              status: approved_signatures.any? ? "found" : "notFound",
              signatures: approved_signatures
@@ -30,22 +25,6 @@ class Api::DigitalSealValidatorController < Api::ApplicationController
   end
 
   private
-
-  def approved_digital_seal_signatures(signatures)
-    Array(signatures).select do |signature|
-      approved_digital_seal_organization?(signature)
-    end
-  end
-
-  def approved_digital_seal_organization?(signature)
-    subject_name =
-      signature.dig("signerStatus", "certificateInfo", "subjectName") ||
-        signature.dig(:signerStatus, :certificateInfo, :subjectName)
-
-    APPROVED_DIGITAL_SEAL_ORGANIZATION_PATTERNS.any? do |pattern|
-      subject_name.to_s.match?(pattern)
-    end
-  end
 
   def digital_seal_validator_params
     params.permit(:file)

--- a/app/frontend/components/shared/chefs/index.tsx
+++ b/app/frontend/components/shared/chefs/index.tsx
@@ -71,28 +71,37 @@ Templates.current = {
                   )
 
             if (currentFileMessages.length > 0) {
-              showWarning = currentFileMessages.some((fileMessage) => fileMessage.error)
+              showWarning = currentFileMessages.some((fileMessage) => fileMessage.error || !fileMessage.signers?.length)
 
-              // Build enhanced list format
+              const contactEmail = t("site.contactEmail")
+              const systemFailureBody = t("projectReadinessTools.digitalSealValidator.systemFailureMessage", {
+                email: contactEmail,
+              })
+                .replace("<1>", `<a href="mailto:${contactEmail}">`)
+                .replace("</1>", "</a>")
+              const signedAtLabel = t("projectReadinessTools.digitalSealValidator.signedAt")
+
+              // Keep existing tooltip layout; only align copy with the standalone tool.
               const fileItems = currentFileMessages
                 .map((fileMessage) => {
                   const hasError = fileMessage.error
                   const fileName = fileMessage.filename || "File"
+                  const hasSigners = fileMessage.signers && fileMessage.signers.length > 0
 
                   if (hasError) {
                     return `
                       <div class="compliance-file-item compliance-file-error">
-                        <div class="compliance-file-name">• ${fileName}</div>
-                        <div class="compliance-file-error-message">${fileMessage.message}</div>
+                        <div class="compliance-file-name">• ${fileName} — ${t("projectReadinessTools.digitalSealValidator.systemFailureTitle")}</div>
+                        <div class="compliance-file-error-message">${systemFailureBody}</div>
                       </div>
                     `
-                  } else if (fileMessage.signers && fileMessage.signers.length > 0) {
+                  } else if (hasSigners) {
                     const signersHtml = fileMessage.signers
                       .map(
                         (signer) => `
                         <div class="compliance-signer">
                           <div class="compliance-signer-name">✓ ${signer.name}${signer.organization ? ` (${signer.organization})` : ""}</div>
-                          <div class="compliance-signer-date">Signed: ${signer.date}</div>
+                          <div class="compliance-signer-date">${signedAtLabel} ${signer.date}</div>
                         </div>
                       `
                       )
@@ -100,14 +109,14 @@ Templates.current = {
 
                     return `
                       <div class="compliance-file-item">
-                        <div class="compliance-file-name">• ${fileName}</div>
+                        <div class="compliance-file-name">• ${fileName} — ${t("projectReadinessTools.digitalSealValidator.foundTitle")}</div>
                         ${signersHtml}
                       </div>
                     `
                   } else {
                     return `
                       <div class="compliance-file-item">
-                        <div class="compliance-file-name">• ${fileName}</div>
+                        <div class="compliance-file-name">• ${fileName} — ${t("projectReadinessTools.digitalSealValidator.notFoundTitle")}</div>
                         <div class="compliance-file-message">${t("projectReadinessTools.digitalSealValidator.noSignaturesFound")}</div>
                       </div>
                     `
@@ -117,7 +126,11 @@ Templates.current = {
 
               computedComplianceHtml = `
                 <div class="compliance-digital-signatures">
-                  <div class="compliance-section-title"><i class="ph-fill ph-lightning-a"></i>${t("projectReadinessTools.digitalSealValidator.digitalSignaturesDetected")}:</div>
+                  <div class="compliance-section-title"><i class="ph-fill ph-lightning-a"></i>${
+                    showWarning
+                      ? t("projectReadinessTools.digitalSealValidator.notFoundTitle")
+                      : t("projectReadinessTools.digitalSealValidator.foundTitle")
+                  }</div>
                   ${fileItems}
                 </div>
               `

--- a/app/frontend/components/shared/chefs/styles.scss
+++ b/app/frontend/components/shared/chefs/styles.scss
@@ -583,12 +583,19 @@
           font-size: var(--chakra-fontSizes-xs);
           color: $bcgov-font;
           font-style: italic;
+          line-height: 1.4;
         }
 
         .compliance-file-error-message {
           margin-left: 16px;
           font-size: var(--chakra-fontSizes-xs);
           color: $bcgov-font;
+          line-height: 1.4;
+
+          a {
+            color: $bcgov-link;
+            text-decoration: underline;
+          }
         }
 
         &.compliance-file-error {

--- a/app/services/automated_compliance/sub_process/doc_digital_seal_validator.rb
+++ b/app/services/automated_compliance/sub_process/doc_digital_seal_validator.rb
@@ -10,12 +10,14 @@ class AutomatedCompliance::SubProcess::DocDigitalSealValidator < AutomatedCompli
           uploaded_file.download,
           uploaded_file.mime_type
         )
-      if response.success
+      # Match standalone tool: UNSIGNED / no approved seals => empty success result (not found),
+      # not a system failure. Filter to AIBC/EGBC the same way as the standalone API.
+      if response.success || response.error.to_s == "UNSIGNED"
         return(
           supporting_document.update(
             compliance_data: {
               status: "success",
-              result: response.signatures
+              result: DigitalSealSignatureFilter.call(response.signatures)
             }
           )
         )

--- a/app/services/digital_seal_signature_filter.rb
+++ b/app/services/digital_seal_signature_filter.rb
@@ -1,0 +1,20 @@
+class DigitalSealSignatureFilter
+  APPROVED_ORGANIZATION_PATTERNS = [
+    /\bAIBC\b|Architectural Institute of British Columbia/i,
+    /\bEGBC\b|Engineers and Geoscientists(?:\s+of)?\s+British Columbia/i
+  ].freeze
+
+  def self.call(signatures)
+    Array(signatures).select { |signature| approved?(signature) }
+  end
+
+  def self.approved?(signature)
+    subject_name =
+      signature.dig("signerStatus", "certificateInfo", "subjectName") ||
+        signature.dig(:signerStatus, :certificateInfo, :subjectName)
+
+    APPROVED_ORGANIZATION_PATTERNS.any? do |pattern|
+      subject_name.to_s.match?(pattern)
+    end
+  end
+end

--- a/spec/services/automated_compliance/sub_process/doc_digital_seal_validator_spec.rb
+++ b/spec/services/automated_compliance/sub_process/doc_digital_seal_validator_spec.rb
@@ -9,6 +9,25 @@ RSpec.describe AutomatedCompliance::SubProcess::DocDigitalSealValidator do
 
   context "document provided" do
     let(:supporting_document) { create(:supporting_document) }
+    let(:approved_signature) do
+      {
+        "signerStatus" => {
+          "certificateInfo" => {
+            "subjectName" =>
+              "CN=Signer, OU=Engineers and Geoscientists British Columbia"
+          }
+        }
+      }
+    end
+    let(:unapproved_signature) do
+      {
+        "signerStatus" => {
+          "certificateInfo" => {
+            "subjectName" => "CN=Signer, OU=Some Other Organization"
+          }
+        }
+      }
+    end
 
     context "the integration call has an error" do
       it "updates the status of the supporting document with failure" do
@@ -24,17 +43,38 @@ RSpec.describe AutomatedCompliance::SubProcess::DocDigitalSealValidator do
       end
     end
 
-    context "the integration call succeeds" do
-      it "updates the document to have successful information" do
+    context "the integration call returns UNSIGNED" do
+      it "stores an empty success result like the standalone not-found state" do
         allow_any_instance_of(Wrappers::DigitalSealValidator).to receive(
           :call
         ).and_return(
-          OpenStruct.new(success: true, signatures: [{ test: "payload" }])
+          OpenStruct.new(success: false, error: "UNSIGNED", signatures: [])
         )
         AutomatedCompliance::SubProcess::DocDigitalSealValidator.new.call(
           supporting_document
         )
         expect(supporting_document.compliance_data["status"]).to eq "success"
+        expect(supporting_document.compliance_data["result"]).to eq([])
+      end
+    end
+
+    context "the integration call succeeds" do
+      it "stores only approved organization signatures" do
+        allow_any_instance_of(Wrappers::DigitalSealValidator).to receive(
+          :call
+        ).and_return(
+          OpenStruct.new(
+            success: true,
+            signatures: [approved_signature, unapproved_signature]
+          )
+        )
+        AutomatedCompliance::SubProcess::DocDigitalSealValidator.new.call(
+          supporting_document
+        )
+        expect(supporting_document.compliance_data["status"]).to eq "success"
+        expect(supporting_document.compliance_data["result"]).to eq(
+          [approved_signature]
+        )
       end
     end
   end

--- a/spec/services/digital_seal_signature_filter_spec.rb
+++ b/spec/services/digital_seal_signature_filter_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe DigitalSealSignatureFilter do
+  let(:approved_signature) do
+    {
+      "signerStatus" => {
+        "certificateInfo" => {
+          "subjectName" =>
+            "CN=Signer, OU=Engineers and Geoscientists British Columbia"
+        }
+      }
+    }
+  end
+  let(:aibc_signature) do
+    {
+      "signerStatus" => {
+        "certificateInfo" => {
+          "subjectName" => "CN=Architect, OU=AIBC"
+        }
+      }
+    }
+  end
+  let(:unapproved_signature) do
+    {
+      "signerStatus" => {
+        "certificateInfo" => {
+          "subjectName" => "CN=Signer, OU=Some Other Organization"
+        }
+      }
+    }
+  end
+
+  it "keeps AIBC and EGBC signatures" do
+    expect(
+      described_class.call(
+        [approved_signature, aibc_signature, unapproved_signature]
+      )
+    ).to eq([approved_signature, aibc_signature])
+  end
+
+  it "returns an empty array when there are no approved signatures" do
+    expect(described_class.call([unapproved_signature])).to eq([])
+  end
+
+  it "handles nil signatures" do
+    expect(described_class.call(nil)).to eq([])
+  end
+end


### PR DESCRIPTION
## 📋 Description

Permit application digital seal validation showed different messaging than the standalone “Check digital seals” tool for the same PDF. In-app validation stored all Consigno signatures and treated `UNSIGNED` responses as system failures, while the standalone tool filtered to AIBC/EGBC organizations and treated unsigned documents as “not found.”

This PR aligns backend classification and frontend tooltip copy with the standalone tool, without changing the existing tooltip layout.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5202](https://yourorg.atlassian.net/browse/HUB-5202) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                        |
| 📑 Design / Figma    | <!-- Paste link -->                                        |
| 📚 Documentation     | <!-- Paste link -->                                        |

---

## ✨ Features / Changes Introduced

- Extract shared `DigitalSealSignatureFilter` for AIBC/EGBC signature filtering, used by both the standalone API and in-app compliance validation
- Treat Consigno `UNSIGNED` responses as success with an empty result (not found), not a system failure
- Filter stored compliance signatures to approved organizations in `DocDigitalSealValidator`, matching standalone behavior
- Update permit application digital seal tooltip copy to use the same i18n keys as the standalone tool (`foundTitle`, `notFoundTitle`, `systemFailureTitle`, etc.)
- Show per-file status in the tooltip (found / not found / system failure) and use a section title that reflects whether any file has a problem
- Add specs for `DigitalSealSignatureFilter` and expanded `DocDigitalSealValidator` cases (UNSIGNED, org filtering)

---

## 🧪 Steps to QA

1. Log in as a submitter and open a draft permit application with a requirement field that accepts digitally sealed PDFs.
2. Upload a PDF with a valid AIBC or EGBC digital seal, save the application, and wait for compliance validation to complete.
3. Hover the digital seal compliance indicator on that field and confirm the tooltip shows **“Digital seal found”** with signer name, organization, and signed date.
4. Upload a PDF with no approved digital seal (or unsigned), save, and confirm the tooltip shows **“Digital seal not found”** with the standalone tool’s “no signatures found” message — not a generic system error.
5. In the same session, open **Project Readiness Tools → Check digital seals** (`/project-readiness-tools/check-digital-seals`) and upload the same PDFs; confirm titles and body copy match the permit application tooltip.
6. On a multi-file requirement field, upload two PDFs (one with a seal, one without), save, and confirm the tooltip lists each file separately with the correct per-file status.

**Expected Behaviour:**

- In-app digital seal messaging matches the standalone tool for the same document.
- Unsigned or non-AIBC/EGBC signatures show “not found,” not “We could not check the digital seal.”
- Real Consigno/integration failures still show the system failure message with a contact email link.
- Multi-file fields show one row per file.

**Before this change:**

- Same unsigned PDF could show a system failure in the permit application while the standalone tool showed “not found.”
- Tooltip copy differed from the standalone tool.

**After this change:**

- Classification and user-facing copy are aligned between permit application tooltips and the standalone validator.

---

## ♿ UI Accessibility Checklist

> Copy and messaging changes only; tooltip structure unchanged.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [x] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5202]: https://hous-bssb.atlassian.net/browse/HUB-5202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ