### PR TITLE
Bugfix/aug 20 step code

### DIFF
--- a/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/part-9-energy-step-editable-block.tsx
+++ b/app/frontend/components/domains/home/review-manager/configuration-management-screen/energy-step-requirements-screen/energy-step-editable-block/part-9-energy-step-editable-block.tsx
@@ -140,42 +140,44 @@ export const Part9EnergyStepEditableBlock = observer(function Part9EnergyStepEdi
             bg={isEditing && !isCustomizing ? "greys.white" : "transparent"}
           >
             <Text fontWeight="bold">{t(`${i18nPrefix}.stepRequired.standardToPass`)}</Text>
-            <Flex gap={14} flex={1}>
-              <Input type="hidden" {...register(`${fieldArrayName}.${defaultIndex}.id`)} />
-              <Input type="hidden" {...register(`${fieldArrayName}.${defaultIndex}.default`)} />
-              <FormControl>
-                <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.energy.title`)}</FormLabel>
-                <Controller
-                  control={control}
-                  rules={{ required: !isCustomizing }}
-                  name={`${fieldArrayName}.${defaultIndex}.energyStepRequired`}
-                  render={({ field: { onChange, value } }) => {
-                    return (
-                      <EnergyStepSelect onChange={onChange} value={value} isDisabled={!isEditing || isCustomizing} />
-                    )
-                  }}
-                />
-              </FormControl>
-              <FormControl>
-                <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.zeroCarbon.title`)}</FormLabel>
-                <Controller
-                  control={control}
-                  rules={{ required: !isCustomizing }}
-                  name={`${fieldArrayName}.${defaultIndex}.zeroCarbonStepRequired`}
-                  render={({ field: { onChange, value } }) => {
-                    return (
-                      <ZeroCarbonStepSelect
-                        onChange={onChange}
-                        value={value}
-                        isDisabled={!isEditing || isCustomizing}
-                        portal
-                      />
-                    )
-                  }}
-                />
-              </FormControl>
+            <Flex direction="column" gap={4} flex={1}>
+              <Flex gap={14} flex={1}>
+                <Input type="hidden" {...register(`${fieldArrayName}.${defaultIndex}.id`)} />
+                <Input type="hidden" {...register(`${fieldArrayName}.${defaultIndex}.default`)} />
+                <FormControl>
+                  <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.energy.title`)}</FormLabel>
+                  <Controller
+                    control={control}
+                    rules={{ required: !isCustomizing }}
+                    name={`${fieldArrayName}.${defaultIndex}.energyStepRequired`}
+                    render={({ field: { onChange, value } }) => {
+                      return (
+                        <EnergyStepSelect onChange={onChange} value={value} isDisabled={!isEditing || isCustomizing} />
+                      )
+                    }}
+                  />
+                </FormControl>
+                <FormControl>
+                  <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.zeroCarbon.title`)}</FormLabel>
+                  <Controller
+                    control={control}
+                    rules={{ required: !isCustomizing }}
+                    name={`${fieldArrayName}.${defaultIndex}.zeroCarbonStepRequired`}
+                    render={({ field: { onChange, value } }) => {
+                      return (
+                        <ZeroCarbonStepSelect
+                          onChange={onChange}
+                          value={value}
+                          isDisabled={!isEditing || isCustomizing}
+                          portal
+                        />
+                      )
+                    }}
+                  />
+                </FormControl>
+              </Flex>
               {!isCustomizing && (
-                <FormControl flex={1}>
+                <FormControl>
                   <FormLabel noOfLines={1}>{t(`${i18nPrefix}.stepRequired.description.title`)}</FormLabel>
                   <Input
                     {...register(`${fieldArrayName}.${defaultIndex}.description`)}

--- a/app/frontend/components/domains/project-readiness-tools/look-up-step-codes-requirements-for-your-project.tsx
+++ b/app/frontend/components/domains/project-readiness-tools/look-up-step-codes-requirements-for-your-project.tsx
@@ -17,7 +17,7 @@ export const LookUpStepCodesRequirementsForYourProjectScreen = () => {
       <Text fontSize="lg" color="text.primary" mb="8">
         {t("home.projectReadinessTools.lookUpStepCodesRequirementsForYourProjectScreen.enterYourProjectAddress")}
       </Text>
-      <StepCodeLookupTool showJurisdictionOnPage={true} />
+      <StepCodeLookupTool />
       <Box>
         <Heading as="h2" size="lg" mb={5}>
           {t("home.projectReadinessTools.lookUpStepCodesRequirementsForYourProjectScreen.generateAStepCodesReport")}

--- a/app/frontend/components/domains/step-code/part-9/checklist/compliance-summary/index.tsx
+++ b/app/frontend/components/domains/step-code/part-9/checklist/compliance-summary/index.tsx
@@ -73,13 +73,13 @@ export const ComplianceSummary = observer(function ComplianceSummary({
             </FormHelperText>
           </FormControl>
           {R.isNil(report.energy.proposedStep) && (
-            <StepNotMetWarning i18nKey="energyStepNotMet" scrollToSection={scrollToEnergyCompliance} fontSize="xs" />
+            <StepNotMetWarning i18nKey="energyStepNotMet" scrollToSection={scrollToEnergyCompliance} fontSize="md" />
           )}
           {R.isNil(report.zeroCarbon.proposedStep) && (
             <StepNotMetWarning
               i18nKey="zeroCarbonStepNotMet"
               scrollToSection={scrollToZeroCarbonCompliance}
-              fontSize="xs"
+              fontSize="md"
             />
           )}
         </VStack>

--- a/app/frontend/components/domains/step-code/project-information.tsx
+++ b/app/frontend/components/domains/step-code/project-information.tsx
@@ -368,10 +368,13 @@ export const ProjectInformation = observer(function StepCodeProjectInformation({
                 <FormLabel htmlFor="referenceNumber" mb={0}>
                   {t("stepCode.projectInformation.identifier")}
                 </FormLabel>
-                <InfoTooltip
-                  {...fieldTooltipProps}
-                  label={t("stepCode.projectInformation.identifierTooltip") as string}
-                />
+                <Text>{t("ui.optional")}</Text>
+                <Flex ml={2}>
+                  <InfoTooltip
+                    {...fieldTooltipProps}
+                    label={t("stepCode.projectInformation.identifierTooltip") as string}
+                  />
+                </Flex>
               </HStack>
               <Input id="referenceNumber" {...register("referenceNumber")} />
             </FormControl>
@@ -497,9 +500,13 @@ export const ProjectInformation = observer(function StepCodeProjectInformation({
                 maxW={{ base: "none", xl: "430px" }}
                 label={t("stepCode.projectInformation.date") as string}
                 fieldName="permitDate"
-                showOptional={false}
                 LabelInfo={() => (
-                  <InfoTooltip {...fieldTooltipProps} label={t("stepCode.projectInformation.dateTooltip") as string} />
+                  <Flex ml={2}>
+                    <InfoTooltip
+                      {...fieldTooltipProps}
+                      label={t("stepCode.projectInformation.dateTooltip") as string}
+                    />
+                  </Flex>
                 )}
               />
             ) : (
@@ -562,7 +569,11 @@ const Field = function Field({ label, value, tooltip }: IFieldProps) {
     <FormControl>
       <HStack gap={1} mb={2}>
         <FormLabel mb={0}>{label}</FormLabel>
-        {tooltip && <InfoTooltip hasArrow placement="top" maxW="400px" whiteSpace="normal" label={tooltip} />}
+        {tooltip && (
+          <Flex ml={2}>
+            <InfoTooltip hasArrow placement="top" maxW="400px" whiteSpace="normal" label={tooltip} />
+          </Flex>
+        )}
       </HStack>
       <Input isDisabled value={value || ""} textOverflow="ellipsis" textAlign="left" />
     </FormControl>

--- a/app/frontend/components/domains/step-code/project-information.tsx
+++ b/app/frontend/components/domains/step-code/project-information.tsx
@@ -20,6 +20,8 @@ import {
   Tbody,
   Td,
   Text,
+  Th,
+  Thead,
   Tr,
 } from "@chakra-ui/react"
 import { DotsThreeVertical, Download, MapPin, ShareNetwork } from "@phosphor-icons/react"
@@ -71,6 +73,18 @@ const stageOptions = [
   EStepCodeChecklistStage.midConstruction,
   EStepCodeChecklistStage.asBuilt,
 ]
+
+const stageTableHeaderProps = {
+  py: 2,
+  textTransform: "none" as const,
+  letterSpacing: "normal",
+  fontSize: "md",
+  fontWeight: "semibold",
+  color: "text.primary",
+  lineHeight: "27px",
+  borderBottom: "1px solid",
+  borderColor: "border.light",
+}
 
 const stepCodesPath = "/step-codes?currentPage=1"
 
@@ -376,17 +390,25 @@ export const ProjectInformation = observer(function StepCodeProjectInformation({
           )}
 
           <FormControl>
-            <FormLabel>
-              {permitApplicationId
-                ? t("stepCode.projectInformation.permitStage")
-                : t("stepCode.projectInformation.stage")}
-            </FormLabel>
             {permitApplicationId && (
               <Text fontSize="sm" color="text.secondary" mb={3}>
                 {t("stepCode.projectInformation.permitStageHelp")}
               </Text>
             )}
             <Table variant="simple" size="sm">
+              <Thead>
+                <Tr borderTop="none">
+                  <Th colSpan={2} pl={0} {...stageTableHeaderProps}>
+                    {permitApplicationId
+                      ? t("stepCode.projectInformation.permitStage")
+                      : t("stepCode.projectInformation.stage")}
+                  </Th>
+                  <Th width="1px" px={2} textAlign="center" whiteSpace="nowrap" {...stageTableHeaderProps}>
+                    {t("stepCode.projectInformation.progress")}
+                  </Th>
+                  <Th pr={0} {...stageTableHeaderProps}></Th>
+                </Tr>
+              </Thead>
               <Tbody>
                 {stageOptions.map((stage) => {
                   const isSelected = selectedStage === stage
@@ -425,7 +447,7 @@ export const ProjectInformation = observer(function StepCodeProjectInformation({
                         />
                       </Td>
                       <Td fontWeight={isSelected ? "bold" : "normal"}>{stageLabel(stage)}</Td>
-                      <Td width="1px" px={2}>
+                      <Td width="1px" px={2} textAlign="center">
                         <StepCodeStageIcon status={stageStatus} />
                       </Td>
                       <Td pr={0} textAlign="right">

--- a/app/frontend/components/shared/step-code-address-search/index.tsx
+++ b/app/frontend/components/shared/step-code-address-search/index.tsx
@@ -40,12 +40,15 @@ const StepCodeAddressSearch = observer(
     })
     const { control } = methods
 
+    const goToStepCodeRequirements = (jurisdiction: IJurisdiction, address: string) => {
+      navigate(`/jurisdictions/${jurisdiction.slug}/step-code-requirements?address=${encodeURIComponent(address)}`)
+    }
+
     const handleCheckAddress = async () => {
       if (!selectedSite) {
         onJurisdictionFound?.(null)
         setShowError(true)
         setSelectedSite(null)
-        //onJurisdictionFound?.(null)
         return
       }
 
@@ -66,13 +69,10 @@ const StepCodeAddressSearch = observer(
         setSelectedSite(null)
         setSelectedOption(null)
       } else if (onJurisdictionFound) {
-        // If parent provided a callback (like in StepCodeLookupTool), call it
+        // Landing (and other inline lookups) keep the 3-link panel on-page
         onJurisdictionFound(jurisdiction, addressLabel)
-        // We don't clear state or navigate here if we're using the lookup tool inline
       } else {
-        navigate(
-          `/jurisdictions/${jurisdiction.slug}/step-code-requirements?address=${encodeURIComponent(addressLabel)}`
-        )
+        goToStepCodeRequirements(jurisdiction, addressLabel)
       }
     }
 
@@ -111,7 +111,11 @@ const StepCodeAddressSearch = observer(
                       if (value) addJurisdiction(value)
                       setManualJurisdiction(value)
                       const addressLabel = selectedOption?.label || ""
-                      onJurisdictionFound?.(value, addressLabel)
+                      if (onJurisdictionFound) {
+                        onJurisdictionFound(value, addressLabel)
+                      } else if (value) {
+                        goToStepCodeRequirements(value, addressLabel)
+                      }
                       setShowError(false) // hide the error and dropdown once selected
                     }}
                     selectedOption={{ label: manualJurisdiction?.reverseQualifiedName, value: manualJurisdiction }}

--- a/app/frontend/i18n/i18n.ts
+++ b/app/frontend/i18n/i18n.ts
@@ -2521,6 +2521,7 @@ Thank you,
             date: "Building permit date",
             dateTooltip: "The date on which the building permit was issued by the issuing jurisdiction.",
             stage: "Step Code stage",
+            progress: "Progress",
             permitStage: "Permit application Step Code stage",
             permitStageHelp:
               "This selects which stage checklist counts for this permit application (completion status, sidebar, and submission). Changing stage here does not change the Step Code’s own stage used when opening the tool outside this permit.",


### PR DESCRIPTION
## 📋 Description

> **Analyzed:** `git diff stable...bugfix/aug-20-step-code` (merge-base range). Commits: `stable..bugfix/aug-20-step-code`.

Small Step Code UI follow-ups. The information page now labels stage **Progress** in the same header row as **Step Code stage**, and marks reference number and building permit date as optional so empty values don’t look required. Tools lookup goes straight to the jurisdiction’s energy step-code requirements page. RM Part 9 energy-step **Description** sits full-width under the step selects. P9 “step not met” warnings use normal 16px text.

Please add before/after screenshots of the Step Code information page and the P9 Description field.

---

## 🔖 What type of PR is this? _(check all that apply)_

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📦 Chore (Release)
- [ ] ✅ Test
- [ ] 🔥 Hot Fix
- [ ] 📝 Documentation

---

## 🎫 Related Tickets & Documents

> Link your Jira story/task so it is tracked. Use the `Fixes`, or `Relates to` keywords where applicable.

| Type | Link |
|------|------|
| 🗂️ Jira Story / Task | [HUB-5502](https://hous-bssb.atlassian.net/browse/HUB-5502), [HUB-5506](https://hous-bssb.atlassian.net/browse/HUB-5506), [HUB-5508](https://hous-bssb.atlassian.net/browse/HUB-5508), [HUB-5516](https://hous-bssb.atlassian.net/browse/HUB-5516) |
| 📄 Related PR(s) | <!-- #PR_NUMBER --> |
| 📑 Design / Figma | <!-- Paste link --> |
| 📚 Documentation | <!-- Paste link --> |

---

## ✨ Features / Changes Introduced

> List the key changes, features, or fixes introduced in this PR.

- **Progress header (HUB-5508):** Step Code stage table uses a header row with **Step Code stage** / **Progress** at the same size and weight, with the divider under the headers.
- **Optional fields (HUB-5516):** Reference number and building permit date show **(optional)**; permit date is no longer forced required. Info tooltips have a bit of left margin.
- **P9 energy-step Description (HUB-5506):** Description is a full-width field under the Energy / Zero Carbon selects instead of a cramped third column.
- **Tools lookup (HUB-5502):** Looking up Step Codes requirements (including after picking a jurisdiction manually) navigates to that jurisdiction’s ESC requirements page instead of keeping the inline 3-link panel.
- **Not-met warnings:** Energy and Zero Carbon “minimum step was not met” boxes in the P9 compliance summary Step Requirements block use `md` (16px) instead of `xs`.

---

## 🧪 Steps to QA

> Provide clear, reproducible steps for the reviewer/QA engineer to verify the changes.

1. Open a Part 9 (and Part 3) Step Code information page. Confirm **Step Code stage** and **Progress** are on one line, same bold label style, with a line under the headers. Stage status icons still show complete / in progress / not started.
2. Confirm **Reference number** shows **(optional)**. Select Mid-construction or As-built and confirm **Building permit date** also shows **(optional)**. Leave both empty and still Start/Continue a checklist.
3. Confirm the info icons sit slightly to the right of the optional labels (not jammed against the text).
4. As a review manager, open Configuration → Energy step code requirements → Part 9, edit a combination, and confirm **Description** is full-width under the two step dropdowns (default row and a customized row if present).
5. **Tools → look up Step Codes requirements:** search an address and confirm you land on that jurisdiction’s energy step-code requirements page. Repeat after choosing a jurisdiction from the manual picker.
6. On a P9 checklist with more than one compliance report and a missing proposed energy or zero-carbon step, open Compliance summary and confirm the red “minimum step was not met” boxes use the same body text size as the rest of the page.

**Expected Behaviour:**
> Stage progress is labeled, optional fields don’t look required, Description wraps full width, tools lookup navigates to the jurisdiction ESC page, and not-met warnings are readable at 16px.

**Before this change:**
> No Progress column header; reference number / permit date looked required; Description sat in a narrow third column; tools lookup could stay on the lookup page; Step Requirements warnings used 12px text.

**After this change:**
> Progress header + optional labels; Description full width; lookup navigates to ESC requirements; not-met warnings at normal size.
>
> _Add before/after screenshots of the information page and the P9 Description field._

---

## ♿ UI Accessibility Checklist

> ⚠️ Skip this section if this PR has no UI changes.

Check the [WebAIM checklist](https://webaim.org/standards/wcag/checklist) for a user-friendly guide and the [WCAG guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) for the full specification. Aim for at least **AA conformance** level where applicable.

- [x] Markup uses **semantic HTML** (e.g. `<button>`, `<nav>`, `<main>`, `<section>`)?
- [ ] Additional context added through `aria-roles` and `aria-labels` where needed?
- [ ] Checked with the [WAVE Browser Extension](https://wave.webaim.org/extension/) for accessibility errors?
- [x] Usable with a **keyboard** and navigable in a **logical order**?
- [ ] Usable with a **screen reader** (e.g. VoiceOver for Mac, NVDA for Windows) with enough context?
- [x] **Colour contrast** meets minimum AA ratio (4.5:1 for text, 3:1 for UI components)?
- [x] No content relies on **colour alone** to convey meaning?
- [x] All images have meaningful **alt text** (or `alt=""` if decorative)?

---

## ✅ General Checklist

> Complete all relevant items before requesting a review.

- [ ] ✅ Tests written and passing for all changes where relevant
- [x] 📝 Commit messages are descriptive and follow the project convention
- [ ] 📗 Related documentation updated; relevant screenshots included
- [ ] 📱 For UI changes: responsive design verified across multiple screen sizes
- [x] 🔒 No sensitive data (API keys, secrets, credentials) committed
- [ ] 🗂️ Jira story/task moved to **Ready for Code Review** state
- [ ] 👀 Self-reviewed this PR before requesting others

[HUB-5502]: https://hous-bssb.atlassian.net/browse/HUB-5502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ