### PR TITLE
Hub 5364 bug bug bash hide conditionally hidden blocks from permit application sidebar and reduce scroll jump

### DIFF
--- a/app/frontend/components/domains/permit-application/checklist-sidebar.tsx
+++ b/app/frontend/components/domains/permit-application/checklist-sidebar.tsx
@@ -11,10 +11,13 @@ interface IChecklistSideBarProps {
 
 export const ChecklistSideBar = observer(({ permitApplication, completedBlocks }: IChecklistSideBarProps) => {
   const { formJson } = permitApplication
-  const { selectedTabIndex, setSelectedTabIndex, indexOfBlockId, getBlockClass } = permitApplication
+  const { selectedTabIndex, setSelectedTabIndex, getBlockClass } = permitApplication
 
   const navHeight = document.getElementById("mainNav")?.offsetHeight
   const permitHeaderHeight = document.getElementById("permitHeader")?.offsetHeight
+
+  // completedBlocks is keyed by live Form.io panel keys (hidden panels omitted once the form is ready).
+  const visibilityReady = Object.keys(completedBlocks).length > 0
 
   // TODO: We should probably switch to use link anchors instead so we have the ability to bring someone directly and also focus on a specific block on the page.
   const handleTabsChange = (index: number, sectionId: string, blockId: string) => {
@@ -25,6 +28,8 @@ export const ChecklistSideBar = observer(({ permitApplication, completedBlocks }
       element.scrollIntoView({ behavior: "instant", block: "center" })
     }
   }
+
+  let tabIndex = 0
 
   return (
     <Hide below="md">
@@ -45,15 +50,21 @@ export const ChecklistSideBar = observer(({ permitApplication, completedBlocks }
           <Tabs orientation="vertical" index={selectedTabIndex} w="full">
             <TabList w="full" border={0} py="4" pb={navHeight}>
               {formJson.components.map((section) => {
+                const visibleBlocks = (section?.components || []).filter(
+                  (block) => !visibilityReady || block.key in completedBlocks
+                )
+                if (visibleBlocks.length === 0) return null
+
                 return (
                   <Box key={section.key}>
                     <Heading as="h3" fontSize="md" textTransform="uppercase" px={4} py={2}>
                       {section.title}
                     </Heading>
-                    {section?.components?.map((block) => {
+                    {visibleBlocks.map((block) => {
                       // Completion for Energy Step Code blocks is decided in getCompletedBlocksFromForm
                       // (digital tool method → stage checklist; file method → Form.io visible fields).
                       const showCompleted = completedBlocks[block.key] || false
+                      const index = tabIndex++
                       return (
                         <Tab
                           key={block.key}
@@ -63,7 +74,7 @@ export const ChecklistSideBar = observer(({ permitApplication, completedBlocks }
                           _selected={{ color: "theme.blue", bg: "theme.blueLight", fontWeight: "bold" }}
                           justifyContent="flex-start"
                           textAlign="left"
-                          onClick={() => handleTabsChange(indexOfBlockId(block.id), section.id, block.id)}
+                          onClick={() => handleTabsChange(index, section.id, block.id)}
                         >
                           <Flex align="center">
                             <Box w={5} mr={2}>

--- a/app/frontend/components/shared/permit-applications/requirement-form.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form.tsx
@@ -11,7 +11,12 @@ import { useMountStatus } from "../../../hooks/use-mount-status"
 import { IPermitApplication } from "../../../models/permit-application"
 import { EFileUploadAttachmentType, EFlashMessageStatus, EStepCodeType } from "../../../types/enums"
 import { IErrorsBoxData } from "../../../types/types"
-import { getCompletedBlocksFromForm, getRequirementByKey } from "../../../utils/formio-component-traversal"
+import {
+  getCompletedBlocksFromForm,
+  getRequirementByKey,
+  reconcileSelectedTabIndex,
+  scrollAdjustmentForHiddenBlocks,
+} from "../../../utils/formio-component-traversal"
 import {
   getEnergyStepCodeMethodFromData,
   singleRequirementFormJson,
@@ -58,7 +63,7 @@ export const RequirementForm = observer(
       jurisdiction,
       submissionData,
       setSelectedTabIndex,
-      indexOfBlockId,
+      selectedTabIndex,
       formJson,
       blockClasses,
       formattedFormJson,
@@ -73,6 +78,66 @@ export const RequirementForm = observer(
     } = permitApplication
 
     const stepCodeCompletionOptions = { isStepCodeComplete }
+    const previousVisibleBlockKeysRef = useRef<string[]>([])
+    const previousCompletedBlocksRef = useRef<Record<string, boolean>>({})
+    const previousBlockLayoutsRef = useRef<{ key: string; absTop: number; height: number }[]>([])
+    const [visibilityVersion, setVisibilityVersion] = useState(0)
+
+    const captureBlockLayouts = () =>
+      blockClasses.flatMap((className) => {
+        const el = document.getElementsByClassName(className)[0] as HTMLElement | undefined
+        if (!el || el.classList.contains("formio-hidden")) return []
+        const rect = el.getBoundingClientRect()
+        return [
+          {
+            key: className.replace(/^formio-component-/, ""),
+            absTop: rect.top + window.scrollY,
+            height: rect.height,
+          },
+        ]
+      })
+
+    const syncCompletedBlocksFromForm = (root) => {
+      if (!root || !onCompletedBlocksChange) return
+
+      const previousKeys = previousVisibleBlockKeysRef.current
+      const nextCompleted = getCompletedBlocksFromForm(root, stepCodeCompletionOptions)
+      const nextKeys = Object.keys(nextCompleted)
+      const keysChanged = previousKeys.length !== nextKeys.length || previousKeys.some((key, i) => key !== nextKeys[i])
+      const completionChanged =
+        keysChanged || nextKeys.some((key) => previousCompletedBlocksRef.current[key] !== nextCompleted[key])
+
+      if (keysChanged && previousKeys.length > 0) {
+        const hiddenKeys = new Set(previousKeys.filter((key) => !nextKeys.includes(key)))
+        // Bonus: counteract layout collapse when a tall block above the viewport hides.
+        if (hiddenKeys.size > 0) {
+          const adjustment = scrollAdjustmentForHiddenBlocks(
+            previousBlockLayoutsRef.current,
+            hiddenKeys,
+            window.scrollY
+          )
+          if (adjustment > 0) window.scrollBy(0, -adjustment)
+        }
+
+        const nextIndex = reconcileSelectedTabIndex(previousKeys, nextKeys, selectedTabIndex)
+        if (nextIndex !== selectedTabIndex) setSelectedTabIndex(nextIndex)
+      }
+
+      previousVisibleBlockKeysRef.current = nextKeys
+      if (completionChanged) {
+        previousCompletedBlocksRef.current = nextCompleted
+        onCompletedBlocksChange(nextCompleted)
+      }
+      if (keysChanged) {
+        requestAnimationFrame(() => {
+          previousBlockLayoutsRef.current = captureBlockLayouts()
+        })
+        setVisibilityVersion((v) => v + 1)
+      }
+    }
+
+    const syncCompletedBlocksFromFormRef = useRef(syncCompletedBlocksFromForm)
+    syncCompletedBlocksFromFormRef.current = syncCompletedBlocksFromForm
 
     const shouldShowDiff = permitApplication?.shouldShowApplicationDiff(isEditing)
     const userShouldSeeDiff = permitApplication?.currentUserShouldSeeApplicationDiff
@@ -144,9 +209,7 @@ export const RequirementForm = observer(
 
     // Recompute block completion when the digital Step Code checklist completion flips
     useEffect(() => {
-      if (onCompletedBlocksChange && formRef.current) {
-        onCompletedBlocksChange(getCompletedBlocksFromForm(formRef.current, stepCodeCompletionOptions))
-      }
+      if (formRef.current) syncCompletedBlocksFromFormRef.current(formRef.current)
     }, [isStepCodeComplete])
 
     useEffect(() => {
@@ -185,8 +248,10 @@ export const RequirementForm = observer(
 
       const formComponentNodes = document.querySelectorAll(".formio-component")
 
-      const blockNodes = Array.from(formComponentNodes).filter((node) =>
-        Array.from(node.classList).some((className) => blockClasses.includes(className))
+      const blockNodes = Array.from(formComponentNodes).filter(
+        (node) =>
+          !node.classList.contains("formio-hidden") &&
+          Array.from(node.classList).some((className) => blockClasses.includes(className))
       )
       const viewportHeight = window.innerHeight // Get the viewport height
       const topValue = -viewportHeight / 2 + 5
@@ -205,10 +270,12 @@ export const RequirementForm = observer(
         }
       })
 
+      previousBlockLayoutsRef.current = captureBlockLayouts()
+
       return () => {
         blockObserver.disconnect()
       }
-    }, [formJson, isMounted, window.innerHeight, wrapperClickCount])
+    }, [formJson, isMounted, window.innerHeight, wrapperClickCount, visibilityVersion])
 
     const handleOpenStepCodePart3 = async (_event) => {
       await triggerSave?.()
@@ -308,17 +375,14 @@ export const RequirementForm = observer(
       const entry = entries.filter((en) => en.isIntersecting)[0]
       if (!entry) return
 
-      const itemWithSectionClassName = Array.from(entry.target.classList).find(
-        (className) =>
-          className.includes("formio-component-formSubmissionDataRSTsection") ||
-          className.includes("formio-component-section-signoff-key")
+      // Index among currently visible blocks so sidebar tabs stay aligned after conditionals hide panels.
+      const visibleBlockNodes = Array.from(document.querySelectorAll(".formio-component")).filter(
+        (node) =>
+          !node.classList.contains("formio-hidden") &&
+          Array.from(node.classList).some((className) => blockClasses.includes(className))
       )
-
-      if (itemWithSectionClassName) {
-        const classNameParts = itemWithSectionClassName.split("|")
-        const blockId = classNameParts[classNameParts.length - 1].slice(-36)
-        setSelectedTabIndex(indexOfBlockId(blockId))
-      }
+      const index = visibleBlockNodes.indexOf(entry.target)
+      if (index >= 0) setSelectedTabIndex(index)
     }
 
     const onFormSubmit = async (submission: any) => {
@@ -346,9 +410,7 @@ export const RequirementForm = observer(
     }
 
     const onBlur = (containerComponent) => {
-      if (onCompletedBlocksChange) {
-        onCompletedBlocksChange(getCompletedBlocksFromForm(containerComponent.root, stepCodeCompletionOptions))
-      }
+      syncCompletedBlocksFromForm(containerComponent.root)
     }
     const onScroll = (event) => {
       setFloatErrorBox(hasErrors && isFirstComponentNearTopOfView(firstComponentKey))
@@ -363,33 +425,21 @@ export const RequirementForm = observer(
         return // Exit if necessary objects are not available
       }
 
-      const componentType = component.type
-
-      // radio: energy_step_code_method toggles tool vs file visibility / completion rules
-      if (componentType === "selectboxes" || componentType === "simplefile" || componentType === "radio") {
-        if (onCompletedBlocksChange) {
-          onCompletedBlocksChange(getCompletedBlocksFromForm(root, stepCodeCompletionOptions))
-        }
-        setErrorBoxData(mapErrorBoxData(root.errors))
-
-        if (componentType === "simplefile") {
-          // https://github.com/formio/formio.js/blob/4.19.x/src/components/file/File.unit.js
-          // formio `pristine` is not set for file updates
-          // using `setPristine(false)` causes the entire form to validate so instead, we use a separate dirty state
-          // trigger save to rerun compliance and save file
-          triggerSave?.({ autosave: true, skipPristineCheck: true })
-        }
+      // Visibility/completion for all field types (incl. block conditionals) is synced in formReady's change listener.
+      if (component.type === "simplefile") {
+        // https://github.com/formio/formio.js/blob/4.19.x/src/components/file/File.unit.js
+        // formio `pristine` is not set for file updates
+        // using `setPristine(false)` causes the entire form to validate so instead, we use a separate dirty state
+        // trigger save to rerun compliance and save file
+        triggerSave?.({ autosave: true, skipPristineCheck: true })
       }
     }
 
-    const onInitialized = (event) => {
+    const onInitialized = (_event) => {
       if (!formRef.current) return
 
       updateCollaborationAssignmentNodes?.()
-
-      if (onCompletedBlocksChange) {
-        onCompletedBlocksChange(getCompletedBlocksFromForm(formRef.current, stepCodeCompletionOptions))
-      }
+      syncCompletedBlocksFromForm(formRef.current)
     }
 
     const formReady = (rootComponent) => {
@@ -398,6 +448,8 @@ export const RequirementForm = observer(
       rootComponent.on("change", (_) => {
         // whenever a form data changes, we update the state of ErrorBox with the new error information
         setErrorBoxData(mapErrorBoxData(formRef.current.errors))
+        // Keep CONTENTS sidebar in sync with Form.io conditionals (any field type can toggle a block).
+        syncCompletedBlocksFromFormRef.current(formRef.current)
       })
 
       rootComponent.on("submitError", (error) => {

--- a/app/frontend/components/shared/permit-applications/requirement-form/hooks/use-block-scroll-spy.ts
+++ b/app/frontend/components/shared/permit-applications/requirement-form/hooks/use-block-scroll-spy.ts
@@ -1,0 +1,85 @@
+import { MutableRefObject, useEffect, useState } from "react"
+import { useMountStatus } from "../../../../../hooks/use-mount-status"
+import { IFormJson } from "../../../../../types/types"
+
+type BlockLayout = { key: string; absTop: number; height: number }
+
+interface IUseBlockScrollSpyParams {
+  boxRef: MutableRefObject<HTMLDivElement | null>
+  formJson: IFormJson | null
+  blockClasses: string[]
+  visibilityVersion: number
+  setSelectedTabIndex: (index: number) => void
+  previousBlockLayoutsRef: MutableRefObject<BlockLayout[]>
+  captureBlockLayouts: () => BlockLayout[]
+}
+
+export function useBlockScrollSpy({
+  boxRef,
+  formJson,
+  blockClasses,
+  visibilityVersion,
+  setSelectedTabIndex,
+  previousBlockLayoutsRef,
+  captureBlockLayouts,
+}: IUseBlockScrollSpyParams) {
+  const isMounted = useMountStatus()
+  const [wrapperClickCount, setWrapperClickCount] = useState(0)
+
+  useEffect(() => {
+    // Observers need to be re-registered whenever a panel is collapsed.
+    // FormIO prevents bubbling, so listen on the wrapper directly.
+    const box = boxRef.current
+    const handleClick = () => {
+      setWrapperClickCount((n) => n + 1)
+    }
+    box?.addEventListener("click", handleClick)
+    return () => {
+      box?.removeEventListener("click", handleClick)
+    }
+  }, [])
+
+  useEffect(() => {
+    // Thin mid-viewport line; selected CONTENTS tab follows the intersecting visible block.
+    if (!isMounted) return
+
+    const formComponentNodes = document.querySelectorAll(".formio-component")
+    const blockNodes = Array.from(formComponentNodes).filter(
+      (node) =>
+        !node.classList.contains("formio-hidden") &&
+        Array.from(node.classList).some((className) => blockClasses.includes(className))
+    )
+    const viewportHeight = window.innerHeight
+    const topValue = -viewportHeight / 2 + 5
+    const bottomValue = -viewportHeight / 2 + 5
+    const rootMarginValue = `${topValue}px 0px ${bottomValue}px 0px`
+    const blockOptions = {
+      rootMargin: rootMarginValue,
+      threshold: 0.0001,
+    }
+
+    const handleBlockIntersection = (entries: IntersectionObserverEntry[]) => {
+      const entry = entries.filter((en) => en.isIntersecting)[0]
+      if (!entry) return
+
+      const visibleBlockNodes = Array.from(document.querySelectorAll(".formio-component")).filter(
+        (node) =>
+          !node.classList.contains("formio-hidden") &&
+          Array.from(node.classList).some((className) => blockClasses.includes(className))
+      )
+      const index = visibleBlockNodes.indexOf(entry.target)
+      if (index >= 0) setSelectedTabIndex(index)
+    }
+
+    const blockObserver = new IntersectionObserver(handleBlockIntersection, blockOptions)
+    blockNodes.forEach((ref) => {
+      if (ref) blockObserver.observe(ref)
+    })
+
+    previousBlockLayoutsRef.current = captureBlockLayouts()
+
+    return () => {
+      blockObserver.disconnect()
+    }
+  }, [formJson, isMounted, window.innerHeight, wrapperClickCount, visibilityVersion])
+}

--- a/app/frontend/components/shared/permit-applications/requirement-form/hooks/use-block-scroll-spy.ts
+++ b/app/frontend/components/shared/permit-applications/requirement-form/hooks/use-block-scroll-spy.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useEffect, useState } from "react"
+import { MutableRefObject, useEffect, useRef, useState } from "react"
 import { useMountStatus } from "../../../../../hooks/use-mount-status"
 import { IFormJson } from "../../../../../types/types"
 
@@ -14,6 +14,66 @@ interface IUseBlockScrollSpyParams {
   captureBlockLayouts: () => BlockLayout[]
 }
 
+const queryVisibleBlockNodes = (blockClasses: string[]) =>
+  Array.from(document.querySelectorAll(".formio-component")).filter(
+    (node) =>
+      !node.classList.contains("formio-hidden") &&
+      Array.from(node.classList).some((className) => blockClasses.includes(className))
+  )
+
+/** Among targets crossing the mid-viewport band, pick the one closest to the midline (document order as tiebreak). */
+export const pickScrollSpyBlockIndex = (
+  intersectingTargets: Iterable<Element>,
+  visibleBlockNodes: Element[],
+  midY: number
+) => {
+  let bestIndex = -1
+  let bestDist = Infinity
+
+  for (const node of intersectingTargets) {
+    const index = visibleBlockNodes.indexOf(node)
+    if (index < 0) continue
+    const rect = (node as HTMLElement).getBoundingClientRect()
+    const dist = Math.abs(rect.top + rect.height / 2 - midY)
+    if (dist < bestDist || (dist === bestDist && index > bestIndex)) {
+      bestDist = dist
+      bestIndex = index
+    }
+  }
+
+  return bestIndex
+}
+
+const mutationAffectsBlockObservers = (mutation: MutationRecord) => {
+  if (mutation.type === "childList") {
+    return [...mutation.addedNodes, ...mutation.removedNodes].some((node) => {
+      if (!(node instanceof Element)) return false
+      return (
+        node.classList.contains("formio-component-panel") ||
+        node.classList.contains("formio-component") ||
+        !!node.querySelector?.(".formio-component-panel, .formio-component")
+      )
+    })
+  }
+
+  if (mutation.type === "attributes" && mutation.attributeName === "class") {
+    const el = mutation.target as Element
+    const oldValue = mutation.oldValue || ""
+    // Collapse / conditional hide / panel redraws typically flip these classes.
+    return (
+      el.classList.contains("formio-component-panel") ||
+      el.classList.contains("formio-hidden") ||
+      oldValue.includes("formio-hidden") ||
+      el.classList.contains("formio-collapsed") ||
+      oldValue.includes("formio-collapsed") ||
+      el.classList.contains("collapsed") ||
+      oldValue.includes("collapsed")
+    )
+  }
+
+  return false
+}
+
 export function useBlockScrollSpy({
   boxRef,
   formJson,
@@ -24,62 +84,75 @@ export function useBlockScrollSpy({
   captureBlockLayouts,
 }: IUseBlockScrollSpyParams) {
   const isMounted = useMountStatus()
-  const [wrapperClickCount, setWrapperClickCount] = useState(0)
+  const [domVersion, setDomVersion] = useState(0)
+  const intersectingTargetsRef = useRef(new Set<Element>())
+  const setSelectedTabIndexRef = useRef(setSelectedTabIndex)
+  setSelectedTabIndexRef.current = setSelectedTabIndex
 
+  // Re-bind observers when Form.io mutates the DOM (collapse/expand, conditionals, redraws).
+  // Do not depend on click/focus — that was the flaky “wake up” path.
   useEffect(() => {
-    // Observers need to be re-registered whenever a panel is collapsed.
-    // FormIO prevents bubbling, so listen on the wrapper directly.
+    if (!isMounted) return
     const box = boxRef.current
-    const handleClick = () => {
-      setWrapperClickCount((n) => n + 1)
+    if (!box) return
+
+    let rafId = 0
+    const scheduleRebind = () => {
+      cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(() => setDomVersion((v) => v + 1))
     }
-    box?.addEventListener("click", handleClick)
+
+    const mutationObserver = new MutationObserver((mutations) => {
+      if (mutations.some(mutationAffectsBlockObservers)) scheduleRebind()
+    })
+
+    mutationObserver.observe(box, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["class"],
+      attributeOldValue: true,
+    })
+
     return () => {
-      box?.removeEventListener("click", handleClick)
+      cancelAnimationFrame(rafId)
+      mutationObserver.disconnect()
     }
-  }, [])
+  }, [isMounted, formJson])
 
   useEffect(() => {
     // Thin mid-viewport line; selected CONTENTS tab follows the intersecting visible block.
     if (!isMounted) return
 
-    const formComponentNodes = document.querySelectorAll(".formio-component")
-    const blockNodes = Array.from(formComponentNodes).filter(
-      (node) =>
-        !node.classList.contains("formio-hidden") &&
-        Array.from(node.classList).some((className) => blockClasses.includes(className))
-    )
+    intersectingTargetsRef.current = new Set()
+    const blockNodes = queryVisibleBlockNodes(blockClasses)
     const viewportHeight = window.innerHeight
-    const topValue = -viewportHeight / 2 + 5
-    const bottomValue = -viewportHeight / 2 + 5
-    const rootMarginValue = `${topValue}px 0px ${bottomValue}px 0px`
+    const midY = viewportHeight / 2
+    const topValue = -midY + 5
+    const bottomValue = -midY + 5
     const blockOptions = {
-      rootMargin: rootMarginValue,
+      rootMargin: `${topValue}px 0px ${bottomValue}px 0px`,
       threshold: 0.0001,
     }
 
     const handleBlockIntersection = (entries: IntersectionObserverEntry[]) => {
-      const entry = entries.filter((en) => en.isIntersecting)[0]
-      if (!entry) return
+      for (const entry of entries) {
+        if (entry.isIntersecting) intersectingTargetsRef.current.add(entry.target)
+        else intersectingTargetsRef.current.delete(entry.target)
+      }
+      if (intersectingTargetsRef.current.size === 0) return
 
-      const visibleBlockNodes = Array.from(document.querySelectorAll(".formio-component")).filter(
-        (node) =>
-          !node.classList.contains("formio-hidden") &&
-          Array.from(node.classList).some((className) => blockClasses.includes(className))
-      )
-      const index = visibleBlockNodes.indexOf(entry.target)
-      if (index >= 0) setSelectedTabIndex(index)
+      const index = pickScrollSpyBlockIndex(intersectingTargetsRef.current, queryVisibleBlockNodes(blockClasses), midY)
+      if (index >= 0) setSelectedTabIndexRef.current(index)
     }
 
     const blockObserver = new IntersectionObserver(handleBlockIntersection, blockOptions)
-    blockNodes.forEach((ref) => {
-      if (ref) blockObserver.observe(ref)
-    })
+    blockNodes.forEach((node) => blockObserver.observe(node))
 
     previousBlockLayoutsRef.current = captureBlockLayouts()
 
     return () => {
       blockObserver.disconnect()
     }
-  }, [formJson, isMounted, window.innerHeight, wrapperClickCount, visibilityVersion])
+  }, [formJson, isMounted, window.innerHeight, visibilityVersion, domVersion, blockClasses])
 }

--- a/app/frontend/components/shared/permit-applications/requirement-form/hooks/use-checklist-visibility.ts
+++ b/app/frontend/components/shared/permit-applications/requirement-form/hooks/use-checklist-visibility.ts
@@ -1,0 +1,97 @@
+import { MutableRefObject, useEffect, useRef, useState } from "react"
+import {
+  getCompletedBlocksFromForm,
+  reconcileSelectedTabIndex,
+  scrollAdjustmentForHiddenBlocks,
+} from "../../../../../utils/formio-component-traversal"
+
+type BlockLayout = { key: string; absTop: number; height: number }
+
+interface IUseChecklistVisibilityParams {
+  formRef: MutableRefObject<any>
+  blockClasses: string[]
+  selectedTabIndex: number
+  setSelectedTabIndex: (index: number) => void
+  isStepCodeComplete: boolean
+  onCompletedBlocksChange?: (sections: Record<string, boolean>) => void
+}
+
+export function useChecklistVisibility({
+  formRef,
+  blockClasses,
+  selectedTabIndex,
+  setSelectedTabIndex,
+  isStepCodeComplete,
+  onCompletedBlocksChange,
+}: IUseChecklistVisibilityParams) {
+  const stepCodeCompletionOptions = { isStepCodeComplete }
+  const previousVisibleBlockKeysRef = useRef<string[]>([])
+  const previousCompletedBlocksRef = useRef<Record<string, boolean>>({})
+  const previousBlockLayoutsRef = useRef<BlockLayout[]>([])
+  const [visibilityVersion, setVisibilityVersion] = useState(0)
+
+  const captureBlockLayouts = () =>
+    blockClasses.flatMap((className) => {
+      const el = document.getElementsByClassName(className)[0] as HTMLElement | undefined
+      if (!el || el.classList.contains("formio-hidden")) return []
+      const rect = el.getBoundingClientRect()
+      return [
+        {
+          key: className.replace(/^formio-component-/, ""),
+          absTop: rect.top + window.scrollY,
+          height: rect.height,
+        },
+      ]
+    })
+
+  const syncCompletedBlocksFromForm = (root) => {
+    if (!root || !onCompletedBlocksChange) return
+
+    const previousKeys = previousVisibleBlockKeysRef.current
+    const nextCompleted = getCompletedBlocksFromForm(root, stepCodeCompletionOptions)
+    const nextKeys = Object.keys(nextCompleted)
+    const keysChanged = previousKeys.length !== nextKeys.length || previousKeys.some((key, i) => key !== nextKeys[i])
+    const completionChanged =
+      keysChanged || nextKeys.some((key) => previousCompletedBlocksRef.current[key] !== nextCompleted[key])
+
+    if (keysChanged && previousKeys.length > 0) {
+      const hiddenKeys = new Set(previousKeys.filter((key) => !nextKeys.includes(key)))
+      // Bonus: counteract layout collapse when a tall block above the viewport hides.
+      if (hiddenKeys.size > 0) {
+        const adjustment = scrollAdjustmentForHiddenBlocks(previousBlockLayoutsRef.current, hiddenKeys, window.scrollY)
+        if (adjustment > 0) window.scrollBy(0, -adjustment)
+      }
+
+      const nextIndex = reconcileSelectedTabIndex(previousKeys, nextKeys, selectedTabIndex)
+      if (nextIndex !== selectedTabIndex) setSelectedTabIndex(nextIndex)
+    }
+
+    previousVisibleBlockKeysRef.current = nextKeys
+    if (completionChanged) {
+      previousCompletedBlocksRef.current = nextCompleted
+      onCompletedBlocksChange(nextCompleted)
+    }
+    if (keysChanged) {
+      requestAnimationFrame(() => {
+        previousBlockLayoutsRef.current = captureBlockLayouts()
+      })
+      setVisibilityVersion((v) => v + 1)
+    }
+  }
+
+  const syncCompletedBlocksFromFormRef = useRef(syncCompletedBlocksFromForm)
+  syncCompletedBlocksFromFormRef.current = syncCompletedBlocksFromForm
+
+  // Recompute block completion when the digital Step Code checklist completion flips
+  useEffect(() => {
+    if (formRef.current) syncCompletedBlocksFromFormRef.current(formRef.current)
+  }, [isStepCodeComplete])
+
+  return {
+    visibilityVersion,
+    syncCompletedBlocksFromForm,
+    syncCompletedBlocksFromFormRef,
+    previousBlockLayoutsRef,
+    captureBlockLayouts,
+  }
+}

--- a/app/frontend/components/shared/permit-applications/requirement-form/hooks/use-requirement-form-events.ts
+++ b/app/frontend/components/shared/permit-applications/requirement-form/hooks/use-requirement-form-events.ts
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { IPermitApplication } from "../../../../../models/permit-application"
+import { EFileUploadAttachmentType, EStepCodeType } from "../../../../../types/enums"
+import { downloadFileFromStorage } from "../../../../../utils/utility-functions"
+
+interface IUseRequirementFormEventsParams {
+  permitApplication: IPermitApplication
+  triggerSave?: (params?: { autosave?: boolean; skipPristineCheck?: boolean }) => Promise<boolean | void> | void
+  onContactsOpen: () => void
+  onPreviousSubmissionOpen: () => void
+}
+
+export function useRequirementFormEvents({
+  permitApplication,
+  triggerSave,
+  onContactsOpen,
+  onPreviousSubmissionOpen,
+}: IUseRequirementFormEventsParams) {
+  const navigate = useNavigate()
+  const [autofillContactKey, setAutofillContactKey] = useState(null)
+  const [previousSubmissionKey, setPreviousSubmissionKey] = useState(null)
+  const [isStepCodeSelectOpen, setIsStepCodeSelectOpen] = useState(false)
+  const [stepCodeSelectType, setStepCodeSelectType] = useState<EStepCodeType>(EStepCodeType.part9StepCode)
+
+  const handleSelectExistingStepCode = async (stepCodeId: string) => {
+    await triggerSave?.()
+    // Assign by updating the StepCode's permitApplicationId (belongs_to association)
+    // @ts-ignore method added on model
+    const ok = await permitApplication.assignExistingStepCode(stepCodeId)
+    if (ok) setIsStepCodeSelectOpen(false)
+  }
+
+  useEffect(() => {
+    const handleOpenStepCodePart3 = async (_event) => {
+      await triggerSave?.()
+      navigate("part-3-step-code")
+    }
+
+    const handleOpenStepCodePart9 = async (_event) => {
+      await triggerSave?.()
+      navigate("part-9-step-code")
+    }
+
+    const handleOpenContactAutofill = async (event) => {
+      setAutofillContactKey(event.detail.key)
+      onContactsOpen()
+    }
+
+    const handleOpenPreviousSubmission = async (event) => {
+      setPreviousSubmissionKey(event.detail.key)
+      onPreviousSubmissionOpen()
+    }
+
+    const handleOpenExistingStepCode = async (event) => {
+      const incoming = event?.detail?.stepCodeType as EStepCodeType
+      setStepCodeSelectType(
+        incoming === EStepCodeType.part3StepCode ? EStepCodeType.part3StepCode : EStepCodeType.part9StepCode
+      )
+      setIsStepCodeSelectOpen(true)
+    }
+
+    const handleDownloadRequirementDocument = async (event) => {
+      downloadFileFromStorage({
+        model: EFileUploadAttachmentType.RequirementDocument,
+        modelId: event.detail.id,
+        filename: event.detail.filename,
+      })
+    }
+
+    const handleOpenResourceLink = (event) => {
+      window.open(event.detail.url, "_blank", "noopener,noreferrer")
+    }
+
+    const handleDownloadResourceDocument = async (event) => {
+      downloadFileFromStorage({
+        model: EFileUploadAttachmentType.ResourceDocument,
+        modelId: event.detail.id,
+        filename: event.detail.filename,
+      })
+    }
+
+    document.addEventListener("openStepCode", handleOpenStepCodePart9)
+    document.addEventListener("openStepCodePart3", handleOpenStepCodePart3)
+    document.addEventListener("openAutofillContact", handleOpenContactAutofill)
+    document.addEventListener("openPreviousSubmission", handleOpenPreviousSubmission)
+    document.addEventListener("openExistingStepCode", handleOpenExistingStepCode)
+    document.addEventListener("downloadRequirementDocument", handleDownloadRequirementDocument)
+    document.addEventListener("openResourceLink", handleOpenResourceLink)
+    document.addEventListener("downloadResourceDocument", handleDownloadResourceDocument)
+
+    return () => {
+      document.removeEventListener("openStepCode", handleOpenStepCodePart9)
+      document.removeEventListener("openStepCodePart3", handleOpenStepCodePart3)
+      document.removeEventListener("openAutofillContact", handleOpenContactAutofill)
+      document.removeEventListener("openPreviousSubmission", handleOpenPreviousSubmission)
+      document.removeEventListener("openExistingStepCode", handleOpenExistingStepCode)
+      document.removeEventListener("downloadRequirementDocument", handleDownloadRequirementDocument)
+      document.removeEventListener("openResourceLink", handleOpenResourceLink)
+      document.removeEventListener("downloadResourceDocument", handleDownloadResourceDocument)
+    }
+  }, [])
+
+  return {
+    autofillContactKey,
+    previousSubmissionKey,
+    isStepCodeSelectOpen,
+    setIsStepCodeSelectOpen,
+    stepCodeSelectType,
+    handleSelectExistingStepCode,
+  }
+}

--- a/app/frontend/components/shared/permit-applications/requirement-form/index.tsx
+++ b/app/frontend/components/shared/permit-applications/requirement-form/index.tsx
@@ -7,32 +7,28 @@ import * as R from "ramda"
 import React, { useEffect, useMemo, useRef, useState } from "react"
 import { Trans, useTranslation } from "react-i18next"
 import { useNavigate } from "react-router-dom"
-import { useMountStatus } from "../../../hooks/use-mount-status"
-import { IPermitApplication } from "../../../models/permit-application"
-import { EFileUploadAttachmentType, EFlashMessageStatus, EStepCodeType } from "../../../types/enums"
-import { IErrorsBoxData } from "../../../types/types"
-import {
-  getCompletedBlocksFromForm,
-  getRequirementByKey,
-  reconcileSelectedTabIndex,
-  scrollAdjustmentForHiddenBlocks,
-} from "../../../utils/formio-component-traversal"
+import { IPermitApplication } from "../../../../models/permit-application"
+import { EFlashMessageStatus } from "../../../../types/enums"
+import { IErrorsBoxData } from "../../../../types/types"
+import { getRequirementByKey } from "../../../../utils/formio-component-traversal"
 import {
   getEnergyStepCodeMethodFromData,
   singleRequirementFormJson,
   singleRequirementSubmissionData,
-} from "../../../utils/formio-helpers"
-import { downloadFileFromStorage } from "../../../utils/utility-functions"
-import { CompareRequirementsBox } from "../../domains/permit-application/compare-requirements-box"
-import { ErrorsBox } from "../../domains/permit-application/errors-box"
-import { BuilderBottomFloatingButtons } from "../../domains/requirement-template/builder-bottom-floating-buttons"
-import { CustomMessageBox } from "../base/custom-message-box"
-import { SharedSpinner } from "../base/shared-spinner"
-import { Form, defaultOptions } from "../chefs"
-import { ContactModal } from "../contact/contact-modal"
-import { PreviousSubmissionModal } from "../revisions/previous-submission-modal"
-import { PermitApplicationSubmitModal } from "./permit-application-submit-modal"
-import { StepCodeSelectModal } from "./step-code-select-modal"
+} from "../../../../utils/formio-helpers"
+import { CompareRequirementsBox } from "../../../domains/permit-application/compare-requirements-box"
+import { ErrorsBox } from "../../../domains/permit-application/errors-box"
+import { BuilderBottomFloatingButtons } from "../../../domains/requirement-template/builder-bottom-floating-buttons"
+import { CustomMessageBox } from "../../base/custom-message-box"
+import { SharedSpinner } from "../../base/shared-spinner"
+import { Form, defaultOptions } from "../../chefs"
+import { ContactModal } from "../../contact/contact-modal"
+import { PreviousSubmissionModal } from "../../revisions/previous-submission-modal"
+import { PermitApplicationSubmitModal } from "../permit-application-submit-modal"
+import { StepCodeSelectModal } from "../step-code-select-modal"
+import { useBlockScrollSpy } from "./hooks/use-block-scroll-spy"
+import { useChecklistVisibility } from "./hooks/use-checklist-visibility"
+import { useRequirementFormEvents } from "./hooks/use-requirement-form-events"
 
 interface IRequirementFormProps {
   permitApplication?: IPermitApplication
@@ -77,85 +73,44 @@ export const RequirementForm = observer(
       isStepCodeComplete,
     } = permitApplication
 
-    const stepCodeCompletionOptions = { isStepCodeComplete }
-    const previousVisibleBlockKeysRef = useRef<string[]>([])
-    const previousCompletedBlocksRef = useRef<Record<string, boolean>>({})
-    const previousBlockLayoutsRef = useRef<{ key: string; absTop: number; height: number }[]>([])
-    const [visibilityVersion, setVisibilityVersion] = useState(0)
-
-    const captureBlockLayouts = () =>
-      blockClasses.flatMap((className) => {
-        const el = document.getElementsByClassName(className)[0] as HTMLElement | undefined
-        if (!el || el.classList.contains("formio-hidden")) return []
-        const rect = el.getBoundingClientRect()
-        return [
-          {
-            key: className.replace(/^formio-component-/, ""),
-            absTop: rect.top + window.scrollY,
-            height: rect.height,
-          },
-        ]
-      })
-
-    const syncCompletedBlocksFromForm = (root) => {
-      if (!root || !onCompletedBlocksChange) return
-
-      const previousKeys = previousVisibleBlockKeysRef.current
-      const nextCompleted = getCompletedBlocksFromForm(root, stepCodeCompletionOptions)
-      const nextKeys = Object.keys(nextCompleted)
-      const keysChanged = previousKeys.length !== nextKeys.length || previousKeys.some((key, i) => key !== nextKeys[i])
-      const completionChanged =
-        keysChanged || nextKeys.some((key) => previousCompletedBlocksRef.current[key] !== nextCompleted[key])
-
-      if (keysChanged && previousKeys.length > 0) {
-        const hiddenKeys = new Set(previousKeys.filter((key) => !nextKeys.includes(key)))
-        // Bonus: counteract layout collapse when a tall block above the viewport hides.
-        if (hiddenKeys.size > 0) {
-          const adjustment = scrollAdjustmentForHiddenBlocks(
-            previousBlockLayoutsRef.current,
-            hiddenKeys,
-            window.scrollY
-          )
-          if (adjustment > 0) window.scrollBy(0, -adjustment)
-        }
-
-        const nextIndex = reconcileSelectedTabIndex(previousKeys, nextKeys, selectedTabIndex)
-        if (nextIndex !== selectedTabIndex) setSelectedTabIndex(nextIndex)
-      }
-
-      previousVisibleBlockKeysRef.current = nextKeys
-      if (completionChanged) {
-        previousCompletedBlocksRef.current = nextCompleted
-        onCompletedBlocksChange(nextCompleted)
-      }
-      if (keysChanged) {
-        requestAnimationFrame(() => {
-          previousBlockLayoutsRef.current = captureBlockLayouts()
-        })
-        setVisibilityVersion((v) => v + 1)
-      }
-    }
-
-    const syncCompletedBlocksFromFormRef = useRef(syncCompletedBlocksFromForm)
-    syncCompletedBlocksFromFormRef.current = syncCompletedBlocksFromForm
+    const {
+      visibilityVersion,
+      syncCompletedBlocksFromForm,
+      syncCompletedBlocksFromFormRef,
+      previousBlockLayoutsRef,
+      captureBlockLayouts,
+    } = useChecklistVisibility({
+      formRef,
+      blockClasses,
+      selectedTabIndex,
+      setSelectedTabIndex,
+      isStepCodeComplete,
+      onCompletedBlocksChange,
+    })
 
     const shouldShowDiff = permitApplication?.shouldShowApplicationDiff(isEditing)
     const userShouldSeeDiff = permitApplication?.currentUserShouldSeeApplicationDiff
 
     const pastVersion = previousToSelectedSubmissionVersion || previousSubmissionVersion
-    const isMounted = useMountStatus()
     const { t } = useTranslation()
     const navigate = useNavigate()
     const { isOpen, onOpen, onClose } = useDisclosure()
     const boxRef = useRef<HTMLDivElement>(null)
 
-    const [wrapperClickCount, setWrapperClickCount] = useState(0)
+    useBlockScrollSpy({
+      boxRef,
+      formJson,
+      blockClasses,
+      visibilityVersion,
+      setSelectedTabIndex,
+      previousBlockLayoutsRef,
+      captureBlockLayouts,
+    })
+
     const [errorBoxData, setErrorBoxData] = useState<IErrorsBoxData[]>([]) // an array of Labels and links to the component
     const [imminentSubmission, setImminentSubmission] = useState(null)
     const [floatErrorBox, setFloatErrorBox] = useState(false)
     const [hasErrors, setHasErrors] = useState(false)
-    const [autofillContactKey, setAutofillContactKey] = useState(null)
-    const [previousSubmissionKey, setPreviousSubmissionKey] = useState(null)
     const [firstComponentKey, setFirstComponentKey] = useState(null)
     const [isCollapsedAll, setIsCollapsedAllState] = useState(false)
 
@@ -194,6 +149,20 @@ export const RequirementForm = observer(
       onClose: onPreviousSubmissionClose,
     } = useDisclosure()
 
+    const {
+      autofillContactKey,
+      previousSubmissionKey,
+      isStepCodeSelectOpen,
+      setIsStepCodeSelectOpen,
+      stepCodeSelectType,
+      handleSelectExistingStepCode,
+    } = useRequirementFormEvents({
+      permitApplication,
+      triggerSave,
+      onContactsOpen,
+      onPreviousSubmissionOpen,
+    })
+
     const infoBoxData = permitApplication.diffToInfoBoxData
 
     useEffect(() => {
@@ -207,25 +176,9 @@ export const RequirementForm = observer(
       // We don't want to trigger a re-render if the permitApplication itself changes, only if the derived data changes
     }, [displayedSubmissionData])
 
-    // Recompute block completion when the digital Step Code checklist completion flips
-    useEffect(() => {
-      if (formRef.current) syncCompletedBlocksFromFormRef.current(formRef.current)
-    }, [isStepCodeComplete])
-
-    useEffect(() => {
-      // The box observers need to be re-registered whenever a panel is collapsed
-      // This triggers a re-registration whenever the body of the box is clicked
-      // Click listener must be registered this way because formIO prevents bubbling
-
-      const box = boxRef.current
-      const handleClick = () => {
-        setWrapperClickCount((n) => n + 1)
-      }
-      box?.addEventListener("click", handleClick)
-      return () => {
-        box?.removeEventListener("click", handleClick)
-      }
-    }, [])
+    const onScroll = (_event) => {
+      setFloatErrorBox(hasErrors && isFirstComponentNearTopOfView(firstComponentKey))
+    }
 
     useEffect(() => {
       if (hasErrors) {
@@ -237,125 +190,6 @@ export const RequirementForm = observer(
         window.removeEventListener("scroll", onScroll)
       }
     }, [hasErrors])
-
-    useEffect(() => {
-      // This useEffect registers the intersection observers for the panels
-      // It uses a thin line running across the middle of the screen
-      // and detects when this line covers at least a small percentage of the panel
-
-      // Problems with render timing necessitates the use of this isMounted state
-      if (!isMounted) return
-
-      const formComponentNodes = document.querySelectorAll(".formio-component")
-
-      const blockNodes = Array.from(formComponentNodes).filter(
-        (node) =>
-          !node.classList.contains("formio-hidden") &&
-          Array.from(node.classList).some((className) => blockClasses.includes(className))
-      )
-      const viewportHeight = window.innerHeight // Get the viewport height
-      const topValue = -viewportHeight / 2 + 5
-      const bottomValue = -viewportHeight / 2 + 5
-      const rootMarginValue = `${topValue}px 0px ${bottomValue}px 0px`
-      const blockOptions = {
-        rootMargin: rootMarginValue,
-        threshold: 0.0001, // Adjust threshold based on needs
-      }
-
-      const blockObserver = new IntersectionObserver(handleBlockIntersection, blockOptions)
-
-      Object.values(blockNodes).forEach((ref) => {
-        if (ref) {
-          blockObserver.observe(ref)
-        }
-      })
-
-      previousBlockLayoutsRef.current = captureBlockLayouts()
-
-      return () => {
-        blockObserver.disconnect()
-      }
-    }, [formJson, isMounted, window.innerHeight, wrapperClickCount, visibilityVersion])
-
-    const handleOpenStepCodePart3 = async (_event) => {
-      await triggerSave?.()
-      navigate("part-3-step-code")
-    }
-
-    const handleOpenStepCodePart9 = async (_event) => {
-      await triggerSave?.()
-      navigate("part-9-step-code")
-    }
-
-    const handleOpenContactAutofill = async (event) => {
-      setAutofillContactKey(event.detail.key)
-      onContactsOpen()
-    }
-
-    const handleOpenPreviousSubmission = async (event) => {
-      setPreviousSubmissionKey(event.detail.key)
-      onPreviousSubmissionOpen()
-    }
-
-    const [isStepCodeSelectOpen, setIsStepCodeSelectOpen] = useState(false)
-    const [stepCodeSelectType, setStepCodeSelectType] = useState<EStepCodeType>(EStepCodeType.part9StepCode)
-    const handleOpenExistingStepCode = async (event) => {
-      const incoming = event?.detail?.stepCodeType as EStepCodeType
-      setStepCodeSelectType(
-        incoming === EStepCodeType.part3StepCode ? EStepCodeType.part3StepCode : EStepCodeType.part9StepCode
-      )
-      setIsStepCodeSelectOpen(true)
-    }
-
-    const handleSelectExistingStepCode = async (stepCodeId: string) => {
-      await triggerSave?.()
-      // Assign by updating the StepCode's permitApplicationId (belongs_to association)
-      // @ts-ignore method added on model
-      const ok = await permitApplication.assignExistingStepCode(stepCodeId)
-      if (ok) setIsStepCodeSelectOpen(false)
-    }
-
-    const handleDownloadRequirementDocument = async (event) => {
-      downloadFileFromStorage({
-        model: EFileUploadAttachmentType.RequirementDocument,
-        modelId: event.detail.id,
-        filename: event.detail.filename,
-      })
-    }
-
-    const handleOpenResourceLink = (event) => {
-      window.open(event.detail.url, "_blank", "noopener,noreferrer")
-    }
-
-    const handleDownloadResourceDocument = async (event) => {
-      downloadFileFromStorage({
-        model: EFileUploadAttachmentType.ResourceDocument,
-        modelId: event.detail.id,
-        filename: event.detail.filename,
-      })
-    }
-
-    useEffect(() => {
-      document.addEventListener("openStepCode", handleOpenStepCodePart9)
-      document.addEventListener("openStepCodePart3", handleOpenStepCodePart3)
-      document.addEventListener("openAutofillContact", handleOpenContactAutofill)
-      document.addEventListener("openPreviousSubmission", handleOpenPreviousSubmission)
-      document.addEventListener("openExistingStepCode", handleOpenExistingStepCode)
-      document.addEventListener("downloadRequirementDocument", handleDownloadRequirementDocument)
-      document.addEventListener("openResourceLink", handleOpenResourceLink)
-      document.addEventListener("downloadResourceDocument", handleDownloadResourceDocument)
-
-      return () => {
-        document.removeEventListener("openStepCode", handleOpenStepCodePart9)
-        document.removeEventListener("openStepCodePart3", handleOpenStepCodePart3)
-        document.removeEventListener("openAutofillContact", handleOpenContactAutofill)
-        document.removeEventListener("openPreviousSubmission", handleOpenPreviousSubmission)
-        document.removeEventListener("openExistingStepCode", handleOpenExistingStepCode)
-        document.removeEventListener("downloadRequirementDocument", handleDownloadRequirementDocument)
-        document.removeEventListener("openResourceLink", handleOpenResourceLink)
-        document.removeEventListener("downloadResourceDocument", handleDownloadResourceDocument)
-      }
-    }, [])
 
     const setIsCollapsedAll = (isCollapsedAll: boolean) => {
       if (isCollapsedAll) {
@@ -370,20 +204,6 @@ export const RequirementForm = observer(
       errors.map((error) => {
         return { label: error.component.label, id: error.component.id, class: error.component.class }
       })
-
-    function handleBlockIntersection(entries: IntersectionObserverEntry[]) {
-      const entry = entries.filter((en) => en.isIntersecting)[0]
-      if (!entry) return
-
-      // Index among currently visible blocks so sidebar tabs stay aligned after conditionals hide panels.
-      const visibleBlockNodes = Array.from(document.querySelectorAll(".formio-component")).filter(
-        (node) =>
-          !node.classList.contains("formio-hidden") &&
-          Array.from(node.classList).some((className) => blockClasses.includes(className))
-      )
-      const index = visibleBlockNodes.indexOf(entry.target)
-      if (index >= 0) setSelectedTabIndex(index)
-    }
 
     const onFormSubmit = async (submission: any) => {
       // Form.io does not validate the digital Step Code tool (button container, input:false).
@@ -411,9 +231,6 @@ export const RequirementForm = observer(
 
     const onBlur = (containerComponent) => {
       syncCompletedBlocksFromForm(containerComponent.root)
-    }
-    const onScroll = (event) => {
-      setFloatErrorBox(hasErrors && isFirstComponentNearTopOfView(firstComponentKey))
     }
 
     const onChange = (changedEvent) => {
@@ -452,7 +269,7 @@ export const RequirementForm = observer(
         syncCompletedBlocksFromFormRef.current(formRef.current)
       })
 
-      rootComponent.on("submitError", (error) => {
+      rootComponent.on("submitError", (_error) => {
         // when the form attempts to submit but has validation errors, we set a flag to show ErrorBox
         setHasErrors(true)
         setErrorBoxData(mapErrorBoxData(formRef.current.errors))

--- a/app/frontend/utils/formio-component-traversal.ts
+++ b/app/frontend/utils/formio-component-traversal.ts
@@ -83,10 +83,59 @@ const findEnergyStepCodeMethodValue = (components): "tool" | "file" | null => {
   return null
 }
 
+/** Form.io sets `_visible` false when a panel is hidden by conditionals; treat unset as visible. */
+export const isFormioComponentVisible = (component: { _visible?: boolean } | null | undefined) =>
+  component?._visible !== false
+
+/**
+ * When the selected sidebar tab's block is hidden, keep highlight on the nearest still-visible
+ * predecessor (else the next remaining block). Returns the current index if it still maps cleanly.
+ */
+export const reconcileSelectedTabIndex = (
+  previousVisibleKeys: string[],
+  nextVisibleKeys: string[],
+  selectedTabIndex: number
+) => {
+  if (nextVisibleKeys.length === 0) return 0
+  const prevKey = previousVisibleKeys[selectedTabIndex]
+  if (prevKey) {
+    const stillVisibleIndex = nextVisibleKeys.indexOf(prevKey)
+    if (stillVisibleIndex !== -1) return stillVisibleIndex
+  }
+  for (let i = selectedTabIndex - 1; i >= 0; i--) {
+    const idx = nextVisibleKeys.indexOf(previousVisibleKeys[i])
+    if (idx !== -1) return idx
+  }
+  for (let i = selectedTabIndex + 1; i < previousVisibleKeys.length; i++) {
+    const idx = nextVisibleKeys.indexOf(previousVisibleKeys[i])
+    if (idx !== -1) return idx
+  }
+  return Math.min(selectedTabIndex, nextVisibleKeys.length - 1)
+}
+
+/** Pixels to subtract from scrollY after blocks above the viewport collapse out of layout. */
+export const scrollAdjustmentForHiddenBlocks = (
+  previousLayouts: { key: string; absTop: number; height: number }[],
+  hiddenKeys: Set<string>,
+  scrollY: number
+) => {
+  let adjustment = 0
+  for (const { key, absTop, height } of previousLayouts) {
+    if (!hiddenKeys.has(key) || height <= 0) continue
+    if (absTop < scrollY) {
+      adjustment += Math.min(height, scrollY - absTop)
+    }
+  }
+  return adjustment
+}
+
 export const getCompletedBlocksFromForm = (rootComponent, options?: { isStepCodeComplete?: boolean }) => {
   const blocksList = findPanelComponents(rootComponent.components)
   let completedBlocks = {}
   blocksList.forEach((panelComponent) => {
+    // Omit conditionally hidden blocks so CONTENTS sidebar / completion state match the live form.
+    if (!isFormioComponentVisible(panelComponent)) return
+
     const incompleteComponents = getNestedComponentsIncomplete(panelComponent.components)
 
     // Digital tool field is a button container (input:false) so Form.io never marks it incomplete.
@@ -508,12 +557,12 @@ export const traverseFormIOComponents = (
 }
 
 export const processFieldsForEphemeral = (formJson: IFormJson) => {
+  // Keep conditionals: preview must exercise show/hide the same as live applications.
+  // Only disable upload/submit affordances that don't make sense on an ephemeral PA.
   traverseFormIORequirements(formJson, (requirement) => {
     if (["simplefile"].includes(requirement.type) || ["submit"].includes(requirement.key)) {
       requirement.disabled = true
     }
-    requirement.conditional = false
-    requirement.customConditional = null
   })
   return formJson
 }

--- a/app/frontend/utils/formio-ephemeral-conditionals.check.mjs
+++ b/app/frontend/utils/formio-ephemeral-conditionals.check.mjs
@@ -1,0 +1,51 @@
+// ponytail: assert-based self-check for processFieldsForEphemeral conditional preservation.
+// Ceiling: duplicated logic — if processFieldsForEphemeral changes, update this file too.
+// Run: node app/frontend/utils/formio-ephemeral-conditionals.check.mjs
+
+import assert from "node:assert/strict"
+
+/** Mirrors processFieldsForEphemeral: disable file/submit only; keep conditionals. */
+const processFieldsForEphemeral = (formJson) => {
+  formJson.components.forEach((section) => {
+    section.components.forEach((block) => {
+      block.components.forEach((requirement) => {
+        if (["simplefile"].includes(requirement.type) || ["submit"].includes(requirement.key)) {
+          requirement.disabled = true
+        }
+      })
+    })
+  })
+  return formJson
+}
+
+const conditional = {
+  show: false,
+  conjunction: "all",
+  conditions: [{ value: "duplex", operator: "isEqual", component: "section.block|category" }],
+}
+
+const formJson = {
+  components: [
+    {
+      components: [
+        {
+          components: [
+            { key: "block|part3_building_area", type: "number", conditional: { ...conditional } },
+            { key: "block|upload", type: "simplefile", conditional: { show: true, when: "x", eq: "y" } },
+            { key: "submit", type: "button" },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+processFieldsForEphemeral(formJson)
+
+const [area, file, submit] = formJson.components[0].components[0].components
+assert.deepEqual(area.conditional, conditional, "field conditionals must survive ephemeral preview")
+assert.equal(file.disabled, true, "simplefile disabled in ephemeral")
+assert.deepEqual(file.conditional, { show: true, when: "x", eq: "y" }, "file conditional preserved")
+assert.equal(submit.disabled, true, "submit disabled in ephemeral")
+
+console.log("formio-ephemeral-conditionals.check.mjs: ok")

--- a/app/frontend/utils/formio-scroll-spy.check.mjs
+++ b/app/frontend/utils/formio-scroll-spy.check.mjs
@@ -1,0 +1,48 @@
+// ponytail: assert-based self-check mirroring pickScrollSpyBlockIndex in use-block-scroll-spy.ts
+// Ceiling: duplicated logic — if the picker changes, update this file too.
+// Run: node app/frontend/utils/formio-scroll-spy.check.mjs
+
+import assert from "node:assert/strict"
+
+const pickScrollSpyBlockIndex = (intersectingTargets, visibleBlockNodes, midY) => {
+  let bestIndex = -1
+  let bestDist = Infinity
+
+  for (const node of intersectingTargets) {
+    const index = visibleBlockNodes.indexOf(node)
+    if (index < 0) continue
+    const rect = node.getBoundingClientRect()
+    const dist = Math.abs(rect.top + rect.height / 2 - midY)
+    if (dist < bestDist || (dist === bestDist && index > bestIndex)) {
+      bestDist = dist
+      bestIndex = index
+    }
+  }
+
+  return bestIndex
+}
+
+const makeNode = (top, height) => ({
+  getBoundingClientRect: () => ({ top, height }),
+})
+
+const a = makeNode(0, 100) // center 50
+const b = makeNode(200, 100) // center 250
+const c = makeNode(400, 100) // center 450
+const visible = [a, b, c]
+const midY = 240
+
+assert.equal(pickScrollSpyBlockIndex([a, b], visible, midY), 1, "closest to midline wins")
+assert.equal(pickScrollSpyBlockIndex([a], visible, midY), 0)
+assert.equal(pickScrollSpyBlockIndex([], visible, midY), -1)
+assert.equal(
+  pickScrollSpyBlockIndex([a, c], visible, 250),
+  2,
+  "equidistant centers → later in document order"
+)
+
+const d = makeNode(200, 100)
+const e = makeNode(200, 100)
+assert.equal(pickScrollSpyBlockIndex([d, e], [d, e], 250), 1, "equal distance → later in document order")
+
+console.log("formio-scroll-spy.check.mjs: ok")

--- a/app/frontend/utils/formio-sidebar-visibility.check.mjs
+++ b/app/frontend/utils/formio-sidebar-visibility.check.mjs
@@ -1,0 +1,58 @@
+// ponytail: assert-based self-check mirroring helpers in formio-component-traversal.ts (no test framework).
+// Ceiling: duplicated logic — if the TS helpers change, update this file too.
+// Run: node app/frontend/utils/formio-sidebar-visibility.check.mjs
+
+import assert from "node:assert/strict"
+
+const reconcileSelectedTabIndex = (previousVisibleKeys, nextVisibleKeys, selectedTabIndex) => {
+  if (nextVisibleKeys.length === 0) return 0
+  const prevKey = previousVisibleKeys[selectedTabIndex]
+  if (prevKey) {
+    const stillVisibleIndex = nextVisibleKeys.indexOf(prevKey)
+    if (stillVisibleIndex !== -1) return stillVisibleIndex
+  }
+  for (let i = selectedTabIndex - 1; i >= 0; i--) {
+    const idx = nextVisibleKeys.indexOf(previousVisibleKeys[i])
+    if (idx !== -1) return idx
+  }
+  for (let i = selectedTabIndex + 1; i < previousVisibleKeys.length; i++) {
+    const idx = nextVisibleKeys.indexOf(previousVisibleKeys[i])
+    if (idx !== -1) return idx
+  }
+  return Math.min(selectedTabIndex, nextVisibleKeys.length - 1)
+}
+
+const scrollAdjustmentForHiddenBlocks = (previousLayouts, hiddenKeys, scrollY) => {
+  let adjustment = 0
+  for (const { key, absTop, height } of previousLayouts) {
+    if (!hiddenKeys.has(key) || height <= 0) continue
+    if (absTop < scrollY) {
+      adjustment += Math.min(height, scrollY - absTop)
+    }
+  }
+  return adjustment
+}
+
+assert.equal(reconcileSelectedTabIndex(["a", "b", "c"], ["a", "b", "c"], 1), 1)
+assert.equal(reconcileSelectedTabIndex(["a", "b", "c"], ["a", "c"], 1), 0, "hidden selected → prior sibling")
+assert.equal(reconcileSelectedTabIndex(["a", "b", "c"], ["a", "c"], 2), 1, "later tab remaps after middle hide")
+assert.equal(reconcileSelectedTabIndex(["a", "b"], ["b"], 0), 0, "first hidden → next remaining")
+
+assert.equal(
+  scrollAdjustmentForHiddenBlocks(
+    [
+      { key: "above", absTop: 100, height: 400 },
+      { key: "below", absTop: 900, height: 400 },
+    ],
+    new Set(["above"]),
+    500
+  ),
+  400
+)
+assert.equal(
+  scrollAdjustmentForHiddenBlocks([{ key: "below", absTop: 900, height: 400 }], new Set(["below"]), 500),
+  0,
+  "blocks below viewport do not adjust scroll"
+)
+
+console.log("formio-sidebar-visibility.check.mjs: ok")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,7 @@ User.find_or_create_by(omniauth_username: "super_admin") do |user|
   user.password = "P@ssword1"
   user.confirmed_at = Time.now
   user.omniauth_uid = "A41927C69D6549B8A396FCA748F53502"
-  user.omniauth_provider = "bceidbasic"
+  user.omniauth_provider = "idir"
   user.omniauth_email = "super_admin@example.com"
   user.omniauth_username = "super_admin"
 end

--- a/lib/local_tools.rb
+++ b/lib/local_tools.rb
@@ -65,13 +65,11 @@ class LocalTools
     end
 
     # Searchkick registers models lazily; eager load so the list is complete.
+    # Re-resolve through the constant table so we never reindex a class object
+    # left behind by a reload (stale STI parents raise SubclassNotFound).
     def searchkick_models
-      if Rails.respond_to?(:autoloaders) && Rails.autoloaders.zeitwerk_enabled?
-        Zeitwerk::Loader.eager_load_all
-      else
-        Rails.application.eager_load!
-      end
-      Searchkick.models
+      Rails.application.eager_load!
+      Searchkick.models.map { |model| model.name.constantize }.uniq
     end
   end
 end

--- a/spec/lib/local_tools_spec.rb
+++ b/spec/lib/local_tools_spec.rb
@@ -18,4 +18,28 @@ RSpec.describe LocalTools do
       )
     end
   end
+
+  describe ".searchkick_models" do
+    it "re-resolves Searchkick.models through constants so stale reload copies are dropped" do
+      allow(Rails.application).to receive(:eager_load!)
+
+      stale =
+        Class.new do
+          def self.name
+            "StepCode"
+          end
+        end
+
+      original = Searchkick.models.dup
+      Searchkick.models << stale
+
+      models = described_class.send(:searchkick_models)
+
+      expect(models).to include(StepCode)
+      expect(models).not_to include(stale)
+      expect(models.count { |m| m.name == "StepCode" }).to eq(1)
+    ensure
+      Searchkick.models.replace(original) if original
+    end
+  end
 end


### PR DESCRIPTION
## 📋 Description

**Analyzed:** `git diff develop...HUB-5364-bug-bug-bash-hide-conditionally-hidden-blocks-from-permit-application-sidebar-and-reduce-scroll-jump` (merge-base range).

Two CONTENTS sidebar bugs on the permit application requirement form, plus a small refactor so the scroll/visibility logic lives in focused hooks.

**HUB-5364 — hidden blocks still listed:** Form.io removes/hides conditionally hidden requirement blocks from the form body, but CONTENTS was driven by static `formJson`, so hidden blocks stayed clickable with mismatched completion icons. Hiding a tall block could also yank scroll / selected tab.

**HUB-5366 — flaky highlight:** Scroll-spy only re-registered observers when the form wrapper was clicked (`wrapperClickCount`), so after collapse/expand, conditionals, or redraws the highlight froze until a click “woke it up.” Multi-entry intersection handling also picked the first changed entry instead of the mid-viewport winner.

Also: ephemeral template preview no longer strips field/block conditionals; `RequirementForm` split into `requirement-form/` hooks; small local-dev fixes (`LocalTools` Searchkick reload safety; seeded super_admin provider `idir`).

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5364](https://hous-bssb.atlassian.net/browse/HUB-5364), [HUB-5366](https://hous-bssb.atlassian.net/browse/HUB-5366) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

- CONTENTS sidebar only lists blocks currently visible under Form.io conditionals; empty sections omitted
- Completion state omits hidden panels; selected tab remaps to the nearest remaining block when the current one hides
- Bonus (5364): adjust `scrollY` when a tall block above the viewport collapses
- Scroll-spy rebinds via `MutationObserver` on Form.io DOM changes (collapse/conditionals/redraws) — no click/focus wake-up
- Scroll-spy picks the intersecting block closest to the mid-viewport line (document-order tiebreak)
- `RequirementForm` moved to `requirement-form/` with `use-checklist-visibility`, `use-block-scroll-spy`, and `use-requirement-form-events` (public import path unchanged)
- Ephemeral (template preview) PAs keep conditionals; still disable file upload / submit
- Local tools: re-resolve Searchkick models through constants after eager load; spec added
- Seeds: super_admin `omniauth_provider` set to `idir`

---

## 🧪 Steps to QA

1. Open a draft permit application with a **block conditional**.
2. With the dependent block **hidden**, confirm it is **absent** from CONTENTS; completion icons only reflect visible blocks.
3. Change answers so the block **shows** again — it returns in the correct place.
4. Click other CONTENTS items — scroll still lands on the correct visible blocks.
5. While scrolled partway down, hide a **tall** block above you — viewport should not violently jump; highlight stays on a still-visible block.
6. Scroll through a **long multi-section** application **without clicking** the form — CONTENTS highlight should track continuously.
7. **Collapse/expand** several panels while scrolling — highlight keeps working with **no extra click**.
8. Toggle a conditional block while scrolling — highlight keeps working with **no extra click**.
9. Click a CONTENTS item — still scrolls to the block; highlight matches scroll position afterward.
10. Open a **template version preview** (ephemeral) with conditionals — show/hide still works in the preview form.

**Expected Behaviour:**
CONTENTS and scroll-spy only track currently visible blocks; highlight updates while scrolling without a click wake-up; collapse/conditionals don’t freeze the spy; ephemeral preview still exercises conditionals.

**Before this change:**
Hidden blocks stayed in CONTENTS; scroll-spy froze until a form click; ephemeral preview stripped conditionals.

**After this change:**
Hidden blocks leave CONTENTS until shown; scroll-spy stays live across scroll/collapse/conditionals; ephemeral preview keeps conditionals.

> Please add before/after screenshots of CONTENTS with a block conditional toggled, and a short note/clip of continuous highlight while scrolling without clicking.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5364]: https://hous-bssb.atlassian.net/browse/HUB-5364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ