### PR TITLE
make selection zip download async

### DIFF
--- a/app/controllers/api/permit_applications_controller.rb
+++ b/app/controllers/api/permit_applications_controller.rb
@@ -390,14 +390,16 @@ class Api::PermitApplicationsController < Api::ApplicationController
     authorize @permit_application
 
     document_ids = Array(params[:supporting_document_ids]).presence
-    SupportingDocumentsZipper
-      .new(@permit_application.id, document_ids: document_ids)
-      .with_zip do |path|
-        send_data File.binread(path),
-                  filename: File.basename(path),
-                  type: "application/zip",
-                  disposition: "attachment"
-      end
+    request_id = SecureRandom.uuid
+
+    SupportingDocumentsZipDownloadJob.perform_async(
+      @permit_application.id,
+      document_ids,
+      request_id,
+      current_user.id
+    )
+
+    render json: { data: { request_id: request_id } }, status: :accepted
   end
 
   def finalize_revision_requests

--- a/app/frontend/components/domains/permit-application/submission-download-modal.tsx
+++ b/app/frontend/components/domains/permit-application/submission-download-modal.tsx
@@ -156,25 +156,33 @@ export const SubmissionDownloadModal = observer(
       allSelected: boolean
       knownFileUrls: string[]
     } | null>(null)
+    const pendingSelectiveZipRequestIdRef = useRef<string | null>(null)
     const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
     const [generationFailed, setGenerationFailed] = useState(false)
     const [awaitingGeneration, setAwaitingGeneration] = useState(false)
+    const [awaitingSelectiveZip, setAwaitingSelectiveZip] = useState(false)
+    const [selectiveZipFailed, setSelectiveZipFailed] = useState(false)
 
-    const onClose = () => {
+    const resetDownloadState = () => {
       setSelectedKeys(new Set())
       setGenerationFailed(false)
       setAwaitingGeneration(false)
+      setAwaitingSelectiveZip(false)
+      setSelectiveZipFailed(false)
       pendingDownloadRef.current = null
+      pendingSelectiveZipRequestIdRef.current = null
+      permitApplication.clearSelectiveZipResult()
+    }
+
+    const onClose = () => {
+      resetDownloadState()
       disclosureOnClose()
     }
 
     useEffect(() => {
       if (!isOpen) {
         zipGenerationTriggeredRef.current = false
-        setSelectedKeys(new Set())
-        setGenerationFailed(false)
-        setAwaitingGeneration(false)
-        pendingDownloadRef.current = null
+        resetDownloadState()
       }
     }, [isOpen])
 
@@ -227,12 +235,13 @@ export const SubmissionDownloadModal = observer(
       })
     }, [allKeys])
 
+    // true = download started immediately; "pending" = waiting on selective zip socket; false = failed
     const performDownload = async (
       fileUrls: string[],
       wasAllSelected: boolean,
       missingKeys: string[] = [],
       knownFileUrls: string[] = []
-    ) => {
+    ): Promise<true | false | "pending"> => {
       const selected = wasAllSelected
         ? documents
         : documents.filter(
@@ -248,16 +257,23 @@ export const SubmissionDownloadModal = observer(
         a.href = doc.fileUrl
         a.download = doc.fileName
         a.click()
-      } else if (wasAllSelected && zipfileUrl) {
+        return true
+      }
+
+      if (wasAllSelected && zipfileUrl) {
         const a = document.createElement("a")
         a.href = zipfileUrl
         a.download = zipfileName || `permit-application-${permitApplication.number}.zip`
         a.click()
-      } else {
-        const ok = await permitApplication.downloadSupportingDocumentsZip(selectedIds)
-        if (!ok) return false
+        return true
       }
-      return true
+
+      const requestId = await permitApplication.downloadSupportingDocumentsZip(selectedIds)
+      if (!requestId) return false
+
+      pendingSelectiveZipRequestIdRef.current = requestId
+      setAwaitingSelectiveZip(true)
+      return "pending"
     }
 
     // After missing PDFs finish, continue the download that was waiting
@@ -270,15 +286,38 @@ export const SubmissionDownloadModal = observer(
       pendingDownloadRef.current = null
       setAwaitingGeneration(false)
       ;(async () => {
-        const ok = await performDownload(
+        const result = await performDownload(
           pending.fileUrls,
           pending.allSelected,
           pending.missingKeys,
           pending.knownFileUrls
         )
-        if (ok) onClose()
+        if (result === true) onClose()
+        if (result === false) setSelectiveZipFailed(true)
       })()
     }, [awaitingGeneration, hasMissingPdfs, generationFailed, isOpen, documents, zipfileUrl])
+
+    // Selective zip ready via websocket — auto-download when requestId matches
+    useEffect(() => {
+      if (!isOpen || !awaitingSelectiveZip || !pendingSelectiveZipRequestIdRef.current) return
+
+      const result = permitApplication.selectiveZipResult
+      if (!result || result.requestId !== pendingSelectiveZipRequestIdRef.current) return
+
+      if (result.error || !result.zipfileUrl) {
+        setSelectiveZipFailed(true)
+        setAwaitingSelectiveZip(false)
+        return
+      }
+
+      const a = document.createElement("a")
+      a.href = result.zipfileUrl
+      a.download = result.zipfileName || `permit-application-${permitApplication.number}.zip`
+      a.click()
+      pendingSelectiveZipRequestIdRef.current = null
+      permitApplication.clearSelectiveZipResult()
+      onClose()
+    }, [isOpen, awaitingSelectiveZip, permitApplication.selectiveZipResult])
 
     const allSelected = allKeys.length > 0 && selectedKeys.size === allKeys.length
     const someSelected = selectedKeys.size > 0 && selectedKeys.size < allKeys.length
@@ -322,15 +361,16 @@ export const SubmissionDownloadModal = observer(
         return
       }
 
-      const ok = await performDownload(
+      const result = await performDownload(
         selectedReady.map((doc) => doc.fileUrl),
         allSelected
       )
-      if (ok) onClose()
+      if (result === true) onClose()
+      if (result === false) setSelectiveZipFailed(true)
     }
 
-    const showPreparing = awaitingGeneration && hasMissingPdfs
-    const showError = awaitingGeneration && generationFailed
+    const showPreparing = awaitingSelectiveZip || (awaitingGeneration && hasMissingPdfs && !selectiveZipFailed)
+    const showError = selectiveZipFailed || (awaitingGeneration && generationFailed)
 
     return (
       <>
@@ -467,13 +507,10 @@ function PreparingView({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation()
   return (
     <VStack align="stretch" spacing={6} p={10} w="full">
-      <VStack align="start" spacing="10px" w="full">
-        <Heading as="h1" fontSize="4xl" fontWeight="bold" lineHeight="normal" m={0} mb={0}>
-          {t("permitApplication.show.preparingFilesHeading")}
-        </Heading>
+      <VStack align="center" spacing={3} w="full" py={6}>
         <Spinner size="md" color="theme.blue" thickness="3px" emptyColor="border.light" />
-        <Text fontSize="lg" lineHeight="1.68">
-          {t("permitApplication.show.preparingFilesBody")}
+        <Text fontSize="md" color="text.secondary">
+          {t("permitApplication.show.generating")}
         </Text>
       </VStack>
       <Flex justify="flex-end" w="full">

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -2118,9 +2118,7 @@ Thank you,
             downloadSectionGenerated: "Application documents",
             downloadSectionOther: "Other",
             downloadSubmitted: "Submitted {{date}}",
-            preparingFilesHeading: "Preparing your files...",
-            preparingFilesBody:
-              "Your files are being prepared and will be available to download shortly. This usually takes less than two minutes.",
+            generating: "Generating...",
             errorPreparingHeading: "Error preparing files",
             errorPreparingTitle: "We couldn’t prepare your files for download",
             errorPreparingBody:

--- a/app/frontend/models/permit-application.ts
+++ b/app/frontend/models/permit-application.ts
@@ -18,6 +18,7 @@ import {
   IDownloadableFile,
   IFormIOBlock,
   IFormJson,
+  IPermitApplicationSelectiveZipReady,
   IPermitApplicationSupportingDocumentsUpdate,
   ISubmissionData,
   ISubmissionVersion,
@@ -36,7 +37,7 @@ import {
 import { format } from "date-fns"
 import { StepCodeModel } from "../stores/step-code-store"
 import { compareSubmissionData } from "../utils/formio-helpers"
-import { convertResourceArrayToRecord, startBlobDownload } from "../utils/utility-functions"
+import { convertResourceArrayToRecord } from "../utils/utility-functions"
 import { ICollaborator } from "./collaborator"
 import { JurisdictionModel } from "./jurisdiction"
 import { IPermitBlockStatus, PermitBlockStatusModel } from "./permit-block-status"
@@ -81,6 +82,7 @@ export const PermitApplicationModel = types.snapshotProcessor(
       zipfileSize: types.maybeNull(types.number),
       zipfileName: types.maybeNull(types.string),
       zipfileUrl: types.maybeNull(types.string),
+      selectiveZipResult: types.maybeNull(types.frozen<IPermitApplicationSelectiveZipReady>()),
       referenceNumber: types.maybeNull(types.string),
       missingPdfs: types.maybeNull(types.array(types.string)),
       isFullyLoaded: types.optional(types.boolean, false),
@@ -914,19 +916,25 @@ export const PermitApplicationModel = types.snapshotProcessor(
         self.zipfileName = data.zipfileName
         self.zipfileUrl = data.zipfileUrl
       },
+      handleSocketSelectiveZipReady: (data: IPermitApplicationSelectiveZipReady) => {
+        self.selectiveZipResult = data
+      },
+      clearSelectiveZipResult: () => {
+        self.selectiveZipResult = null
+      },
       generateMissingPdfs: flow(function* () {
         const response = yield self.environment.api.generatePermitApplicationMissingPdfs(self.id)
         return response.ok
       }),
 
       downloadSupportingDocumentsZip: flow(function* (supportingDocumentIds: string[]) {
+        self.selectiveZipResult = null
         const response = yield* toGenerator(
           self.environment.api.downloadSupportingDocumentsZip(self.id, supportingDocumentIds)
         )
-        if (!response.ok) return false
+        if (!response.ok) return null
 
-        startBlobDownload(response.data, "application/zip", `permit-application-${self.number || self.id}-files.zip`)
-        return true
+        return response.data?.data?.requestId ?? null
       }),
 
       unassignPermitCollaboration: flow(function* (collaborationId: string) {

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -741,10 +741,9 @@ export class Api {
   }
 
   async downloadSupportingDocumentsZip(id: string, supportingDocumentIds: string[]) {
-    return this.client.post<BlobPart>(
+    return this.client.post<IApiResponse<{ requestId: string }, {}>>(
       `/permit_applications/${id}/download_supporting_documents_zip`,
-      { supportingDocumentIds },
-      { responseType: "blob", headers: { Accept: "application/zip" } }
+      { supportingDocumentIds }
     )
   }
 

--- a/app/frontend/stores/permit-application-store.ts
+++ b/app/frontend/stores/permit-application-store.ts
@@ -22,6 +22,7 @@ import {
 import {
   IPermitApplicationComplianceUpdate,
   IPermitApplicationSearchFilters,
+  IPermitApplicationSelectiveZipReady,
   IPermitApplicationSupportingDocumentsUpdate,
   IUserPushPayload,
   TCreatePermitApplicationFormData,
@@ -317,6 +318,7 @@ export const PermitApplicationStoreModel = types
         zipfileSize: overrides.zipfileSize || null,
         zipfileName: overrides.zipfileName || null,
         zipfileUrl: overrides.zipfileUrl || null,
+        selectiveZipResult: overrides.selectiveZipResult || null,
         referenceNumber: overrides.referenceNumber || null,
         missingPdfs: overrides.missingPdfs || null,
         isFullyLoaded: overrides.isFullyLoaded ?? false,
@@ -423,6 +425,10 @@ export const PermitApplicationStoreModel = types
           payloadData = payload.data as IPermitApplicationSupportingDocumentsUpdate
 
           self.permitApplicationMap.get(payloadData?.id)?.handleSocketSupportingDocsUpdate(payloadData)
+          break
+        case EPermitApplicationSocketEventTypes.selectiveZipReady:
+          payloadData = payload.data as IPermitApplicationSelectiveZipReady
+          self.permitApplicationMap.get(payloadData?.id)?.handleSocketSelectiveZipReady(payloadData)
           break
         case EPermitApplicationSocketEventTypes.updatePermitBlockStatus:
           payloadData = payload.data as IPermitBlockStatus

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -425,6 +425,7 @@ export enum EPermitApplicationSocketEventTypes {
   updateCompliance = "update_compliance",
   updateSupportingDocuments = "update_supporting_documents",
   updatePermitBlockStatus = "update_permit_block_status",
+  selectiveZipReady = "selective_zip_ready",
 }
 
 export enum EJurisdictionSocketEventTypes {

--- a/app/frontend/types/types.ts
+++ b/app/frontend/types/types.ts
@@ -495,13 +495,6 @@ export interface IReportDocumentNotificationObjectData {
   downloadUrl?: string
 }
 
-export type TSocketEventData =
-  | IPermitApplicationComplianceUpdate
-  | IPermitApplicationSupportingDocumentsUpdate
-  | IPermitBlockStatus
-  | INotification
-  | ITemplateVersionUpdate
-
 export interface IPermitApplicationSupportingDocumentsUpdate {
   id: string
   supportingDocuments: IPermitApplication["supportingDocuments"]
@@ -511,6 +504,22 @@ export interface IPermitApplicationSupportingDocumentsUpdate {
   zipfileUrl: null | string
   allSubmissionVersionCompletedSupportingDocuments?: IDownloadableFile[]
 }
+
+export interface IPermitApplicationSelectiveZipReady {
+  id: string
+  requestId: string
+  zipfileUrl?: string | null
+  zipfileName?: string | null
+  error?: boolean
+}
+
+export type TSocketEventData =
+  | IPermitApplicationComplianceUpdate
+  | IPermitApplicationSupportingDocumentsUpdate
+  | IPermitApplicationSelectiveZipReady
+  | IPermitBlockStatus
+  | INotification
+  | ITemplateVersionUpdate
 
 export interface IUserPushPayload {
   data: TSocketEventData

--- a/app/jobs/supporting_documents_zip_download_job.rb
+++ b/app/jobs/supporting_documents_zip_download_job.rb
@@ -1,0 +1,64 @@
+class SupportingDocumentsZipDownloadJob
+  include Sidekiq::Worker
+  sidekiq_options queue: :file_processing
+
+  def perform(permit_application_id, document_ids, request_id, user_id)
+    zipfile_url = nil
+    zipfile_name = nil
+
+    SupportingDocumentsZipper
+      .new(permit_application_id, document_ids: document_ids)
+      .with_zip do |path|
+        zipfile_name = File.basename(path)
+        File.open(path.to_s, "rb") do |file|
+          uploaded = ZipfileUploader.new(:store).upload(file)
+          zipfile_url =
+            uploaded.url(
+              public: false,
+              expires_in: 3600,
+              response_content_disposition:
+                ContentDisposition.attachment(zipfile_name)
+            )
+        end
+      end
+
+    broadcast(
+      permit_application_id,
+      request_id,
+      user_id,
+      zipfile_url: zipfile_url,
+      zipfile_name: zipfile_name
+    )
+  rescue StandardError => e
+    Rails.logger.error(
+      "SupportingDocumentsZipDownloadJob failed for #{permit_application_id}: #{e.message}"
+    )
+    broadcast(permit_application_id, request_id, user_id, error: true)
+  end
+
+  private
+
+  def broadcast(
+    permit_application_id,
+    request_id,
+    user_id,
+    zipfile_url: nil,
+    zipfile_name: nil,
+    error: false
+  )
+    WebsocketBroadcaster.push_update_to_relevant_users(
+      [user_id],
+      Constants::Websockets::Events::PermitApplication::DOMAIN,
+      Constants::Websockets::Events::PermitApplication::TYPES[
+        :selective_zip_ready
+      ],
+      {
+        id: permit_application_id,
+        request_id: request_id,
+        zipfile_url: zipfile_url,
+        zipfile_name: zipfile_name,
+        error: error
+      }
+    )
+  end
+end

--- a/app/services/constants/websockets.rb
+++ b/app/services/constants/websockets.rb
@@ -10,7 +10,8 @@ module Constants
         TYPES = {
           update_compliance: :update_compliance,
           update_supporting_documents: :update_supporting_documents,
-          update_permit_block_status: :update_permit_block_status
+          update_permit_block_status: :update_permit_block_status,
+          selective_zip_ready: :selective_zip_ready
         }.freeze
       end
 

--- a/spec/jobs/supporting_documents_zip_download_job_spec.rb
+++ b/spec/jobs/supporting_documents_zip_download_job_spec.rb
@@ -1,0 +1,90 @@
+require "rails_helper"
+require "sidekiq/testing"
+
+RSpec.describe SupportingDocumentsZipDownloadJob, type: :job do
+  before { Sidekiq::Testing.fake! }
+
+  let(:permit_application_id) { "pa-1" }
+  let(:document_ids) { %w[doc-1 doc-2] }
+  let(:request_id) { "req-123" }
+  let(:user_id) { "user-1" }
+  let(:zip_path) { Pathname.new("/tmp/zipfiles/test.zip") }
+  let(:uploaded) { instance_double("Shrine::UploadedFile") }
+  let(:uploader) { instance_double("ZipfileUploader") }
+
+  before do
+    allow(WebsocketBroadcaster).to receive(:push_update_to_relevant_users)
+  end
+
+  def expect_broadcast(payload)
+    expect(WebsocketBroadcaster).to have_received(
+      :push_update_to_relevant_users
+    ).with(
+      [user_id],
+      Constants::Websockets::Events::PermitApplication::DOMAIN,
+      Constants::Websockets::Events::PermitApplication::TYPES[
+        :selective_zip_ready
+      ],
+      hash_including(payload)
+    )
+  end
+
+  it "uploads a selective zip via with_zip and broadcasts the download url" do
+    zipper = instance_double("SupportingDocumentsZipper")
+    allow(SupportingDocumentsZipper).to receive(:new).with(
+      permit_application_id,
+      document_ids: document_ids
+    ).and_return(zipper)
+    allow(zipper).to receive(:with_zip).and_yield(zip_path)
+    allow(zipper).to receive(:perform)
+
+    allow(File).to receive(:open).with(zip_path.to_s, "rb").and_yield(
+      StringIO.new("zip-bytes")
+    )
+    allow(ZipfileUploader).to receive(:new).with(:store).and_return(uploader)
+    allow(uploader).to receive(:upload).and_return(uploaded)
+    allow(uploaded).to receive(:url).and_return(
+      "https://example.com/selective.zip"
+    )
+
+    described_class.new.perform(
+      permit_application_id,
+      document_ids,
+      request_id,
+      user_id
+    )
+
+    expect(zipper).to have_received(:with_zip)
+    expect(zipper).not_to have_received(:perform)
+    expect(uploader).to have_received(:upload)
+    expect_broadcast(
+      id: permit_application_id,
+      request_id: request_id,
+      zipfile_url: "https://example.com/selective.zip",
+      zipfile_name: "test.zip",
+      error: false
+    )
+  end
+
+  it "broadcasts an error payload when zipping fails" do
+    allow(SupportingDocumentsZipper).to receive(:new).and_raise(
+      StandardError,
+      "boom"
+    )
+
+    described_class.new.perform(
+      permit_application_id,
+      document_ids,
+      request_id,
+      user_id
+    )
+
+    expect_broadcast(
+      id: permit_application_id,
+      request_id: request_id,
+      zipfile_url: nil,
+      zipfile_name: nil,
+      error: true
+    )
+  end
+end

--- a/spec/policies/permit_application_policy_spec.rb
+++ b/spec/policies/permit_application_policy_spec.rb
@@ -315,6 +315,25 @@ RSpec.describe PermitApplicationPolicy do
       ).to be false
     end
 
+    it "download_supporting_documents_zip? mirrors generate_missing_pdfs?" do
+      record =
+        double(
+          "PermitApplication",
+          submitter: submitter,
+          jurisdiction_id: jurisdiction.id
+        )
+      policy = described_class.new(UserContext.new(submitter, sandbox), record)
+      expect(policy.download_supporting_documents_zip?).to eq(
+        policy.generate_missing_pdfs?
+      )
+
+      stranger_policy =
+        described_class.new(UserContext.new(create(:user), sandbox), record)
+      expect(stranger_policy.download_supporting_documents_zip?).to eq(
+        stranger_policy.generate_missing_pdfs?
+      )
+    end
+
     it "finalize_revision_requests? respects designated reviewer feature" do
       reviewer = create(:user, :review_manager, jurisdiction:)
       delegatee_rel = double("DelegateeRel", first: nil)

--- a/spec/requests/api/permit_applications_spec.rb
+++ b/spec/requests/api/permit_applications_spec.rb
@@ -587,4 +587,43 @@ RSpec.describe "Api::PermitApplications", type: :request do
       )
     end
   end
+
+  describe "POST /api/permit_applications/:id/download_supporting_documents_zip" do
+    let(:document_ids) { %w[doc-1 doc-2] }
+
+    it "enqueues a selective zip job and returns a request_id" do
+      allow(SupportingDocumentsZipDownloadJob).to receive(:perform_async)
+
+      post "/api/permit_applications/#{permit_application.id}/download_supporting_documents_zip",
+           params: {
+             supporting_document_ids: document_ids
+           },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:accepted)
+      request_id = json_response.dig("data", "request_id")
+      expect(request_id).to be_present
+      expect(SupportingDocumentsZipDownloadJob).to have_received(
+        :perform_async
+      ).with(permit_application.id, document_ids, request_id, submitter.id)
+    end
+
+    it "forbids users who cannot download" do
+      sign_in other_user
+      allow(SupportingDocumentsZipDownloadJob).to receive(:perform_async)
+
+      post "/api/permit_applications/#{permit_application.id}/download_supporting_documents_zip",
+           params: {
+             supporting_document_ids: document_ids
+           },
+           headers: headers,
+           as: :json
+
+      expect(response).to have_http_status(:forbidden)
+      expect(SupportingDocumentsZipDownloadJob).not_to have_received(
+        :perform_async
+      )
+    end
+  end
 end


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-2906-ui-update-attachment-download-ui-for-permit-applications` (merge-base range).

Redesigns the permit application submission download modal so reviewers/submitters can select which files to download, grouped by form section. Adds a selective supporting-documents zip endpoint so multi-file selections (that are not the full cached package) can be downloaded as a zip. System PDFs that are still generating are shown as selectable placeholders, with a preparing/error state while generation completes.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-2906](https://hous-bssb.atlassian.net/browse/HUB-2906) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Redesigned download modal with select-all / per-section / per-file checkboxes and section grouping (application documents, form sections, other)
- Selective multi-file zip download via `POST .../download_supporting_documents_zip` (reuses full-package `zipfileUrl` when everything is selected and the package is ready; single file still uses direct file URL)
- Exposes supporting document `id` / `dataKey` for selection and grouping; zipper supports filtering by document ids and building a zip without uploading to `zipfile_data`
- Preparing / error UI while missing system PDFs finish generating; review JSON download remains available
- Specs for selective zipper filtering

---

## 🧪 Steps to QA

1. Open a **submitted** permit application and open the download modal (submitter and review-staff paths).
2. Confirm files are grouped into sections, with select-all and per-section checkboxes.
3. Download a **single** selected file — file downloads directly (not as a zip).
4. Select **all** files when the full package zip is already available — downloads the existing package zip.
5. Select a **subset** of multiple files — receives a zip containing only those files.
6. If system PDFs are still missing, select them and download — modal shows preparing state, then completes when files are ready (or shows the error state if generation fails).
7. As review staff, confirm “Download the application as JSON” still works.
8. Confirm a user without access cannot use the selective zip download.

**Expected Behaviour:**
Users can choose which submission files to download; multi-file subsets come back as a zip; full-package and single-file shortcuts still work; missing PDFs are handled with clear preparing/error feedback.

**Before this change:**
Download modal listed files with individual links plus a single “download all as ZIP” for the prebuilt package only — no multi-select / selective zip.

**After this change:**
Checkbox-based selection by section, selective zip for partial multi-file downloads, and preparing/error states for in-progress system PDFs.

_(Add before/after screenshots of the modal if available.)_

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-2906]: https://hous-bssb.atlassian.net/browse/HUB-2906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ