### PR TITLE
Hub 5068 jurisdictions about page UI updates

### DIFF
--- a/app/frontend/components/domains/jurisdictions/jurisdiction-about-snippet-cards.tsx
+++ b/app/frontend/components/domains/jurisdictions/jurisdiction-about-snippet-cards.tsx
@@ -118,11 +118,6 @@ export const JurisdictionAboutSnippetCards = observer(({ control, canManage }: I
     keyStagesHtml: JURISDICTION_ABOUT_TWO_LINE_MAX_CHARS,
   }
 
-  const lineClamp: Partial<Record<TSnippetFieldName, number>> = {
-    processingTimeHtml: 2,
-    keyStagesHtml: 2,
-  }
-
   return (
     <SimpleGrid columns={{ base: 1, md: Math.min(visibleFields.length, 3) }} spacing={6} w="full" alignItems="stretch">
       {visibleFields.map((fieldName) => {
@@ -197,6 +192,7 @@ export const JurisdictionAboutSnippetCards = observer(({ control, canManage }: I
                                 rows={2}
                                 maxLength={maxLen[fieldName as TEditableSnippetFieldName]}
                                 resize="none"
+                                minH="unset"
                                 fontSize="sm"
                                 bg="greys.white"
                                 borderColor={fieldState.error ? "semantic.error" : "border.light"}
@@ -204,6 +200,7 @@ export const JurisdictionAboutSnippetCards = observer(({ control, canManage }: I
                                 placeholder={t("jurisdiction.aboutSnippets.placeholder")}
                                 aria-label={titles[fieldName]}
                                 aria-invalid={!!fieldState.error}
+                                sx={{ fieldSizing: "content" }}
                               />
                               {fieldState.error?.message ? (
                                 <Text fontSize="xs" color="semantic.error" role="alert">
@@ -212,12 +209,7 @@ export const JurisdictionAboutSnippetCards = observer(({ control, canManage }: I
                               ) : null}
                             </>
                           ) : (
-                            <Text
-                              fontSize="md"
-                              color="theme.blueAlt"
-                              {...(lineClamp[fieldName] != null ? { noOfLines: lineClamp[fieldName] } : {})}
-                              whiteSpace="pre-wrap"
-                            >
+                            <Text fontSize="md" color="theme.blueAlt" whiteSpace="pre-wrap">
                               {text.trim() ? text : canManage ? t("jurisdiction.aboutSnippets.emptyHint") : ""}
                             </Text>
                           )}

--- a/app/frontend/components/domains/jurisdictions/jurisdiction-contact-info-banner.tsx
+++ b/app/frontend/components/domains/jurisdictions/jurisdiction-contact-info-banner.tsx
@@ -357,14 +357,7 @@ function DisplayValue({
   }
 
   return (
-    <Text
-      as="span"
-      fontSize="sm"
-      color="text.link"
-      textDecoration="underline"
-      whiteSpace="pre-wrap"
-      wordBreak="break-word"
-    >
+    <Text fontSize="sm" color="text.primary" whiteSpace="pre-wrap" wordBreak="break-word">
       {text}
     </Text>
   )


### PR DESCRIPTION
## 📋 Description

Small UI polish on the jurisdiction About page so snippet and contact info content reads correctly.

- **Snippet cards:** Processing Time and Key Stages no longer truncate in view mode, and their edit textareas grow with content via native `field-sizing: content` (with `rows={2}` as fallback in unsupported browsers).
- **Contact info banner:** Office hours no longer render with link styling (blue + underline) when they are plain text. Address, phone, and email remain clickable links.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5068](https://yourorg.atlassian.net/browse/HUB-5068) |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                        |
| 📑 Design / Figma    | <!-- Paste link -->                                        |
| 📚 Documentation     | <!-- Paste link -->                                        |

---

## ✨ Features / Changes Introduced

- Remove 2-line clamp on Processing Time and Key Stages snippet cards so full text is visible in view mode
- Allow snippet edit textareas to grow vertically with content using CSS `field-sizing: content`
- Style office hours in the contact info banner as plain text (`text.primary`) instead of link styling

---

## 🧪 Steps to QA

1. Open a jurisdiction About page as a **manager** (edit permissions).
2. In the snippet cards, add multi-line text to **Processing Time** and **Key Stages** (including line breaks), save, and confirm both fields show the full text in view mode (no ellipsis).
3. Click **Edit** on each snippet card and confirm the textarea grows as you type more lines.
4. In the contact info banner, enter **office hours** text (e.g. `Mon–Fri 9am–5pm`) and confirm it displays as normal body text — not blue/underlined.
5. Confirm **office address**, **telephone**, and **email** still render as clickable links with link styling.
6. View the same jurisdiction About page as a **non-manager** and confirm snippet/contact content still displays correctly.

**Expected Behaviour:**

- Snippet text is fully readable without truncation.
- Edit mode textareas expand with content.
- Only actionable contact fields look like links; office hours does not.

**Before this change:**

- Snippet cards truncated Processing Time and Key Stages after two lines.
- Edit textareas stayed at a fixed height.
- Office hours looked like a link but was not clickable.

**After this change:**

- Snippet cards show full text; edit fields grow with content.
- Office hours uses primary text styling.

_Add before/after screenshots if helpful._

---

## ♿ UI Accessibility Checklist

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [x] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [x] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5068]: https://hous-bssb.atlassian.net/browse/HUB-5068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ