### PR TITLE
HUB-5169 prevent background scroll while drawers and modals are open

### DIFF
--- a/app/frontend/styles/theme/components/drawer.ts
+++ b/app/frontend/styles/theme/components/drawer.ts
@@ -1,0 +1,11 @@
+export const Drawer = {
+  baseStyle: {
+    dialogContainer: {
+      position: "fixed",
+      inset: 0,
+      width: "auto",
+      height: "auto",
+      overflow: "hidden",
+    },
+  },
+}

--- a/app/frontend/styles/theme/index.ts
+++ b/app/frontend/styles/theme/index.ts
@@ -1,5 +1,6 @@
 import { extendTheme } from "@chakra-ui/react"
 import { Button } from "./components/button"
+import { Drawer } from "./components/drawer"
 import { FormLabel } from "./components/form-label"
 import { Heading } from "./components/heading"
 import { Input } from "./components/input"
@@ -87,17 +88,6 @@ const styles = {
       width: "100vw",
       height: "100vh",
       zIndex: "0",
-    },
-  },
-}
-const Drawer = {
-  baseStyle: {
-    dialogContainer: {
-      position: "fixed",
-      inset: 0,
-      width: "auto",
-      height: "auto",
-      overflow: "hidden",
     },
   },
 }

--- a/app/frontend/styles/theme/index.ts
+++ b/app/frontend/styles/theme/index.ts
@@ -22,6 +22,9 @@ const styles = {
   global: {
     html: {
       scrollBehaviour: "smooth",
+      "&:has(.chakra-modal__content-container)": {
+        overflow: "hidden",
+      },
     },
     body: {
       color: "text.primary",
@@ -87,7 +90,19 @@ const styles = {
     },
   },
 }
-const components = { Button, FormLabel, Heading, Input, Link, Select, Text, Table, Radio, Tag, Tabs }
+const Drawer = {
+  baseStyle: {
+    dialogContainer: {
+      position: "fixed",
+      inset: 0,
+      width: "auto",
+      height: "auto",
+      overflow: "hidden",
+    },
+  },
+}
+
+const components = { Button, FormLabel, Heading, Input, Link, Select, Text, Table, Radio, Tag, Tabs, Drawer }
 const overrides = { styles, colors, fonts, fontSizes, sizes, radii, space, shadows, components }
 
 export const theme = extendTheme(overrides)


### PR DESCRIPTION
## 📋 Description

On the template builder (and other long pages), opening **Add requirement** while scrolled down caused the drawer to be clipped at the top. The page could also keep scrolling behind the open drawer, which made the issue worse.

**Root cause:** Chakra drawers are modal overlays, but scroll-lock only targeted `body` while `html` remained the scroll container. With the page already scrolled, the drawer shell was not reliably viewport-aligned.

**Fix:** Global Chakra theme updates:
1. Pin all Drawer `dialogContainer` shells to the viewport (`position: fixed; inset: 0`).
2. Lock `html` overflow while any Chakra overlay is open (drawers and modals share `.chakra-modal__content-container`).

This is a generic fix for all drawers app-wide, not a one-off change to the Add requirement component.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5169](https://bcgov.atlassian.net/browse/HUB-5169)    |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                        |
| 📑 Design / Figma    | <!-- Paste link -->                                        |
| 📚 Documentation     | <!-- Paste link -->                                        |

---

## ✨ Features / Changes Introduced

- Add Drawer theme override so drawer overlay containers are fixed to the viewport
- Lock `html` overflow while Chakra drawers/modals are open to prevent background page scroll
- Applies app-wide to all `<Drawer>` components; `html` lock also applies while `<Modal>` overlays are open

---

## 🧪 Steps to QA

### Primary repro (template builder — Add requirement)

1. Log in as an admin/review manager with access to permit template editing.
2. Open a permit template in the template builder (`/requirement-templates/:id/edit` or equivalent early-access/combined builder route).
3. Scroll the main page content to the **bottom**.
4. Click **Add requirement**.
5. With the drawer open, try scrolling with the mouse wheel / trackpad on the page behind the drawer.

**Expected behaviour:**
- The Add requirement drawer is fully visible (header/close button not cut off at the top).
- The main page does **not** scroll behind the drawer.
- Closing the drawer returns you to roughly the same scroll position.

**Before this change:**
- Drawer top was clipped when the page was scrolled down.
- Main page scrollbar stayed active; scrolling behind the drawer could worsen or trigger the cutoff.

**After this change:**
- Drawer stays viewport-aligned; background scroll is locked.

### Regression checks (other drawers)

6. Open the **Help** drawer on the same template builder page (scrolled and not scrolled) — confirm full height and no background scroll.
7. Open the **nav menu** drawer (top placement, navbar gap) — confirm menu content is visible and scrollable inside the drawer.
8. On a permit application edit screen, open a **collaborators** or similar right-side drawer — confirm normal open/close behaviour.

### Modal sanity check

9. On any long page, open a confirmation or form **modal** — confirm the page does not scroll behind it while open.

_Add before/after screenshots for the Add requirement repro if available._

---

## ♿ UI Accessibility Checklist

> No new UI elements or markup changes. Behaviour-only fix (scroll locking and overlay positioning). Existing drawer focus trap and keyboard close behaviour should be unchanged.

- [x] Markup uses **semantic HTML** (no markup changes in this PR)
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**? (unchanged)
- [x] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context? (unchanged)
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [ ] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5169]: https://hous-bssb.atlassian.net/browse/HUB-5169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ