### PR TITLE
Hub 5324 💥 bug bash permit type filter shows irrelevant options and overflows the screen

### DIFF
--- a/app/controllers/api/concerns/search/jurisdiction_permit_applications.rb
+++ b/app/controllers/api/concerns/search/jurisdiction_permit_applications.rb
@@ -50,7 +50,11 @@ module Api::Concerns::Search::JurisdictionPermitApplications
       total_count: @jurisdiction_permit_application_search.total_count,
       status_counts: jurisdiction_application_status_counts,
       unread_count: unread_status_counts.values.sum,
-      unread_status_counts: unread_status_counts
+      unread_status_counts: unread_status_counts,
+      requirement_template_options:
+        jurisdiction_requirement_template_options(
+          jurisdiction_permit_application_search_params[:permit_project_id]
+        )
     }
 
     @jurisdiction_permit_applications =
@@ -114,7 +118,11 @@ module Api::Concerns::Search::JurisdictionPermitApplications
       status_counts: jurisdiction_application_status_counts,
       column_totals: column_totals,
       unread_count: unread_status_counts.values.sum,
-      unread_status_counts: unread_status_counts
+      unread_status_counts: unread_status_counts,
+      requirement_template_options:
+        jurisdiction_requirement_template_options(
+          jurisdiction_permit_application_search_params[:permit_project_id]
+        )
     }
   end
 
@@ -205,6 +213,44 @@ module Api::Concerns::Search::JurisdictionPermitApplications
       "Failed to compute application status counts: #{e.message}"
     )
     {}
+  end
+
+  # Permit types represented in the inbox, independent of current filters/query.
+  def jurisdiction_requirement_template_options(permit_project_id = nil)
+    and_conditions = []
+    and_conditions << { jurisdiction_id: @jurisdiction.id }
+    and_conditions << { discarded: false }
+    and_conditions << { status: { not: "new_draft" } }
+    unless current_user.super_admin?
+      and_conditions << { sandbox_id: current_sandbox&.id }
+    end
+
+    if permit_project_id.present?
+      and_conditions << { permit_project_id: permit_project_id }
+    end
+
+    buckets =
+      PermitApplication
+        .search(
+          "*",
+          where: {
+            _and: and_conditions
+          },
+          aggs: [:requirement_template_id],
+          body_options: {
+            size: 0
+          }
+        )
+        .aggs
+        .dig("requirement_template_id", "buckets") || []
+
+    ids = buckets.map { |bucket| bucket["key"] }
+    OptionsBlueprint.render_as_hash(RequirementTemplate.where(id: ids))
+  rescue => e
+    Rails.logger.warn(
+      "Failed to compute requirement template options: #{e.message}"
+    )
+    []
   end
 
   def jurisdiction_permit_application_search_params

--- a/app/controllers/api/concerns/search/jurisdiction_permit_projects.rb
+++ b/app/controllers/api/concerns/search/jurisdiction_permit_projects.rb
@@ -76,7 +76,8 @@ module Api::Concerns::Search::JurisdictionPermitProjects
       total_count: @jurisdiction_permit_project_search.total_count,
       state_counts: jurisdiction_state_counts,
       unread_count: unread_state_counts.values.sum,
-      unread_state_counts: unread_state_counts
+      unread_state_counts: unread_state_counts,
+      requirement_template_options: jurisdiction_requirement_template_options
     }
   end
 
@@ -146,7 +147,8 @@ module Api::Concerns::Search::JurisdictionPermitProjects
       state_counts: jurisdiction_state_counts,
       column_totals: column_totals,
       unread_count: unread_state_counts.values.sum,
-      unread_state_counts: unread_state_counts
+      unread_state_counts: unread_state_counts,
+      requirement_template_options: jurisdiction_requirement_template_options
     }
   end
 
@@ -233,6 +235,39 @@ module Api::Concerns::Search::JurisdictionPermitProjects
   rescue => e
     Rails.logger.warn("Failed to compute state counts: #{e.message}")
     {}
+  end
+
+  # Permit types represented in the inbox, independent of current filters/query.
+  def jurisdiction_requirement_template_options
+    where = {
+      jurisdiction_id: @jurisdiction.id,
+      discarded: false,
+      status: {
+        not: "new_draft"
+      }
+    }
+    where[:sandbox_id] = current_sandbox&.id unless current_user.super_admin?
+
+    buckets =
+      PermitApplication
+        .search(
+          "*",
+          where: where,
+          aggs: [:requirement_template_id],
+          body_options: {
+            size: 0
+          }
+        )
+        .aggs
+        .dig("requirement_template_id", "buckets") || []
+
+    ids = buckets.map { |bucket| bucket["key"] }
+    OptionsBlueprint.render_as_hash(RequirementTemplate.where(id: ids))
+  rescue => e
+    Rails.logger.warn(
+      "Failed to compute requirement template options: #{e.message}"
+    )
+    []
   end
 
   def jurisdiction_permit_project_search_params

--- a/app/controllers/api/requirement_templates_controller.rb
+++ b/app/controllers/api/requirement_templates_controller.rb
@@ -31,10 +31,8 @@ class Api::RequirementTemplatesController < Api::ApplicationController
 
   def for_filter
     authorize :requirement_template, :for_filter?
-    templates = RequirementTemplate.with_published_version.kept
-    render_success templates,
-                   nil,
-                   { blueprint: OptionsBlueprint, view: :default }
+    templates = filter_requirement_templates
+    render_success templates, nil, { blueprint: OptionsBlueprint }
   end
 
   def show
@@ -347,6 +345,24 @@ class Api::RequirementTemplatesController < Api::ApplicationController
 
   def set_template_version
     @template_version = TemplateVersion.find(params[:id])
+  end
+
+  def filter_requirement_templates
+    apps =
+      policy_scope(
+        PermitApplication.kept.joins(
+          :permit_project,
+          template_version: :requirement_template
+        )
+      )
+
+    if params[:permit_project_id].present?
+      project = PermitProject.find(params[:permit_project_id])
+      authorize project, :show?
+      apps = apps.where(permit_project_id: project.id)
+    end
+
+    RequirementTemplate.where(id: apps.select("requirement_templates.id"))
   end
 
   def requirement_template_params

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/filters/permit-type-filter.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/filters/permit-type-filter.tsx
@@ -1,7 +1,7 @@
 import { observer } from "mobx-react-lite"
-import React, { useEffect } from "react"
+import React from "react"
 import { useTranslation } from "react-i18next"
-import { useMst } from "../../../../../setup/root"
+import { IOption } from "../../../../../types/types"
 import { InboxFilter } from "../../../../shared/filters/inbox-filter"
 
 interface IProps {
@@ -9,6 +9,7 @@ interface IProps {
   onChange: (value: string[]) => void
   onApply: () => void
   onClear: () => void
+  options: IOption[]
 }
 
 export const RequirementTemplateInboxFilter = observer(function RequirementTemplateInboxFilter({
@@ -16,13 +17,9 @@ export const RequirementTemplateInboxFilter = observer(function RequirementTempl
   onChange,
   onApply,
   onClear,
+  options,
 }: IProps) {
   const { t } = useTranslation()
-  const { requirementTemplateStore } = useMst()
-
-  useEffect(() => {
-    requirementTemplateStore.fetchFilterOptions()
-  }, [])
 
   return (
     <InboxFilter
@@ -30,7 +27,7 @@ export const RequirementTemplateInboxFilter = observer(function RequirementTempl
       isMulti={true}
       value={value}
       onChange={(val) => onChange(val as string[])}
-      options={[...requirementTemplateStore.filterOptions]}
+      options={options}
       onApply={onApply}
       onClear={onClear}
     />

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-permits-tab.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/project-detail/inbox-permits-tab.tsx
@@ -104,6 +104,7 @@ export const InboxPermitsTab = observer(function InboxPermitsTab({ permitProject
                   permitProject.setRequirementTemplateIdFilter([])
                   permitProject.search()
                 }}
+                options={[...permitProject.requirementTemplateOptions]}
               />
               {permitProject.displayMode === EInboxDisplayMode.list && (
                 <StatusFilter

--- a/app/frontend/components/domains/jurisdictions/submission-inbox/submissions-tab-panel-content.tsx
+++ b/app/frontend/components/domains/jurisdictions/submission-inbox/submissions-tab-panel-content.tsx
@@ -224,6 +224,7 @@ export const SubmissionsTabPanelContent = observer(function SubmissionsTabPanelC
                     activeSearchStore.setRequirementTemplateIdFilter([])
                     activeSearchStore.search()
                   }}
+                  options={[...activeSearchStore.requirementTemplateOptions]}
                 />
                 {displayMode === EInboxDisplayMode.list && viewMode === EInboxViewMode.applications && (
                   <StatusFilter

--- a/app/frontend/components/domains/permit-project/requirement-template-filter.tsx
+++ b/app/frontend/components/domains/permit-project/requirement-template-filter.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react-lite"
-import React, { useEffect } from "react"
+import React, { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
+import { useParams } from "react-router-dom"
 import { ISearch } from "../../../lib/create-search-model"
 import { useMst } from "../../../setup/root"
 import { CheckboxFilter } from "../../shared/filters/checkbox-filter"
@@ -13,12 +14,24 @@ export const RequirementTemplateFilter = observer(function RequirementTemplateId
   searchModel,
 }: IProps<TSearchModel>) {
   const { t } = useTranslation()
+  const { permitProjectId } = useParams<{ permitProjectId?: string }>()
   const { requirementTemplateStore } = useMst()
-  const { requirementTemplateIdFilter, setRequirementTemplateIdFilter, search } = searchModel as any
+  const { requirementTemplateIdFilter, setRequirementTemplateIdFilter, search, isSearching } = searchModel as any
+  const wasSearching = useRef(false)
+
+  const fetchOptions = () =>
+    requirementTemplateStore.fetchFilterOptions(permitProjectId ? { permitProjectId } : undefined)
 
   useEffect(() => {
-    requirementTemplateStore.fetchFilterOptions()
-  }, [])
+    fetchOptions()
+  }, [permitProjectId])
+
+  useEffect(() => {
+    const searchJustFinished = wasSearching.current && !isSearching
+    wasSearching.current = isSearching
+    if (!searchJustFinished) return
+    fetchOptions()
+  }, [isSearching, permitProjectId])
 
   const handleChange = (nextValue: string[]) => {
     setRequirementTemplateIdFilter(nextValue)

--- a/app/frontend/components/shared/filters/checkbox-filter.tsx
+++ b/app/frontend/components/shared/filters/checkbox-filter.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Checkbox,
   Divider,
@@ -63,8 +64,15 @@ export const CheckboxFilter = observer(function CheckboxFilter({ value, onChange
       >
         {title}
       </MenuButton>
-      <MenuList p={4} zIndex="dropdown">
-        <VStack align="start" spacing={4}>
+      <MenuList
+        p={4}
+        zIndex="dropdown"
+        maxH="min(420px, calc(100vh - 96px))"
+        display="flex"
+        flexDirection="column"
+        overflow="hidden"
+      >
+        <VStack align="stretch" spacing={4} flex={1} minH={0} overflow="hidden">
           <InputGroup>
             <InputLeftElement pointerEvents="none">
               <MagnifyingGlass />
@@ -72,20 +80,24 @@ export const CheckboxFilter = observer(function CheckboxFilter({ value, onChange
             <Input placeholder={t("ui.search")} value={searchTerm} onChange={(e) => setSearchTerm(e.target.value)} />
           </InputGroup>
           <Divider />
-          {filteredOptions.length === 0 ? (
-            <Text color="greys.grey01" fontSize="sm" px={2} w="full" textAlign="center">
-              {t("ui.noOptionsFound")}
-            </Text>
-          ) : (
-            filteredOptions.map((option) => {
-              const checkboxProps = getCheckboxProps({ value: option.value })
-              return (
-                <Checkbox key={option.value} {...checkboxProps}>
-                  {option.label}
-                </Checkbox>
-              )
-            })
-          )}
+          <Box overflowY="auto" minH={0} flex={1} w="full">
+            {filteredOptions.length === 0 ? (
+              <Text color="greys.grey01" fontSize="sm" px={2} w="full" textAlign="center">
+                {t("ui.noOptionsFound")}
+              </Text>
+            ) : (
+              <VStack align="start" spacing={4}>
+                {filteredOptions.map((option) => {
+                  const checkboxProps = getCheckboxProps({ value: option.value })
+                  return (
+                    <Checkbox key={option.value} {...checkboxProps}>
+                      {option.label}
+                    </Checkbox>
+                  )
+                })}
+              </VStack>
+            )}
+          </Box>
           <Divider />
           <Button
             onClick={onReset}

--- a/app/frontend/components/shared/filters/inbox-filter.tsx
+++ b/app/frontend/components/shared/filters/inbox-filter.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Checkbox,
   Divider,
@@ -140,41 +141,54 @@ export const InboxFilter = observer(function InboxFilter({
           </HStack>
         </Button>
       </PopoverTrigger>
-      <PopoverContent w="auto" minW="200px" p={4} zIndex="dropdown">
-        <PopoverBody p={0}>
-          <VStack align="start" spacing={3}>
-            {isMulti ? (
-              <>
-                <Checkbox
-                  isChecked={Array.isArray(localValue) && localValue.length === options.length && options.length > 0}
-                  isIndeterminate={
-                    Array.isArray(localValue) && localValue.length > 0 && localValue.length < options.length
-                  }
-                  onChange={handleSelectAll}
-                >
-                  {t("ui.selectAll")}
-                </Checkbox>
-                {options.map((option) => (
-                  <Checkbox
-                    key={option.value}
-                    isChecked={Array.isArray(localValue) && localValue.includes(option.value)}
-                    onChange={() => handleCheckboxToggle(option.value)}
-                  >
-                    {option.label}
-                  </Checkbox>
-                ))}
-                <Divider />
-                <HStack w="full" justifyContent="space-between">
-                  <Button variant="link" size="sm" onClick={handleClear}>
-                    {t("ui.clear")}
-                  </Button>
-                  <Button variant="primary" size="sm" onClick={handleApply}>
-                    {t("ui.apply")}
-                  </Button>
-                </HStack>
-              </>
-            ) : (
-              <>
+      <PopoverContent
+        w="auto"
+        minW="200px"
+        p={4}
+        zIndex="dropdown"
+        maxH="min(420px, calc(100vh - 96px))"
+        display="flex"
+        flexDirection="column"
+        overflow="hidden"
+      >
+        <PopoverBody p={0} display="flex" flexDirection="column" minH={0} overflow="hidden">
+          {isMulti ? (
+            <VStack align="stretch" spacing={3} flex={1} minH={0} overflow="hidden">
+              <Checkbox
+                isChecked={Array.isArray(localValue) && localValue.length === options.length && options.length > 0}
+                isIndeterminate={
+                  Array.isArray(localValue) && localValue.length > 0 && localValue.length < options.length
+                }
+                onChange={handleSelectAll}
+              >
+                {t("ui.selectAll")}
+              </Checkbox>
+              <Box overflowY="auto" minH={0} flex={1}>
+                <VStack align="start" spacing={3}>
+                  {options.map((option) => (
+                    <Checkbox
+                      key={option.value}
+                      isChecked={Array.isArray(localValue) && localValue.includes(option.value)}
+                      onChange={() => handleCheckboxToggle(option.value)}
+                    >
+                      {option.label}
+                    </Checkbox>
+                  ))}
+                </VStack>
+              </Box>
+              <Divider />
+              <HStack w="full" justifyContent="space-between">
+                <Button variant="link" size="sm" onClick={handleClear}>
+                  {t("ui.clear")}
+                </Button>
+                <Button variant="primary" size="sm" onClick={handleApply}>
+                  {t("ui.apply")}
+                </Button>
+              </HStack>
+            </VStack>
+          ) : (
+            <VStack align="stretch" spacing={3} flex={1} minH={0} overflow="hidden">
+              <Box overflowY="auto" minH={0} flex={1}>
                 <RadioGroup
                   value={typeof localValue === "string" ? localValue : ""}
                   onChange={(val) => setLocalValue(val)}
@@ -187,13 +201,13 @@ export const InboxFilter = observer(function InboxFilter({
                     ))}
                   </VStack>
                 </RadioGroup>
-                <Divider />
-                <Button variant="primary" size="sm" w="full" onClick={handleApply}>
-                  {t("ui.apply")}
-                </Button>
-              </>
-            )}
-          </VStack>
+              </Box>
+              <Divider />
+              <Button variant="primary" size="sm" w="full" onClick={handleApply}>
+                {t("ui.apply")}
+              </Button>
+            </VStack>
+          )}
         </PopoverBody>
       </PopoverContent>
     </Popover>

--- a/app/frontend/models/permit-application-inbox-search-shared.ts
+++ b/app/frontend/models/permit-application-inbox-search-shared.ts
@@ -2,7 +2,7 @@ import * as humps from "humps"
 import { t } from "i18next"
 import { cast, types } from "mobx-state-tree"
 import { EPermitApplicationInboxSortFields, EPermitApplicationStatus, ERadioFilterValue } from "../types/enums"
-import { IPermitApplicationInboxSearchFilters } from "../types/types"
+import { IOption, IPermitApplicationInboxSearchFilters } from "../types/types"
 import { setQueryParam } from "../utils/utility-functions"
 
 export function decamelizeHashKeys(hash: Record<string, number>): Record<string, number> {
@@ -21,6 +21,7 @@ export const PermitApplicationInboxSearchSharedFragment = types
     unreadColumnCounts: types.optional(types.frozen<Record<string, number>>(), {}),
     /** Jurisdiction-wide (or project-scoped) count of unread applications — ignores current filters/query. */
     unreadCount: types.optional(types.number, 0),
+    requirementTemplateOptions: types.optional(types.array(types.frozen<IOption>()), []),
     requirementTemplateIdFilter: types.optional(types.array(types.string), []),
     statusFilter: types.optional(types.array(types.enumeration(Object.values(EPermitApplicationStatus))), []),
     unreadFilter: types.optional(types.enumeration(Object.values(ERadioFilterValue)), ERadioFilterValue.include),
@@ -49,6 +50,9 @@ export const PermitApplicationInboxSearchSharedFragment = types
     },
     setUnreadCount(count: number) {
       self.unreadCount = count ?? 0
+    },
+    setRequirementTemplateOptions(options: IOption[]) {
+      self.requirementTemplateOptions = cast(options ?? [])
     },
     adjustUnreadCountForColumn(columnKey: string, delta: number) {
       const counts = { ...self.unreadColumnCounts }

--- a/app/frontend/models/permit-project-inbox-application-search.ts
+++ b/app/frontend/models/permit-project-inbox-application-search.ts
@@ -68,6 +68,9 @@ export const PermitProjectInboxApplicationSearchSlice = types
         if (response.data.meta?.unreadStatusCounts) {
           self.setUnreadColumnCounts(response.data.meta.unreadStatusCounts)
         }
+        if (response.data.meta?.requirementTemplateOptions) {
+          self.setRequirementTemplateOptions(response.data.meta.requirementTemplateOptions)
+        }
       }
       return response.ok
     }),

--- a/app/frontend/services/api/index.ts
+++ b/app/frontend/services/api/index.ts
@@ -765,8 +765,8 @@ export class Api {
     return this.client.post<IRequirementTemplateResponse>(`/requirement_templates/search`, params)
   }
 
-  async fetchRequirementTemplatesForFilter() {
-    return this.client.get<IApiResponse<{ id: string; nickname: string }[], {}>>(`/requirement_templates/for_filter`)
+  async fetchRequirementTemplatesForFilter(params?: { permitProjectId?: string }) {
+    return this.client.get<IOptionResponse>(`/requirement_templates/for_filter`, params)
   }
 
   async fetchRequirementTemplate(id: string) {

--- a/app/frontend/stores/requirement-template-store.ts
+++ b/app/frontend/stores/requirement-template-store.ts
@@ -180,12 +180,11 @@ export const RequirementTemplateStoreModel = types
 
       return false
     }),
-    fetchFilterOptions: flow(function* () {
-      const response = yield* toGenerator(self.environment.api.fetchRequirementTemplatesForFilter())
+    fetchFilterOptions: flow(function* (params?: { permitProjectId?: string }) {
+      const response = yield* toGenerator(self.environment.api.fetchRequirementTemplatesForFilter(params))
       if (response.ok) {
         self.filterOptions = cast(response.data.data)
       }
-      return response.ok
     }),
     searchTagOptions: flow(function* (query: string) {
       const response = yield* toGenerator(

--- a/app/frontend/stores/submission-inbox-store.ts
+++ b/app/frontend/stores/submission-inbox-store.ts
@@ -20,7 +20,12 @@ import {
   EProjectState,
   ERadioFilterValue,
 } from "../types/enums"
-import { IPermitApplicationInboxSearchFilters, IPermitProjectInboxSearchFilters, TSearchParams } from "../types/types"
+import {
+  IOption,
+  IPermitApplicationInboxSearchFilters,
+  IPermitProjectInboxSearchFilters,
+  TSearchParams,
+} from "../types/types"
 import { pushQueryParams, setQueryParam } from "../utils/utility-functions"
 
 const KANBAN_PER_COLUMN = 10
@@ -38,6 +43,7 @@ export const PermitProjectInboxStoreModel = types
       unreadColumnCounts: types.optional(types.frozen<Record<string, number>>(), {}),
       /** Jurisdiction-wide count of unread projects (ignores current filters/query). */
       unreadCount: types.optional(types.number, 0),
+      requirementTemplateOptions: types.optional(types.array(types.frozen<IOption>()), []),
       requirementTemplateIdFilter: types.optional(types.array(types.string), []),
       stateFilter: types.optional(types.array(types.string), []),
       unreadFilter: types.optional(types.enumeration(Object.values(ERadioFilterValue)), ERadioFilterValue.include),
@@ -76,6 +82,9 @@ export const PermitProjectInboxStoreModel = types
     },
     setUnreadCount(count: number) {
       self.unreadCount = count ?? 0
+    },
+    setRequirementTemplateOptions(options: IOption[]) {
+      self.requirementTemplateOptions = cast(options ?? [])
     },
     adjustUnreadCountForColumn(columnKey: string, delta: number) {
       const counts = { ...self.unreadColumnCounts }
@@ -179,6 +188,9 @@ export const PermitProjectInboxStoreModel = types
         }
         if (response.data.meta?.unreadStateCounts) {
           self.setUnreadColumnCounts(response.data.meta.unreadStateCounts)
+        }
+        if (response.data.meta?.requirementTemplateOptions) {
+          self.setRequirementTemplateOptions(response.data.meta.requirementTemplateOptions)
         }
       }
       return response.ok
@@ -307,6 +319,9 @@ export const PermitApplicationInboxStoreModel = types
         }
         if (response.data.meta?.unreadStatusCounts) {
           self.setUnreadColumnCounts(response.data.meta.unreadStatusCounts)
+        }
+        if (response.data.meta?.requirementTemplateOptions) {
+          self.setRequirementTemplateOptions(response.data.meta.requirementTemplateOptions)
         }
       }
       return response.ok

--- a/spec/concerns/jurisdiction_permit_project_search_spec.rb
+++ b/spec/concerns/jurisdiction_permit_project_search_spec.rb
@@ -182,9 +182,15 @@ RSpec.describe Api::Concerns::Search::JurisdictionPermitProjects,
           :current_page,
           :total_count,
           :state_counts,
-          :unread_count
+          :unread_count,
+          :requirement_template_options
         )
         expect(meta[:total_count]).to eq(3)
+        option_ids =
+          meta[:requirement_template_options].map do |option|
+            option.with_indifferent_access[:value]
+          end
+        expect(option_ids).to contain_exactly(template_a.id, template_b.id)
       end
 
       it "populates meta with unread_count for all unread projects in the jurisdiction" do

--- a/spec/concerns/permit_application_search_spec.rb
+++ b/spec/concerns/permit_application_search_spec.rb
@@ -178,6 +178,47 @@ RSpec.describe Api::Concerns::Search::JurisdictionPermitApplications,
         )
         expect(meta[:status_counts].values.sum).to eq(meta[:total_count])
       end
+
+      it "returns requirement_template_options for inbox applications only" do
+        unused =
+          create(:requirement_template, nickname: "Unused published permit")
+        create(
+          :template_version,
+          requirement_template: unused,
+          status: :published
+        )
+        PermitApplication.reindex
+
+        controller.perform_jurisdiction_permit_application_search
+        meta =
+          controller.instance_variable_get(
+            :@jurisdiction_permit_application_meta
+          )
+        option_ids =
+          meta[:requirement_template_options].map do |option|
+            option.with_indifferent_access[:value]
+          end
+
+        inbox_template_ids =
+          (
+            submitted_permit_applications + resubmitted_permit_applications +
+              revisions_requested_permit_applications
+          ).map { |pa| pa.template_version.requirement_template_id }.uniq
+        draft_template_ids =
+          draft_permit_applications.map do |pa|
+            pa.template_version.requirement_template_id
+          end
+        other_jur_template_ids =
+          (
+            submitted_permit_applications_different_jur +
+              resubmitted_permit_applications_different_jur
+          ).map { |pa| pa.template_version.requirement_template_id }
+
+        expect(option_ids).to match_array(inbox_template_ids)
+        expect(option_ids).not_to include(*draft_template_ids)
+        expect(option_ids).not_to include(*other_jur_template_ids)
+        expect(option_ids).not_to include(unused.id)
+      end
     end
 
     context "when searching for the jurisdictions permit applications as a review manager" do
@@ -416,6 +457,24 @@ RSpec.describe Api::Concerns::Search::JurisdictionPermitApplications,
         # Regression: status_counts must use the same permit_project scope as the
         # list search (not jurisdiction-wide aggregates).
         expect(meta[:status_counts].values.sum).to eq(meta[:total_count])
+      end
+
+      it "scopes requirement_template_options in meta to that permit project" do
+        controller.perform_jurisdiction_permit_application_search
+        meta =
+          controller.instance_variable_get(
+            :@jurisdiction_permit_application_meta
+          )
+        option_ids =
+          meta[:requirement_template_options].map do |option|
+            option.with_indifferent_access[:value]
+          end
+        project_template_ids =
+          submitted_permit_applications
+            .map { |pa| pa.template_version.requirement_template_id }
+            .uniq
+
+        expect(option_ids).to match_array(project_template_ids)
       end
 
       it "scopes unread_count in meta to that permit project" do

--- a/spec/concerns/permit_application_search_spec.rb
+++ b/spec/concerns/permit_application_search_spec.rb
@@ -187,6 +187,50 @@ RSpec.describe Api::Concerns::Search::JurisdictionPermitApplications,
           requirement_template: unused,
           status: :published
         )
+
+        # Factory template_versions reuse RequirementTemplate.first, so drafts
+        # and other-jurisdiction apps share the inbox template unless we
+        # attach dedicated ones here.
+        draft_only =
+          create(:requirement_template, nickname: "Draft only permit")
+        create(
+          :permit_application,
+          status: :new_draft,
+          submitter: submitter,
+          permit_project:
+            create(
+              :permit_project,
+              jurisdiction: jurisdiction,
+              owner: submitter
+            ),
+          template_version:
+            create(
+              :template_version,
+              requirement_template: draft_only,
+              status: :published
+            )
+        )
+
+        other_jur_only =
+          create(:requirement_template, nickname: "Other city permit")
+        create(
+          :permit_application,
+          :newly_submitted,
+          submitter: submitter,
+          permit_project:
+            create(
+              :permit_project,
+              jurisdiction: other_jurisdiction,
+              owner: submitter
+            ),
+          template_version:
+            create(
+              :template_version,
+              requirement_template: other_jur_only,
+              status: :published
+            )
+        )
+
         PermitApplication.reindex
 
         controller.perform_jurisdiction_permit_application_search
@@ -204,20 +248,13 @@ RSpec.describe Api::Concerns::Search::JurisdictionPermitApplications,
             submitted_permit_applications + resubmitted_permit_applications +
               revisions_requested_permit_applications
           ).map { |pa| pa.template_version.requirement_template_id }.uniq
-        draft_template_ids =
-          draft_permit_applications.map do |pa|
-            pa.template_version.requirement_template_id
-          end
-        other_jur_template_ids =
-          (
-            submitted_permit_applications_different_jur +
-              resubmitted_permit_applications_different_jur
-          ).map { |pa| pa.template_version.requirement_template_id }
 
         expect(option_ids).to match_array(inbox_template_ids)
-        expect(option_ids).not_to include(*draft_template_ids)
-        expect(option_ids).not_to include(*other_jur_template_ids)
-        expect(option_ids).not_to include(unused.id)
+        expect(option_ids).not_to include(
+          draft_only.id,
+          other_jur_only.id,
+          unused.id
+        )
       end
     end
 

--- a/spec/controllers/requirement_templates_controller_spec.rb
+++ b/spec/controllers/requirement_templates_controller_spec.rb
@@ -176,4 +176,112 @@ RSpec.describe Api::RequirementTemplatesController,
       end
     end
   end
+
+  describe "GET #for_filter" do
+    let(:jurisdiction) { create(:sub_district) }
+    let(:other_jurisdiction) { create(:sub_district) }
+    let(:submitter) { create(:user, :submitter) }
+
+    let!(:inbox_template) do
+      create(:requirement_template, nickname: "Plumbing permit")
+    end
+    let!(:draft_only_template) do
+      create(:requirement_template, nickname: "Draft only permit")
+    end
+    let!(:other_jurisdiction_template) do
+      create(:requirement_template, nickname: "Other city permit")
+    end
+    let!(:unused_published_template) do
+      create(:requirement_template, nickname: "Unused published permit")
+    end
+
+    let!(:inbox_version) do
+      create(
+        :template_version,
+        requirement_template: inbox_template,
+        status: :published
+      )
+    end
+    let!(:draft_version) do
+      create(
+        :template_version,
+        requirement_template: draft_only_template,
+        status: :published
+      )
+    end
+    let!(:other_version) do
+      create(
+        :template_version,
+        requirement_template: other_jurisdiction_template,
+        status: :published
+      )
+    end
+    let!(:unused_version) do
+      create(
+        :template_version,
+        requirement_template: unused_published_template,
+        status: :published
+      )
+    end
+
+    let!(:inbox_project) do
+      create(:permit_project, jurisdiction: jurisdiction, owner: submitter)
+    end
+
+    before do
+      create(
+        :permit_application,
+        status: :newly_submitted,
+        submitter: submitter,
+        permit_project: inbox_project,
+        template_version: inbox_version
+      )
+      create(
+        :permit_application,
+        status: :new_draft,
+        submitter: submitter,
+        permit_project: inbox_project,
+        template_version: draft_version
+      )
+      create(
+        :permit_application,
+        status: :newly_submitted,
+        submitter: submitter,
+        permit_project:
+          create(
+            :permit_project,
+            jurisdiction: other_jurisdiction,
+            owner: submitter
+          ),
+        template_version: other_version
+      )
+    end
+
+    def option_labels
+      json_response["data"].map { |option| option["label"] }
+    end
+
+    it "returns only templates on the current user's applications when unscoped" do
+      sign_in submitter
+      get :for_filter
+
+      expect(response).to have_http_status(:success)
+      expect(option_labels).to contain_exactly(
+        "Plumbing permit",
+        "Draft only permit",
+        "Other city permit"
+      )
+    end
+
+    it "returns only templates on a submitter's project, including drafts" do
+      sign_in submitter
+      get :for_filter, params: { permit_project_id: inbox_project.id }
+
+      expect(response).to have_http_status(:success)
+      expect(option_labels).to contain_exactly(
+        "Plumbing permit",
+        "Draft only permit"
+      )
+    end
+  end
 end


### PR DESCRIPTION
## 📋 Description

The permit type filter listed every published template in the jurisdiction, including prototypes with no matching submissions, and the menu grew off-screen with no scrollbar.

Inbox search now returns only types that appear on current inbox applications (not drafts; scoped to the project on the project permits tab). Submitter `for_filter` is scoped to applications the user can see, including drafts. Filter menus cap height, scroll the option list only, and keep Apply / Clear / Reset (and submitter search) visible.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [x] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

| Type                 | Link                                                                      |
| -------------------- | ------------------------------------------------------------------------- |
| 🗂️ Jira Story / Task | [HUB-5324](https://hous-bssb.atlassian.net/browse/HUB-5324)               |
| 📄 Related PR(s)     | <!-- #PR_NUMBER -->                                                       |
| 📑 Design / Figma    | <!-- Paste link -->                                                       |
| 📚 Documentation     | <!-- Paste link -->                                                       |

---

## ✨ Features / Changes Introduced

- Review manager Submissions and project inbox: Permit type options come from search meta (types on inbox applications), not every published template
- Submitter project/permits filters: `for_filter` returns only templates on the current user’s applications (drafts included; optional project scope)
- Permit type (and other inbox) menus scroll when long; Apply / Clear stay pinned. Submitter checkbox filter gets the same treatment (search and Reset stay put)
- Specs for inbox options, project-scoped options, and submitter `for_filter`

---

## 🧪 Steps to QA

1. As a review manager, open Submissions → Applications (list). Open **Permit type**.
2. Confirm options match types on inbox applications, not unused/prototype published templates. Confirm a long list scrolls and Apply / Clear stay visible.
3. Apply a type filter and confirm the list updates. Clear and confirm it resets.
4. Open a project → Permits tab. Open **Permit type** and confirm options are only types on that project’s inbox applications. Confirm scroll + pinned actions.
5. As a submitter, open My projects and a project’s permits list. Open the permit type filter. Confirm only types on your applications (including drafts); on a project, only that project. Confirm search stays at the top, the list scrolls, and Reset stays visible.

**Expected Behaviour:**

Filter options are types represented in the current list’s dataset (inbox for RMs, the user’s applications for submitters). Long menus scroll without covering the page or hiding actions.

**Before this change:**

Every published permit type in the jurisdiction appeared. The menu extended past the viewport with no scrollbar.

**After this change:**

Irrelevant types are gone. Long lists scroll; Apply / Clear / Reset remain on screen.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [x] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5324]: https://hous-bssb.atlassian.net/browse/HUB-5324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ