### PR TITLE
update builder restore copy and colors

### DIFF
--- a/app/frontend/components/domains/requirement-template/screens/template-version-actions-menu.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-actions-menu.tsx
@@ -99,6 +99,7 @@ export const TemplateVersionActionsMenu = observer(function TemplateVersionActio
             promptHeader={t("templateVersionPreview.restoreLayout.confirmTitle")}
             promptMessage={<Text whiteSpace="pre-line">{t("templateVersionPreview.restoreLayout.confirmBody")}</Text>}
             confirmText={t("templateVersionPreview.restoreLayout.confirmButton")}
+            confirmButtonBg="semantic.error"
             onConfirm={handleRestoreLayout}
             renderTrigger={(onOpen) => (
               <MenuItem onClick={onOpen}>{t("templateVersionPreview.restoreLayout.triggerButton")}</MenuItem>

--- a/app/frontend/components/domains/requirement-template/screens/template-version-block-actions-menu.tsx
+++ b/app/frontend/components/domains/requirement-template/screens/template-version-block-actions-menu.tsx
@@ -57,6 +57,7 @@ export const TemplateVersionBlockActionsMenu = observer(function TemplateVersion
             <Text whiteSpace="pre-line">{t("templateVersionPreview.blockActions.restoreConfirmBody")}</Text>
           }
           confirmText={t("templateVersionPreview.blockActions.restoreConfirmButton")}
+          confirmButtonBg="semantic.error"
           onConfirm={handleRestore}
           renderTrigger={(onOpen) => (
             <MenuItem onClick={onOpen}>{t("templateVersionPreview.blockActions.restoreSourceBlock")}</MenuItem>

--- a/app/frontend/components/shared/modals/confirmation-modal.tsx
+++ b/app/frontend/components/shared/modals/confirmation-modal.tsx
@@ -18,6 +18,7 @@ interface IConfirmationModalProps {
   promptMessage?: string | ReactNode
   promptHeader?: string
   confirmText?: string
+  confirmButtonBg?: string
   renderTrigger: (onOpen: () => void) => ReactNode
 }
 
@@ -26,6 +27,7 @@ export const ConfirmationModal = ({
   promptMessage,
   promptHeader,
   confirmText,
+  confirmButtonBg,
   renderTrigger,
 }: IConfirmationModalProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
@@ -51,7 +53,12 @@ export const ConfirmationModal = ({
           <ModalBody>{promptMessage ?? t("ui.confirm")}</ModalBody>
           <ModalFooter>
             <Flex justify="flex-start" w="full" gap={4}>
-              <Button variant="primary" onClick={handleConfirm}>
+              <Button
+                variant="primary"
+                bg={confirmButtonBg}
+                _hover={confirmButtonBg ? { bg: confirmButtonBg, opacity: 0.9 } : undefined}
+                onClick={handleConfirm}
+              >
                 {confirmText ?? t("ui.confirm")}
               </Button>
               <Button variant="secondary" onClick={handleCancel}>

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -4844,7 +4844,7 @@ Thank you,
             menuLabel: "Go to",
             formPreview: "Form preview",
             builder: "Builder",
-            catalogue: "Catalogue",
+            catalogue: "Template catalogue",
           },
 
           immutableVersionNotice:
@@ -4857,9 +4857,9 @@ Thank you,
           },
           restoreLayout: {
             triggerButton: "Restore layout to builder",
-            confirmTitle: "Restore layout from this version?",
+            confirmTitle: "Overwrite current builder layout?",
             confirmBody:
-              "This will replace the current builder layout (sections, block arrangement, and show/hide rules) with the layout from this version.\n\nIt does not rewind the wording or settings inside shared question blocks. If a block from this version is missing or archived in the library, the restore will fail.\n\nAny unsaved builder edits will be lost.",
+              "This is a destructive action. It will overwrite your current builder state with the layout from this version (sections, block arrangement, and show/hide rules).\n\n It does not rewind the wording or settings inside shared question blocks. If a block from this version is missing or archived in the library, the restore will fail.",
             confirmButton: "Restore layout",
           },
           blockActions: {
@@ -4867,7 +4867,7 @@ Thank you,
             restoreSourceBlock: "Restore source block",
             restoreConfirmTitle: "Restore this shared block from the version?",
             restoreConfirmBody:
-              "This overwrites the live shared requirement block in the library so it matches this version’s snapshot (field arrangement, required/optional, conditionals, and related placement settings).\n\nImportant limitations:\n• Every permit template that uses this block will get these restored placements — not only the template you are viewing.\n• Question bank definitions are not rewritten. Bank-linked fields keep following the live question bank wording unless this version stored a placement-specific hint/instructions override.\n• If a linked bank question no longer exists (or is archived), that field is restored as block-only using the wording frozen in this version.\n• Attached requirement documents / downloadable files are not restored.\n• Already-submitted applications stay on their frozen template version; this changes the library going forward.\n• If the block was archived, it will be un-archived in the library (re-adding it to a template’s layout is separate — use Restore layout if needed).\n• If the block was permanently deleted from the library, restore cannot recreate it.",
+              "This overwrites the live shared requirement block in the library so it matches this version’s snapshot (field arrangement, required/optional, conditionals, and related placement settings).\n\nImportant limitations:\n\n• Every permit template that uses this block will get these restored placements, not only the template you are viewing.\n\n• Question bank definitions are not rewritten. Bank-linked fields keep following the live question bank wording unless this version stored a placement-specific hint/instructions override.\n\n• If a linked bank question no longer exists (or is archived), that field is restored as block-only using the wording frozen in this version.\n\n• Attached requirement documents / downloadable files are not restored.\n\n• If the block was archived, it will be un-archived in the library (re-adding it to a template’s layout is separate; use Restore layout if needed).\n\n• If the block was permanently deleted from the library, restore cannot recreate it.",
             restoreConfirmButton: "Overwrite shared block",
           },
           schedulePublish: {


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff integration/question-bank...chore/builder-restore-copy` (merge-base range).

Hardens copy and styling on template-version restore confirmations so users clearly see these actions overwrite current state. Layout restore wording is more destructive, shared-block restore copy drops em-dashes and tightens limitations, and both confirm buttons use `semantic.error`. Also renames the Go to menu label from “Catalogue” to “Template catalogue”.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5399](https://hous-bssb.atlassian.net/browse/HUB-5399) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- Update restore-layout confirmation title/body to stress overwrite of current builder state
- Style Restore layout and Overwrite shared block confirm buttons with `semantic.error`
- Add optional `confirmButtonBg` to the shared prompt confirmation modal
- Clean shared-block restore copy (no em-dashes; clearer limitation list)
- Rename Go to → “Template catalogue”

---

## 🧪 Steps to QA

1. Open a template version that has Actions → **Restore layout to builder**
2. Open the confirmation modal
3. Confirm title/body warn that the action overwrites the current builder layout, and that **Restore layout** is red (`semantic.error`)
4. On a version with blocks, open a block’s **Block actions** → **Restore source block**
5. Confirm the modal body has no em-dashes, limitations read clearly, and **Overwrite shared block** is the same red
6. Cancel both modals (no restore) to leave data unchanged
7. From the version screen Go to menu, confirm the label reads **Template catalogue**

**Expected Behaviour:**
> Both restore confirmations look destructive (red confirm), and copy makes overwrite risk clear without em-dashes.

**Before this change:**
> Confirm buttons used the default primary style; layout restore copy was milder; block restore copy used em-dashes.

**After this change:**
> Confirm buttons use `semantic.error`; layout restore copy emphasizes overwrite; block restore copy is cleaned up; catalogue label is “Template catalogue”.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5399]: https://hous-bssb.atlassian.net/browse/HUB-5399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ