### PR TITLE
Fix permit application specs wiped by populate_base_form_data

### DIFF
--- a/lib/local_tools.rb
+++ b/lib/local_tools.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# Local-only console helpers. Refuses to run outside development/test.
+#
+#   LocalTools.help
+#   LocalTools.reindex_all
+#   LocalTools.reindex(PermitApplication)
+#   LocalTools.cache_clear
+class LocalTools
+  class NotLocalError < StandardError
+  end
+
+  class << self
+    def help
+      ensure_local!
+      puts <<~HELP
+        LocalTools (development/test only)
+          .reindex_all          Full Searchkick reindex of all models
+          .reindex(Model)       Reindex one Searchkick model (Class or name)
+          .cache_clear          Rails.cache.clear
+          .help                 This list
+      HELP
+      nil
+    end
+
+    def reindex_all
+      ensure_local!
+      models = searchkick_models
+      puts "Reindexing #{models.size} models..."
+      models.each do |model|
+        puts "  #{model.name}..."
+        model.reindex
+      end
+      puts "Done."
+      models.map(&:name)
+    end
+
+    def reindex(model)
+      ensure_local!
+      klass = model.is_a?(Class) ? model : model.to_s.constantize
+      unless searchkick_models.include?(klass)
+        raise ArgumentError, "#{klass.name} is not a Searchkick model"
+      end
+
+      puts "Reindexing #{klass.name}..."
+      klass.reindex
+      puts "Done."
+      klass.name
+    end
+
+    def cache_clear
+      ensure_local!
+      Rails.cache.clear
+      puts "Rails.cache cleared."
+      true
+    end
+
+    private
+
+    def ensure_local!
+      return if Rails.env.local?
+
+      raise NotLocalError,
+            "LocalTools is only available in development/test (current: #{Rails.env})"
+    end
+
+    # Searchkick registers models lazily; eager load so the list is complete.
+    def searchkick_models
+      if Rails.respond_to?(:autoloaders) && Rails.autoloaders.zeitwerk_enabled?
+        Zeitwerk::Loader.eager_load_all
+      else
+        Rails.application.eager_load!
+      end
+      Searchkick.models
+    end
+  end
+end

--- a/spec/lib/local_tools_spec.rb
+++ b/spec/lib/local_tools_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe LocalTools do
+  describe "env guard" do
+    it "allows calls in local environments" do
+      allow(Rails.env).to receive(:local?).and_return(true)
+      expect { described_class.help }.not_to raise_error
+    end
+
+    it "refuses to run outside local environments" do
+      allow(Rails.env).to receive(:local?).and_return(false)
+
+      expect { described_class.reindex_all }.to raise_error(
+        LocalTools::NotLocalError,
+        %r{development/test}
+      )
+    end
+  end
+end

--- a/spec/models/permit_application_spec.rb
+++ b/spec/models/permit_application_spec.rb
@@ -247,18 +247,17 @@ RSpec.describe PermitApplication, type: :model do
 
     describe "#energy_step_code_method" do
       it "reads tool or file from submission data" do
-        permit_application =
-          create(
-            :permit_application,
-            submission_data: {
-              "data" => {
-                "section1" => {
-                  "formSubmissionDataRSTsection1|RB1|energy_step_code_method" =>
-                    "tool"
-                }
+        permit_application = create(:permit_application)
+        permit_application.update!(
+          submission_data: {
+            "data" => {
+              "section1" => {
+                "formSubmissionDataRSTsection1|RB1|energy_step_code_method" =>
+                  "tool"
               }
             }
-          )
+          }
+        )
 
         expect(permit_application.energy_step_code_method).to eq("tool")
         expect(permit_application.using_digital_energy_step_code_tool?).to be(
@@ -269,21 +268,20 @@ RSpec.describe PermitApplication, type: :model do
 
     describe "#can_submit?" do
       it "is false when digital tool method is selected but step code is incomplete" do
-        permit_application =
-          create(
-            :permit_application,
-            submission_data: {
-              "data" => {
-                "section-completion-key" => {
-                  "signed" => true
-                },
-                "section1" => {
-                  "formSubmissionDataRSTsection1|RB1|energy_step_code_method" =>
-                    "tool"
-                }
+        permit_application = create(:permit_application)
+        permit_application.update!(
+          submission_data: {
+            "data" => {
+              "section-completion-key" => {
+                "signed" => true
+              },
+              "section1" => {
+                "formSubmissionDataRSTsection1|RB1|energy_step_code_method" =>
+                  "tool"
               }
             }
-          )
+          }
+        )
         create(:part_3_step_code, permit_application: permit_application)
         allow(permit_application).to receive(:inbox_enabled?).and_return(true)
         allow(permit_application).to receive(


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...chore/spec-fix-and-tools` (merge-base range).

Fixes flaky/incorrect PermitApplication specs that set `submission_data` on `create`. `before_validation :populate_base_form_data, on: :create` always resets submission data to `{ data: {} }`, so those examples never actually exercised `#energy_step_code_method` / `#can_submit?` with the intended values. Specs now create the record, then `update!` submission data (same pattern as existing snapshot examples).

Also adds `LocalTools` — local-only console helpers for Searchkick reindex and cache clear, guarded to development/test.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation
- [x] 📦 Chore (local tooling)

---

## 🎫 Related Tickets & Documents

> No Jira key found on the branch name, commit messages, or request.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-XXXX](https://hous-bssb.atlassian.net/browse/HUB-XXXX) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Update `#energy_step_code_method` and `#can_submit?` examples so submission data is set after create (avoids wipe by `populate_base_form_data`)
- Add `LocalTools` for local console: `reindex_all`, `reindex(Model)`, `cache_clear`, with env guard
- Spec coverage for the LocalTools local-env guard

---

## 🧪 Steps to QA

No UI changes in this PR — browser QA not applicable.

**Expected Behaviour:**
- `#energy_step_code_method` / related submit-gating specs pass with real submission data after create
- `LocalTools` is usable in local console and refused outside development/test

---

## ♿ UI Accessibility Checklist

No UI changes in this PR.

---

## ✅ General Checklist

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [x] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others