### PR TITLE
Bugfix/aug 17 bugs

### DIFF
--- a/app/frontend/components/domains/project-meeting/project-meeting-request-screen.tsx
+++ b/app/frontend/components/domains/project-meeting/project-meeting-request-screen.tsx
@@ -15,7 +15,7 @@ import { CaretLeft } from "@phosphor-icons/react"
 import { observer } from "mobx-react-lite"
 import React, { useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Link as RouterLink, useNavigate, useParams, useSearchParams } from "react-router-dom"
+import { Navigate, Link as RouterLink, useNavigate, useParams, useSearchParams } from "react-router-dom"
 import { usePermitProject } from "../../../hooks/resources/use-permit-project"
 import { useMst } from "../../../setup/root"
 import { EFlashMessageStatus } from "../../../types/enums"
@@ -46,6 +46,9 @@ export const ProjectMeetingRequestScreen = observer(function ProjectMeetingReque
 
   if (projectError || createError) return <ErrorScreen />
   if (!projectIsLoaded) return <LoadingScreen />
+  if (currentPermitProject.activeProjectMeeting) {
+    return <Navigate to={`/projects/${permitProjectId}/meetings`} replace />
+  }
   if (!permitProjectId || !projectMeetingsAvailable) {
     return <ErrorScreen error={new Error(t("projectMeeting.validation.featureUnavailable"))} />
   }

--- a/app/frontend/components/domains/requirements-library/grid-header.tsx
+++ b/app/frontend/components/domains/requirements-library/grid-header.tsx
@@ -51,7 +51,7 @@ export const GridHeaders = observer(function GridHeaders() {
               borderColor={"border.light"}
               px={4}
             >
-              <Text>{getSortColumnHeader(field)}</Text>
+              <Text whiteSpace="nowrap">{getSortColumnHeader(field)}</Text>
               {field === ERequirementLibrarySortFields.associations ? (
                 <HStack w={"fit-content"} spacing={3}>
                   <SortIcon<ERequirementLibrarySortFields>

--- a/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
+++ b/app/frontend/components/domains/requirements-library/requirement-blocks-table.tsx
@@ -65,7 +65,7 @@ export const RequirementBlocksTable = observer(function RequirementBlocksTable({
   return (
     <VStack as={"article"} spacing={5} {...containerProps}>
       <SearchGrid
-        templateColumns="minmax(0, 3fr) minmax(140px, 1fr) 180px 170px 88px"
+        templateColumns="minmax(12rem, 3fr) minmax(140px, 1fr) 180px 170px 88px"
         pos={"relative"}
         sx={{
           "[role='row']:not(:last-child) > [role='cell']": { borderBottom: "none" },

--- a/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
+++ b/app/frontend/components/domains/requirements-library/requirements-library-drawer.tsx
@@ -49,7 +49,7 @@ export const RequirementsLibraryDrawer = observer(function RequirementsLibraryDr
       )}
       <Drawer id="add-requirement-drawer" isOpen={isOpen} onClose={onClose} finalFocusRef={btnRef} placement={"right"}>
         <DrawerOverlay />
-        <DrawerContent display={"flex"} flexDir={"column"} maxW={"720px"} h={"full"} p={8}>
+        <DrawerContent display={"flex"} flexDir={"column"} maxW={"container.lg"} h={"full"} p={8}>
           <DrawerCloseButton fontSize={"xs"} />
           <RequirementBlocksTable
             h={"calc(100% - 120px)"}


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff develop...bugfix/aug-17-bugs` (merge-base range).

Bug-bash follow-ups: stop submitters from opening a second meeting request via URL, and give the requirement-blocks picker a bit more room so headers and names don’t collapse.

**Meeting request URL:** Overview and Meetings already hide the request CTA when a project has an active meeting, but `/projects/:id/meetings/new` did not. `ProjectMeetingRequestScreen` now redirects to the project Meetings tab once the project is loaded and `activeProjectMeeting` is present. Create was already rejected server-side; the intro/continue UI is no longer shown.

**Requirement blocks picker:** The add-requirement drawer is wider (`container.lg`), the name column keeps a 12rem minimum, and sort headers no longer wrap.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5383](https://hous-bssb.atlassian.net/browse/HUB-5383), [HUB-5370](https://hous-bssb.atlassian.net/browse/HUB-5370) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

> List the key changes, features, or fixes introduced in this PR.

- Redirect submitters from `/projects/:id/meetings/new` to the project Meetings tab when the project already has an active meeting (covers the direct URL and add-permits landing on the same screen)
- Widen the requirements-library drawer and keep the name column / sort headers from collapsing or wrapping

---

## 🧪 Steps to QA

> Provide clear, reproducible steps for the reviewer/QA engineer to verify the changes.

### HUB-5370 — second meeting via URL

1. Sign in as a submitter on a project that **already has an active meeting request**.
2. Confirm Overview and the Meetings tab still hide/disable the request-a-meeting CTA.
3. Visit `/projects/<project_id>/meetings/new`.
4. Confirm you land on the project **Meetings** tab and do **not** see the request intro / Continue flow.
5. On a project **with no active meeting**, visit `/projects/<project_id>/meetings/new` and confirm the request flow still works as before.

**Expected Behaviour:** With an active meeting, the new-request URL never shows the request UI; without one, requesting a meeting is unchanged.

**Before this change:** Submitters could walk through the request steps via URL (create/submit then failed).

**After this change:** They are redirected to the Meetings tab immediately.

### HUB-5383 — requirement blocks picker

1. Open a requirement template (or similar) and open the add-requirement / requirements-library drawer.
2. Confirm the drawer is wider, the name column has room, and column headers stay on one line.

**Expected Behaviour:** Picker is readable without cramped/wrapping headers.

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards/guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

_(No new interactive controls; meeting fix is a redirect. Drawer/table layout only.)_

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [x] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [x] 👀 Self-reviewed this PR before requesting others
- [ ] 

[HUB-5383]: https://hous-bssb.atlassian.net/browse/HUB-5383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ