### PR TITLE
Hub 5167 jurisdiction about page add tooltip to map

### DIFF
--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-overview-tab.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-overview-tab.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Flex, Grid, Heading, HStack, Text, Tooltip, useDisclosure, VStack } from "@chakra-ui/react"
+import { Box, Divider, Flex, Grid, Heading, HStack, Text, useDisclosure, VStack } from "@chakra-ui/react"
 import { CaretRight, Info, SquaresFour, Steps } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React from "react"
@@ -99,16 +99,14 @@ export const InboxOverviewTab = observer(({ permitProject }: IProps) => {
             </VStack>
           </Box>
           <Box>
-            <Tooltip label={t("permitProject.overview.mapVisualReferenceDisclaimer")} hasArrow>
-              <Box height={{ base: "200px", lg: "250px" }} borderRadius="md" overflow="hidden">
-                <ProjectMap
-                  coordinates={permitProject.mapPosition}
-                  pid={pid}
-                  parcelGeometry={permitProject.parcelGeometry}
-                  onOpenFullscreen={onOpenMapFullscreen}
-                />
-              </Box>
-            </Tooltip>
+            <Box height={{ base: "200px", lg: "250px" }} borderRadius="md" overflow="hidden">
+              <ProjectMap
+                coordinates={permitProject.mapPosition}
+                pid={pid}
+                parcelGeometry={permitProject.parcelGeometry}
+                onOpenFullscreen={onOpenMapFullscreen}
+              />
+            </Box>
           </Box>
         </Grid>
       </Box>

--- a/app/frontend/components/domains/permit-project/overview-tab-panel-content.tsx
+++ b/app/frontend/components/domains/permit-project/overview-tab-panel-content.tsx
@@ -1,16 +1,4 @@
-import {
-  Box,
-  Button,
-  ButtonGroup,
-  Flex,
-  Grid,
-  Heading,
-  HStack,
-  Text,
-  Tooltip,
-  useDisclosure,
-  VStack,
-} from "@chakra-ui/react"
+import { Box, Button, ButtonGroup, Flex, Grid, Heading, HStack, Text, useDisclosure, VStack } from "@chakra-ui/react"
 import { CaretRight, ClipboardText, Info, Pencil, SquaresFour, Steps } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React, { useState } from "react"
@@ -222,16 +210,14 @@ export const OverviewTabPanelContent = observer(({ permitProject }: IProps) => {
             )}
           </Box>
           <Box>
-            <Tooltip label={t("permitProject.overview.mapVisualReferenceDisclaimer")} hasArrow>
-              <Box height={{ base: "200px", lg: "250px" }} borderRadius="md" overflow="hidden">
-                <ProjectMap
-                  coordinates={permitProject.mapPosition}
-                  pid={pid}
-                  parcelGeometry={permitProject.parcelGeometry}
-                  onOpenFullscreen={onOpenMapFullscreen}
-                />
-              </Box>
-            </Tooltip>
+            <Box height={{ base: "200px", lg: "250px" }} borderRadius="md" overflow="hidden">
+              <ProjectMap
+                coordinates={permitProject.mapPosition}
+                pid={pid}
+                parcelGeometry={permitProject.parcelGeometry}
+                onOpenFullscreen={onOpenMapFullscreen}
+              />
+            </Box>
           </Box>
         </Grid>
       </Box>

--- a/app/frontend/components/shared/module-wrappers/jurisdiction-map.tsx
+++ b/app/frontend/components/shared/module-wrappers/jurisdiction-map.tsx
@@ -6,7 +6,9 @@ import * as reactiveUtils from "@arcgis/core/core/reactiveUtils"
 import Polyline from "@arcgis/core/geometry/Polyline"
 import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer"
 import MapView from "@arcgis/core/views/MapView"
+import { Box, Tooltip } from "@chakra-ui/react"
 import React, { useEffect, useRef } from "react"
+import { useTranslation } from "react-i18next"
 import { TLatLngTuple } from "../../../types/types"
 
 interface IJurisdictionMapProps {
@@ -26,6 +28,7 @@ export const JurisdictionMap = ({
   onZoomChange,
   isEditingMap = false,
 }: IJurisdictionMapProps) => {
+  const { t } = useTranslation()
   const mapDiv = useRef<HTMLDivElement>(null)
   const viewRef = useRef<MapView | null>(null)
   const graphicsLayerRef = useRef<GraphicsLayer | null>(null)
@@ -171,5 +174,9 @@ export const JurisdictionMap = ({
     view.ui.add("zoom", "top-left")
   }, [])
 
-  return <div ref={mapDiv} style={{ height: "250px", width: "100%", zIndex: 0 }} />
+  return (
+    <Tooltip label={t("map.visualReferenceDisclaimer")} hasArrow>
+      <Box ref={mapDiv} h="250px" w="100%" zIndex={0} />
+    </Tooltip>
+  )
 }

--- a/app/frontend/components/shared/module-wrappers/jurisdiction-map.tsx
+++ b/app/frontend/components/shared/module-wrappers/jurisdiction-map.tsx
@@ -176,7 +176,9 @@ export const JurisdictionMap = ({
 
   return (
     <Tooltip label={t("map.visualReferenceDisclaimer")} hasArrow>
-      <Box ref={mapDiv} h="250px" w="100%" zIndex={0} />
+      <Box>
+        <Box ref={mapDiv} h="250px" w="100%" zIndex={0} />
+      </Box>
     </Tooltip>
   )
 }

--- a/app/frontend/components/shared/module-wrappers/project-map.tsx
+++ b/app/frontend/components/shared/module-wrappers/project-map.tsx
@@ -7,7 +7,7 @@ import GraphicsLayer from "@arcgis/core/layers/GraphicsLayer"
 import SimpleFillSymbol from "@arcgis/core/symbols/SimpleFillSymbol"
 import SimpleMarkerSymbol from "@arcgis/core/symbols/SimpleMarkerSymbol"
 import MapView from "@arcgis/core/views/MapView"
-import { Box, Center, IconButton, Text } from "@chakra-ui/react"
+import { Box, Center, IconButton, Text, Tooltip } from "@chakra-ui/react"
 import { ArrowsOut, MapTrifold, Warning } from "@phosphor-icons/react"
 import React, { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -164,9 +164,10 @@ export const ProjectMap = ({ coordinates, pid, parcelGeometry, onOpenFullscreen 
     updateGraphics()
   }, [isMapReady, updateGraphics])
 
-  // Error state
+  let mapContent: React.ReactNode
+
   if (hasError) {
-    return (
+    mapContent = (
       <Center
         h="100%"
         w="100%"
@@ -182,11 +183,8 @@ export const ProjectMap = ({ coordinates, pid, parcelGeometry, onOpenFullscreen 
         </Text>
       </Center>
     )
-  }
-
-  // No location data state
-  if (!coordinates && !parcelGeometry && pid) {
-    return (
+  } else if (!coordinates && !parcelGeometry && pid) {
+    mapContent = (
       <Center
         h="100%"
         w="100%"
@@ -202,43 +200,49 @@ export const ProjectMap = ({ coordinates, pid, parcelGeometry, onOpenFullscreen 
         </Text>
       </Center>
     )
+  } else {
+    mapContent = (
+      <Box position="relative" h="100%" w="100%" minH={{ base: "200px", lg: "300px" }}>
+        {!isMapReady && (
+          <Center position="absolute" inset={0} bg="greys.grey03" zIndex={1} borderRadius="md">
+            <SharedSpinner my={0} />
+          </Center>
+        )}
+
+        {onOpenFullscreen && isMapReady && (
+          <IconButton
+            aria-label={t("permitProject.map.openFullscreen")}
+            icon={<ArrowsOut size={18} />}
+            size="sm"
+            position="absolute"
+            top={2}
+            right={2}
+            zIndex={1}
+            bg="white"
+            shadow="md"
+            borderRadius="md"
+            _hover={{ bg: "gray.100" }}
+            onClick={onOpenFullscreen}
+          />
+        )}
+
+        <Box
+          ref={mapDiv}
+          h="100%"
+          w="100%"
+          borderRadius="md"
+          role="application"
+          aria-label={pid ? t("permitProject.map.ariaLabelWithPid", { pid }) : t("permitProject.map.ariaLabel")}
+        />
+      </Box>
+    )
   }
 
   return (
-    <Box position="relative" h="100%" w="100%" minH={{ base: "200px", lg: "300px" }}>
-      {/* Loading overlay */}
-      {!isMapReady && (
-        <Center position="absolute" inset={0} bg="greys.grey03" zIndex={1} borderRadius="md">
-          <SharedSpinner my={0} />
-        </Center>
-      )}
-
-      {/* Fullscreen button */}
-      {onOpenFullscreen && isMapReady && (
-        <IconButton
-          aria-label={t("permitProject.map.openFullscreen")}
-          icon={<ArrowsOut size={18} />}
-          size="sm"
-          position="absolute"
-          top={2}
-          right={2}
-          zIndex={1}
-          bg="white"
-          shadow="md"
-          borderRadius="md"
-          _hover={{ bg: "gray.100" }}
-          onClick={onOpenFullscreen}
-        />
-      )}
-
-      <Box
-        ref={mapDiv}
-        h="100%"
-        w="100%"
-        borderRadius="md"
-        role="application"
-        aria-label={pid ? t("permitProject.map.ariaLabelWithPid", { pid }) : t("permitProject.map.ariaLabel")}
-      />
-    </Box>
+    <Tooltip label={t("map.visualReferenceDisclaimer")} hasArrow>
+      <Box h="100%" w="100%">
+        {mapContent}
+      </Box>
+    </Tooltip>
   )
 }

--- a/app/frontend/components/shared/module-wrappers/project-map.tsx
+++ b/app/frontend/components/shared/module-wrappers/project-map.tsx
@@ -164,84 +164,61 @@ export const ProjectMap = ({ coordinates, pid, parcelGeometry, onOpenFullscreen 
     updateGraphics()
   }, [isMapReady, updateGraphics])
 
-  let mapContent: React.ReactNode
-
-  if (hasError) {
-    mapContent = (
-      <Center
-        h="100%"
-        w="100%"
-        minH={{ base: "200px", lg: "300px" }}
-        bg="greys.grey03"
-        borderRadius="md"
-        flexDirection="column"
-        gap={2}
-      >
-        <Warning size={32} />
-        <Text fontSize="sm" color="text.secondary" textAlign="center">
-          {t("permitProject.map.errorLoading")}
-        </Text>
-      </Center>
-    )
-  } else if (!coordinates && !parcelGeometry && pid) {
-    mapContent = (
-      <Center
-        h="100%"
-        w="100%"
-        minH={{ base: "200px", lg: "300px" }}
-        bg="greys.grey03"
-        borderRadius="md"
-        flexDirection="column"
-        gap={2}
-      >
-        <MapTrifold size={32} />
-        <Text fontSize="sm" color="text.secondary" textAlign="center">
-          {t("permitProject.map.noLocation")}
-        </Text>
-      </Center>
-    )
-  } else {
-    mapContent = (
-      <Box position="relative" h="100%" w="100%" minH={{ base: "200px", lg: "300px" }}>
-        {!isMapReady && (
-          <Center position="absolute" inset={0} bg="greys.grey03" zIndex={1} borderRadius="md">
-            <SharedSpinner my={0} />
-          </Center>
-        )}
-
-        {onOpenFullscreen && isMapReady && (
-          <IconButton
-            aria-label={t("permitProject.map.openFullscreen")}
-            icon={<ArrowsOut size={18} />}
-            size="sm"
-            position="absolute"
-            top={2}
-            right={2}
-            zIndex={1}
-            bg="white"
-            shadow="md"
-            borderRadius="md"
-            _hover={{ bg: "gray.100" }}
-            onClick={onOpenFullscreen}
-          />
-        )}
-
-        <Box
-          ref={mapDiv}
-          h="100%"
-          w="100%"
-          borderRadius="md"
-          role="application"
-          aria-label={pid ? t("permitProject.map.ariaLabelWithPid", { pid }) : t("permitProject.map.ariaLabel")}
-        />
-      </Box>
-    )
-  }
+  const noLocation = !coordinates && !parcelGeometry && pid
 
   return (
     <Tooltip label={t("map.visualReferenceDisclaimer")} hasArrow>
       <Box h="100%" w="100%">
-        {mapContent}
+        {hasError || noLocation ? (
+          <Center
+            h="100%"
+            w="100%"
+            minH={{ base: "200px", lg: "300px" }}
+            bg="greys.grey03"
+            borderRadius="md"
+            flexDirection="column"
+            gap={2}
+          >
+            {hasError ? <Warning size={32} /> : <MapTrifold size={32} />}
+            <Text fontSize="sm" color="text.secondary" textAlign="center">
+              {t(hasError ? "permitProject.map.errorLoading" : "permitProject.map.noLocation")}
+            </Text>
+          </Center>
+        ) : (
+          <Box position="relative" h="100%" w="100%" minH={{ base: "200px", lg: "300px" }}>
+            {!isMapReady && (
+              <Center position="absolute" inset={0} bg="greys.grey03" zIndex={1} borderRadius="md">
+                <SharedSpinner my={0} />
+              </Center>
+            )}
+
+            {onOpenFullscreen && isMapReady && (
+              <IconButton
+                aria-label={t("permitProject.map.openFullscreen")}
+                icon={<ArrowsOut size={18} />}
+                size="sm"
+                position="absolute"
+                top={2}
+                right={2}
+                zIndex={1}
+                bg="white"
+                shadow="md"
+                borderRadius="md"
+                _hover={{ bg: "gray.100" }}
+                onClick={onOpenFullscreen}
+              />
+            )}
+
+            <Box
+              ref={mapDiv}
+              h="100%"
+              w="100%"
+              borderRadius="md"
+              role="application"
+              aria-label={pid ? t("permitProject.map.ariaLabelWithPid", { pid }) : t("permitProject.map.ariaLabel")}
+            />
+          </Box>
+        )}
       </Box>
     </Tooltip>
   )

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -477,6 +477,10 @@ const options = {
           chooseSandboxMode: "Choose a training mode",
           new: "new",
         },
+        map: {
+          visualReferenceDisclaimer:
+            "Map is for visual reference only and is not intended for use in GIS analysis, surveying, construction or other activities.",
+        },
         notification: {
           title: "Notifications",
           nUnread: "{{ n }} new",
@@ -1467,8 +1471,6 @@ Thank you,
             updatedAt: "Last modified",
             status: "Status",
             allPermits: "View all applications",
-            mapVisualReferenceDisclaimer:
-              "Map is for visual reference only and is not intended for use in GIS analysis, surveying, construction or other activities.",
           },
           activity: {
             title: "Activity",


### PR DESCRIPTION
## 📋 Description

Adds a visual-reference disclaimer tooltip to the jurisdiction about page map (HUB-5167) by moving the disclaimer into the shared map components instead of duplicating it at each call site.

Previously, the disclaimer tooltip only wrapped `ProjectMap` on project overview screens. The jurisdiction about page uses `JurisdictionMap` and had no disclaimer. This PR centralizes the tooltip in `JurisdictionMap` and `ProjectMap`, and moves the copy to a shared i18n key (`map.visualReferenceDisclaimer`).

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                            |
| -------------------- | --------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5167](https://hous-bssb.atlassian.net/browse/HUB-5167) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                             |
| 📑 Design / Figma    | <!-- Paste link -->                                             |
| 📚 Documentation     | <!-- Paste link -->                                             |

---

## ✨ Features / Changes Introduced

- Added a hover tooltip with the map visual-reference disclaimer to `JurisdictionMap` (jurisdiction about page)
- Moved the disclaimer tooltip into `ProjectMap` so all project map usages get it consistently (overview, inbox, fullscreen modal)
- Removed duplicated tooltip wrappers from `overview-tab-panel-content.tsx` and `inbox-overview-tab.tsx`
- Introduced shared i18n key `map.visualReferenceDisclaimer` and removed `permitProject.overview.mapVisualReferenceDisclaimer`
- Refactored `ProjectMap` to consolidate error and no-location states while keeping the ArcGIS container on an inner `Box` (tooltip wraps an outer `Box`)

---

## 🧪 Steps to QA

1. Open a jurisdiction about page (e.g. `/jurisdictions/:id`) that shows the map in the supported section
2. Hover over the map and confirm the tooltip appears: _"Map is for visual reference only and is not intended for use in GIS analysis, surveying, construction or other activities."_
3. Confirm the jurisdiction map still pans and zooms normally
4. Open a project overview page and hover the map — confirm the same disclaimer tooltip appears
5. Open a project from the submission inbox overview tab and hover the map — confirm the same disclaimer tooltip appears
6. Open the fullscreen map modal from a project overview and hover the map — confirm the disclaimer tooltip appears there as well
7. If possible, test a project with no map location data and confirm the no-location state still renders correctly

**Expected Behaviour:**

- All maps using `JurisdictionMap` or `ProjectMap` show the visual-reference disclaimer on hover
- Map interactions (pan, zoom, fullscreen) continue to work as before

**Before this change:**

- The disclaimer tooltip only appeared on project overview/inbox screens
- The jurisdiction about page map had no disclaimer

**After this change:**

- The disclaimer is shown from the shared map components, including the jurisdiction about page

> Please add before/after screenshots of the jurisdiction about page map tooltip for the PR.

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [x] Additional context added through `aria-roles` and `aria-labels` where needed? _(existing `aria-label` on `ProjectMap` preserved)_
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**? _(tooltip is hover-triggered only)_
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5167]: https://hous-bssb.atlassian.net/browse/HUB-5167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ