### PR TITLE
HUB-5224 close current page link on mega menu

### DIFF
--- a/app/frontend/components/domains/navigation/nav-bar-menu.tsx
+++ b/app/frontend/components/domains/navigation/nav-bar-menu.tsx
@@ -90,6 +90,10 @@ export const NavBarMenu = observer(function NavBarMenu({}: INavBarMenuProps) {
     onClose()
   }, [location.pathname])
 
+  const closeOnLinkClick = (event: React.MouseEvent) => {
+    if ((event.target as HTMLElement).closest("a[href]")) onClose()
+  }
+
   // Close menu when clicking outside (including the navbar above the drawer)
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -235,7 +239,7 @@ export const NavBarMenu = observer(function NavBarMenu({}: INavBarMenuProps) {
           flexDirection="column"
           h="auto"
         >
-          <DrawerBody flex="1" minH={0} overflow="auto">
+          <DrawerBody flex="1" minH={0} overflow="auto" onClick={closeOnLinkClick}>
             <MenuCloseProvider value={onClose}>
               <Container maxW="container.lg" px={8}>
                 <Grid templateColumns={{ base: "1fr", md: "3fr 3fr 2fr" }} gap={8} py={5}>


### PR DESCRIPTION
## 📋 Description

Clicking a mega menu link for the page you are already on left the drawer open with no visible feedback. The menu only closed when `location.pathname` changed, but React Router does not change the path when navigating to the current route.

This PR closes the mega menu on any link click inside the drawer, including same-page links. We intentionally close rather than reload — a full page reload would wipe in-progress form state without adding meaningful value. `RouterLink` still scrolls to the top of the page on click, so selecting the current-page link dismisses the menu and returns the user to the top of the page.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                       |
| -------------------- | ---------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5224](https://yourorg.atlassian.net/browse/HUB-5224) |
| 📄 Related PR(s)     | <!-- N/A -->                                               |
| 📑 Design / Figma    | <!-- N/A -->                                               |
| 📚 Documentation     | <!-- N/A -->                                               |

---

## ✨ Features / Changes Introduced

- Close the mega menu drawer when any `<a>` link inside the drawer is clicked, including links to the current page
- Preserve existing route-change close behaviour via `useEffect` on `location.pathname`
- Non-link menu actions (e.g. Help drawer, Sandbox toggle) are unaffected — only anchor clicks trigger close

---

## 🧪 Steps to QA

1. Open any page that is linked from the mega menu (e.g. `/welcome`, `/jurisdictions`, `/project-readiness-tools`)
2. Open the mega menu (hamburger on mobile, **Menu** button on desktop)
3. Click the link for the page you are currently viewing
4. Verify the mega menu closes immediately
5. Verify you remain on the same page and are scrolled to the top
6. Repeat on a different page via a different mega menu link
7. Open the mega menu again and click a link to a **different** page — verify the menu closes and navigation works as before
8. Test on both mobile and desktop breakpoints
9. Open the mega menu, tab through links with the keyboard, and activate a link with Enter — verify the menu closes

**Expected Behaviour:**

- Any mega menu link click closes the drawer, including the current-page link
- Current-page link does not reload the page; user stays on the same route with scroll reset to top
- Keyboard focus returns to the menu toggle button after the drawer closes

**Before this change:**

- Clicking the current-page link left the mega menu open with no visible response; the user had to close it manually

**After this change:**

- Clicking any link in the mega menu closes the drawer; current-page links provide clear feedback by dismissing the menu and scrolling to top

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [ ] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [ ] No content relies on **colour alone** to convey meaning?
- [ ] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5224]: https://hous-bssb.atlassian.net/browse/HUB-5224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ