### PR TITLE
HUB-5252 remove blue tags advisory box

### DIFF
--- a/app/frontend/components/domains/permit-project/add-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-project/add-permit-application-screen.tsx
@@ -21,9 +21,7 @@ import { usePermitProject } from "../../../hooks/resources/use-permit-project"
 import { useTemplateVersions } from "../../../hooks/resources/use-template-versions"
 import { ITemplateVersion } from "../../../models/template-version"
 import { useMst } from "../../../setup/root"
-import { EFlashMessageStatus } from "../../../types/enums"
 import { groupTemplateVersionsByCategory } from "../../../utils/template-version-grouping"
-import { CustomMessageBox } from "../../shared/base/custom-message-box"
 import { ErrorScreen } from "../../shared/base/error-screen"
 import { RouterLinkButton } from "../../shared/navigation/router-link-button"
 import ProjectInfoRow from "../../shared/project/project-info-row"
@@ -175,13 +173,6 @@ export const AddPermitApplicationToProjectScreen = observer(() => {
           <Heading as="h2" variant="yellowline">
             {t("permitProject.addPermits.permits.heading")}
           </Heading>
-
-          <CustomMessageBox
-            status={EFlashMessageStatus.info}
-            title={t("permitProject.addPermits.bcbcPartHeading")}
-            description={t("permitProject.addPermits.bcbcPart")}
-            mb={6}
-          />
 
           {/* Search bar */}
           <InputGroup mb={6} maxW="full">

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -1504,9 +1504,6 @@ Thank you,
             fn: "These are First Nations specific permits",
             sandboxWarning: "Training sandbox permits can only be added into your own jurisdiction's training sandbox",
             button: "Add applications",
-            bcbcPartHeading: "Tags",
-            bcbcPart:
-              "Right now, you can apply for permits for small-scale projects. This includes residential buildings, small structures, trades permits, and site work.",
             noPermitsAvailable: "No permits are available",
             noPermitsAvailableDescription:
               "There are currently no permits available for this jurisdiction. Contact your local government for more information.",


### PR DESCRIPTION
## 📋 Description

Removes the blue info advisory box from the **Add applications to project** screen. The box was labeled “Tags” but displayed copy about small-scale / BCBC permit eligibility, which was confusing and no longer accurate for that context.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                                                      |
| -------------------- | ----------------------------------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5252](https://hous-bssb.atlassian.net/browse/HUB-5252)                               |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                                                       |
| 📑 Design / Figma    | <!-- N/A -->                                                                              |
| 📚 Documentation     | <!-- N/A -->                                                                              |

---

## ✨ Features / Changes Introduced

- Remove `CustomMessageBox` from `add-permit-application-screen.tsx` on the project “Add applications” flow
- Remove unused i18n strings `permitProject.addPermits.bcbcPartHeading` and `permitProject.addPermits.bcbcPart`
- Remove unused imports (`CustomMessageBox`, `EFlashMessageStatus`)

---

## 🧪 Steps to QA

1. Open a permit project and navigate to **Add applications** (project overview → add permit flow).
2. Confirm the blue info box under the “Permits” heading is **no longer shown**.
3. Confirm the permit search/list and **Add applications** flow still work as before.

**Expected Behaviour:**

- No misleading “Tags” advisory copy on the add-applications screen.
- Rest of the page is unchanged.

**Before this change:**

- Blue info box displayed “Tags” heading with copy about small-scale / residential permit eligibility.

**After this change:**

- Info box removed; users go straight to the permit search and list.

---

## ♿ UI Accessibility Checklist

> No meaningful accessibility changes — one informational element removed.

- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5252]: https://hous-bssb.atlassian.net/browse/HUB-5252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ