### PR TITLE
Hub 5253 release notes 5 bug fixes

### DIFF
--- a/app/frontend/components/domains/release-notes/release-note-year-nav.tsx
+++ b/app/frontend/components/domains/release-notes/release-note-year-nav.tsx
@@ -14,7 +14,7 @@ export const ReleaseNoteYearNav = observer(function ReleaseNoteYearNav({
   onSelectYear,
 }: ReleaseNoteYearNavProps) {
   return (
-    <VStack align="stretch" spacing={0} w="180px" flexShrink={0} alignSelf="flex-start">
+    <VStack align="stretch" spacing={0} w="180px" flexShrink={0} alignSelf="flex-start" maxH="full" overflowY="auto">
       {years.map((year) => {
         const isSelected = year === selectedYear
         return (

--- a/app/frontend/components/domains/release-notes/release-notes-screen.tsx
+++ b/app/frontend/components/domains/release-notes/release-notes-screen.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Container, Flex, Heading, Text, VStack } from "@chakra-ui/react"
 import { Envelope } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
-import React, { useEffect, useRef, useState } from "react"
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useLocation } from "react-router-dom"
 import { useSearch } from "../../../hooks/use-search"
@@ -17,8 +17,10 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
   const location = useLocation()
   const { releaseNoteStore } = useMst()
   const { t } = useTranslation()
+  const containerRef = useRef<HTMLDivElement>(null)
   const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const highlightedHashRef = useRef<string | null>(null)
+  const [availableHeight, setAvailableHeight] = useState<number | null>(null)
   const [initializedHash, setInitializedHash] = useState<string | null>(null)
   const [highlightedReleaseNoteId, setHighlightedReleaseNoteId] = useState<string | null>(null)
   const {
@@ -57,6 +59,20 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
 
   // selectedReleaseType ?? "all": useSearch skips any null dep, so "all types" needs a sentinel
   useSearch(releaseNoteStore, [viewingYearInitialized ? selectedYear : null, selectedReleaseType ?? "all"])
+
+  useLayoutEffect(() => {
+    const updateAvailableHeight = () => {
+      if (!containerRef.current) return
+
+      const { top } = containerRef.current.getBoundingClientRect()
+      setAvailableHeight(Math.max(0, Math.floor(window.innerHeight - top)))
+    }
+
+    updateAvailableHeight()
+    window.addEventListener("resize", updateAvailableHeight)
+
+    return () => window.removeEventListener("resize", updateAvailableHeight)
+  }, [])
 
   useEffect(() => {
     const releaseNoteId = parseReleaseNoteIdFromHash(location.hash)
@@ -130,9 +146,19 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
     )
 
   return (
-    <Container maxW="container.lg" py={6} px={{ base: 4, md: 8 }} pb={12} as="main">
-      <VStack align="stretch" spacing={8}>
-        <Flex justify="space-between" align="flex-start" gap={4} flexWrap="wrap">
+    <Container
+      ref={containerRef}
+      maxW="container.lg"
+      py={6}
+      px={{ base: 4, md: 8 }}
+      as="main"
+      display="flex"
+      flexDirection="column"
+      h={availableHeight === null ? "auto" : `${availableHeight}px`}
+      overflow="hidden"
+    >
+      <VStack align="stretch" spacing={8} flex={1} minH={0} overflow="hidden">
+        <Flex justify="space-between" align="flex-start" gap={4} flexWrap="wrap" flexShrink={0}>
           <Heading as="h1" fontSize="3xl" m={0}>
             {t("releaseNote.viewing.title")}
           </Heading>
@@ -141,17 +167,29 @@ export const ReleaseNotesScreen = observer(function ReleaseNotesScreen() {
           </Button>
         </Flex>
 
-        <Flex align="flex-start" gap={5} w="full">
+        <Flex align="stretch" gap={5} w="full" flex={1} minH={0} overflow="hidden">
           <ReleaseNoteYearNav years={availableYears} selectedYear={selectedYear} onSelectYear={selectViewingYear} />
 
-          <Flex direction="column" flex={1} minW={0}>
-            <Flex align="center" justify="space-between" gap={4} flexWrap="wrap" bg="greys.grey03" px={4} py={3} mb={6}>
+          <Flex direction="column" flex={1} minW={0} minH={0} overflow="hidden">
+            <Flex
+              align="center"
+              justify="space-between"
+              gap={4}
+              flexWrap="wrap"
+              bg="greys.grey03"
+              px={4}
+              py={3}
+              mb={6}
+              flexShrink={0}
+            >
               <ReleaseNoteTypeFilter value={selectedReleaseType} onChange={selectReleaseTypeFilter} />
             </Flex>
 
-            <Box mb={6}>{isSearching ? <SharedSpinner /> : releaseNotesContent}</Box>
+            <Box flex={1} minH={0} overflowY="auto" pr={1}>
+              {isSearching ? <SharedSpinner /> : releaseNotesContent}
+            </Box>
 
-            <Flex w="full" justify="space-between" align="center" flexWrap="wrap" gap={4}>
+            <Flex w="full" justify="space-between" align="center" flexWrap="wrap" gap={4} flexShrink={0} pt={4} pb={1}>
               <PerPageSelect
                 handleCountPerPageChange={handleCountPerPageChange}
                 countPerPage={countPerPage}

--- a/app/frontend/components/shared/base/footer.tsx
+++ b/app/frontend/components/shared/base/footer.tsx
@@ -92,6 +92,9 @@ export const Footer = observer(() => {
                     <RouterLink to="/videos" color="text.primary">
                       {t("site.videos")}
                     </RouterLink>
+                    <RouterLink to="/release-notes" color="text.primary">
+                      {t("releaseNote.title")}
+                    </RouterLink>
                     <Link
                       href="https://www2.gov.bc.ca/gov/content?id=F2AE1595C6044E819A316925F0A74E09"
                       target="_blank"

--- a/app/frontend/components/shared/base/footer.tsx
+++ b/app/frontend/components/shared/base/footer.tsx
@@ -22,7 +22,6 @@ export const Footer = observer(() => {
     "/letter-of-assurance",
     "/privacy-policy",
     "/onboarding-checklist-page-for-lg-adopting",
-    "/release-notes",
   ]
 
   const shouldShowFooter = onlyShowFooterOnRoutes.some((route) => matchPath(route, location.pathname))


### PR DESCRIPTION
## 📋 Description

Undo addition of footer. Add a “Release notes” link to the site footer under the Building Permit Hub column.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                                                                                                    |
| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5253](https://yourorg.atlassian.net/browse/HUB-5253)                                                                             |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                                                                                                     |
| 📑 Design / Figma    | [4672 — Release Notes Publishing & Viewing Experience](https://www.figma.com/design/EcvQ2gBOAmCBfvJrBUaCGI/4672---Release-Notes-Publishing---Viewing-Experience) |
| 📚 Documentation     | <!-- Paste link -->                                                                                                                     |

---

## ✨ Features / Changes Introduced

- Constrain the release notes page to the viewport and scroll the year nav and note list inside the layout (pagination remains visible at the bottom).
- Add a “Release notes” link to the site footer (Building Permit Hub column, after Videos).
- Do not render the site footer on `/release-notes` (removed from `onlyShowFooterOnRoutes`).

---

## 🧪 Steps to QA

1. Open a page that shows the site footer (e.g. `/welcome`, `/contact`, or `/videos`).
2. In the **Building Permit Hub** column, confirm **Release notes** appears after **Videos** and navigates to `/release-notes`.
3. On `/release-notes`, confirm the **site footer does not appear** (only the main app nav/header).
4. With multiple release notes loaded (or a long list), confirm:
   - The page does not grow with the full document; the main content area uses the viewport.
   - The **year nav** scrolls independently when there are many years.
   - The **release note list** scrolls in its panel.
   - **Per page** and pagination stay visible at the bottom of the content area while scrolling notes.
5. Resize the browser window and confirm layout still fits without breaking scroll regions.
6. Open a deep link with a hash (e.g. from a notification: `/release-notes#release-note-…`) and confirm the target note still scrolls into view and highlights as expected.

**Expected Behaviour:**

- Footer link reaches release notes from public/marketing-style pages.
- Release notes page matches Figma: no footer, fixed viewport layout with internal scrolling.

**Before this change:**

- Release notes page could scroll the entire page; pagination could sit far below long content.
- No footer link to release notes; footer may have been shown on `/release-notes`.

**After this change:**

- Footer promotes release notes from

[HUB-5253]: https://hous-bssb.atlassian.net/browse/HUB-5253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ