### PR TITLE
Bugfix/aug 13 bugfixes

### DIFF
--- a/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
+++ b/app/frontend/components/domains/permit-application/edit-permit-application-screen.tsx
@@ -26,7 +26,7 @@ import { useMst } from "../../../setup/root"
 import { ICustomEventMap } from "../../../types/dom"
 import { ECollaborationType, ECustomEvents, ERequirementType } from "../../../types/enums"
 import { findPidComponentKey } from "../../../utils/formio-component-traversal"
-import { handleScrollToBottom } from "../../../utils/utility-functions"
+import { handleScrollToBottom, handleScrollToTop } from "../../../utils/utility-functions"
 import { CopyableValue } from "../../shared/base/copyable-value"
 import { ErrorScreen } from "../../shared/base/error-screen"
 import { LoadingScreen } from "../../shared/base/loading-screen"
@@ -235,6 +235,7 @@ export const EditPermitApplicationScreen = observer(({}: IEditPermitApplicationS
   const handleClickFinishLater = async () => {
     const success = await handleSave()
     if (success) {
+      handleScrollToTop()
       navigate(parentProjectPath)
     }
   }

--- a/app/frontend/styles/theme/components/radio.ts
+++ b/app/frontend/styles/theme/components/radio.ts
@@ -3,6 +3,15 @@ import { createMultiStyleConfigHelpers } from "@chakra-ui/react"
 
 const { definePartsStyle, defineMultiStyleConfig } = createMultiStyleConfigHelpers(radioAnatomy.keys)
 
+const baseStyle = definePartsStyle({
+  control: {
+    bg: "greys.white",
+    _disabled: {
+      bg: "greys.grey03",
+    },
+  },
+})
+
 const binary = definePartsStyle({
   container: {
     py: 3,
@@ -17,4 +26,4 @@ const binary = definePartsStyle({
   },
 })
 
-export const Radio = defineMultiStyleConfig({ variants: { binary } })
+export const Radio = defineMultiStyleConfig({ baseStyle, variants: { binary } })


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...bugfix/aug-13-bugfixes` (merge-base range).

Two submitter/reviewer UI fixes.

**Save and finish later** uses `navigate()` instead of a `RouterLink`, so the window kept the permit form’s scroll offset. Landing on the project permits page (often shorter than the form) showed empty space instead of starting at the top. Scroll is now reset before that navigation.

Radio controls had a transparent fill, so they blended into tinted surfaces such as the Schedule meeting card (`theme.blueLight`). The Chakra Radio theme now uses a white control fill app-wide; disabled radios stay grey. Selected state is unchanged.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5476](https://hous-bssb.atlassian.net/browse/HUB-5476), [HUB-5493](https://hous-bssb.atlassian.net/browse/HUB-5493) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

> List the key changes, features, or fixes introduced in this PR.

- Reset window scroll before navigating away from permit application edit via **Save and finish later**
- Set Chakra Radio control fill to white in the shared theme so radios stay visible on tinted backgrounds
- Keep disabled radio fill grey so they still read as inactive

---

## 🧪 Steps to QA

> Provide clear, reproducible steps for the reviewer/QA engineer to verify the changes.

### HUB-5476 — Save and finish later scroll

1. Sign in as a submitter and open a draft permit application edit screen.
2. Scroll down the form (a little or all the way).
3. Click **Save and finish later**.
4. Confirm the project permits page (or projects list if there is no project) loads at the top, with no empty space below the content.

**Expected Behaviour:** Destination page starts at the top after save-and-leave.

**Before this change:** The next page kept the form’s scroll offset and often showed whitespace.

**After this change:** Scroll resets, then navigation runs.

### HUB-5493 — White radio buttons

1. Open a project meeting as a reviewer and find the **Schedule meeting** card (tinted background).
2. Confirm **Contact method** radio circles are white and easy to see; select one and confirm the selected state still looks correct.
3. Spot-check other radios (step code yes/no, sandbox switch, etc.) — same white fill.
4. If a disabled radio is available, confirm it stays grey.

**Expected Behaviour:** Unchecked radios have a white fill on any background; selected and disabled states still read clearly.

**Before this change:** Circles looked grey/faded on light blue cards.

**After this change:** White fill from the shared Radio theme.

Please attach before/after screenshots of the Schedule meeting radios.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others

[HUB-5476]: https://hous-bssb.atlassian.net/browse/HUB-5476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ