### PR TITLE
Hub 5358 bug bug bash block save while uppy s 3 uploads are in progress

### DIFF
--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/resources-screen.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/resources-screen.tsx
@@ -204,14 +204,14 @@ export const ResourcesScreen = observer(function ResourcesScreen() {
     })
   }
 
-  const { uppy: modalUppy } = useUppyS3({
+  const { uppy: modalUppy, isUploading } = useUppyS3({
     onUploadSuccess: handleUploadSuccess,
     maxNumberOfFiles: 1,
     autoProceed: true,
   })
 
   const onModalSubmit = async (formData: IResourceModalForm) => {
-    if (!currentJurisdiction) return
+    if (isUploading || !currentJurisdiction) return
 
     setIsSubmitting(true)
     try {
@@ -373,7 +373,7 @@ export const ResourcesScreen = observer(function ResourcesScreen() {
               <Button variant="ghost" mr={3} onClick={handleCloseModal} isDisabled={isSubmitting}>
                 {t("ui.cancel")}
               </Button>
-              <Button type="submit" variant="primary" isLoading={isSubmitting}>
+              <Button type="submit" variant="primary" isLoading={isSubmitting} isDisabled={isSubmitting || isUploading}>
                 {t("ui.save")}
               </Button>
             </ModalFooter>

--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/resources-screen.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/resources-screen.tsx
@@ -23,8 +23,6 @@ import {
 } from "@chakra-ui/react"
 import { CaretLeft, Link, Pencil, Plus, Trash, X } from "@phosphor-icons/react"
 import { UppyFile } from "@uppy/core"
-import "@uppy/core/dist/style.min.css"
-import Dashboard from "@uppy/react/lib/Dashboard.js"
 import { format } from "date-fns"
 import { observer } from "mobx-react-lite"
 import React, { useEffect, useRef, useState } from "react"
@@ -53,6 +51,7 @@ import {
   TextFormControl,
   UrlFormControl,
 } from "../../../../shared/form/input-form-control"
+import { UppyDashboard } from "../../../../shared/uppy-dashboard"
 
 interface IResourceModalForm {
   category: string
@@ -206,6 +205,7 @@ export const ResourcesScreen = observer(function ResourcesScreen() {
 
   const { uppy: modalUppy, isUploading } = useUppyS3({
     onUploadSuccess: handleUploadSuccess,
+    onFileRemoved: () => modalSetValue("resourceDocumentAttributes", undefined),
     maxNumberOfFiles: 1,
     autoProceed: true,
   })
@@ -357,7 +357,7 @@ export const ResourcesScreen = observer(function ResourcesScreen() {
                   <Box ref={modalContainerRef}>
                     <FormLabel>{t("home.configurationManagement.resources.file")}</FormLabel>
                     <Box position="relative" mt={2}>
-                      <Dashboard uppy={modalUppy} height={300} width="100%" proudlyDisplayPoweredByUppy={false} />
+                      <UppyDashboard uppy={modalUppy} height={300} width="100%" />
                     </Box>
                   </Box>
                 ) : (

--- a/app/frontend/components/domains/pre-check/form-section/upload-drawings.tsx
+++ b/app/frontend/components/domains/pre-check/form-section/upload-drawings.tsx
@@ -16,8 +16,6 @@ import {
 } from "@chakra-ui/react"
 import { Trash } from "@phosphor-icons/react"
 import { UppyFile } from "@uppy/core"
-import "@uppy/core/dist/style.min.css"
-import Dashboard from "@uppy/react/lib/Dashboard.js"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useFieldArray, useForm } from "react-hook-form"
@@ -28,6 +26,7 @@ import { useMst } from "../../../../setup/root"
 import { EFileUploadAttachmentType } from "../../../../types/enums"
 import { IDesignDocument } from "../../../../types/types"
 import { FileDownloadButton } from "../../../shared/base/file-download-button"
+import { UppyDashboard } from "../../../shared/uppy-dashboard"
 import { PreCheckBackLink } from "../pre-check-back-link"
 import { FormFooter } from "./form-footer"
 
@@ -60,7 +59,7 @@ export const UploadDrawings = observer(function UploadDrawings() {
     },
   })
 
-  const { fields, append, update } = useFieldArray({
+  const { fields, append, update, remove } = useFieldArray({
     control,
     name: "designDocumentsAttributes",
   })
@@ -103,8 +102,24 @@ export const UploadDrawings = observer(function UploadDrawings() {
     }
   }
 
+  const handleUppyFileRemoved = (file: UppyFile<{}, {}>) => {
+    const key = file.uploadURL?.split("/").pop()
+    const index = designDocumentsAttributes.findIndex(
+      (doc) => (key && doc.file?.id === key) || (!doc.id && doc.file?.metadata?.filename === file.name)
+    )
+    if (index === -1) return
+
+    const doc = designDocumentsAttributes[index]
+    if (doc.id) {
+      update(index, { ...doc, _destroy: true })
+    } else {
+      remove(index)
+    }
+  }
+
   const { uppy, isUploading } = useUppyS3({
     onUploadSuccess: handleUploadSuccess,
+    onFileRemoved: handleUppyFileRemoved,
     maxNumberOfFiles: 1,
     autoProceed: true,
     maxFileSizeMB: 200,
@@ -200,7 +215,7 @@ export const UploadDrawings = observer(function UploadDrawings() {
 
       {!currentPreCheck?.isSubmitted && !currentPreCheck?.isUploadDrawingsComplete && (
         <Box position="relative" mb={6}>
-          <Dashboard uppy={uppy} width="100%" height={276} proudlyDisplayPoweredByUppy={false} />
+          <UppyDashboard uppy={uppy} width="100%" height={276} />
         </Box>
       )}
 

--- a/app/frontend/components/domains/pre-check/form-section/upload-drawings.tsx
+++ b/app/frontend/components/domains/pre-check/form-section/upload-drawings.tsx
@@ -103,20 +103,20 @@ export const UploadDrawings = observer(function UploadDrawings() {
     }
   }
 
-  const onSubmit = async (data: IUploadDrawingsFormData) => {
-    if (!currentPreCheck) return
-    await updatePreCheck(currentPreCheck.id, {
-      designDocumentsAttributes: data.designDocumentsAttributes,
-    })
-  }
-
-  const { uppy } = useUppyS3({
+  const { uppy, isUploading } = useUppyS3({
     onUploadSuccess: handleUploadSuccess,
     maxNumberOfFiles: 1,
     autoProceed: true,
     maxFileSizeMB: 200,
     allowedFileTypes: ["application/pdf", ".pdf", ".chk"],
   })
+
+  const onSubmit = async (data: IUploadDrawingsFormData) => {
+    if (isUploading || !currentPreCheck) return
+    await updatePreCheck(currentPreCheck.id, {
+      designDocumentsAttributes: data.designDocumentsAttributes,
+    })
+  }
 
   return (
     <Box>
@@ -225,7 +225,7 @@ export const UploadDrawings = observer(function UploadDrawings() {
         handleSubmit={handleSubmit}
         onSubmit={onSubmit}
         isLoading={isSubmitting}
-        isDisabled={!hasUploadedFile}
+        isDisabled={!hasUploadedFile || isUploading}
         disabledMessage={
           !hasUploadedFile
             ? t("preCheck.sections.uploadDrawings.uploadRequired", "Please upload a file before continuing.")

--- a/app/frontend/components/domains/project-meeting/project-meeting-screen/shared/uppy-dashboard-field.tsx
+++ b/app/frontend/components/domains/project-meeting/project-meeting-screen/shared/uppy-dashboard-field.tsx
@@ -1,8 +1,7 @@
 import { Box } from "@chakra-ui/react"
 import { Uppy } from "@uppy/core"
-import "@uppy/core/dist/style.min.css"
-import Dashboard from "@uppy/react/lib/Dashboard.js"
 import React from "react"
+import { UppyDashboard } from "../../../../shared/uppy-dashboard"
 
 const uppyDashboardSx = {
   ".uppy-Dashboard": { width: "100%" },
@@ -19,6 +18,6 @@ interface UppyDashboardFieldProps {
 
 export const UppyDashboardField = ({ uppy, mb = 6 }: UppyDashboardFieldProps) => (
   <Box position="relative" w="100%" mb={mb} sx={uppyDashboardSx}>
-    <Dashboard uppy={uppy} width="100%" height={220} proudlyDisplayPoweredByUppy={false} />
+    <UppyDashboard uppy={uppy} width="100%" height={220} />
   </Box>
 )

--- a/app/frontend/components/domains/project-readiness-tools/check-digital-seals.tsx
+++ b/app/frontend/components/domains/project-readiness-tools/check-digital-seals.tsx
@@ -14,8 +14,6 @@ import {
 } from "@chakra-ui/react"
 import { CheckCircle } from "@phosphor-icons/react"
 import type { UppyFile } from "@uppy/core"
-import "@uppy/core/dist/style.min.css"
-import Dashboard from "@uppy/react/lib/Dashboard.js"
 import * as R from "ramda"
 import React, { useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
@@ -28,6 +26,7 @@ import {
   type DigitalSealSignerDisplay,
   type DigitalSealValidatorActionResult,
 } from "../../../utils/digital-seal-validation"
+import { UppyDashboard } from "../../shared/uppy-dashboard"
 
 export const CheckDigitalSealsScreen = () => {
   const { t } = useTranslation()
@@ -292,7 +291,7 @@ export const CheckDigitalSealsScreen = () => {
               },
             }}
           >
-            <Dashboard uppy={uppy} width="100%" height={250} proudlyDisplayPoweredByUppy={false} />
+            <UppyDashboard uppy={uppy} width="100%" height={250} />
           </Box>
         )}
       </VStack>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/block-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/block-setup.tsx
@@ -16,8 +16,6 @@ import {
 } from "@chakra-ui/react"
 import { ArrowCounterClockwise, Trash, Upload } from "@phosphor-icons/react"
 import { UppyFile } from "@uppy/core"
-import "@uppy/core/dist/style.min.css"
-import Dashboard from "@uppy/react/lib/Dashboard.js"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
 import React, { useEffect, useRef } from "react"
@@ -27,6 +25,7 @@ import useUppyS3 from "../../../../hooks/use-uppy-s3"
 import { IRequirementBlock } from "../../../../models/requirement-block"
 import { useMst } from "../../../../setup/root"
 import { TagsSelect } from "../../../shared/select/selectors/tags-select"
+import { UppyDashboard } from "../../../shared/uppy-dashboard"
 import { BlockSetupOptionsMenu } from "../block-setup-options-menu"
 import { IRequirementBlockForm } from "./index"
 
@@ -189,7 +188,7 @@ export const BlockSetup = observer(function BlockSetup({
             </Flex>
           ))}
           <Box position="relative">
-            <Dashboard uppy={uppy} height={300} />
+            <UppyDashboard uppy={uppy} height={300} />
             {R.isEmpty(uppy.getFiles()) && (
               <Center position="absolute" top={"48%"} left={"48%"}>
                 <Upload size={24} />

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/block-setup.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/block-setup.tsx
@@ -20,7 +20,7 @@ import "@uppy/core/dist/style.min.css"
 import Dashboard from "@uppy/react/lib/Dashboard.js"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
-import React, { useRef } from "react"
+import React, { useEffect, useRef } from "react"
 import { Controller, useFieldArray, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import useUppyS3 from "../../../../hooks/use-uppy-s3"
@@ -37,9 +37,11 @@ const helperTextStyles: Partial<TextProps> = {
 export const BlockSetup = observer(function BlockSetup({
   requirementBlock,
   withOptionsMenu,
+  onIsUploadingChange,
 }: {
   requirementBlock?: IRequirementBlock
   withOptionsMenu?: boolean
+  onIsUploadingChange?: (isUploading: boolean) => void
 }) {
   const { requirementBlockStore } = useMst()
   const { t } = useTranslation()
@@ -89,7 +91,16 @@ export const BlockSetup = observer(function BlockSetup({
     }
   }
 
-  const { uppy } = useUppyS3({ onUploadSuccess: handleUploadSuccess, maxNumberOfFiles: 10, autoProceed: true })
+  const { uppy, isUploading } = useUppyS3({
+    onUploadSuccess: handleUploadSuccess,
+    maxNumberOfFiles: 10,
+    autoProceed: true,
+  })
+
+  useEffect(() => {
+    onIsUploadingChange?.(isUploading)
+    return () => onIsUploadingChange?.(false)
+  }, [isUploading, onIsUploadingChange])
 
   return (
     <Box as={"section"} w={"350px"} boxShadow={"md"} borderRadius={"xl"} bg={"greys.grey10"} ref={containerRef}>

--- a/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-block-modal/index.tsx
@@ -12,7 +12,7 @@ import {
 import { Archive } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import * as R from "ramda"
-import React, { useEffect } from "react"
+import React, { useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { useAutoComplianceModuleConfigurations } from "../../../../hooks/resources/use-auto-compliance-module-configurations"
@@ -58,6 +58,7 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
   const { createRequirementBlock } = requirementBlockStore
   const { isOpen, onOpen, onClose } = useDisclosure()
   const hasAutoOpenedRef = React.useRef(false)
+  const [isUploadingDocuments, setIsUploadingDocuments] = useState(false)
 
   const { autoComplianceModuleConfigurations, error } = useAutoComplianceModuleConfigurations()
 
@@ -101,6 +102,8 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
   } = formProps
 
   const onSubmit = async (data: IRequirementBlockForm) => {
+    if (isUploadingDocuments) return
+
     let isSuccess = false
 
     const mappedRequirementAttributes = data.requirementsAttributes.map((ra, index) => {
@@ -240,6 +243,7 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
                   <Button
                     variant={"primary"}
                     isLoading={isSubmitting}
+                    isDisabled={isUploadingDocuments}
                     onClick={(e) => {
                       e.stopPropagation()
                       handleSubmit(onSubmit)()
@@ -261,6 +265,7 @@ export const RequirementsBlockModal = observer(function RequirementsBlockModal({
                         : undefined
                     }
                     withOptionsMenu={withOptionsMenu}
+                    onIsUploadingChange={setIsUploadingDocuments}
                   />
 
                   <FieldsSetup requirementBlock={requirementBlock} isEditable={isEditable} />

--- a/app/frontend/components/domains/super-admin/help-video-modal.tsx
+++ b/app/frontend/components/domains/super-admin/help-video-modal.tsx
@@ -104,24 +104,25 @@ export const HelpVideoModal = ({ isOpen, onClose, video, sections, onSubmit }: I
     }
   }
 
-  const { uppy: videoUppy } = useUppyS3({
+  const { uppy: videoUppy, isUploading: isVideoUploading } = useUppyS3({
     onUploadSuccess: buildUploadHandler("videoDocumentAttributes"),
     maxNumberOfFiles: 1,
     autoProceed: true,
     allowedFileTypes: ["video/mp4"],
   })
-  const { uppy: captionUppy } = useUppyS3({
+  const { uppy: captionUppy, isUploading: isCaptionUploading } = useUppyS3({
     onUploadSuccess: buildUploadHandler("captionDocumentAttributes"),
     maxNumberOfFiles: 1,
     autoProceed: true,
     allowedFileTypes: [".vtt", "text/vtt"],
   })
-  const { uppy: transcriptUppy } = useUppyS3({
+  const { uppy: transcriptUppy, isUploading: isTranscriptUploading } = useUppyS3({
     onUploadSuccess: buildUploadHandler("transcriptDocumentAttributes"),
     maxNumberOfFiles: 1,
     autoProceed: true,
     allowedFileTypes: [".txt", ".pdf", "text/plain", "application/pdf"],
   })
+  const isUploading = isVideoUploading || isCaptionUploading || isTranscriptUploading
 
   useEffect(() => {
     if (!isOpen) return
@@ -147,6 +148,7 @@ export const HelpVideoModal = ({ isOpen, onClose, video, sections, onSubmit }: I
   }, [captionUppy, isOpen, reset, sections, transcriptUppy, video, videoUppy])
 
   const submit = handleSubmit(async (data) => {
+    if (isUploading) return
     const success = await onSubmit(data)
     if (success) onClose()
   })
@@ -218,7 +220,7 @@ export const HelpVideoModal = ({ isOpen, onClose, video, sections, onSubmit }: I
           </VStack>
         </ModalBody>
         <ModalFooter gap={4} justifyContent="flex-start">
-          <Button variant="primary" type="submit" isLoading={isSubmitting} isDisabled={!hasSections}>
+          <Button variant="primary" type="submit" isLoading={isSubmitting} isDisabled={!hasSections || isUploading}>
             {translate("ui.save")}
           </Button>
           <Button variant="secondary" onClick={onClose} isDisabled={isSubmitting}>

--- a/app/frontend/components/domains/super-admin/help-video-modal.tsx
+++ b/app/frontend/components/domains/super-admin/help-video-modal.tsx
@@ -19,9 +19,6 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { UppyFile } from "@uppy/core"
-import "@uppy/core/dist/style.min.css"
-import "@uppy/dashboard/dist/style.css"
-import Dashboard from "@uppy/react/lib/Dashboard.js"
 import React, { useEffect, useRef } from "react"
 import { useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
@@ -29,6 +26,7 @@ import useUppyS3 from "../../../hooks/use-uppy-s3"
 import { IHelpVideo } from "../../../models/help-video"
 import { IHelpVideoSection } from "../../../models/help-video-section"
 import { Editor } from "../../shared/editor/editor"
+import { UppyDashboard } from "../../shared/uppy-dashboard"
 
 const DEFAULT_ABOUT_HTML = "<p>Add about text</p><h3><b>Topics covered</b></h3><ul><li>...</li></ul>"
 
@@ -104,20 +102,27 @@ export const HelpVideoModal = ({ isOpen, onClose, video, sections, onSubmit }: I
     }
   }
 
+  const buildFileRemovedHandler = (fieldName: TDocumentFieldName) => () => {
+    setValue(fieldName, undefined)
+  }
+
   const { uppy: videoUppy, isUploading: isVideoUploading } = useUppyS3({
     onUploadSuccess: buildUploadHandler("videoDocumentAttributes"),
+    onFileRemoved: buildFileRemovedHandler("videoDocumentAttributes"),
     maxNumberOfFiles: 1,
     autoProceed: true,
     allowedFileTypes: ["video/mp4"],
   })
   const { uppy: captionUppy, isUploading: isCaptionUploading } = useUppyS3({
     onUploadSuccess: buildUploadHandler("captionDocumentAttributes"),
+    onFileRemoved: buildFileRemovedHandler("captionDocumentAttributes"),
     maxNumberOfFiles: 1,
     autoProceed: true,
     allowedFileTypes: [".vtt", "text/vtt"],
   })
   const { uppy: transcriptUppy, isUploading: isTranscriptUploading } = useUppyS3({
     onUploadSuccess: buildUploadHandler("transcriptDocumentAttributes"),
+    onFileRemoved: buildFileRemovedHandler("transcriptDocumentAttributes"),
     maxNumberOfFiles: 1,
     autoProceed: true,
     allowedFileTypes: [".txt", ".pdf", "text/plain", "application/pdf"],
@@ -245,7 +250,7 @@ const UploadField = ({ label, currentFileName, uppy }: { label: string; currentF
           {(t as any)("helpVideos.management.fields.currentFile", { fileName: currentFileName })}
         </Text>
       )}
-      <Dashboard uppy={uppy} height={180} width="100%" proudlyDisplayPoweredByUppy={false} />
+      <UppyDashboard uppy={uppy} height={180} width="100%" />
     </Box>
   )
 }

--- a/app/frontend/components/shared/uppy-dashboard.tsx
+++ b/app/frontend/components/shared/uppy-dashboard.tsx
@@ -1,0 +1,13 @@
+import "@uppy/core/dist/style.min.css"
+import Dashboard from "@uppy/react/lib/Dashboard.js"
+import React, { ComponentProps } from "react"
+
+type UppyDashboardProps = ComponentProps<typeof Dashboard>
+
+/**
+ * App-wide Uppy Dashboard defaults. Always allow removing a completed upload so
+ * users can replace a file without remounting the form.
+ */
+export const UppyDashboard = (props: UppyDashboardProps) => (
+  <Dashboard proudlyDisplayPoweredByUppy={false} showRemoveButtonAfterComplete {...props} />
+)

--- a/app/frontend/hooks/use-uppy-s3.ts
+++ b/app/frontend/hooks/use-uppy-s3.ts
@@ -1,7 +1,7 @@
 // src/hooks/useUppyS3.ts
 import AwsS3 from "@uppy/aws-s3"
 import Uppy, { UppyFile } from "@uppy/core"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import {
   FILE_UPLOAD_CHUNK_SIZE_IN_BYTES,
   FILE_UPLOAD_MAX_SIZE,
@@ -15,6 +15,7 @@ const MAX_FILE_SIZE_BYTES = FILE_UPLOAD_MAX_SIZE * 1024 * 1024
 
 interface UseUppyS3Props {
   onUploadSuccess?: (file: UppyFile<{}, {}>, response: any) => void
+  onFileRemoved?: (file: UppyFile<{}, {}>) => void
   maxNumberOfFiles?: number
   autoProceed?: boolean
   maxFileSizeMB?: number
@@ -30,6 +31,7 @@ interface UppyError {
 
 const useUppyS3 = ({
   onUploadSuccess,
+  onFileRemoved,
   maxNumberOfFiles = 1,
   autoProceed = false,
   maxFileSizeMB,
@@ -38,6 +40,8 @@ const useUppyS3 = ({
   const { uiStore } = useMst()
   const maxFileSize = maxFileSizeMB ? maxFileSizeMB * 1024 * 1024 : MAX_FILE_SIZE_BYTES
   const [isUploading, setIsUploading] = useState(false)
+  const onFileRemovedRef = useRef(onFileRemoved)
+  onFileRemovedRef.current = onFileRemoved
   const [uppy] = useState(() =>
     new Uppy({
       restrictions: {
@@ -249,8 +253,15 @@ const useUppyS3 = ({
   )
 
   useEffect(() => {
+    // Any file that hasn't finished counts as uploading — including the gap after
+    // file-added / before uploadStarted flips true (autoProceed still leaves Save
+    // clickable with the old uploadStarted && !uploadComplete check).
     const syncUploading = () => {
-      setIsUploading(uppy.getFiles().some((file) => file.progress?.uploadStarted && !file.progress?.uploadComplete))
+      setIsUploading(uppy.getFiles().some((file) => !file.progress?.uploadComplete))
+    }
+    const handleFileRemoved = (file: UppyFile<{}, {}>) => {
+      syncUploading()
+      onFileRemovedRef.current?.(file)
     }
     const onRestrictionFailed = (_file: UppyFile<{}, {}> | undefined, error: Error) => {
       if (error?.message) {
@@ -258,21 +269,27 @@ const useUppyS3 = ({
       }
     }
 
+    uppy.on("file-added", syncUploading)
     uppy.on("upload", syncUploading)
+    uppy.on("upload-progress", syncUploading)
+    uppy.on("upload-success", syncUploading)
     uppy.on("complete", syncUploading)
     uppy.on("error", syncUploading)
     uppy.on("cancel-all", syncUploading)
     uppy.on("upload-error", syncUploading)
-    uppy.on("file-removed", syncUploading)
+    uppy.on("file-removed", handleFileRemoved)
     uppy.on("restriction-failed", onRestrictionFailed)
 
     return () => {
+      uppy.off("file-added", syncUploading)
       uppy.off("upload", syncUploading)
+      uppy.off("upload-progress", syncUploading)
+      uppy.off("upload-success", syncUploading)
       uppy.off("complete", syncUploading)
       uppy.off("error", syncUploading)
       uppy.off("cancel-all", syncUploading)
       uppy.off("upload-error", syncUploading)
-      uppy.off("file-removed", syncUploading)
+      uppy.off("file-removed", handleFileRemoved)
       uppy.off("restriction-failed", onRestrictionFailed)
     }
   }, [uppy, uiStore])

--- a/app/frontend/styles/chakra-overrides.scss
+++ b/app/frontend/styles/chakra-overrides.scss
@@ -412,40 +412,80 @@
   .uppy-StatusBar:not([aria-hidden="true"]) {
     height: 40px;
   }
+
+  // StatusBar already shows "Complete". Uppy also parks a check on the preview's
+  // top-right — the same corner as the remove control on our compact thumbs.
+  .uppy-Dashboard-Item.is-complete .uppy-Dashboard-Item-progress {
+    display: none;
+  }
 }
 
-.uppy-Dashboard .uppy-size--md {
+// uppy-size--* is on .uppy-Dashboard itself — must be a compound selector, not a descendant.
+// Keep a compact list row (small thumb + meta) at every breakpoint instead of Uppy's
+// large floated cards, and pin the remove control to the thumbnail's top-right.
+.uppy-Dashboard.uppy-size--md,
+.uppy-Dashboard.uppy-size--lg,
+.uppy-Dashboard.uppy-size--xl {
   .uppy-Dashboard-Item {
-    height: 185px;
+    float: none;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    margin: 0;
+    padding: 12px;
   }
 
   .uppy-Dashboard-Item-preview {
-    width: 100%;
-    height: 125px;
+    width: 44px;
+    height: 44px;
+    flex-shrink: 0;
   }
 
   .uppy-Dashboard-Item-previewIcon {
-    width: 36px;
-    height: 36px;
+    width: 22px;
+    height: 22px;
+  }
+
+  .uppy-Dashboard-Item-fileInfoAndButtons {
+    padding-top: 0;
+    padding-inline-start: 12px;
+    align-items: center;
+  }
+
+  // actionWrapper overlays the 44×44 preview so remove can sit on its corner
+  .uppy-Dashboard-Item-actionWrapper {
+    position: absolute;
+    top: 12px;
+    inset-inline-start: 12px;
+    width: 44px;
+    height: 44px;
+    margin: 0;
+    z-index: 2;
+  }
+
+  .uppy-Dashboard-Item-action--remove {
+    position: absolute;
+    top: -6px;
+    inset-inline-end: -6px;
+    width: 18px;
+    height: 18px;
+    padding: 0;
   }
 }
 
-.uppy-Dashboard .uppy-size--lg {
-  .uppy-Dashboard-Item {
-    height: 175px;
-  }
-
-  .uppy-Dashboard-Item-preview {
-    height: 115px;
-  }
+[dir="ltr"] .uppy-Dashboard.uppy-size--md .uppy-Dashboard-Item-action--remove,
+[dir="ltr"] .uppy-Dashboard.uppy-size--lg .uppy-Dashboard-Item-action--remove,
+[dir="ltr"] .uppy-Dashboard.uppy-size--xl .uppy-Dashboard-Item-action--remove {
+  right: -6px;
+  left: auto;
 }
 
-.uppy-Dashboard .uppy-size--xl {
-  .uppy-Dashboard-Item {
-    height: 185px;
-  }
-
-  .uppy-Dashboard-Item-preview {
-    height: 125px;
-  }
+[dir="rtl"] .uppy-Dashboard.uppy-size--md .uppy-Dashboard-Item-action--remove,
+[dir="rtl"] .uppy-Dashboard.uppy-size--lg .uppy-Dashboard-Item-action--remove,
+[dir="rtl"] .uppy-Dashboard.uppy-size--xl .uppy-Dashboard-Item-action--remove {
+  left: -6px;
+  right: auto;
 }


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5358-bug-bug-bash-block-save-while-uppy-s-3-uploads-are-in-progress` (merge-base range).

Uppy S3 uploads finish asynchronously after the user picks a file, but form file attributes are only set in `onUploadSuccess`. Several forms could Save/Submit while an upload was still in progress (or in the gap after file-add before `uploadStarted`), so the saved record could miss the document. Completed uploads also couldn’t be removed/replaced without closing the modal, because Dashboard hides the remove control after complete by default.

This PR gates Save/Submit/Continue on `isUploading` across ungated `useUppyS3` consumers, hardens upload-state detection in the hook, defaults Dashboard to `showRemoveButtonAfterComplete` via a shared `UppyDashboard`, and fixes compact thumbnail / remove-button styling in the shared Uppy overrides.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5358](https://hous-bssb.atlassian.net/browse/HUB-5358) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

> List the key changes, features, or fixes introduced in this PR.

- Gate Save/Submit/Continue with `isUploading` on jurisdiction resources, help videos, requirements block modal, and pre-check upload drawings (project-meeting docs / notes already gated)
- Harden `useUppyS3` `isUploading`: any incomplete file counts as uploading; sync on `file-added` / `upload-progress` / `upload-success`; optional `onFileRemoved`
- Add shared `UppyDashboard` with `showRemoveButtonAfterComplete` (and hide Uppy branding) as the default for all Dashboard call sites
- Clear form file attrs when a completed upload is removed (resources, help video, upload drawings)
- Fix Uppy override CSS: compound `uppy-size--*` selectors, compact 44px list-row thumbs, remove control on thumbnail corner, hide redundant per-file complete check

---

## 🧪 Steps to QA

1. Open jurisdiction **Configuration management → Resources**, add/edit a **file** resource, and start uploading a file (use a larger file so the upload is visible).
2. Confirm **Save** disables as soon as the file appears in the Dashboard (not only after progress starts), and stays disabled until upload completes; then Save persists the file.
3. After upload completes, remove the file with the thumbnail **X**, pick a different file, and Save — without closing/reopening the modal. Confirm the X is usable (not overlapping a green check on the thumb).
4. Spot-check the same disable / replace / re-enable flow on: Help video add/edit, Requirements library block Save with documents, Pre-check **Upload drawings** Continue.
5. Confirm project-meeting supporting documents / authorization Continue still disables while uploading (regression).

**Expected Behaviour:**
> Save/Submit/Continue is disabled for any incomplete Uppy file on that form. Users can remove a completed upload and choose a new file in-place. Thumbnail remove control is clear and clickable.

**Before this change:**
> Users could save while an upload was still running (or before it started), and often had to close the modal to replace a selected file.

**After this change:**
> Upload state gates submit actions; completed files are removable/replaceable via Dashboard; compact thumb + remove styling is consistent across Uppy surfaces.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5358]: https://hous-bssb.atlassian.net/browse/HUB-5358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ