### PR TITLE
Hub 5428 bug submitters r ms cannot load projects applications UI switching between recently viewed items

### DIFF
--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-project-detail-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-project-detail-screen.tsx
@@ -17,17 +17,19 @@ import { InboxPermitsTab } from "./inbox-permits-tab"
 
 export const InboxProjectDetailScreen = observer(() => {
   const { currentPermitProject, error } = usePermitProject()
-  const { jurisdictionId } = useParams<{ jurisdictionId: string }>()
+  const { jurisdictionId, permitProjectId } = useParams<{ jurisdictionId: string; permitProjectId: string }>()
   const location = useLocation()
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { siteConfigurationStore } = useMst()
+  const projectMatchesRoute = currentPermitProject?.id === permitProjectId
   const projectMeetingsEnabled = Boolean(
     siteConfigurationStore.projectMeetingsEnabled && currentPermitProject?.jurisdiction?.projectMeetingsEnabled
   )
+  // Derive from the URL, not store current — store lags during project switches and was redirecting to the wrong project.
   const inboxProjectBasePath =
-    jurisdictionId && currentPermitProject
-      ? `/jurisdictions/${jurisdictionId}/submission-inbox/projects/${currentPermitProject.id}`
+    jurisdictionId && permitProjectId
+      ? `/jurisdictions/${jurisdictionId}/submission-inbox/projects/${permitProjectId}`
       : null
 
   const TABS_DATA: ITabItem[] = useMemo(() => {
@@ -77,12 +79,19 @@ export const InboxProjectDetailScreen = observer(() => {
   }, [inboxProjectBasePath, projectMeetingsEnabled, t])
 
   useEffect(() => {
-    if (!currentPermitProject || !inboxProjectBasePath) return
+    if (!inboxProjectBasePath) return
+
+    if (location.pathname === inboxProjectBasePath) {
+      navigate(`${inboxProjectBasePath}/overview`, { replace: true })
+      return
+    }
+
+    if (!projectMatchesRoute || TABS_DATA.length === 0) return
 
     if (!TABS_DATA.some((tab) => location.pathname === tab.to || location.pathname.startsWith(`${tab.to}/`))) {
       navigate(`${inboxProjectBasePath}/overview`, { replace: true })
     }
-  }, [TABS_DATA, currentPermitProject, inboxProjectBasePath, location.pathname, navigate])
+  }, [TABS_DATA, projectMatchesRoute, inboxProjectBasePath, location.pathname, navigate])
 
   useEffect(() => {
     if (currentPermitProject) {
@@ -106,7 +115,7 @@ export const InboxProjectDetailScreen = observer(() => {
   }
 
   if (error) return <ErrorScreen error={error} />
-  if (!currentPermitProject && !error) return <LoadingScreen />
+  if (!projectMatchesRoute && !error) return <LoadingScreen />
   if (!currentPermitProject) return <Text>{t("permitProject.details.notFound")}</Text>
 
   return (

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-project-detail-screen.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-project-detail-screen.tsx
@@ -1,10 +1,11 @@
 import { Container, Flex, Heading, IconButton, TabPanel, TabPanels, Tabs, Text } from "@chakra-ui/react"
 import { CalendarBlank, CaretLeft, Chat, ClipboardText, SquaresFour, TrendUp } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
-import React, { useEffect, useMemo, useTransition } from "react"
+import React, { useEffect, useMemo } from "react"
 import { useTranslation } from "react-i18next"
-import { Link as RouterLink, useLocation, useNavigate, useParams } from "react-router-dom"
+import { Link as RouterLink, useParams } from "react-router-dom"
 import { usePermitProject } from "../../../../../hooks/resources/use-permit-project"
+import { useProjectDetailTabs } from "../../../../../hooks/use-project-detail-tabs"
 import { useMst } from "../../../../../setup/root"
 import { ErrorScreen } from "../../../../shared/base/error-screen"
 import { LoadingScreen } from "../../../../shared/base/loading-screen"
@@ -18,11 +19,8 @@ import { InboxPermitsTab } from "./inbox-permits-tab"
 export const InboxProjectDetailScreen = observer(() => {
   const { currentPermitProject, error } = usePermitProject()
   const { jurisdictionId, permitProjectId } = useParams<{ jurisdictionId: string; permitProjectId: string }>()
-  const location = useLocation()
   const { t } = useTranslation()
-  const navigate = useNavigate()
   const { siteConfigurationStore } = useMst()
-  const projectMatchesRoute = currentPermitProject?.id === permitProjectId
   const projectMeetingsEnabled = Boolean(
     siteConfigurationStore.projectMeetingsEnabled && currentPermitProject?.jurisdiction?.projectMeetingsEnabled
   )
@@ -78,41 +76,19 @@ export const InboxProjectDetailScreen = observer(() => {
     ]
   }, [inboxProjectBasePath, projectMeetingsEnabled, t])
 
-  useEffect(() => {
-    if (!inboxProjectBasePath) return
-
-    if (location.pathname === inboxProjectBasePath) {
-      navigate(`${inboxProjectBasePath}/overview`, { replace: true })
-      return
-    }
-
-    if (!projectMatchesRoute || TABS_DATA.length === 0) return
-
-    if (!TABS_DATA.some((tab) => location.pathname === tab.to || location.pathname.startsWith(`${tab.to}/`))) {
-      navigate(`${inboxProjectBasePath}/overview`, { replace: true })
-    }
-  }, [TABS_DATA, projectMatchesRoute, inboxProjectBasePath, location.pathname, navigate])
+  const { projectMatchesRoute, tabIndex, handleTabChange, isPending } = useProjectDetailTabs({
+    basePath: inboxProjectBasePath,
+    tabs: TABS_DATA,
+    routeProjectId: permitProjectId,
+    currentProjectId: currentPermitProject?.id,
+    replaceOnTabChange: true,
+  })
 
   useEffect(() => {
     if (currentPermitProject) {
       currentPermitProject.markAsViewed()
     }
   }, [currentPermitProject])
-
-  const [isPending, startTransition] = useTransition()
-
-  const getTabIndex = () => {
-    const tabIndex = TABS_DATA.findIndex(
-      (tab) => location.pathname === tab.to || location.pathname.startsWith(`${tab.to}/`)
-    )
-    return tabIndex === -1 ? 0 : tabIndex
-  }
-
-  const handleTabChange = (index: number) => {
-    startTransition(() => {
-      navigate(TABS_DATA[index].to, { replace: true })
-    })
-  }
 
   if (error) return <ErrorScreen error={error} />
   if (!projectMatchesRoute && !error) return <LoadingScreen />
@@ -142,7 +118,7 @@ export const InboxProjectDetailScreen = observer(() => {
         flex={1}
         minH={0}
         minW={0}
-        index={getTabIndex()}
+        index={tabIndex}
         onChange={handleTabChange}
         display="flex"
         isLazy

--- a/app/frontend/components/domains/permit-project/permit-project-screen.tsx
+++ b/app/frontend/components/domains/permit-project/permit-project-screen.tsx
@@ -1,11 +1,12 @@
 import { Box, Container, Flex, IconButton, TabPanel, TabPanels, Tabs, Text } from "@chakra-ui/react"
 import { CalendarBlank, CaretLeft, Chat, ClipboardText, Folder, SquaresFour, TrendUp } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
-import React, { useEffect, useMemo, useTransition } from "react"
+import React, { useEffect, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { Link as RouterLink, useLocation, useNavigate, useParams } from "react-router-dom"
+import { Link as RouterLink, useParams } from "react-router-dom"
 import { usePermitProject } from "../../../hooks/resources/use-permit-project"
+import { useProjectDetailTabs } from "../../../hooks/use-project-detail-tabs"
 import { useMst } from "../../../setup/root"
 import { ErrorScreen } from "../../shared/base/error-screen"
 import { LoadingScreen } from "../../shared/base/loading-screen"
@@ -23,10 +24,7 @@ export const PermitProjectScreen = observer(() => {
   const { currentPermitProject, error } = usePermitProject()
   const { permitProjectId } = useParams<{ permitProjectId: string }>()
   const { permitProjectStore, siteConfigurationStore } = useMst()
-  const location = useLocation()
   const { t } = useTranslation()
-  const navigate = useNavigate()
-  const projectMatchesRoute = currentPermitProject?.id === permitProjectId
   const projectMeetingsEnabled = Boolean(
     siteConfigurationStore.projectMeetingsEnabled && currentPermitProject?.jurisdiction?.projectMeetingsEnabled
   )
@@ -59,6 +57,13 @@ export const PermitProjectScreen = observer(() => {
     ]
   }, [projectBasePath, projectMeetingsEnabled, t])
 
+  const { projectMatchesRoute, tabIndex, handleTabChange, isPending } = useProjectDetailTabs({
+    basePath: projectBasePath,
+    tabs: TABS_DATA,
+    routeProjectId: permitProjectId,
+    currentProjectId: currentPermitProject?.id,
+  })
+
   const getDefaultValues = () => {
     return {
       title: currentPermitProject?.title,
@@ -72,40 +77,8 @@ export const PermitProjectScreen = observer(() => {
   const { updatePermitProject } = permitProjectStore
 
   useEffect(() => {
-    if (!projectBasePath) return
-
-    // Bare /projects/:id → overview for the URL project only (never store current).
-    if (location.pathname === projectBasePath) {
-      navigate(`${projectBasePath}/overview`, { replace: true })
-      return
-    }
-
-    // Unknown subpath canonicalize only once store matches the route (avoids cross-project redirects).
-    if (!projectMatchesRoute || TABS_DATA.length === 0) return
-
-    if (!TABS_DATA.some((tab) => location.pathname === tab.to || location.pathname.startsWith(`${tab.to}/`))) {
-      navigate(`${projectBasePath}/overview`, { replace: true })
-    }
-  }, [TABS_DATA, projectMatchesRoute, projectBasePath, location.pathname, navigate])
-
-  useEffect(() => {
     reset(getDefaultValues())
   }, [currentPermitProject, reset]) // Recalculate if title changes, as it might affect height
-
-  const [isPending, startTransition] = useTransition()
-
-  const getTabIndex = () => {
-    const tabIndex = TABS_DATA.findIndex(
-      (tab) => location.pathname === tab.to || location.pathname.startsWith(`${tab.to}/`)
-    )
-    return tabIndex === -1 ? 0 : tabIndex
-  }
-
-  const handleTabChange = (index: number) => {
-    startTransition(() => {
-      navigate(TABS_DATA[index].to)
-    })
-  }
 
   const onSubmit = async (data: { title: string }) => {
     if (!currentPermitProject) return
@@ -157,15 +130,7 @@ export const PermitProjectScreen = observer(() => {
           </Flex>
         </Container>
       </Flex>
-      <Tabs
-        w="full"
-        flexGrow={1}
-        index={getTabIndex()}
-        onChange={handleTabChange}
-        display="flex"
-        isLazy
-        variant="sidebar"
-      >
+      <Tabs w="full" flexGrow={1} index={tabIndex} onChange={handleTabChange} display="flex" isLazy variant="sidebar">
         <ProjectSidebarTabList p={0} tabsData={TABS_DATA} />
         <TabPanels>
           <TabPanel>

--- a/app/frontend/components/domains/permit-project/permit-project-screen.tsx
+++ b/app/frontend/components/domains/permit-project/permit-project-screen.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react-lite"
 import React, { useEffect, useMemo, useTransition } from "react"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
-import { Link as RouterLink, useLocation, useNavigate } from "react-router-dom"
+import { Link as RouterLink, useLocation, useNavigate, useParams } from "react-router-dom"
 import { usePermitProject } from "../../../hooks/resources/use-permit-project"
 import { useMst } from "../../../setup/root"
 import { ErrorScreen } from "../../shared/base/error-screen"
@@ -21,14 +21,17 @@ import { ITabItem, ProjectSidebarTabList } from "./project-sidebar-tab-list"
 
 export const PermitProjectScreen = observer(() => {
   const { currentPermitProject, error } = usePermitProject()
+  const { permitProjectId } = useParams<{ permitProjectId: string }>()
   const { permitProjectStore, siteConfigurationStore } = useMst()
   const location = useLocation()
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const projectMatchesRoute = currentPermitProject?.id === permitProjectId
   const projectMeetingsEnabled = Boolean(
     siteConfigurationStore.projectMeetingsEnabled && currentPermitProject?.jurisdiction?.projectMeetingsEnabled
   )
-  const projectBasePath = currentPermitProject ? `/projects/${currentPermitProject.id}` : null
+  // Derive from the URL, not store current — store lags during project switches and was redirecting to the wrong project.
+  const projectBasePath = permitProjectId ? `/projects/${permitProjectId}` : null
 
   const TABS_DATA: ITabItem[] = useMemo(() => {
     if (!projectBasePath) return []
@@ -69,12 +72,21 @@ export const PermitProjectScreen = observer(() => {
   const { updatePermitProject } = permitProjectStore
 
   useEffect(() => {
-    if (!currentPermitProject || !projectBasePath) return
+    if (!projectBasePath) return
+
+    // Bare /projects/:id → overview for the URL project only (never store current).
+    if (location.pathname === projectBasePath) {
+      navigate(`${projectBasePath}/overview`, { replace: true })
+      return
+    }
+
+    // Unknown subpath canonicalize only once store matches the route (avoids cross-project redirects).
+    if (!projectMatchesRoute || TABS_DATA.length === 0) return
 
     if (!TABS_DATA.some((tab) => location.pathname === tab.to || location.pathname.startsWith(`${tab.to}/`))) {
       navigate(`${projectBasePath}/overview`, { replace: true })
     }
-  }, [TABS_DATA, currentPermitProject, projectBasePath, location.pathname, navigate])
+  }, [TABS_DATA, projectMatchesRoute, projectBasePath, location.pathname, navigate])
 
   useEffect(() => {
     reset(getDefaultValues())
@@ -101,7 +113,7 @@ export const PermitProjectScreen = observer(() => {
   }
 
   if (error) return <ErrorScreen error={error} />
-  if (!currentPermitProject && !error) return <LoadingScreen />
+  if (!projectMatchesRoute && !error) return <LoadingScreen />
   if (!currentPermitProject) return <Text>{t("permitProject.details.notFound")}</Text>
 
   return (

--- a/app/frontend/hooks/resources/use-permit-project.ts
+++ b/app/frontend/hooks/resources/use-permit-project.ts
@@ -14,6 +14,8 @@ export const usePermitProject = (permitProjectIdOverride?: string) => {
   const [error, setError] = useState<Error | undefined>(undefined)
 
   useEffect(() => {
+    let cancelled = false
+
     const loadPermitProject = async () => {
       if (!isUUID(permitProjectId)) return
       if (currentPermitProject?.id === permitProjectId && currentPermitProject.isFullyLoaded) return
@@ -23,6 +25,7 @@ export const usePermitProject = (permitProjectIdOverride?: string) => {
           setCurrentPermitProject(null)
         }
         const project = await fetchPermitProject(permitProjectId)
+        if (cancelled) return
         if (project) {
           setCurrentPermitProject(project.id)
           setError(null)
@@ -30,12 +33,16 @@ export const usePermitProject = (permitProjectIdOverride?: string) => {
           setError(new Error("Failed to fetch project details."))
         }
       } catch (e) {
+        if (cancelled) return
         console.error("Failed to fetch permit project:", e)
         setError(new Error("An error occurred while fetching project details."))
       }
     }
 
     loadPermitProject()
+    return () => {
+      cancelled = true
+    }
     // Intentionally omit currentPermitProject from deps: including it would re-run on every MST field update.
     // permitProjectId + sandbox identify which project to load; tab/query path changes do not.
   }, [permitProjectId, currentSandbox?.id, fetchPermitProject, setCurrentPermitProject])

--- a/app/frontend/hooks/use-project-detail-tabs.ts
+++ b/app/frontend/hooks/use-project-detail-tabs.ts
@@ -1,0 +1,60 @@
+import { useEffect, useTransition } from "react"
+import { useLocation, useNavigate } from "react-router-dom"
+
+type TProjectDetailTab = {
+  to: string
+}
+
+interface IUseProjectDetailTabsOptions {
+  basePath: string | null
+  tabs: TProjectDetailTab[]
+  routeProjectId: string | undefined
+  currentProjectId: string | undefined
+  /** Inbox uses replace so back stays on the inbox list; submitter project screen uses push. */
+  replaceOnTabChange?: boolean
+}
+
+export const useProjectDetailTabs = ({
+  basePath,
+  tabs,
+  routeProjectId,
+  currentProjectId,
+  replaceOnTabChange = false,
+}: IUseProjectDetailTabsOptions) => {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [isPending, startTransition] = useTransition()
+  const projectMatchesRoute = Boolean(routeProjectId && currentProjectId === routeProjectId)
+
+  useEffect(() => {
+    if (!basePath) return
+
+    // Bare project path → overview for the URL project only (never store current).
+    if (location.pathname === basePath) {
+      navigate(`${basePath}/overview`, { replace: true })
+      return
+    }
+
+    // Unknown subpath canonicalize only once store matches the route (avoids cross-project redirects).
+    if (!projectMatchesRoute || tabs.length === 0) return
+
+    if (!tabs.some((tab) => location.pathname === tab.to || location.pathname.startsWith(`${tab.to}/`))) {
+      navigate(`${basePath}/overview`, { replace: true })
+    }
+  }, [tabs, projectMatchesRoute, basePath, location.pathname, navigate])
+
+  const matchedTabIndex = tabs.findIndex(
+    (tab) => location.pathname === tab.to || location.pathname.startsWith(`${tab.to}/`)
+  )
+  const tabIndex = matchedTabIndex === -1 ? 0 : matchedTabIndex
+
+  const handleTabChange = (index: number) => {
+    const tab = tabs[index]
+    if (!tab) return
+    startTransition(() => {
+      navigate(tab.to, replaceOnTabChange ? { replace: true } : undefined)
+    })
+  }
+
+  return { projectMatchesRoute, tabIndex, handleTabChange, isPending }
+}


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5428-bug-submitters-r-ms-cannot-load-projects-applications-ui-switching-between-recently-viewed-items` (merge-base range).

Fixes a race where switching between recently viewed projects made the URL and project UI oscillate between the previous and newly selected project.

**Root cause:** Project detail screens built tab paths / overview redirects from MST `currentPermitProject`, which still held the previous project while the route had already changed. That redirected the browser back to the old project; concurrent `fetchPermitProject` calls then kept flipping the store and URL in a loop.

**Fix:** Derive base paths from the URL `:permitProjectId`, ignore stale fetches in `usePermitProject`, wait to render until store current matches the route, and extract shared tab/redirect logic into `useProjectDetailTabs` (used by submitter and inbox project detail screens).

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5428](https://hous-bssb.atlassian.net/browse/HUB-5428) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Stop overview/tab redirects from using stale store `currentPermitProject`; use URL project id instead
- Cancel/ignore in-flight `usePermitProject` loads when the route project id changes
- Show loading until store current matches the route project (avoids flashing the wrong project)
- Extract shared tab index / tab change / redirect behaviour into `useProjectDetailTabs` for submitter + inbox detail screens

---

## 🧪 Steps to QA

1. Sign in as a submitter with at least two projects.
2. Open project A’s overview (`/projects/:id/overview`).
3. Use the back arrow to return to the projects list.
4. Open project B from the list.
5. Repeat A → list → B → list → A several times in succession.
6. Optionally repeat the same pattern from the jurisdiction submission-inbox project detail view if available.

**Expected Behaviour:**
> The URL and project title/content settle immediately on the project you clicked. No oscillation between projects.

**Before this change:**
> Switching between recently viewed projects could make the URL and UI flip back and forth between the previous and new project (sometimes until a hard refresh).

**After this change:**
> Each project navigation loads once and stays on the selected project.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

No meaningful accessibility surface changes (routing/loading behaviour only; existing markup/labels unchanged).

- [ ] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [ ] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5428]: https://hous-bssb.atlassian.net/browse/HUB-5428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ