### PR TITLE
Hub 5399 restore on question bank

### DIFF
--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -432,6 +432,22 @@ class Api::TemplateVersionsController < Api::ApplicationController
     end
   end
 
+  def restore_layout
+    authorize @template_version, :restore_layout?
+
+    begin
+      RequirementTemplateStructureRestoreService.new(@template_version).call!
+      render_requirement_template_success(
+        "requirement_template.restore_layout_success"
+      )
+    rescue RequirementTemplateStructureRestoreError => e
+      render_error "requirement_template.restore_layout_error",
+                   message_opts: {
+                     error_message: e.message
+                   }
+    end
+  end
+
   def share_draft
     authorize @template_version, :update?
 

--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -448,6 +448,27 @@ class Api::TemplateVersionsController < Api::ApplicationController
     end
   end
 
+  def restore_requirement_block
+    authorize @template_version, :restore_requirement_block?
+
+    begin
+      block =
+        RequirementBlockSnapshotRestoreService.new(
+          @template_version,
+          restore_requirement_block_params[:requirement_block_id]
+        ).call!
+
+      render_success block,
+                     "requirement_template.restore_requirement_block_success",
+                     { blueprint: RequirementBlockBlueprint }
+    rescue RequirementBlockSnapshotRestoreError => e
+      render_error "requirement_template.restore_requirement_block_error",
+                   message_opts: {
+                     error_message: e.message
+                   }
+    end
+  end
+
   def share_draft
     authorize @template_version, :update?
 
@@ -637,6 +658,10 @@ class Api::TemplateVersionsController < Api::ApplicationController
       notified_jurisdiction_ids: [],
       promote_block_ids: []
     )
+  end
+
+  def restore_requirement_block_params
+    params.permit(:requirement_block_id)
   end
 
   def render_requirement_template_success(message_key)

--- a/app/controllers/api/template_versions_controller.rb
+++ b/app/controllers/api/template_versions_controller.rb
@@ -461,11 +461,10 @@ class Api::TemplateVersionsController < Api::ApplicationController
       render_success block,
                      "requirement_template.restore_requirement_block_success",
                      { blueprint: RequirementBlockBlueprint }
-    rescue RequirementBlockSnapshotRestoreError => e
+    rescue RequirementBlockSnapshotRestoreError, StandardError => e
       render_error "requirement_template.restore_requirement_block_error",
-                   message_opts: {
-                     error_message: e.message
-                   }
+                   { message_opts: { error_message: e.message } },
+                   e
     end
   end
 

--- a/app/errors/requirement_block_snapshot_restore_error.rb
+++ b/app/errors/requirement_block_snapshot_restore_error.rb
@@ -1,0 +1,2 @@
+class RequirementBlockSnapshotRestoreError < StandardError
+end

--- a/app/errors/requirement_template_structure_restore_error.rb
+++ b/app/errors/requirement_template_structure_restore_error.rb
@@ -1,0 +1,2 @@
+class RequirementTemplateStructureRestoreError < StandardError
+end

--- a/app/frontend/components/domains/requirement-template/screens/template-version-actions-menu.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-actions-menu.tsx
@@ -1,0 +1,128 @@
+import { Button, Menu, MenuButton, MenuItem, MenuList, Text } from "@chakra-ui/react"
+import { CaretDown } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React, { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { useNavigate } from "react-router-dom"
+import { IRequirementTemplate } from "../../../../models/requirement-template"
+import { ITemplateVersion } from "../../../../models/template-version"
+import { useMst } from "../../../../setup/root"
+import { ConfirmationModal } from "../../../shared/confirmation-modal"
+import { ConfirmationModal as PromptConfirmationModal } from "../../../shared/modals/confirmation-modal"
+import { PublishScheduleModal } from "../publish-schedule-modal"
+
+interface IProps {
+  templateVersion: ITemplateVersion
+  requirementTemplate?: IRequirementTemplate
+  showSchedulePublish: boolean
+  showDiscard: boolean
+  scheduledConflicts: Array<{ id: string; versionDate: Date }>
+  onScheduleConfirm: (scheduleDate: Date) => Promise<void>
+  onForcePublishNow?: () => Promise<void>
+  onSaveAndValidate: () => Promise<any[]>
+}
+
+export const TemplateVersionActionsMenu = observer(function TemplateVersionActionsMenu({
+  templateVersion,
+  requirementTemplate,
+  showSchedulePublish,
+  showDiscard,
+  scheduledConflicts,
+  onScheduleConfirm,
+  onForcePublishNow,
+  onSaveAndValidate,
+}: IProps) {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { requirementTemplateStore } = useMst()
+  const [isDiscardingDraft, setIsDiscardingDraft] = useState(false)
+  const [isRestoringLayout, setIsRestoringLayout] = useState(false)
+
+  const requirementTemplateId = templateVersion.requirementTemplateId
+
+  const handleDiscardDraft = async (closeModal: () => void) => {
+    if (!requirementTemplateId) return
+    setIsDiscardingDraft(true)
+    try {
+      const updated = await requirementTemplateStore.discardDraft(templateVersion.id)
+      if (updated) {
+        closeModal()
+        navigate(`/requirement-templates/${requirementTemplateId}/edit`)
+      }
+    } finally {
+      setIsDiscardingDraft(false)
+    }
+  }
+
+  const handleRestoreLayout = async () => {
+    if (!requirementTemplateId) return
+    setIsRestoringLayout(true)
+    try {
+      const updated = await requirementTemplateStore.restoreLayout(templateVersion.id)
+      if (updated) {
+        navigate(`/requirement-templates/${requirementTemplateId}/edit`)
+      }
+    } finally {
+      setIsRestoringLayout(false)
+    }
+  }
+
+  return (
+    <Menu>
+      <MenuButton
+        as={Button}
+        variant="secondary"
+        rightIcon={<CaretDown />}
+        isLoading={isRestoringLayout || isDiscardingDraft}
+      >
+        {t("templateVersionPreview.actions.menuLabel")}
+      </MenuButton>
+      <MenuList>
+        {showSchedulePublish && requirementTemplate && (
+          <PublishScheduleModal
+            requirementTemplate={requirementTemplate}
+            minDate={requirementTemplate.nextAvailableScheduleDate}
+            scheduledConflicts={scheduledConflicts}
+            onScheduleConfirm={onScheduleConfirm}
+            onForcePublishNow={onForcePublishNow}
+            onSaveAndValidate={onSaveAndValidate}
+            translationNamespace="templateVersionPreview.schedulePublish"
+            triggerLabel={t("templateVersionPreview.schedulePublish.triggerButton")}
+            hideManageAccessButton
+            renderTrigger={(onOpen) => (
+              <MenuItem onClick={onOpen}>{t("templateVersionPreview.schedulePublish.triggerButton")}</MenuItem>
+            )}
+          />
+        )}
+        {requirementTemplateId && (
+          <PromptConfirmationModal
+            promptHeader={t("templateVersionPreview.restoreLayout.confirmTitle")}
+            promptMessage={<Text whiteSpace="pre-line">{t("templateVersionPreview.restoreLayout.confirmBody")}</Text>}
+            confirmText={t("templateVersionPreview.restoreLayout.confirmButton")}
+            onConfirm={handleRestoreLayout}
+            renderTrigger={(onOpen) => (
+              <MenuItem onClick={onOpen}>{t("templateVersionPreview.restoreLayout.triggerButton")}</MenuItem>
+            )}
+          />
+        )}
+        {showDiscard && (
+          <ConfirmationModal
+            title={t("templateVersionPreview.discardDraft.title")}
+            body={t("templateVersionPreview.discardDraft.body")}
+            onConfirm={handleDiscardDraft}
+            renderTriggerButton={(props) => (
+              <MenuItem {...props} color="semantic.error">
+                {t("templateVersionPreview.discardDraft.triggerButton")}
+              </MenuItem>
+            )}
+            renderConfirmationButton={(props) => (
+              <Button {...props} colorScheme="red" isLoading={isDiscardingDraft}>
+                {t("templateVersionPreview.discardDraft.confirmButton")}
+              </Button>
+            )}
+          />
+        )}
+      </MenuList>
+    </Menu>
+  )
+})

--- a/app/frontend/components/domains/requirement-template/screens/template-version-block-actions-menu.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-block-actions-menu.tsx
@@ -1,0 +1,68 @@
+import { Button, Menu, MenuButton, MenuItem, MenuList, Text } from "@chakra-ui/react"
+import { CaretDown } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React, { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Link as RouterLink } from "react-router-dom"
+import { useMst } from "../../../../setup/root"
+import { ConfirmationModal } from "../../../shared/modals/confirmation-modal"
+
+interface IProps {
+  templateVersionId: string
+  requirementTemplateId: string
+  requirementBlockId: string
+}
+
+export const TemplateVersionBlockActionsMenu = observer(function TemplateVersionBlockActionsMenu({
+  templateVersionId,
+  requirementTemplateId,
+  requirementBlockId,
+}: IProps) {
+  const { t } = useTranslation()
+  const { requirementTemplateStore } = useMst()
+  const [isRestoring, setIsRestoring] = useState(false)
+
+  const editPath = `/requirement-templates/${requirementTemplateId}/edit?openRequirementBlockId=${requirementBlockId}`
+
+  const handleRestore = async () => {
+    setIsRestoring(true)
+    try {
+      await requirementTemplateStore.restoreRequirementBlockFromVersion(templateVersionId, requirementBlockId)
+    } finally {
+      setIsRestoring(false)
+    }
+  }
+
+  return (
+    <Menu>
+      <MenuButton
+        as={Button}
+        variant="link"
+        color="text.primary"
+        textDecoration="none"
+        _hover={{ textDecoration: "underline" }}
+        rightIcon={<CaretDown />}
+        onClick={(e) => e.stopPropagation()}
+        isLoading={isRestoring}
+      >
+        {t("templateVersionPreview.blockActions.menuLabel")}
+      </MenuButton>
+      <MenuList onClick={(e) => e.stopPropagation()}>
+        <MenuItem as={RouterLink} to={editPath} target="_blank" rel="noopener noreferrer">
+          {t("templateVersionPreview.blockActions.editSourceBlock")}
+        </MenuItem>
+        <ConfirmationModal
+          promptHeader={t("templateVersionPreview.blockActions.restoreConfirmTitle")}
+          promptMessage={
+            <Text whiteSpace="pre-line">{t("templateVersionPreview.blockActions.restoreConfirmBody")}</Text>
+          }
+          confirmText={t("templateVersionPreview.blockActions.restoreConfirmButton")}
+          onConfirm={handleRestore}
+          renderTrigger={(onOpen) => (
+            <MenuItem onClick={onOpen}>{t("templateVersionPreview.blockActions.restoreSourceBlock")}</MenuItem>
+          )}
+        />
+      </MenuList>
+    </Menu>
+  )
+})

--- a/app/frontend/components/domains/requirement-template/screens/template-version-block-actions-menu.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-block-actions-menu.tsx
@@ -49,7 +49,7 @@ export const TemplateVersionBlockActionsMenu = observer(function TemplateVersion
       </MenuButton>
       <MenuList onClick={(e) => e.stopPropagation()}>
         <MenuItem as={RouterLink} to={editPath} target="_blank" rel="noopener noreferrer">
-          {t("templateVersionPreview.blockActions.editSourceBlock")}
+          {t("templateVersionPreview.openInBuilder")}
         </MenuItem>
         <ConfirmationModal
           promptHeader={t("templateVersionPreview.blockActions.restoreConfirmTitle")}

--- a/app/frontend/components/domains/requirement-template/screens/template-version-go-to-menu.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-go-to-menu.tsx
@@ -1,0 +1,41 @@
+import { Button, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react"
+import { CaretDown } from "@phosphor-icons/react"
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { useTranslation } from "react-i18next"
+import { Link as RouterLink } from "react-router-dom"
+
+interface IProps {
+  templateVersionId: string
+  requirementTemplateId?: string
+  showBuilder: boolean
+}
+
+export const TemplateVersionGoToMenu = observer(function TemplateVersionGoToMenu({
+  templateVersionId,
+  requirementTemplateId,
+  showBuilder,
+}: IProps) {
+  const { t } = useTranslation()
+
+  return (
+    <Menu>
+      <MenuButton as={Button} variant="secondary" rightIcon={<CaretDown />}>
+        {t("templateVersionPreview.goTo.menuLabel")}
+      </MenuButton>
+      <MenuList>
+        <MenuItem as={RouterLink} to={`/template-versions/${templateVersionId}/preview`}>
+          {t("templateVersionPreview.goTo.formPreview")}
+        </MenuItem>
+        {showBuilder && requirementTemplateId && (
+          <MenuItem as={RouterLink} to={`/requirement-templates/${requirementTemplateId}/edit`}>
+            {t("templateVersionPreview.goTo.builder")}
+          </MenuItem>
+        )}
+        <MenuItem as={RouterLink} to="/requirement-templates">
+          {t("templateVersionPreview.goTo.catalogue")}
+        </MenuItem>
+      </MenuList>
+    </Menu>
+  )
+})

--- a/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, FormControl, FormLabel, HStack, Switch, Text } from "@chakra-ui/react"
+import { Box, Flex, HStack } from "@chakra-ui/react"
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useMemo, useState } from "react"
@@ -10,18 +10,16 @@ import { IRequirementTemplate } from "../../../../models/requirement-template"
 import { useMst } from "../../../../setup/root"
 import { ErrorScreen } from "../../../shared/base/error-screen"
 import { LoadingScreen } from "../../../shared/base/loading-screen"
-import { ConfirmationModal } from "../../../shared/confirmation-modal"
 import { FloatingHelpDrawer } from "../../../shared/floating-help-drawer"
-import { ConfirmationModal as PromptConfirmationModal } from "../../../shared/modals/confirmation-modal"
-import { RouterLinkButton } from "../../../shared/navigation/router-link-button"
 import { BuilderBottomFloatingButtons } from "../builder-bottom-floating-buttons"
-import { PublishScheduleModal } from "../publish-schedule-modal"
 import { SectionsDisplay } from "../sections-display"
 import { SectionsSidebar } from "../sections-sidebar"
 import { SharePreviewPopover } from "../share-preview-popover"
 import { useSectionHighlight } from "../use-section-highlight"
 import { BuilderHeader } from "./base-edit-requirement-template-screen/builder-header"
+import { TemplateVersionActionsMenu } from "./template-version-actions-menu"
 import { TemplateVersionBlockActionsMenu } from "./template-version-block-actions-menu"
+import { TemplateVersionGoToMenu } from "./template-version-go-to-menu"
 
 const scrollToIdPrefix = "template-version-scroll-to-id-"
 export const formScrollToId = (id: string) => `${scrollToIdPrefix}${id}`
@@ -30,16 +28,13 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
   const { templateVersion, error } = useTemplateVersion()
   const denormalizedTemplate = templateVersion?.denormalizedTemplateJson
   const { t } = useTranslation()
-  const { userStore, templateVersionStore, requirementTemplateStore } = useMst()
+  const { userStore, requirementTemplateStore } = useMst()
   const {
     rootContainerRef: rightContainerRef,
     sectionRefs,
     sectionIdToHighlight: currentSectionId,
   } = useSectionHighlight({ sections: denormalizedTemplate?.requirementTemplateSections })
   const [isCollapsedAll, setIsCollapsedAll] = useState(false)
-  const [isDiscardingDraft, setIsDiscardingDraft] = useState(false)
-  const [isTogglingPubliclyPreviewable, setIsTogglingPubliclyPreviewable] = useState(false)
-  const [isRestoringLayout, setIsRestoringLayout] = useState(false)
   const navigate = useNavigate()
 
   const isSuperAdmin = !!userStore.currentUser?.isSuperAdmin
@@ -71,6 +66,8 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
   )
 
   const showSchedulePublishControls = isDraft && isSuperAdmin && !!requirementTemplate?.isFullyLoaded
+  // Restore layout applies to any status; Promote/Discard stay draft-only inside the menu.
+  const showActionsMenu = isSuperAdmin && !!requirementTemplateId
 
   const onSaveAndValidate = async () => {
     if (!templateVersion) return []
@@ -111,47 +108,6 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
 
   const templateSections = denormalizedTemplate?.requirementTemplateSections ?? []
   const hasNoSections = templateSections.length === 0
-
-  const onClose = () => {
-    window.history.state && window.history.state.idx > 0 ? navigate(-1) : navigate(`/requirement-templates`)
-  }
-
-  const handleTogglePubliclyPreviewable = async () => {
-    if (!templateVersion) return
-    setIsTogglingPubliclyPreviewable(true)
-    try {
-      await templateVersionStore.togglePubliclyPreviewable(templateVersion.id, !templateVersion.publiclyPreviewable)
-    } finally {
-      setIsTogglingPubliclyPreviewable(false)
-    }
-  }
-
-  const handleDiscardDraft = async (closeModal: () => void) => {
-    if (!templateVersion || !requirementTemplateId) return
-    setIsDiscardingDraft(true)
-    try {
-      const updated = await requirementTemplateStore.discardDraft(templateVersion.id)
-      if (updated) {
-        closeModal()
-        navigate(`/requirement-templates/${requirementTemplateId}/edit`)
-      }
-    } finally {
-      setIsDiscardingDraft(false)
-    }
-  }
-
-  const handleRestoreLayout = async () => {
-    if (!templateVersion || !requirementTemplateId) return
-    setIsRestoringLayout(true)
-    try {
-      const updated = await requirementTemplateStore.restoreLayout(templateVersion.id)
-      if (updated) {
-        navigate(`/requirement-templates/${requirementTemplateId}/edit`)
-      }
-    } finally {
-      setIsRestoringLayout(false)
-    }
-  }
 
   return (
     <Box as="main" id="view-template-version">
@@ -198,79 +154,26 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
             boxShadow={"elevations.elevation02"}
           >
             <HStack spacing={3}>
-              {templateVersion.isDraft && isSuperAdmin && (
-                <FormControl display="flex" alignItems="center" width="auto" mr={2}>
-                  <FormLabel htmlFor="publicly-previewable-toggle" mb="0" mr={2} fontSize="sm">
-                    {t("requirementTemplate.publiclyPreviewable.toggleLabel")}
-                  </FormLabel>
-                  <Switch
-                    id="publicly-previewable-toggle"
-                    isChecked={templateVersion.publiclyPreviewable}
-                    isDisabled={isTogglingPubliclyPreviewable}
-                    onChange={handleTogglePubliclyPreviewable}
-                  />
-                </FormControl>
-              )}
               {templateVersion.isDraft && (
                 <SharePreviewPopover draftTemplateVersion={templateVersion} variant="primary" />
               )}
-              {/* HUB-5289: Draft snapshots still cannot be repaired in place; discard and recreate after fixing the builder. */}
-              {templateVersion.isDraft && isSuperAdmin && (
-                <ConfirmationModal
-                  title={t("templateVersionPreview.discardDraft.title")}
-                  body={t("templateVersionPreview.discardDraft.body")}
-                  onConfirm={handleDiscardDraft}
-                  renderTriggerButton={(props) => (
-                    <Button {...props} variant="ghost" color="semantic.error">
-                      {t("templateVersionPreview.discardDraft.triggerButton")}
-                    </Button>
-                  )}
-                  renderConfirmationButton={(props) => (
-                    <Button {...props} colorScheme="red" isLoading={isDiscardingDraft}>
-                      {t("templateVersionPreview.discardDraft.confirmButton")}
-                    </Button>
-                  )}
-                />
-              )}
-              {showSchedulePublishControls && requirementTemplate && (
-                <PublishScheduleModal
+              {showActionsMenu && (
+                <TemplateVersionActionsMenu
+                  templateVersion={templateVersion}
                   requirementTemplate={requirementTemplate}
-                  minDate={requirementTemplate.nextAvailableScheduleDate}
+                  showSchedulePublish={showSchedulePublishControls}
+                  showDiscard={isDraft}
                   scheduledConflicts={scheduledConflicts}
                   onScheduleConfirm={onScheduleConfirm}
                   onForcePublishNow={onForcePublishNow}
                   onSaveAndValidate={onSaveAndValidate}
-                  translationNamespace="templateVersionPreview.schedulePublish"
-                  triggerLabel={t("templateVersionPreview.schedulePublish.triggerButton")}
-                  hideManageAccessButton
                 />
               )}
-              {isSuperAdmin && requirementTemplateId && (
-                <PromptConfirmationModal
-                  promptHeader={t("templateVersionPreview.restoreLayout.confirmTitle")}
-                  promptMessage={
-                    <Text whiteSpace="pre-line">{t("templateVersionPreview.restoreLayout.confirmBody")}</Text>
-                  }
-                  confirmText={t("templateVersionPreview.restoreLayout.confirmButton")}
-                  onConfirm={handleRestoreLayout}
-                  renderTrigger={(onOpen) => (
-                    <Button variant="secondary" onClick={onOpen} isLoading={isRestoringLayout}>
-                      {t("templateVersionPreview.restoreLayout.triggerButton")}
-                    </Button>
-                  )}
-                />
-              )}
-              {isSuperAdmin && requirementTemplateId && (
-                <RouterLinkButton to={`/requirement-templates/${requirementTemplateId}/edit`} variant="secondary">
-                  {t("templateVersionPreview.goToBuilder")}
-                </RouterLinkButton>
-              )}
-              <RouterLinkButton to={`/template-versions/${templateVersion.id}/preview`} variant="secondary">
-                {t("ui.previewForm")}
-              </RouterLinkButton>
-              <Button variant={"secondary"} onClick={onClose}>
-                {t("ui.close")}
-              </Button>
+              <TemplateVersionGoToMenu
+                templateVersionId={templateVersion.id}
+                requirementTemplateId={requirementTemplateId}
+                showBuilder={isSuperAdmin && !!requirementTemplateId}
+              />
             </HStack>
           </Flex>
           <FloatingHelpDrawer />
@@ -297,10 +200,6 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
       <BuilderBottomFloatingButtons isCollapsedAll={isCollapsedAll} setIsCollapsedAll={setIsCollapsedAll} />
     </Box>
   )
-
-  function scrollToTop() {
-    rightContainerRef.current?.scrollTo({ behavior: "smooth", top: 0 })
-  }
 
   function scrollIntoView(id: string) {
     const element = document.getElementById(formScrollToId(id))

--- a/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, FormControl, FormLabel, HStack, Switch } from "@chakra-ui/react"
+import { Box, Button, Flex, FormControl, FormLabel, HStack, Switch, Text } from "@chakra-ui/react"
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useMemo, useState } from "react"
@@ -12,6 +12,7 @@ import { ErrorScreen } from "../../../shared/base/error-screen"
 import { LoadingScreen } from "../../../shared/base/loading-screen"
 import { ConfirmationModal } from "../../../shared/confirmation-modal"
 import { FloatingHelpDrawer } from "../../../shared/floating-help-drawer"
+import { ConfirmationModal as PromptConfirmationModal } from "../../../shared/modals/confirmation-modal"
 import { RouterLinkButton } from "../../../shared/navigation/router-link-button"
 import { BuilderBottomFloatingButtons } from "../builder-bottom-floating-buttons"
 import { PublishScheduleModal } from "../publish-schedule-modal"
@@ -20,6 +21,7 @@ import { SectionsSidebar } from "../sections-sidebar"
 import { SharePreviewPopover } from "../share-preview-popover"
 import { useSectionHighlight } from "../use-section-highlight"
 import { BuilderHeader } from "./base-edit-requirement-template-screen/builder-header"
+import { TemplateVersionBlockActionsMenu } from "./template-version-block-actions-menu"
 
 const scrollToIdPrefix = "template-version-scroll-to-id-"
 export const formScrollToId = (id: string) => `${scrollToIdPrefix}${id}`
@@ -244,7 +246,7 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
                 />
               )}
               {isSuperAdmin && requirementTemplateId && (
-                <ConfirmationModal
+                <PromptConfirmationModal
                   promptHeader={t("templateVersionPreview.restoreLayout.confirmTitle")}
                   promptMessage={
                     <Text whiteSpace="pre-line">{t("templateVersionPreview.restoreLayout.confirmBody")}</Text>
@@ -279,20 +281,13 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
             setSectionRef={setSectionRef}
             formScrollToId={formScrollToId}
             renderEdit={
-              isSuperAdmin && requirementTemplateId
+              isSuperAdmin && requirementTemplateId && templateVersion
                 ? ({ denormalizedRequirementBlock }) => (
-                    <RouterLinkButton
-                      to={builderBlockPath(denormalizedRequirementBlock.id)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      variant="link"
-                      color="text.primary"
-                      textDecoration="none"
-                      _hover={{ textDecoration: "underline" }}
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {t("templateVersionPreview.openInBuilder")}
-                    </RouterLinkButton>
+                    <TemplateVersionBlockActionsMenu
+                      templateVersionId={templateVersion.id}
+                      requirementTemplateId={requirementTemplateId}
+                      requirementBlockId={denormalizedRequirementBlock.id}
+                    />
                   )
                 : undefined
             }
@@ -313,10 +308,6 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
     if (element) {
       element.scrollIntoView({ behavior: "smooth", block: "start" })
     }
-  }
-
-  function builderBlockPath(requirementBlockId: string) {
-    return `/requirement-templates/${requirementTemplateId}/edit?openRequirementBlockId=${requirementBlockId}`
   }
 
   function setSectionRef(el: HTMLElement, id: string) {

--- a/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-screen.tsx
@@ -37,6 +37,7 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
   const [isCollapsedAll, setIsCollapsedAll] = useState(false)
   const [isDiscardingDraft, setIsDiscardingDraft] = useState(false)
   const [isTogglingPubliclyPreviewable, setIsTogglingPubliclyPreviewable] = useState(false)
+  const [isRestoringLayout, setIsRestoringLayout] = useState(false)
   const navigate = useNavigate()
 
   const isSuperAdmin = !!userStore.currentUser?.isSuperAdmin
@@ -137,6 +138,19 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
     }
   }
 
+  const handleRestoreLayout = async () => {
+    if (!templateVersion || !requirementTemplateId) return
+    setIsRestoringLayout(true)
+    try {
+      const updated = await requirementTemplateStore.restoreLayout(templateVersion.id)
+      if (updated) {
+        navigate(`/requirement-templates/${requirementTemplateId}/edit`)
+      }
+    } finally {
+      setIsRestoringLayout(false)
+    }
+  }
+
   return (
     <Box as="main" id="view-template-version">
       <BuilderHeader
@@ -227,6 +241,21 @@ export const TemplateVersionScreen = observer(function TemplateVersionScreen() {
                   translationNamespace="templateVersionPreview.schedulePublish"
                   triggerLabel={t("templateVersionPreview.schedulePublish.triggerButton")}
                   hideManageAccessButton
+                />
+              )}
+              {isSuperAdmin && requirementTemplateId && (
+                <ConfirmationModal
+                  promptHeader={t("templateVersionPreview.restoreLayout.confirmTitle")}
+                  promptMessage={
+                    <Text whiteSpace="pre-line">{t("templateVersionPreview.restoreLayout.confirmBody")}</Text>
+                  }
+                  confirmText={t("templateVersionPreview.restoreLayout.confirmButton")}
+                  onConfirm={handleRestoreLayout}
+                  renderTrigger={(onOpen) => (
+                    <Button variant="secondary" onClick={onOpen} isLoading={isRestoringLayout}>
+                      {t("templateVersionPreview.restoreLayout.triggerButton")}
+                    </Button>
+                  )}
                 />
               )}
               {isSuperAdmin && requirementTemplateId && (

--- a/app/frontend/components/domains/requirement-template/share-preview-popover.tsx
+++ b/app/frontend/components/domains/requirement-template/share-preview-popover.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   FormControl,
   FormHelperText,
+  FormLabel,
   HStack,
   Heading,
   IconButton,
@@ -16,6 +17,7 @@ import {
   PopoverContent,
   PopoverHeader,
   PopoverTrigger,
+  Switch,
   Text,
   Textarea,
   VStack,
@@ -271,8 +273,10 @@ export const SharePreviewPopover: React.FC<ISharePreviewPopoverProps> = observer
     const { isOpen, onOpen, onClose } = useDisclosure()
     const { t } = useTranslation()
     const [isInviting, setIsInviting] = useState(false)
-    const { uiStore } = useMst()
+    const [isTogglingPubliclyPreviewable, setIsTogglingPubliclyPreviewable] = useState(false)
+    const { uiStore, userStore, templateVersionStore } = useMst()
 
+    const isSuperAdmin = !!userStore.currentUser?.isSuperAdmin
     const previews: ITemplateVersionPreview[] = (dtv.templateVersionPreviews as ITemplateVersionPreview[]) ?? []
     const previewerCount = previews.length
 
@@ -303,12 +307,23 @@ export const SharePreviewPopover: React.FC<ISharePreviewPopoverProps> = observer
       setIsInviting(false)
     }
 
+    const handleTogglePubliclyPreviewable = async () => {
+      setIsTogglingPubliclyPreviewable(true)
+      try {
+        await templateVersionStore.togglePubliclyPreviewable(dtv.id, !dtv.publiclyPreviewable)
+      } finally {
+        setIsTogglingPubliclyPreviewable(false)
+      }
+    }
+
     return (
       <Box>
         <Popover isOpen={isOpen} onClose={onClose}>
           <PopoverTrigger>
             <Button variant="link" onClick={onOpen} {...rest}>
-              {t("templateVersionPreview.sharing.sharePreviewLink", { n: previewerCount.toString() })}
+              {t("templateVersionPreview.sharing.sharePreviewLink", {
+                n: dtv.publiclyPreviewable ? "public" : previewerCount.toString(),
+              })}
             </Button>
           </PopoverTrigger>
           <PopoverContent width="lg">
@@ -353,10 +368,27 @@ export const SharePreviewPopover: React.FC<ISharePreviewPopoverProps> = observer
                     {t("templateVersionPreview.sharing.inviteToPreviewButton")}
                   </Button>
                 </Box>
-              ) : !R.isEmpty(previews) ? (
-                previews.map((preview) => <PreviewCard key={preview.id} templateVersionPreview={preview} />)
               ) : (
-                <Box color="greys.grey01">{t("templateVersionPreview.sharing.noPreviewersYet")}</Box>
+                <VStack align="stretch" spacing={3}>
+                  {isSuperAdmin && (
+                    <FormControl display="flex" alignItems="center">
+                      <FormLabel htmlFor="publicly-previewable-toggle" mb="0" mr={3} fontSize="sm" flex="1">
+                        {t("requirementTemplate.publiclyPreviewable.toggleLabel")}
+                      </FormLabel>
+                      <Switch
+                        id="publicly-previewable-toggle"
+                        isChecked={dtv.publiclyPreviewable}
+                        isDisabled={isTogglingPubliclyPreviewable}
+                        onChange={handleTogglePubliclyPreviewable}
+                      />
+                    </FormControl>
+                  )}
+                  {!R.isEmpty(previews) ? (
+                    previews.map((preview) => <PreviewCard key={preview.id} templateVersionPreview={preview} />)
+                  ) : (
+                    <Box color="greys.grey01">{t("templateVersionPreview.sharing.noPreviewersYet")}</Box>
+                  )}
+                </VStack>
               )}
             </PopoverBody>
           </PopoverContent>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4835,13 +4835,16 @@ Thank you,
           earlyAccessTitle: "Early access – submissions not yet enabled",
           earlyAccessDescription:
             "This permit is available for early access to help your team get familiar with the application process. You can view and edit your application, but submission is currently disabled. Submissions will be enabled once this permit type is officially launched in your jurisdiction.",
-          goToBuilder: "Go to builder",
-          openInBuilder: "Open in builder",
-          discardDraft: {
-            triggerButton: "Discard early access version",
-            title: "Discard this early access version?",
-            body: "This ends access to the early access snapshot and its previews. Fix the configuration in the builder, then create a new early access version.",
-            confirmButton: "Discard early access version",
+          reviseInBuilder: "Revise in builder",
+          editSourceBlock: "Edit source block",
+          immutableVersionNotice:
+            "This early access version is an immutable snapshot. To revise it, update the source template in the builder and create a new early access version. Existing preview links will continue to show this version.",
+          restoreLayout: {
+            triggerButton: "Restore layout to builder",
+            confirmTitle: "Restore layout from this version?",
+            confirmBody:
+              "This will replace the current builder layout (sections, block arrangement, and show/hide rules) with the layout from this version.\n\nIt does not rewind the wording or settings inside shared question blocks. If a block from this version is missing or archived in the library, the restore will fail.\n\nAny unsaved builder edits will be lost.",
+            confirmButton: "Restore layout",
           },
           schedulePublish: {
             triggerButton: "Promote",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4837,6 +4837,16 @@ Thank you,
             "This permit is available for early access to help your team get familiar with the application process. You can view and edit your application, but submission is currently disabled. Submissions will be enabled once this permit type is officially launched in your jurisdiction.",
           goToBuilder: "Go to builder",
           openInBuilder: "Open in builder",
+          actions: {
+            menuLabel: "Actions",
+          },
+          goTo: {
+            menuLabel: "Go to",
+            formPreview: "Form preview",
+            builder: "Builder",
+            catalogue: "Catalogue",
+          },
+
           immutableVersionNotice:
             "This early access version is an immutable snapshot. To revise it, update the source template in the builder and create a new early access version. Existing preview links will continue to show this version.",
           discardDraft: {

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4846,6 +4846,15 @@ Thank you,
               "This will replace the current builder layout (sections, block arrangement, and show/hide rules) with the layout from this version.\n\nIt does not rewind the wording or settings inside shared question blocks. If a block from this version is missing or archived in the library, the restore will fail.\n\nAny unsaved builder edits will be lost.",
             confirmButton: "Restore layout",
           },
+          blockActions: {
+            menuLabel: "Block actions",
+            editSourceBlock: "Edit source block",
+            restoreSourceBlock: "Restore source block",
+            restoreConfirmTitle: "Restore this shared block from the version?",
+            restoreConfirmBody:
+              "This overwrites the live shared requirement block in the library so it matches this version’s snapshot (name, fields, labels, required/optional, conditionals, and related settings).\n\nImportant limitations:\n• Every permit template builder that uses this block will get these restored field definitions — not only the template you are viewing.\n• Attached requirement documents / downloadable files are not restored.\n• Already-submitted applications stay on their frozen template version; this changes the library going forward.\n• If the block was archived, it will be un-archived in the library (re-adding it to a template’s layout is separate — use Restore layout if needed).\n• If the block was permanently deleted from the library, restore cannot recreate it.",
+            restoreConfirmButton: "Overwrite shared block",
+          },
           schedulePublish: {
             triggerButton: "Promote",
             scheduleModalTitle: "Promote early access version?",

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4835,10 +4835,16 @@ Thank you,
           earlyAccessTitle: "Early access – submissions not yet enabled",
           earlyAccessDescription:
             "This permit is available for early access to help your team get familiar with the application process. You can view and edit your application, but submission is currently disabled. Submissions will be enabled once this permit type is officially launched in your jurisdiction.",
-          reviseInBuilder: "Revise in builder",
-          editSourceBlock: "Edit source block",
+          goToBuilder: "Go to builder",
+          openInBuilder: "Open in builder",
           immutableVersionNotice:
             "This early access version is an immutable snapshot. To revise it, update the source template in the builder and create a new early access version. Existing preview links will continue to show this version.",
+          discardDraft: {
+            triggerButton: "Discard",
+            title: "Discard early access version?",
+            body: "This will permanently discard this early access version. Previewers will lose access. This cannot be undone.",
+            confirmButton: "Discard",
+          },
           restoreLayout: {
             triggerButton: "Restore layout to builder",
             confirmTitle: "Restore layout from this version?",
@@ -4848,11 +4854,10 @@ Thank you,
           },
           blockActions: {
             menuLabel: "Block actions",
-            editSourceBlock: "Edit source block",
             restoreSourceBlock: "Restore source block",
             restoreConfirmTitle: "Restore this shared block from the version?",
             restoreConfirmBody:
-              "This overwrites the live shared requirement block in the library so it matches this version’s snapshot (name, fields, labels, required/optional, conditionals, and related settings).\n\nImportant limitations:\n• Every permit template builder that uses this block will get these restored field definitions — not only the template you are viewing.\n• Attached requirement documents / downloadable files are not restored.\n• Already-submitted applications stay on their frozen template version; this changes the library going forward.\n• If the block was archived, it will be un-archived in the library (re-adding it to a template’s layout is separate — use Restore layout if needed).\n• If the block was permanently deleted from the library, restore cannot recreate it.",
+              "This overwrites the live shared requirement block in the library so it matches this version’s snapshot (field arrangement, required/optional, conditionals, and related placement settings).\n\nImportant limitations:\n• Every permit template that uses this block will get these restored placements — not only the template you are viewing.\n• Question bank definitions are not rewritten. Bank-linked fields keep following the live question bank wording unless this version stored a placement-specific hint/instructions override.\n• If a linked bank question no longer exists (or is archived), that field is restored as block-only using the wording frozen in this version.\n• Attached requirement documents / downloadable files are not restored.\n• Already-submitted applications stay on their frozen template version; this changes the library going forward.\n• If the block was archived, it will be un-archived in the library (re-adding it to a template’s layout is separate — use Restore layout if needed).\n• If the block was permanently deleted from the library, restore cannot recreate it.",
             restoreConfirmButton: "Overwrite shared block",
           },
           schedulePublish: {

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -1005,6 +1005,13 @@ export class Api {
     return this.client.post<ApiResponse<IRequirementTemplate>>(`/template_versions/${templateVersionId}/restore_layout`)
   }
 
+  async restoreRequirementBlockFromVersion(templateVersionId: string, requirementBlockId: string) {
+    return this.client.post<IRequirementBlockResponse>(
+      `/template_versions/${templateVersionId}/restore_requirement_block`,
+      { requirementBlockId }
+    )
+  }
+
   async shareDraft(templateVersionId: string) {
     return this.client.post<ApiResponse<ITemplateVersion>>(`/template_versions/${templateVersionId}/share_draft`)
   }

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -1001,6 +1001,10 @@ export class Api {
     return this.client.post<ApiResponse<ITemplateVersion>>(`/template_versions/${templateVersionId}/refresh_draft`)
   }
 
+  async restoreTemplateLayout(templateVersionId: string) {
+    return this.client.post<ApiResponse<IRequirementTemplate>>(`/template_versions/${templateVersionId}/restore_layout`)
+  }
+
   async shareDraft(templateVersionId: string) {
     return this.client.post<ApiResponse<ITemplateVersion>>(`/template_versions/${templateVersionId}/share_draft`)
   }

--- a/app/frontend/stores/requirement-template-store.ts
+++ b/app/frontend/stores/requirement-template-store.ts
@@ -305,6 +305,19 @@ export const RequirementTemplateStoreModel = types
 
       return false
     }),
+
+    restoreRequirementBlockFromVersion: flow(function* (templateVersionId: string, requirementBlockId: string) {
+      const response = yield* toGenerator(
+        self.environment.api.restoreRequirementBlockFromVersion(templateVersionId, requirementBlockId)
+      )
+
+      if (response.ok) {
+        self.rootStore.requirementBlockStore.mergeUpdate(response.data.data, "requirementBlockMap")
+        return self.rootStore.requirementBlockStore.getRequirementBlockById(requirementBlockId)
+      }
+
+      return false
+    }),
   }))
 
 export interface IRequirementTemplateStoreModel extends Instance<typeof RequirementTemplateStoreModel> {}

--- a/app/frontend/stores/requirement-template-store.ts
+++ b/app/frontend/stores/requirement-template-store.ts
@@ -292,6 +292,19 @@ export const RequirementTemplateStoreModel = types
       return ((response.data as IConfigErrorResponse | undefined)?.meta?.configErrors ??
         []) as IRequirementTemplateConfigError[]
     }),
+
+    restoreLayout: flow(function* (templateVersionId: string) {
+      const response = yield* toGenerator(self.environment.api.restoreTemplateLayout(templateVersionId))
+
+      if (response.ok) {
+        const templateData = response.data.data
+        templateData.isFullyLoaded = true
+        self.mergeUpdate(templateData, "requirementTemplateMap")
+        return self.requirementTemplateMap.get(templateData.id) as IRequirementTemplate
+      }
+
+      return false
+    }),
   }))
 
 export interface IRequirementTemplateStoreModel extends Instance<typeof RequirementTemplateStoreModel> {}

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -401,9 +401,19 @@ class Requirement < ApplicationRecord
   end
 
   def validate_value_options
-    if input_options.blank? || input_options["value_options"].blank? ||
-         !input_options["value_options"].is_a?(Array) ||
-         !input_options["value_options"].all? { |option|
+    # Bank-linked placements keep value_options on the question; use merged options.
+    options =
+      (
+        if requirement_question_id.present?
+          effective_input_options
+        else
+          input_options
+        end
+      )
+
+    if options.blank? || options["value_options"].blank? ||
+         !options["value_options"].is_a?(Array) ||
+         !options["value_options"].all? { |option|
            option.is_a?(Hash) &&
              (option.key?("label") && option["label"].is_a?(String)) &&
              (option.key?("value") && option["value"].is_a?(String))
@@ -436,6 +446,8 @@ class Requirement < ApplicationRecord
 
   def convert_value_options
     return unless attribute_changed?(:input_options)
+    # Placement-only updates (e.g. linked bank restore) may omit value_options.
+    return if input_options.blank? || input_options["value_options"].blank?
 
     inverted_computed_compliance_options_map =
       computed_compliance[
@@ -533,44 +545,72 @@ class Requirement < ApplicationRecord
       return
     end
 
-    current_attributes_of_interest =
-      self
-        .attributes
-        .slice("requirement_code", "input_type", "input_options")
-        .deep_dup
+    # Use effective options so bank-linked placements (value_options on the question)
+    # still satisfy the schema. Exact Hash== was too brittle for QB + restore.
+    actual_options = (effective_input_options || {}).deep_dup
 
     # The front-end sends the conditional as an empty object due to the form setup when conditionals are not added.
-    # Since the energy_step_code_method does not have any conditionals, the schema wouldn't match.
-    # The easiest way to handle this is to remove the conditional key for energy_step_code_method
-    # if it is an empty hash as we don't care about it. if it as it will have no effect to conditionals.
-    # Note we don't want to remove the key if it has other conditionals, as we want the validation below
-    # to catch that, as it is an invalid schema. Also the key is only removed from the duplicated attributes.
+    # Since the energy_step_code_method does not have any conditionals, ignore blank conditionals.
     if requirement_code == ENERGY_STEP_CODE_SELECT_REQUIREMENT_CODE &&
-         (
-           current_attributes_of_interest.dig(
-             "input_options",
-             "conditional"
-           ).present? &&
-             current_attributes_of_interest.dig(
-               "input_options",
-               "conditional"
-             ).empty?
-         )
-      current_attributes_of_interest["input_options"].delete("conditional")
+         actual_options["conditional"].blank?
+      actual_options.delete("conditional")
     end
 
-    unless ENERGY_STEP_CODE_PART_9_DEPENDENCY_REQUIRED_SCHEMA[
-             requirement_code.to_sym
-           ] == current_attributes_of_interest ||
-             ENERGY_STEP_CODE_PART_3_DEPENDENCY_REQUIRED_SCHEMA[
-               requirement_code.to_sym
-             ] == current_attributes_of_interest
-      errors.add(
-        :base,
-        :incorrect_requirement_schema,
-        requirement_code: requirement_code
-      )
+    actual = {
+      "requirement_code" => requirement_code,
+      "input_type" => effective_input_type.to_s,
+      "input_options" => actual_options
+    }
+
+    matches =
+      energy_step_code_schema_match?(
+        ENERGY_STEP_CODE_PART_9_DEPENDENCY_REQUIRED_SCHEMA[
+          requirement_code.to_sym
+        ],
+        actual
+      ) ||
+        energy_step_code_schema_match?(
+          ENERGY_STEP_CODE_PART_3_DEPENDENCY_REQUIRED_SCHEMA[
+            requirement_code.to_sym
+          ],
+          actual
+        )
+
+    return if matches
+
+    errors.add(
+      :base,
+      :incorrect_requirement_schema,
+      requirement_code: requirement_code
+    )
+  end
+
+  # Required keys/values must match; labels may differ; extra actual keys allowed.
+  def energy_step_code_schema_match?(expected, actual)
+    return false if expected.blank?
+    unless expected["requirement_code"] == actual["requirement_code"]
+      return false
     end
+    return false unless expected["input_type"].to_s == actual["input_type"].to_s
+
+    expected_opts = expected["input_options"] || {}
+    actual_opts = actual["input_options"] || {}
+
+    if expected_opts["value_options"].present?
+      expected_values =
+        expected_opts["value_options"].filter_map do |o|
+          o["value"] if o.is_a?(Hash)
+        end
+      actual_values =
+        Array(actual_opts["value_options"]).filter_map do |o|
+          o["value"] if o.is_a?(Hash)
+        end
+      return false unless expected_values == actual_values
+    end
+
+    expected_opts
+      .except("value_options")
+      .all? { |key, value| actual_opts[key] == value }
   end
 
   def validate_architectural_drawing_related_requirements_schema

--- a/app/policies/template_version_policy.rb
+++ b/app/policies/template_version_policy.rb
@@ -88,6 +88,10 @@ class TemplateVersionPolicy < ApplicationPolicy
       !record.requirement_template.discarded?
   end
 
+  def restore_requirement_block?
+    restore_layout?
+  end
+
   def force_publish_draft?
     promote_draft? && ENV["ENABLE_TEMPLATE_FORCE_PUBLISH"] == "true"
   end

--- a/app/policies/template_version_policy.rb
+++ b/app/policies/template_version_policy.rb
@@ -83,6 +83,11 @@ class TemplateVersionPolicy < ApplicationPolicy
     promote_draft?
   end
 
+  def restore_layout?
+    user&.super_admin? && record&.requirement_template.present? &&
+      !record.requirement_template.discarded?
+  end
+
   def force_publish_draft?
     promote_draft? && ENV["ENABLE_TEMPLATE_FORCE_PUBLISH"] == "true"
   end

--- a/app/services/requirement_block_snapshot_restore_service.rb
+++ b/app/services/requirement_block_snapshot_restore_service.rb
@@ -1,6 +1,7 @@
 # Overwrites a shared RequirementBlock (and its requirements) from a
 # TemplateVersion snapshot. Does not restore requirement documents / file
-# attachments. Affects every template that uses the block.
+# attachments. Never mutates RequirementQuestion bank rows.
+# Affects every template that uses the block.
 class RequirementBlockSnapshotRestoreService
   COMPLIANCE_OPTIONS_MAP_PREFIX = "compliance-options-map-prefix-".freeze
 
@@ -13,12 +14,8 @@ class RequirementBlockSnapshotRestoreService
     reviewer_role
   ].freeze
 
-  REQUIREMENT_ATTRS = %w[
+  PLACEMENT_ATTRS = %w[
     requirement_code
-    label
-    input_type
-    hint
-    instructions
     required
     related_content
     required_for_in_person_hint
@@ -29,7 +26,10 @@ class RequirementBlockSnapshotRestoreService
   def initialize(template_version, requirement_block_id)
     @template_version = template_version
     @requirement_block_id = requirement_block_id.to_s
+    @detached_requirement_codes = []
   end
+
+  attr_reader :detached_requirement_codes
 
   def call!
     if @requirement_block_id.blank?
@@ -106,8 +106,6 @@ class RequirementBlockSnapshotRestoreService
     snapshot_ids =
       snapshot_requirements.map { |req| dig_key(req, "id") }.compact.map(&:to_s)
 
-    # Update / create from snapshot first so uniqueness checks stay valid,
-    # then remove live requirements that are no longer in the snapshot.
     snapshot_requirements.each_with_index do |req_payload, index|
       attrs = requirement_attributes(req_payload, index)
       req_id = dig_key(req_payload, "id")&.to_s
@@ -130,15 +128,74 @@ class RequirementBlockSnapshotRestoreService
   def requirement_attributes(req_payload, position)
     attrs = { position: position }
 
-    REQUIREMENT_ATTRS.each do |attr|
+    PLACEMENT_ATTRS.each do |attr|
       value = dig_key(req_payload, attr)
       attrs[attr] = value unless value.nil?
     end
 
-    input_options = dig_key(req_payload, "input_options")
-    attrs["input_options"] = normalize_input_options(input_options || {})
+    question_id = dig_key(req_payload, "requirement_question_id")&.to_s
+    bank =
+      question_id.present? ? RequirementQuestion.find_by(id: question_id) : nil
+
+    if question_id.present? && bank.present? && !bank.discarded?
+      apply_linked_attributes!(attrs, req_payload, question_id)
+    elsif question_id.present?
+      apply_detached_attributes!(attrs, req_payload)
+    else
+      apply_local_attributes!(attrs, req_payload)
+    end
 
     attrs
+  end
+
+  # Bank kept: re-link FK, restore override columns (nil = inherit), placement-only options.
+  # Label/input_type copied from effective for DB presence; display still prefers bank.
+  def apply_linked_attributes!(attrs, req_payload, question_id)
+    attrs["requirement_question_id"] = question_id
+    attrs["label"] = dig_key(req_payload, "label")
+    attrs["input_type"] = dig_key(req_payload, "input_type")
+    attrs["hint"] = override_or_inherit(req_payload, "hint_override")
+    attrs["instructions"] = override_or_inherit(
+      req_payload,
+      "instructions_override"
+    )
+    attrs["input_options"] = placement_only_input_options(
+      dig_key(req_payload, "input_options")
+    )
+  end
+
+  # Bank missing/discarded: detach and materialize effective snapshot wording locally.
+  def apply_detached_attributes!(attrs, req_payload)
+    code = dig_key(req_payload, "requirement_code")
+    @detached_requirement_codes << code if code.present?
+
+    attrs["requirement_question_id"] = nil
+    apply_local_attributes!(attrs, req_payload)
+  end
+
+  def apply_local_attributes!(attrs, req_payload)
+    attrs["requirement_question_id"] = nil
+    attrs["label"] = dig_key(req_payload, "label")
+    attrs["input_type"] = dig_key(req_payload, "input_type")
+    attrs["hint"] = dig_key(req_payload, "hint")
+    attrs["instructions"] = dig_key(req_payload, "instructions")
+    attrs["input_options"] = normalize_input_options(
+      dig_key(req_payload, "input_options") || {}
+    )
+  end
+
+  # When override key is present (including JSON null), use it. Otherwise inherit (nil).
+  def override_or_inherit(req_payload, override_key)
+    if key_present?(req_payload, override_key)
+      return dig_key(req_payload, override_key)
+    end
+
+    nil
+  end
+
+  def placement_only_input_options(input_options)
+    opts = normalize_input_options(input_options || {})
+    opts.slice(*RequirementQuestion::PLACEMENT_INPUT_OPTION_KEYS)
   end
 
   def normalize_input_options(input_options)
@@ -165,5 +222,14 @@ class RequirementBlockSnapshotRestoreService
     key = snake_key.to_s
     camel_key = key.camelize(:lower)
     hash[key] || hash[key.to_sym] || hash[camel_key] || hash[camel_key.to_sym]
+  end
+
+  def key_present?(hash, snake_key)
+    return false unless hash.is_a?(Hash)
+
+    key = snake_key.to_s
+    camel_key = key.camelize(:lower)
+    hash.key?(key) || hash.key?(key.to_sym) || hash.key?(camel_key) ||
+      hash.key?(camel_key.to_sym)
   end
 end

--- a/app/services/requirement_block_snapshot_restore_service.rb
+++ b/app/services/requirement_block_snapshot_restore_service.rb
@@ -1,0 +1,169 @@
+# Overwrites a shared RequirementBlock (and its requirements) from a
+# TemplateVersion snapshot. Does not restore requirement documents / file
+# attachments. Affects every template that uses the block.
+class RequirementBlockSnapshotRestoreService
+  COMPLIANCE_OPTIONS_MAP_PREFIX = "compliance-options-map-prefix-".freeze
+
+  BLOCK_ATTRS = %w[
+    name
+    description
+    display_name
+    display_description
+    sign_off_role
+    reviewer_role
+  ].freeze
+
+  REQUIREMENT_ATTRS = %w[
+    requirement_code
+    label
+    input_type
+    hint
+    instructions
+    required
+    related_content
+    required_for_in_person_hint
+    required_for_multiple_owners
+    elective
+  ].freeze
+
+  def initialize(template_version, requirement_block_id)
+    @template_version = template_version
+    @requirement_block_id = requirement_block_id.to_s
+  end
+
+  def call!
+    if @requirement_block_id.blank?
+      raise RequirementBlockSnapshotRestoreError,
+            I18n.t(
+              "services.requirement_block_snapshot_restore_service.missing_block_id"
+            )
+    end
+
+    snapshot = find_block_snapshot!
+    block = RequirementBlock.find_by(id: @requirement_block_id)
+
+    if block.nil?
+      raise RequirementBlockSnapshotRestoreError,
+            I18n.t(
+              "services.requirement_block_snapshot_restore_service.block_not_found"
+            )
+    end
+
+    ActiveRecord::Base.transaction do
+      block.undiscard if block.discarded?
+
+      apply_block_attributes!(block, snapshot)
+      sync_requirements!(block, snapshot)
+
+      unless block.save
+        raise RequirementBlockSnapshotRestoreError,
+              block.errors.full_messages.join(", ")
+      end
+
+      block.reload
+    end
+  end
+
+  private
+
+  def find_block_snapshot!
+    blocks_json = @template_version.requirement_blocks_json || {}
+    snapshot =
+      blocks_json[@requirement_block_id] ||
+        blocks_json[@requirement_block_id.to_sym]
+
+    if snapshot.blank?
+      raise RequirementBlockSnapshotRestoreError,
+            I18n.t(
+              "services.requirement_block_snapshot_restore_service.block_not_in_snapshot"
+            )
+    end
+
+    unless snapshot.is_a?(Hash)
+      raise RequirementBlockSnapshotRestoreError,
+            I18n.t(
+              "services.requirement_block_snapshot_restore_service.malformed_snapshot"
+            )
+    end
+
+    snapshot
+  end
+
+  def apply_block_attributes!(block, snapshot)
+    BLOCK_ATTRS.each do |attr|
+      value = dig_key(snapshot, attr)
+      block.public_send("#{attr}=", value) unless value.nil?
+    end
+
+    associations = dig_key(snapshot, "associations")
+    block.association_list = Array(associations) if associations
+  end
+
+  def sync_requirements!(block, snapshot)
+    snapshot_requirements = dig_key(snapshot, "requirements")
+    snapshot_requirements = [] unless snapshot_requirements.is_a?(Array)
+
+    snapshot_ids =
+      snapshot_requirements.map { |req| dig_key(req, "id") }.compact.map(&:to_s)
+
+    # Update / create from snapshot first so uniqueness checks stay valid,
+    # then remove live requirements that are no longer in the snapshot.
+    snapshot_requirements.each_with_index do |req_payload, index|
+      attrs = requirement_attributes(req_payload, index)
+      req_id = dig_key(req_payload, "id")&.to_s
+
+      if req_id.present?
+        existing = block.requirements.find_by(id: req_id)
+        if existing
+          existing.update!(attrs)
+        else
+          block.requirements.create!(attrs.merge(id: req_id))
+        end
+      else
+        block.requirements.create!(attrs)
+      end
+    end
+
+    block.requirements.where.not(id: snapshot_ids).find_each(&:destroy!)
+  end
+
+  def requirement_attributes(req_payload, position)
+    attrs = { position: position }
+
+    REQUIREMENT_ATTRS.each do |attr|
+      value = dig_key(req_payload, attr)
+      attrs[attr] = value unless value.nil?
+    end
+
+    input_options = dig_key(req_payload, "input_options")
+    attrs["input_options"] = normalize_input_options(input_options || {})
+
+    attrs
+  end
+
+  def normalize_input_options(input_options)
+    return {} if input_options.blank?
+
+    opts = input_options.deep_dup
+    opts = opts.deep_stringify_keys if opts.respond_to?(:deep_stringify_keys)
+
+    options_map = opts.dig("computed_compliance", "options_map")
+    if options_map.is_a?(Hash)
+      opts["computed_compliance"][
+        "options_map"
+      ] = options_map.transform_keys do |key|
+        key.to_s.delete_prefix(COMPLIANCE_OPTIONS_MAP_PREFIX)
+      end
+    end
+
+    opts
+  end
+
+  def dig_key(hash, snake_key)
+    return nil unless hash.is_a?(Hash)
+
+    key = snake_key.to_s
+    camel_key = key.camelize(:lower)
+    hash[key] || hash[key.to_sym] || hash[camel_key] || hash[camel_key.to_sym]
+  end
+end

--- a/app/services/requirement_template_structure_restore_service.rb
+++ b/app/services/requirement_template_structure_restore_service.rb
@@ -1,0 +1,128 @@
+# Rebuilds a RequirementTemplate's sections and TemplateSectionBlock join rows
+# from a TemplateVersion's denormalized_template_json snapshot.
+# Re-links existing RequirementBlocks by ID; does not mutate block content.
+class RequirementTemplateStructureRestoreService
+  def initialize(template_version)
+    @template_version = template_version
+    @requirement_template = template_version.requirement_template
+  end
+
+  def call!
+    if @requirement_template.blank? || @requirement_template.discarded?
+      raise RequirementTemplateStructureRestoreError,
+            I18n.t(
+              "services.requirement_template_structure_restore_service.template_unavailable"
+            )
+    end
+
+    snapshot = @template_version.denormalized_template_json
+    if snapshot.blank?
+      raise RequirementTemplateStructureRestoreError,
+            I18n.t(
+              "services.requirement_template_structure_restore_service.empty_snapshot"
+            )
+    end
+
+    section_payloads = extract_sections(snapshot)
+    block_refs = collect_block_refs(section_payloads)
+    validate_blocks!(block_refs)
+
+    ActiveRecord::Base.transaction do
+      @requirement_template.requirement_template_sections.destroy_all
+
+      section_payloads.each_with_index do |section_payload, section_index|
+        section =
+          @requirement_template.requirement_template_sections.create!(
+            name: dig_key(section_payload, "name"),
+            position: section_index
+          )
+
+        extract_template_section_blocks(
+          section_payload
+        ).each_with_index do |tsb_payload, block_index|
+          section.template_section_blocks.create!(
+            requirement_block_id: block_id_from(tsb_payload),
+            position: block_index,
+            conditional: dig_key(tsb_payload, "conditional")
+          )
+        end
+      end
+
+      @requirement_template.touch
+      @requirement_template.reload
+    end
+  end
+
+  private
+
+  def extract_sections(snapshot)
+    sections = dig_key(snapshot, "requirement_template_sections")
+    unless sections.is_a?(Array)
+      raise RequirementTemplateStructureRestoreError,
+            I18n.t(
+              "services.requirement_template_structure_restore_service.malformed_snapshot"
+            )
+    end
+    sections
+  end
+
+  def extract_template_section_blocks(section_payload)
+    blocks = dig_key(section_payload, "template_section_blocks")
+    blocks.is_a?(Array) ? blocks : []
+  end
+
+  def collect_block_refs(section_payloads)
+    refs = []
+    section_payloads.each do |section_payload|
+      extract_template_section_blocks(section_payload).each do |tsb_payload|
+        id = block_id_from(tsb_payload)
+        name =
+          dig_key(tsb_payload, "requirement_block")&.then do |b|
+            dig_key(b, "name") || dig_key(b, "display_name")
+          end
+        refs << { id: id, name: name }
+      end
+    end
+    refs
+  end
+
+  def block_id_from(tsb_payload)
+    dig_key(tsb_payload, "requirement_block_id") ||
+      dig_key(dig_key(tsb_payload, "requirement_block") || {}, "id")
+  end
+
+  def validate_blocks!(block_refs)
+    missing = []
+
+    block_refs.each do |ref|
+      id = ref[:id]
+      if id.blank?
+        missing << (ref[:name].presence || "(missing id)")
+        next
+      end
+
+      block = RequirementBlock.find_by(id: id)
+      if block.nil? || block.discarded?
+        label = ref[:name].presence || block&.name || id
+        missing << label
+      end
+    end
+
+    return if missing.empty?
+
+    raise RequirementTemplateStructureRestoreError,
+          I18n.t(
+            "services.requirement_template_structure_restore_service.missing_blocks",
+            blocks: missing.uniq.join(", ")
+          )
+  end
+
+  # Snapshot JSON may use snake_case (Blueprinter render_as_hash) or camelCase.
+  def dig_key(hash, snake_key)
+    return nil unless hash.is_a?(Hash)
+
+    key = snake_key.to_s
+    camel_key = key.camelize(:lower)
+    hash[key] || hash[key.to_sym] || hash[camel_key] || hash[camel_key.to_sym]
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -632,6 +632,12 @@ en:
       promote_draft_error:
         title: Error
         message: "%{error_message}"
+      restore_layout_success:
+        title: ""
+        message: "Template layout restored from this version"
+      restore_layout_error:
+        title: Error
+        message: "%{error_message}"
       no_draft_error:
         title: Error
         message: "No early access version exists for this template"
@@ -1175,6 +1181,11 @@ en:
       publish_before_schedule_date: "Version cannot be published before it's scheduled date"
       copy_customizations_error: "Old jurisdiction customizations could not be copied to new template version for jurisdiction_id:%{jurisdiction_id}"
       copy_customizations_log_error: "Error copying customizations to new template version: %{message}"
+    requirement_template_structure_restore_service:
+      template_unavailable: "Cannot restore layout because the template is missing or archived"
+      empty_snapshot: "This version has no layout snapshot to restore from"
+      malformed_snapshot: "This version's layout snapshot is invalid"
+      missing_blocks: "Cannot restore layout. These blocks are missing or archived in the library: %{blocks}"
   formio:
     requirement_template:
       completion_title: "Completion"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -638,6 +638,12 @@ en:
       restore_layout_error:
         title: Error
         message: "%{error_message}"
+      restore_requirement_block_success:
+        title: ""
+        message: "Requirement block restored from this version"
+      restore_requirement_block_error:
+        title: Error
+        message: "%{error_message}"
       no_draft_error:
         title: Error
         message: "No early access version exists for this template"
@@ -1186,6 +1192,11 @@ en:
       empty_snapshot: "This version has no layout snapshot to restore from"
       malformed_snapshot: "This version's layout snapshot is invalid"
       missing_blocks: "Cannot restore layout. These blocks are missing or archived in the library: %{blocks}"
+    requirement_block_snapshot_restore_service:
+      missing_block_id: "A requirement block id is required"
+      block_not_found: "This requirement block no longer exists in the library"
+      block_not_in_snapshot: "This requirement block is not present in the selected version snapshot"
+      malformed_snapshot: "This version's block snapshot is invalid"
   formio:
     requirement_template:
       completion_title: "Completion"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,7 @@ Rails.application.routes.draw do
         delete "discard_draft", to: "template_versions#discard_draft"
         post "promote_draft", to: "template_versions#promote_draft"
         post "validate_config", to: "template_versions#validate_config"
+        post "restore_layout", to: "template_versions#restore_layout"
         post "invite_draft_previewers",
              to: "template_versions#invite_draft_previewers"
         post "share_draft", to: "template_versions#share_draft"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,8 @@ Rails.application.routes.draw do
         post "promote_draft", to: "template_versions#promote_draft"
         post "validate_config", to: "template_versions#validate_config"
         post "restore_layout", to: "template_versions#restore_layout"
+        post "restore_requirement_block",
+             to: "template_versions#restore_requirement_block"
         post "invite_draft_previewers",
              to: "template_versions#invite_draft_previewers"
         post "share_draft", to: "template_versions#share_draft"

--- a/spec/controllers/template_versions_controller_spec.rb
+++ b/spec/controllers/template_versions_controller_spec.rb
@@ -375,4 +375,79 @@ RSpec.describe Api::TemplateVersionsController,
       end
     end
   end
+
+  describe "POST #restore_layout" do
+    let!(:requirement_template) do
+      create(:full_requirement_template, sections_count: 1)
+    end
+    let!(:template_version) do
+      create(
+        :template_version,
+        requirement_template: requirement_template,
+        status: :published,
+        denormalized_template_json:
+          RequirementTemplateBlueprint.render_as_hash(
+            requirement_template,
+            view: :template_snapshot
+          )
+      )
+    end
+
+    context "as a super admin" do
+      let!(:super_admin) { create(:user, :super_admin) }
+
+      before { sign_in super_admin }
+
+      it "restores the template layout from the version snapshot" do
+        original_names =
+          requirement_template
+            .requirement_template_sections
+            .order(:position)
+            .pluck(:name)
+        requirement_template.requirement_template_sections.destroy_all
+        requirement_template.requirement_template_sections.create!(
+          name: "Changed",
+          position: 0
+        )
+
+        post :restore_layout, params: { id: template_version.id }
+
+        expect(response).to have_http_status(:success)
+        expect(
+          requirement_template
+            .reload
+            .requirement_template_sections
+            .order(:position)
+            .pluck(:name)
+        ).to eq(original_names)
+      end
+
+      it "returns an error when blocks are missing" do
+        snapshot = template_version.denormalized_template_json.deep_dup
+        snapshot["requirement_template_sections"].first[
+          "template_section_blocks"
+        ].first[
+          "requirement_block"
+        ][
+          "id"
+        ] = SecureRandom.uuid
+        template_version.update!(denormalized_template_json: snapshot)
+
+        post :restore_layout, params: { id: template_version.id }
+
+        expect(response).to have_http_status(:bad_request)
+        expect(json_response.dig("meta", "message", "message")).to match(
+          /missing or archived/i
+        )
+      end
+    end
+
+    context "as a non-admin user" do
+      it "denies access" do
+        post :restore_layout, params: { id: template_version.id }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end

--- a/spec/controllers/template_versions_controller_spec.rb
+++ b/spec/controllers/template_versions_controller_spec.rb
@@ -450,4 +450,61 @@ RSpec.describe Api::TemplateVersionsController,
       end
     end
   end
+
+  describe "POST #restore_requirement_block" do
+    let!(:requirement_template) do
+      create(:full_requirement_template, sections_count: 1)
+    end
+    let!(:block) do
+      requirement_template
+        .requirement_template_sections
+        .first
+        .requirement_blocks
+        .first
+    end
+    let!(:template_version) do
+      blocks_json = {
+        block.id =>
+          RequirementBlockBlueprint.render_as_hash(block, parent_key: "section")
+      }
+      create(
+        :template_version,
+        requirement_template: requirement_template,
+        status: :published,
+        requirement_blocks_json: blocks_json
+      )
+    end
+
+    context "as a super admin" do
+      let!(:super_admin) { create(:user, :super_admin) }
+
+      before { sign_in super_admin }
+
+      it "restores the shared requirement block from the version snapshot" do
+        original_name = block.name
+        block.update!(name: "Changed")
+
+        post :restore_requirement_block,
+             params: {
+               id: template_version.id,
+               requirement_block_id: block.id
+             }
+
+        expect(response).to have_http_status(:success)
+        expect(block.reload.name).to eq(original_name)
+      end
+    end
+
+    context "as a non-admin user" do
+      it "denies access" do
+        post :restore_requirement_block,
+             params: {
+               id: template_version.id,
+               requirement_block_id: block.id
+             }
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end

--- a/spec/policies/template_version_policy_spec.rb
+++ b/spec/policies/template_version_policy_spec.rb
@@ -151,6 +151,10 @@ RSpec.describe TemplateVersionPolicy, type: :policy do
       expect(draft_policy(admin, version).restore_layout?).to be true
       expect(draft_policy(non_admin, version).restore_layout?).to be false
       expect(draft_policy(admin, discarded_version).restore_layout?).to be false
+      expect(draft_policy(admin, version).restore_requirement_block?).to be true
+      expect(
+        draft_policy(non_admin, version).restore_requirement_block?
+      ).to be false
     end
 
     it "permits force publishing draft versions only when enabled" do

--- a/spec/policies/template_version_policy_spec.rb
+++ b/spec/policies/template_version_policy_spec.rb
@@ -139,6 +139,20 @@ RSpec.describe TemplateVersionPolicy, type: :policy do
       expect(draft_policy(admin, published_record).promote_draft?).to be false
     end
 
+    it "permits restore_layout for super admins on any version with a kept template" do
+      kept_template =
+        double("RequirementTemplate", discarded?: false, present?: true)
+      discarded_template =
+        double("RequirementTemplate", discarded?: true, present?: true)
+      version = double("TemplateVersion", requirement_template: kept_template)
+      discarded_version =
+        double("TemplateVersion", requirement_template: discarded_template)
+
+      expect(draft_policy(admin, version).restore_layout?).to be true
+      expect(draft_policy(non_admin, version).restore_layout?).to be false
+      expect(draft_policy(admin, discarded_version).restore_layout?).to be false
+    end
+
     it "permits force publishing draft versions only when enabled" do
       allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with(

--- a/spec/services/requirement_block_snapshot_restore_service_spec.rb
+++ b/spec/services/requirement_block_snapshot_restore_service_spec.rb
@@ -1,0 +1,125 @@
+require "rails_helper"
+
+RSpec.describe RequirementBlockSnapshotRestoreService do
+  let!(:template) { create(:full_requirement_template, sections_count: 1) }
+  let!(:block) do
+    template.requirement_template_sections.first.requirement_blocks.first
+  end
+  let!(:template_version) do
+    blocks_json = {}
+    template.requirement_template_sections.each do |section|
+      section.requirement_blocks.each do |requirement_block|
+        blocks_json[
+          requirement_block.id
+        ] = RequirementBlockBlueprint.render_as_hash(
+          requirement_block,
+          parent_key: section.key
+        )
+      end
+    end
+
+    create(
+      :template_version,
+      requirement_template: template,
+      status: :published,
+      requirement_blocks_json: blocks_json,
+      denormalized_template_json:
+        RequirementTemplateBlueprint.render_as_hash(
+          template,
+          view: :template_snapshot
+        )
+    )
+  end
+
+  describe "#call!" do
+    it "overwrites block fields and requirements from the snapshot" do
+      original_label = block.requirements.order(:position).first.label
+      original_name = block.name
+
+      block.update!(name: "Changed name", display_name: "Changed display")
+      block.requirements.order(:position).first.update!(label: "Changed label")
+      create(
+        :requirement,
+        requirement_block: block,
+        label: "Extra field added later",
+        input_type: :text
+      )
+
+      result = described_class.new(template_version, block.id).call!
+
+      expect(result.id).to eq(block.id)
+      expect(result.name).to eq(original_name)
+      expect(result.requirements.map(&:label)).to include(original_label)
+      expect(result.requirements.map(&:label)).not_to include(
+        "Extra field added later"
+      )
+    end
+
+    it "restores a discarded block" do
+      original_name = block.name
+      block.discard
+
+      result = described_class.new(template_version, block.id).call!
+
+      expect(result).not_to be_discarded
+      expect(result.name).to eq(original_name)
+    end
+
+    it "raises when the block is not in the snapshot" do
+      expect {
+        described_class.new(template_version, SecureRandom.uuid).call!
+      }.to raise_error(
+        RequirementBlockSnapshotRestoreError,
+        /not present in the selected version/
+      )
+    end
+
+    it "raises when the live block was hard-deleted" do
+      block_id = block.id
+      # destroy join rows then the block record itself
+      TemplateSectionBlock.where(requirement_block_id: block_id).delete_all
+      Requirement.where(requirement_block_id: block_id).delete_all
+      RequirementBlock.where(id: block_id).delete_all
+
+      expect {
+        described_class.new(template_version, block_id).call!
+      }.to raise_error(RequirementBlockSnapshotRestoreError, /no longer exists/)
+    end
+
+    it "normalizes compliance options_map prefixes from the blueprint" do
+      req = block.requirements.order(:position).first
+      req.update!(
+        input_options: {
+          "computed_compliance" => {
+            "module" => "ParcelInfoExtractor",
+            "value" => "FEATURE_AREA_SQM",
+            "options_map" => {
+              "raw_key" => "mapped"
+            }
+          }
+        }
+      )
+
+      snapshot =
+        RequirementBlockBlueprint.render_as_hash(
+          block.reload,
+          parent_key: "section"
+        )
+      template_version.update!(
+        requirement_blocks_json: {
+          block.id => snapshot
+        }
+      )
+
+      # Mutate live options so restore has something to reverse
+      req.update!(input_options: {})
+
+      result = described_class.new(template_version, block.id).call!
+      restored_req = result.requirements.find(req.id)
+
+      expect(
+        restored_req.input_options.dig("computed_compliance", "options_map")
+      ).to eq({ "raw_key" => "mapped" })
+    end
+  end
+end

--- a/spec/services/requirement_block_snapshot_restore_service_spec.rb
+++ b/spec/services/requirement_block_snapshot_restore_service_spec.rb
@@ -6,8 +6,17 @@ RSpec.describe RequirementBlockSnapshotRestoreService do
     template.requirement_template_sections.first.requirement_blocks.first
   end
   let!(:template_version) do
+    create(
+      :template_version,
+      requirement_template: template,
+      status: :published,
+      requirement_blocks_json: snapshot_blocks_json(template)
+    )
+  end
+
+  def snapshot_blocks_json(requirement_template)
     blocks_json = {}
-    template.requirement_template_sections.each do |section|
+    requirement_template.requirement_template_sections.each do |section|
       section.requirement_blocks.each do |requirement_block|
         blocks_json[
           requirement_block.id
@@ -17,17 +26,12 @@ RSpec.describe RequirementBlockSnapshotRestoreService do
         )
       end
     end
+    blocks_json
+  end
 
-    create(
-      :template_version,
-      requirement_template: template,
-      status: :published,
-      requirement_blocks_json: blocks_json,
-      denormalized_template_json:
-        RequirementTemplateBlueprint.render_as_hash(
-          template,
-          view: :template_snapshot
-        )
+  def refresh_version_snapshot!
+    template_version.update!(
+      requirement_blocks_json: snapshot_blocks_json(template.reload)
     )
   end
 
@@ -76,7 +80,6 @@ RSpec.describe RequirementBlockSnapshotRestoreService do
 
     it "raises when the live block was hard-deleted" do
       block_id = block.id
-      # destroy join rows then the block record itself
       TemplateSectionBlock.where(requirement_block_id: block_id).delete_all
       Requirement.where(requirement_block_id: block_id).delete_all
       RequirementBlock.where(id: block_id).delete_all
@@ -99,19 +102,7 @@ RSpec.describe RequirementBlockSnapshotRestoreService do
           }
         }
       )
-
-      snapshot =
-        RequirementBlockBlueprint.render_as_hash(
-          block.reload,
-          parent_key: "section"
-        )
-      template_version.update!(
-        requirement_blocks_json: {
-          block.id => snapshot
-        }
-      )
-
-      # Mutate live options so restore has something to reverse
+      refresh_version_snapshot!
       req.update!(input_options: {})
 
       result = described_class.new(template_version, block.id).call!
@@ -120,6 +111,122 @@ RSpec.describe RequirementBlockSnapshotRestoreService do
       expect(
         restored_req.input_options.dig("computed_compliance", "options_map")
       ).to eq({ "raw_key" => "mapped" })
+    end
+
+    context "with question bank links" do
+      let!(:bank_question) do
+        create(
+          :requirement_question,
+          label: "Bank label",
+          hint: "Bank default hint",
+          instructions: "Bank default instructions",
+          input_type: :text,
+          input_options: {
+            "value_options" => []
+          }
+        )
+      end
+      let!(:req) { block.requirements.order(:position).first }
+      let!(:sibling_req) { block.requirements.order(:position).second }
+
+      before do
+        # Conditional must reference a real sibling requirement_code in this block
+        req.update!(
+          requirement_question: bank_question,
+          label: "Bank label",
+          input_type: :text,
+          hint: nil,
+          instructions: nil,
+          input_options: {
+            "conditional" => {
+              "when" => sibling_req.requirement_code,
+              "eq" => "yes",
+              "show" => true,
+              "operator" => "isEqual"
+            }
+          }
+        )
+        refresh_version_snapshot!
+      end
+
+      it "re-links the bank question and restores nil overrides as inherit" do
+        req.update!(
+          hint: "Temporary override",
+          instructions: "Temporary instructions",
+          requirement_question_id: nil
+        )
+
+        result = described_class.new(template_version.reload, block.id).call!
+        restored = result.requirements.find(req.id)
+
+        expect(restored.requirement_question_id).to eq(bank_question.id)
+        expect(restored.read_attribute(:hint)).to be_nil
+        expect(restored.read_attribute(:instructions)).to be_nil
+        expect(restored.effective_hint).to eq("Bank default hint")
+        expect(restored.input_options.dig("conditional", "when")).to eq(
+          sibling_req.requirement_code
+        )
+        # Bank row unchanged
+        expect(bank_question.reload.hint).to eq("Bank default hint")
+        expect(bank_question.label).to eq("Bank label")
+      end
+
+      it "restores placement hint/instructions overrides without mutating the bank" do
+        req.update!(
+          hint: "Placement override",
+          instructions: "Placement instructions"
+        )
+        refresh_version_snapshot!
+
+        req.update!(hint: nil, instructions: nil)
+        bank_question.update!(
+          hint: "Live bank changed",
+          label: "Live bank label"
+        )
+
+        result = described_class.new(template_version.reload, block.id).call!
+        restored = result.requirements.find(req.id)
+
+        expect(restored.requirement_question_id).to eq(bank_question.id)
+        expect(restored.read_attribute(:hint)).to eq("Placement override")
+        expect(restored.read_attribute(:instructions)).to eq(
+          "Placement instructions"
+        )
+        expect(bank_question.reload.hint).to eq("Live bank changed")
+        expect(bank_question.label).to eq("Live bank label")
+        expect(restored.effective_label).to eq("Live bank label")
+      end
+
+      it "detaches and materializes effective wording when the bank question is gone" do
+        refresh_version_snapshot!
+        bank_id = bank_question.id
+        req.update!(requirement_question_id: nil) # allow destroy
+        RequirementQuestion.where(id: bank_id).delete_all
+
+        service = described_class.new(template_version.reload, block.id)
+        result = service.call!
+        restored = result.requirements.find(req.id)
+
+        expect(restored.requirement_question_id).to be_nil
+        expect(restored.label).to eq("Bank label")
+        expect(restored.hint).to eq("Bank default hint")
+        expect(restored.instructions).to eq("Bank default instructions")
+        expect(service.detached_requirement_codes).to include(
+          restored.requirement_code
+        )
+      end
+
+      it "detaches and materializes when the bank question is discarded" do
+        refresh_version_snapshot!
+        bank_question.discard
+
+        result = described_class.new(template_version.reload, block.id).call!
+        restored = result.requirements.find(req.id)
+
+        expect(restored.requirement_question_id).to be_nil
+        expect(restored.label).to eq("Bank label")
+        expect(restored.hint).to eq("Bank default hint")
+      end
     end
   end
 end

--- a/spec/services/requirement_template_structure_restore_service_spec.rb
+++ b/spec/services/requirement_template_structure_restore_service_spec.rb
@@ -1,0 +1,176 @@
+require "rails_helper"
+
+RSpec.describe RequirementTemplateStructureRestoreService do
+  let!(:template) { create(:full_requirement_template, sections_count: 2) }
+  let!(:template_version) do
+    create(
+      :template_version,
+      requirement_template: template,
+      denormalized_template_json:
+        RequirementTemplateBlueprint.render_as_hash(
+          template,
+          view: :template_snapshot
+        ),
+      status: :published
+    )
+  end
+
+  describe "#call!" do
+    it "rebuilds sections, block order, and conditionals from the snapshot" do
+      first_tsb =
+        template
+          .requirement_template_sections
+          .order(:position)
+          .first
+          .template_section_blocks
+          .order(:position)
+          .first
+      conditional = {
+        "when_block_id" => first_tsb.requirement_block_id,
+        "when_requirement_code" => "energy_step_code",
+        "eq" => "yes",
+        "show" => true
+      }
+      first_tsb.update!(conditional: conditional)
+
+      # Snapshot after conditional is set
+      template_version.update!(
+        denormalized_template_json:
+          RequirementTemplateBlueprint.render_as_hash(
+            template.reload,
+            view: :template_snapshot
+          )
+      )
+
+      # Capture expected layout before destroy_all clears join rows
+      expected_names =
+        template.requirement_template_sections.order(:position).pluck(:name)
+      expected_block_ids_by_section =
+        template
+          .requirement_template_sections
+          .order(:position)
+          .map do |section|
+            section
+              .template_section_blocks
+              .order(:position)
+              .pluck(:requirement_block_id)
+          end
+      first_block_id = first_tsb.requirement_block_id
+
+      # Mutate live layout so restore has something to reverse
+      template.requirement_template_sections.destroy_all
+      leftover_section =
+        template.requirement_template_sections.create!(
+          name: "Leftover",
+          position: 0
+        )
+      leftover_section.template_section_blocks.create!(
+        requirement_block: create(:requirement_block),
+        position: 0
+      )
+
+      result = described_class.new(template_version.reload).call!
+
+      expect(result.id).to eq(template.id)
+      restored = result.requirement_template_sections.order(:position).to_a
+      expect(restored.map(&:name)).to eq(expected_names)
+
+      restored.each_with_index do |section, i|
+        expect(
+          section
+            .template_section_blocks
+            .order(:position)
+            .map(&:requirement_block_id)
+        ).to eq(expected_block_ids_by_section[i])
+      end
+
+      restored_first_tsb =
+        restored.first.template_section_blocks.find_by(
+          requirement_block_id: first_block_id
+        )
+      expect(restored_first_tsb.conditional).to eq(conditional)
+    end
+
+    it "aborts with no partial writes when a block is missing" do
+      snapshot = template_version.denormalized_template_json.deep_dup
+      missing_id = SecureRandom.uuid
+      snapshot["requirement_template_sections"].first[
+        "template_section_blocks"
+      ].first[
+        "requirement_block"
+      ][
+        "id"
+      ] = missing_id
+      template_version.update!(denormalized_template_json: snapshot)
+
+      section_ids_before =
+        template.requirement_template_sections.pluck(:id).sort
+
+      expect { described_class.new(template_version).call! }.to raise_error(
+        RequirementTemplateStructureRestoreError,
+        /missing or archived/
+      )
+
+      expect(
+        template.reload.requirement_template_sections.pluck(:id).sort
+      ).to eq(section_ids_before)
+    end
+
+    it "aborts when a referenced block is discarded" do
+      block =
+        template.requirement_template_sections.first.requirement_blocks.first
+      block.discard
+
+      expect { described_class.new(template_version).call! }.to raise_error(
+        RequirementTemplateStructureRestoreError,
+        /missing or archived/
+      )
+    end
+
+    it "raises when the snapshot is empty" do
+      template_version.update!(denormalized_template_json: {})
+
+      expect { described_class.new(template_version).call! }.to raise_error(
+        RequirementTemplateStructureRestoreError,
+        /no layout snapshot/
+      )
+    end
+
+    it "raises when the snapshot is malformed" do
+      template_version.update!(
+        denormalized_template_json: {
+          "requirement_template_sections" => "not-an-array"
+        }
+      )
+
+      expect { described_class.new(template_version).call! }.to raise_error(
+        RequirementTemplateStructureRestoreError,
+        /invalid/
+      )
+    end
+
+    it "raises when the parent template is discarded" do
+      template.discard
+
+      expect { described_class.new(template_version).call! }.to raise_error(
+        RequirementTemplateStructureRestoreError,
+        /missing or archived/
+      )
+    end
+
+    it "accepts camelCase snapshot keys" do
+      snake =
+        RequirementTemplateBlueprint.render_as_hash(
+          template,
+          view: :template_snapshot
+        )
+      camel = snake.deep_transform_keys { |k| k.to_s.camelize(:lower) }
+      template_version.update!(denormalized_template_json: camel)
+
+      template.requirement_template_sections.destroy_all
+
+      result = described_class.new(template_version).call!
+      expect(result.requirement_template_sections.count).to be > 0
+    end
+  end
+end


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff integration/question-bank...HUB-5399-restore-on-question-bank` (merge-base range).

Super admins can restore a template version’s **layout** into the live builder, and restore an individual **shared requirement block** from a version snapshot—adapted for the question bank so bank rows are never mutated. Linked placements keep FKs/overrides when the bank question still exists; missing/discarded bank questions detach and materialize effective snapshot wording as block-only. Also consolidates the crowded template-version sticky bar into Share / Actions / Go to, and loosens value-options + energy-step schema checks so bank-linked restores don’t fail falsely. Restore failures surface via `render_error` toasts.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5399](https://hous-bssb.atlassian.net/browse/HUB-5399) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- **Restore layout to builder** — `POST …/restore_layout` rewrites template sections/block arrangement (and show/hide rules) from the version snapshot; aborts if a referenced block is missing/discarded
- **Restore source block** — `POST …/restore_requirement_block` overwrites the shared library block from the snapshot; question-bank aware (link + overrides when bank kept; detach + materialize when missing/discarded; never mutates `RequirementQuestion`)
- Super-admin UI on the template version screen: layout restore, per-block actions menu, confirmation copy that states bank/shared-block limitations
- Sticky bar consolidated: **Share** (public preview toggle inside; label shows `(public)` when on), **Actions** (Promote / Restore layout / Discard — draft-only items gated), **Go to** (Form preview / Builder / Catalogue)
- Actions available on published/scheduled versions for Restore layout; Promote/Discard remain draft-only
- Requirement model: skip `convert_value_options` when placement has no `value_options`; validate value options via effective options when bank-linked; looser energy step schema matching for QB
- Specs for restore services, controller, and policy

---

## 🧪 Steps to QA

1. As a **super admin**, open an early-access (draft) template version.
2. Confirm the sticky bar shows **Share | Actions ▾ | Go to ▾** (not a long row of individual buttons).
3. Open **Share** — toggle “Show on public standardization preview”; confirm the Share button reads **Share (public)** when on, and falls back to the previewer count when off.
4. **Go to** — Form preview, Builder, and Catalogue navigate correctly.
5. **Actions → Restore layout to builder** — confirm the warning, run restore, land in the builder with the version’s section/block layout.
6. On a block, use **Block actions → Restore source block** for a bank-linked field; confirm the shared block updates and the bank question itself is unchanged.
7. Repeat block restore for a case where the linked bank question was discarded/deleted — field should detach and keep snapshot wording locally.
8. Open a **published** template version as super admin — Actions should still offer Restore layout (no Promote/Discard).
9. Trigger a failing restore (e.g. missing library block for layout restore) and confirm an **error toast** appears (not a silent failure / bare 500).
10. As a non–super-admin draft previewer, confirm Share + Go to appear and Actions does not.

**Expected Behaviour:**
> Super admins can restore layout and shared blocks from a version with clear limitations; question bank rows are never rewritten; the top bar stays compact; failures show toasts.

**Before this change:**
> No way to push a frozen version’s layout/block state back into the live builder/library; top bar was crowded with many primary/secondary controls.

**After this change:**
> Restore flows work with question-bank semantics; sticky bar is Share / Actions / Go to. Please attach before/after screenshots of the top bar.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5399]: https://hous-bssb.atlassian.net/browse/HUB-5399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ