### PR TITLE
add dockerization for non node or rails services for dev conveniece

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ To make things easier to develop on various platforms locally, there is a `docke
 - This local dockerized version does not contain a service for `Consigno Verifio Notarius Server` which is proprietary licensed software that helps with validating PDFs. Therefore all functionality around this will not work. You can either run the service manually outside Docker and refer to it using the ENV vars, or find a private repository that has the image that you can then run in `docker-compose`
 - The local dockerized version does not setup Minio (which can be used to locally to mock Object Storage as it is S3 compatible - see instructions for local setup below). You can set this up manually outside the docker setup or add your own docker compose service for it. Just hook it up via the ENV vars (see `.env.example`) or simply switch the app to use actual `BCGOV_OBJECT_STORAGE` if you have a bucket allocation already.
 
+## Supporting services only (hybrid local)
+
+If you run Rails / Sidekiq / Vite / AnyCable RPC on the host but want Docker for the supporting daemons, use `docker-compose.services.yml`. This starts Elasticsearch (`:9200`), Minio (API `:9001`, console `:9002`), and `anycable-go` (`:8080`). It does **not** start Redis, Postgres, Rails, Sidekiq, Vite, or AnyCable RPC.
+
+```bash
+docker compose -f docker-compose.services.yml up -d
+```
+
+Then on the host (with Redis already running):
+
+```bash
+bundle exec anycable          # RPC on :50051 — required by the anycable-go container
+npm run dev
+bundle exec sidekiq ...
+bundle exec rails s
+```
+
+Notes:
+
+- `anycable-go` reaches host Redis at `host.docker.internal:6379` (db `1`) and host AnyCable RPC at `host.docker.internal:50051`. Keep Redis on `:6379` and start `bundle exec anycable` before relying on websockets.
+- Point host `.env` at these services, e.g. `ELASTICSEARCH_URL=http://localhost:9200` and Minio via `BCGOV_OBJECT_STORAGE_ENDPOINT=http://127.0.0.1:9001` with access key / secret matching the compose defaults (`minioadmin` / `minioadmin`). Create a bucket once in the Minio console at `http://127.0.0.1:9002` if needed.
+- Stop infra with `docker compose -f docker-compose.services.yml down` (add `-v` only if you want to wipe Elasticsearch / Minio data volumes).
+
 ## Running the application locally (non-dockerized)
 
 - Install Dependencies: `bundle install` and `npm install`
@@ -95,13 +118,13 @@ The app uses the [Sidekiq](https://github.com/sidekiq/sidekiq) library for backg
 The app uses [Anycable](https://anycable.io/) to serve websockets in a scalable way. To run the websocket server locally:
 
 - Ensure to `bundle install`
-- [Download the `anycable-go` websocket server on OSX: `brew install anycable-go`](https://docs.anycable.io/anycable-go/getting_started)
-- Add an ENV var `ANYCABLE_REDIS_URL=redis://localhost:6379/2`. It is recommended to set this value to a different Redis db than Sidekiq.
+- Either run `anycable-go` via [Supporting services only (hybrid local)](#supporting-services-only-hybrid-local), or [install it on OSX with `brew install anycable-go`](https://docs.anycable.io/anycable-go/getting_started)
+- Host AnyCable Redis should use db `1` (see `ANYCABLE_DEV_REDIS_URL` in `.env_example`), a different Redis db than Sidekiq
 
-After installation run both the `anycable-go` websocket server as well as the RPC server
+After installation run the RPC server (and `anycable-go` if you are not using the services compose):
 
 - RPC Server: `bundle exec anycable`
-- Anycable-Go Sockets: `anycable-go --port=8080`
+- Anycable-Go Sockets: `anycable-go --port=8080` (or the `anycable-go` service in `docker-compose.services.yml`)
 
 ### Notorius - Digital Seal Validation
 
@@ -110,7 +133,8 @@ After installation run both the `anycable-go` websocket server as well as the RP
 ### Local - File storage setup
 
 - For the local environment, if you want to test the full file upload process, you would want to run a local version of minio to simulate the object storage environment.
-- Install minio:
+- Easiest: start Minio via [Supporting services only (hybrid local)](#supporting-services-only-hybrid-local) (`docker-compose.services.yml`), then use the console at `http://127.0.0.1:9002` (defaults `minioadmin` / `minioadmin`).
+- Or install and run Minio on the host:
 
 ```
 brew install minio

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -1,0 +1,52 @@
+# LOCAL development only — supporting infra for a host-run Rails app.
+# Does not start Rails, Sidekiq, Vite, AnyCable RPC, Redis, or Postgres.
+#
+# Usage:
+#   docker compose -f docker-compose.services.yml up -d
+#   docker compose -f docker-compose.services.yml down
+#
+# Host still runs: redis, bundle exec anycable, npm run dev, sidekiq, rails s
+# anycable-go expects host Redis on :6379 and host AnyCable RPC on :50051.
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.0
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.transport.ssl.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - cluster.routing.allocation.disk.threshold_enabled=false
+    ports:
+      - "9200:9200"
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --address ":9001" --console-address ":9002"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9001:9001"
+      - "9002:9002"
+    volumes:
+      - minio_data:/data
+
+  anycable-go:
+    image: anycable/anycable-go:1.4.8
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      ANYCABLE_HOST: "0.0.0.0"
+      ANYCABLE_PORT: "8080"
+      ANYCABLE_RPC_HOST: host.docker.internal:50051
+      ANYCABLE_REDIS_URL: redis://host.docker.internal:6379/1
+      ANYCABLE_LOG_LEVEL: debug
+    ports:
+      - "8080:8080"
+
+volumes:
+  elasticsearch_data:
+  minio_data:


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...vibes/dockerize-local-infra` (merge-base range).

Adds a local-only `docker-compose.services.yml` so developers can Dockerize supporting infra (Elasticsearch, Minio, anycable-go) while keeping Rails, Sidekiq, Vite, AnyCable RPC, Redis, and Postgres on the host. Motivation: fewer manual terminal processes for daemons, without losing easy host logs/shutdown for the app and workers. README documents the hybrid workflow and points AnyCable/Minio sections at the new compose file.

No Jira key found on the branch or commits.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [x] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [x] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-XXXX](https://hous-bssb.atlassian.net/browse/HUB-XXXX) _(none found — replace if you have a ticket)_ |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | README — Supporting services only (hybrid local) |

---

## ✨ Features / Changes Introduced

- New `docker-compose.services.yml` with Elasticsearch (`:9200`), Minio (API `:9001`, console `:9002`), and anycable-go (`:8080`)
- anycable-go wired to host Redis / AnyCable RPC via `host.docker.internal` (with `host-gateway` for Linux)
- README section for the hybrid workflow; AnyCable and Minio docs updated to mention the services compose

---

## 🧪 Steps to QA

1. With host Redis running, start services: `docker compose -f docker-compose.services.yml up -d`
2. Confirm containers are healthy and ports respond: Elasticsearch `http://localhost:9200`, Minio console `http://127.0.0.1:9002` (login `minioadmin` / `minioadmin`), anycable-go on `:8080`
3. Start host processes: `bundle exec anycable`, `npm run dev`, Sidekiq, `rails s` (with `.env` pointing at `ELASTICSEARCH_URL=http://localhost:9200` and Minio `BCGOV_OBJECT_STORAGE_*` matching compose defaults)
4. In the browser: exercise a search path that uses Elasticsearch, a file upload that hits Minio, and a websocket-backed UI path
5. Stop infra with `docker compose -f docker-compose.services.yml down` and confirm host Rails can be stopped independently

**Expected Behaviour:**
> Supporting daemons run in Docker; app/workers/Vite/AnyCable RPC stay on the host. Search, uploads, and websockets work against published localhost ports.

**Before this change:**
> Developers had to start Elasticsearch, Minio, and anycable-go manually (or use the full-stack compose that also runs Rails/Sidekiq in Docker).

**After this change:**
> One `docker compose -f docker-compose.services.yml up -d` covers those three; host workflow for Rails/Sidekiq is unchanged.

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant _(N/A — local tooling/docs only)_
- [x] 📝 Commit messages are descriptive and follow the project convention
- [x] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes _(N/A)_
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed _(compose uses well-known local Minio defaults)_
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others