### PR TITLE
Bugfix/aug 6 updates

### DIFF
--- a/app/frontend/components/shared/base/inputs/user-input.tsx
+++ b/app/frontend/components/shared/base/inputs/user-input.tsx
@@ -65,8 +65,9 @@ export const UserInput = observer(({ index, remove, adminOnly }: IUserInputProps
           />
         </FormControl>
         <EmailFormControl fieldName={`users.${index}.email`} validate required />
-        <TextFormControl label={t("user.firstName")} fieldName={`users.${index}.firstName`} required />
-        <TextFormControl label={t("user.lastName")} fieldName={`users.${index}.lastName`} required />
+        {/* Names come from IDIR/BCeID on accept; invite-time first/last are optional. */}
+        <TextFormControl label={t("user.firstName")} fieldName={`users.${index}.firstName`} />
+        <TextFormControl label={t("user.lastName")} fieldName={`users.${index}.lastName`} />
         <Box alignSelf="flex-end" minW={150}>
           {isSubmitting ? (
             <SharedSpinner position="relative" top={4} left={5} minW="fit-content" />

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -2261,7 +2261,7 @@ Thank you,
               copy: "Copy this block",
               removeConfirmationModal: {
                 title: "Confirm you want to archive this requirement block.",
-                body: "Archiving this requirement blocks will remove it from all early access templates. This action cannot be undone.",
+                body: "Archiving this requirement block will remove it from all templates. This action cannot be undone.",
               },
             },
             clickToWriteDisplayName: "Click to write display name",


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...bugfix/aug-6-updates` (merge-base range).

Two small UI copy/validation fixes:

1. **Invite users** — First and last name are no longer required when inviting users. Names are expected to come from IDIR/BCeID when the invite is accepted, so forcing them at invite time was unnecessary friction.
2. **Archive requirement block** — Confirmation modal body had incorrect grammar (“blocks”) and underspecified scope (“early access templates”). Copy now correctly says archiving removes the block from all templates and cannot be undone.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5307](https://hous-bssb.atlassian.net/browse/HUB-5307), [HUB-5381](https://hous-bssb.atlassian.net/browse/HUB-5381) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Make first/last name optional on the shared user invite input (`UserInput`)
- Update archive requirement block confirmation copy to correct grammar and reflect removal from all templates

---

## 🧪 Steps to QA

### HUB-5307 — Invite name fields optional

1. Open a flow that uses the invite-users form (e.g. invite jurisdiction users / manage users invite).
2. Enter a valid email and leave first name and last name blank.
3. Submit the invite.

**Expected Behaviour:** Invite succeeds without requiring first or last name. Email remains required.

**Before this change:** First and last name were required and blocked submit when empty.

**After this change:** First and last name can be left blank; invite still works.

### HUB-5381 — Archive requirement block copy

1. As a user who can manage requirement blocks, open a requirement block and choose archive/remove.
2. Read the confirmation modal title and body.

**Expected Behaviour:** Body reads: “Archiving this requirement block will remove it from all templates. This action cannot be undone.”

**Before this change:** Body said “Archiving this requirement blocks will remove it from all early access templates…”

**After this change:** Singular “block” and “all templates” (not only early access).

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5307]: https://hous-bssb.atlassian.net/browse/HUB-5307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ