### PR TITLE
HUB-5383 [Bug Bash] Slim requirement blocks picker — drop Form fields…

### DIFF
--- a/app/frontend/components/domains/requirements-library/grid-header.tsx
+++ b/app/frontend/components/domains/requirements-library/grid-header.tsx
@@ -22,7 +22,7 @@ export const GridHeaders = observer(function GridHeaders() {
       <Box display={"contents"} role={"row"}>
         <GridItem
           as={Flex}
-          gridColumn={"span 6"}
+          gridColumn={"span 5"}
           p={6}
           bg={"greys.grey10"}
           justifyContent={"space-between"}

--- a/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
@@ -4,6 +4,11 @@ import {
   Flex,
   HStack,
   ListItem,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Portal,
   StackProps,
   Tag,
   Text,
@@ -21,20 +26,15 @@ import { useMst } from "../../../setup/root"
 import { Paginator } from "../../shared/base/inputs/paginator"
 import { PerPageSelect } from "../../shared/base/inputs/per-page-select"
 import { SharedSpinner } from "../../shared/base/shared-spinner"
-import { ElectiveTag } from "../../shared/elective-tag"
 import { SearchGrid } from "../../shared/grid/search-grid"
 import { SearchGridItem } from "../../shared/grid/search-grid-item"
-import { HasAutomatedComplianceTag } from "../../shared/has-automated-compliance-tag"
-import { HasConditionalTag } from "../../shared/has-conditional-tag"
-import { HasDataValidationTag } from "../../shared/has-data-validation-tag"
+import { SearchGridRow } from "../../shared/grid/search-grid-row"
 import { GridHeaders } from "./grid-header"
 import { RequirementsBlockModal } from "./requirements-block-modal"
 
 interface IProps extends Partial<StackProps> {
   renderActionButton?: (props: ButtonProps & { requirementBlock: IRequirementBlock }) => JSX.Element
 }
-
-const ROW_CLASS_NAME = "requirements-library-grid-row"
 
 export const RequirementBlocksTable = observer(function RequirementBlocksTable({
   renderActionButton,
@@ -64,18 +64,24 @@ export const RequirementBlocksTable = observer(function RequirementBlocksTable({
 
   return (
     <VStack as={"article"} spacing={5} {...containerProps}>
-      <SearchGrid gridRowClassName={ROW_CLASS_NAME} templateColumns="repeat(6, 1fr)" pos={"relative"}>
+      <SearchGrid
+        templateColumns="minmax(0, 3fr) minmax(140px, 1fr) 180px 170px 88px"
+        pos={"relative"}
+        sx={{
+          "[role='row']:not(:last-child) > [role='cell']": { borderBottom: "none" },
+        }}
+      >
         <GridHeaders />
 
         {isSearching ? (
-          <Flex py={50} gridColumn={"span 6"}>
+          <Flex py={50} gridColumn={"span 5"}>
             <SharedSpinner />
           </Flex>
         ) : (
           tableRequirementBlocks.map((requirementBlock) => {
             return (
-              <Box key={requirementBlock.id} className={ROW_CLASS_NAME} role={"row"} display={"contents"}>
-                <SearchGridItem minW="250px" maxW="280px">
+              <SearchGridRow key={requirementBlock.id}>
+                <SearchGridItem>
                   <Flex direction="column" overflow="hidden">
                     <Text as={"span"} fontWeight={700} noOfLines={2} title={requirementBlock.name}>
                       {requirementBlock.name}
@@ -85,7 +91,7 @@ export const RequirementBlocksTable = observer(function RequirementBlocksTable({
                     </Text>
                   </Flex>
                 </SearchGridItem>
-                <SearchGridItem maxW="150px" minW="120px">
+                <SearchGridItem>
                   <HStack as={"ul"} wrap={"wrap"} spacing={1}>
                     {requirementBlock.associations.map((association) => (
                       <Tag key={association} as={"li"} bg={"greys.grey03"} color={"text.secondary"} fontSize={"xs"}>
@@ -94,43 +100,20 @@ export const RequirementBlocksTable = observer(function RequirementBlocksTable({
                     ))}
                   </HStack>
                 </SearchGridItem>
-                <SearchGridItem pr={0} minW="180px" maxW="220px">
-                  <UnorderedList ml={0} pl={0} w={"full"}>
-                    {requirementBlock.requirements.map((requirement) => {
-                      return (
-                        <ListItem
-                          key={requirement.id}
-                          color={"text.secondary"}
-                          fontSize={"xs"}
-                          mb="1"
-                          noOfLines={1}
-                          title={requirement.label}
-                        >
-                          {requirement.label}
-                        </ListItem>
-                      )
-                    })}
-                  </UnorderedList>
+                <SearchGridItem justifyContent="center">
+                  <FormFieldsCountCell requirementBlock={requirementBlock} />
                 </SearchGridItem>
-                <SearchGridItem maxW="120px" minW="100px" fontSize={"sm"}>
+                <SearchGridItem fontSize={"sm"}>
                   {format(requirementBlock.updatedAt, datefnsTableDateFormat)}
                 </SearchGridItem>
-                <SearchGridItem maxW="180px" minW="150px">
-                  <HStack flexWrap={"wrap"} maxW={"full"} alignSelf={"middle"}>
-                    {requirementBlock.hasAnyElective && <ElectiveTag hasElective />}
-                    {requirementBlock.hasAnyConditional && <HasConditionalTag />}
-                    {requirementBlock.hasAnyDataValidation && <HasDataValidationTag />}
-                    {requirementBlock.hasAutomatedCompliance && <HasAutomatedComplianceTag />}
-                  </HStack>
-                </SearchGridItem>
-                <SearchGridItem justifyContent={"center"} minW="100px" flexShrink={0}>
+                <SearchGridItem justifyContent={"center"}>
                   {renderActionButton ? (
                     renderActionButton({ requirementBlock })
                   ) : (
                     <RequirementsBlockModal withOptionsMenu requirementBlock={requirementBlock} />
                   )}
                 </SearchGridItem>
-              </Box>
+              </SearchGridRow>
             )
           })
         )}
@@ -153,3 +136,51 @@ export const RequirementBlocksTable = observer(function RequirementBlocksTable({
     </VStack>
   )
 })
+
+function FormFieldsCountCell({ requirementBlock }: { requirementBlock: IRequirementBlock }) {
+  const count = requirementBlock.requirements.length
+  const countTag = (
+    <Tag
+      bg="greys.grey03"
+      color="text.secondary"
+      fontSize="xs"
+      cursor={count > 0 ? "help" : undefined}
+      _hover={count > 0 ? { bg: "greys.grey02" } : undefined}
+    >
+      {count}
+    </Tag>
+  )
+
+  if (count === 0) return countTag
+
+  return (
+    <Popover trigger="hover" placement="left-start" isLazy openDelay={200} closeDelay={100}>
+      <PopoverTrigger>
+        <Box as="span" display="inline-block">
+          {countTag}
+        </Box>
+      </PopoverTrigger>
+      <Portal>
+        <PopoverContent
+          // chakra-overrides.scss sets .chakra-popover__popper to z-index 20 !important, below Drawer (1400)
+          rootProps={{ sx: { zIndex: "1500 !important" } }}
+          w="auto"
+          minW="200px"
+          maxW="320px"
+          maxH="240px"
+          overflowY="auto"
+        >
+          <PopoverBody p={3}>
+            <UnorderedList ml={0} pl={4} spacing={1}>
+              {requirementBlock.requirements.map((requirement) => (
+                <ListItem key={requirement.id} color="text.secondary" fontSize="xs">
+                  {requirement.label}
+                </ListItem>
+              ))}
+            </UnorderedList>
+          </PopoverBody>
+        </PopoverContent>
+      </Portal>
+    </Popover>
+  )
+}

--- a/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
@@ -49,7 +49,7 @@ export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDr
       )}
       <Drawer id="add-requirement-drawer" isOpen={isOpen} onClose={onClose} finalFocusRef={btnRef} placement={"right"}>
         <DrawerOverlay />
-        <DrawerContent display={"flex"} flexDir={"column"} maxW={"80%"} h={"full"} p={8}>
+        <DrawerContent display={"flex"} flexDir={"column"} maxW={"720px"} h={"full"} p={8}>
           <DrawerCloseButton fontSize={"xs"} />
           <RequirementBlocksTable
             h={"calc(100% - 120px)"}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -2384,7 +2384,6 @@ Thank you,
             requirementDocuments: "Related documents",
             architecturalDrawing: "Design drawing package",
           },
-          configurationsColumn: "Configurations",
           fieldDescriptions: {
             description: "Provide some context for admins and managers for this fieldset.",
             associations: "Assign a tag to help organize and find this requirement block easier.",

--- a/app/frontend/stores/requirement-block-store.ts
+++ b/app/frontend/stores/requirement-block-store.ts
@@ -52,8 +52,6 @@ export const RequirementBlockStoreModel = types
           return t("requirementsLibrary.fields.formFields")
         case ERequirementLibrarySortFields.updatedAt:
           return t("requirementsLibrary.fields.updatedAt")
-        case ERequirementLibrarySortFields.configurations:
-          return t("requirementsLibrary.configurationsColumn")
       }
     },
   }))

--- a/app/frontend/types/enums.ts
+++ b/app/frontend/types/enums.ts
@@ -131,7 +131,6 @@ export enum ERequirementLibrarySortFields {
   associations = "associations",
   requirementLabels = "requirement_labels",
   updatedAt = "updated_at",
-  configurations = "configurations",
 }
 
 export enum EJurisdictionTypes {


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...bugfix/aug-12-bugs` (merge-base range).

Slims the requirement blocks search grid (library page and template “add block” drawer). The Configurations column is gone, and Form Fields is a count tag with a hover popover instead of an inline list. Column widths, row separators, and drawer width are adjusted so names have room and the picker is less sprawling.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5383](https://hous-bssb.atlassian.net/browse/HUB-5383) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

> List the key changes, features, or fixes introduced in this PR.

- Removed the Configurations column (elective / conditional / data validation / automated compliance tags) from the requirement block grid
- Form Fields now shows a centered count tag; hovering a non-zero count opens a popover with the field list (works in the template drawer as well as the library page)
- Full-width 1px row separators via `SearchGridRow`; Name gets most of the width, other columns sized to their headers
- Add-requirement drawer narrowed from 80% viewport to 720px

---

## 🧪 Steps to QA

> Provide clear, reproducible steps for the reviewer/QA engineer to verify the changes.

1. Sign in as a super admin and open **Requirements library**
2. Confirm columns are Name, Associations, Form Fields, Updated at, and the action column — no Configurations column
3. Confirm Name has the most width, Form Fields / Updated at headers stay on one line, and row lines run the full width of the table
4. Confirm each Form Fields cell is a centered grey tag; hover a non-zero count and confirm the field list appears; a `0` tag should not open a popover
5. Open a requirement template in edit mode, click **Add requirement**, and repeat steps 2–4 in the drawer
6. Confirm the drawer is narrower than before (not ~80% of the screen) and the popover appears above the drawer, not behind it

**Expected Behaviour:**
> Compact grid with a count-on-hover Form Fields column, continuous thin row lines, and a ~720px add-block drawer.

**Before this change:**
> Six equal columns including a Configurations tag column and a full inline Form Fields list; drawer spanned most of the viewport.

**After this change:**
> Five columns, Form Fields as a hoverable count tag, Name-weighted layout, thinner full-width separators, narrower drawer.

Please add before/after screenshots of the library grid and the add-block drawer.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards/guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [ ] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5383]: https://hous-bssb.atlassian.net/browse/HUB-5383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ